### PR TITLE
[Feat] Add "Undo" button to task completion notification

### DIFF
--- a/frontend/src/components/tasks/TaskCard.vue
+++ b/frontend/src/components/tasks/TaskCard.vue
@@ -285,6 +285,7 @@
     <v-snackbar v-model="taskStatusUpdated" :timeout="4000" color="secondary">
       {{ taskStatus }}
       <template #actions>
+        <v-btn color="warning" variant="text" @click="undoTaskCompletion"> Undo </v-btn>
         <v-btn color="white" variant="text" @click="taskStatusUpdated = false"> Close </v-btn>
       </template>
     </v-snackbar>
@@ -454,6 +455,11 @@
       name: props.task.name,
     });
     taskStatusUpdated.value = true;
+  };
+  const undoTaskCompletion = () => {
+    taskStatus.value = t('page.tasks.questcard.statusundoing', { name: props.task.name });
+    markTaskUncomplete();
+    taskStatusUpdated.value = false;
   };
   const markTaskAvailable = () => {
     // Go through all the predecessors and mark them as complete

--- a/frontend/src/locales/de.json5
+++ b/frontend/src/locales/de.json5
@@ -66,6 +66,7 @@
         statuscomplete: 'Markiere {name} als abgeschlossen',
         statusuncomplete: 'Markiere {name} als unvollständig',
         statusavailable: 'Markiere alle Vorraussetzungen für {name} als abgeschlossen',
+        statusundoing: 'Mache Abschluss von {name} rückgängig...',
         nonkappa: 'Nicht für Kappa benötigt',
         keysneeded: '{keys} wird gebraucht auf {map} | eine {keys} wird gebraucht auf {map}',
         objectiveshidden: '{count} Teilaufgaben nicht auf dieser Karte ({uncompleted} uncompleted)',

--- a/frontend/src/locales/en.json5
+++ b/frontend/src/locales/en.json5
@@ -66,6 +66,7 @@
         statuscomplete: 'Marked {name} as complete',
         statusuncomplete: 'Marked {name} as uncompleted',
         statusavailable: 'Marked all prerequisites for {name} as complete',
+        statusundoing: 'Undoing completion of {name}...',
         nonkappa: 'Not Kappa Required',
         keysneeded: '{keys} needed on {map} | One of {keys} needed on {map}',
         objectiveshidden: '{count} objectives not on this map ({uncompleted} uncompleted)',

--- a/frontend/src/locales/es.json5
+++ b/frontend/src/locales/es.json5
@@ -63,6 +63,7 @@
         statuscomplete: 'Marcado {name} como completo',
         statusuncomplete: 'Marcado {name} como no completado',
         statusavailable: 'Marcados todos los requisitos previos para {name} como completados',
+        statusundoing: 'Deshaciendo completado de {name}...',
         nonkappa: 'No se requiere Kappa',
         keysneeded: '{keys} necesaria en {map} | {keys} necesarias en {map}',
         objectiveshidden: '{count} objetivos no están en este mapa ({uncompleted} sin completar)',

--- a/frontend/src/locales/fr.json5
+++ b/frontend/src/locales/fr.json5
@@ -66,6 +66,7 @@
         statuscomplete: 'Marquer {name} comme terminé',
         statusuncomplete: 'Marquer {name} comme non terminé',
         statusavailable: 'Marquer tous les pre-requis de {name} comme terminés',
+        statusundoing: 'Annulation de la complétion de {name}...',
         nonkappa: 'Non requis pour la Kappa',
         keysneeded: '{keys} requis sur {map} | Une des {keys} requis sur {map}',
         objectiveshidden: '{count} objectifs non présent sur la carte ({uncompleted} non terminés)',

--- a/frontend/src/locales/ru.json5
+++ b/frontend/src/locales/ru.json5
@@ -66,6 +66,7 @@
         statuscomplete: 'Отмеченно {name} как завершено',
         statusuncomplete: 'Отмечено {name} как не завершено',
         statusavailable: 'Все предварительные условия для {name} отмечены как завершенные',
+        statusundoing: 'Отмена выполнения {name}...',
         nonkappa: 'Не требуются для Каппа',
         keysneeded: '{keys} нужны на {map} | Один из {keys} нужен на {map}',
         objectiveshidden: '{count} целей не на этой карте ({uncompleted} не завершено)',

--- a/frontend/src/locales/uk.json5
+++ b/frontend/src/locales/uk.json5
@@ -66,6 +66,7 @@
         statuscomplete: 'Відзначено {name} як завершено',
         statusuncomplete: 'Відзначено {name} як незавершене',
         statusavailable: 'Усі попередні умови для {name} позначені як завершені',
+        statusundoing: 'Скасування виконання {name}...',
         nonkappa: 'Не потрібні для Каппа',
         keysneeded: '{keys} потрібні на {map} | Один з {keys} потрібен на {map}',
         objectiveshidden: '{count} цілей не на цій карті ({uncompleted} не завершено)',


### PR DESCRIPTION
Implements an "Undo" button on the task completion snackbar, allowing you to quickly revert accidental task completions.

Key changes:
- Added an "Undo" button alongside the "Close" button in the task completion notification (`TaskCard.vue`).
- Clicking "Undo" calls `markTaskUncomplete()` to revert the task's status and immediately closes the notification.
- Provides an "Undoing..." message in the snackbar for immediate visual feedback when "Undo" is pressed.
- Added internationalization support for the new "Undoing..." message in all supported locales.
- The "Undo" button is styled with `color="warning"` for better visibility.

This change addresses issue #33 by streamlining the process of correcting accidental task completions, reducing your friction.