### PR TITLE
fix: place smaller task zones on top of larger ones

### DIFF
--- a/frontend/src/features/maps/MapMarker.vue
+++ b/frontend/src/features/maps/MapMarker.vue
@@ -146,6 +146,7 @@
       top: relativeLocation.value.topPercent + '%',
       left: relativeLocation.value.leftPercent + '%',
       transform: 'translate(-50%, -125%)',
+      zIndex: 100,
     };
   });
 </script>


### PR DESCRIPTION
- fix smaller task zones being unreachable when covered by larger ones.
- fix task tooltips on the map appearing under some zones.

Fixes #40 

<img width="1121" height="413" alt="image" src="https://github.com/user-attachments/assets/a8dd9de2-e19c-478f-ad63-cd9558f95550" />  
<img width="650" height="294" alt="image" src="https://github.com/user-attachments/assets/d25a48ae-80f8-44aa-891c-61a6ff4b803b" />  
