### PR TITLE
fix trader unlock reward display

### DIFF
--- a/app/features/tasks/TaskCardRewards.vue
+++ b/app/features/tasks/TaskCardRewards.vue
@@ -31,11 +31,11 @@
       </template>
       <!-- Trader Unlock -->
       <span
-        v-if="traderUnlockReward"
+        v-if="displayedTraderUnlock?.name"
         class="inline-flex items-center gap-1.5 rounded bg-amber-500/10 px-2 py-0.5"
       >
         <UIcon name="i-mdi-lock-open-variant" aria-hidden="true" class="h-4 w-4 text-amber-400" />
-        <span class="text-amber-300">{{ traderUnlockReward.name }}</span>
+        <span class="text-amber-300">{{ displayedTraderUnlock.name }}</span>
       </span>
       <!-- Item Rewards Summary -->
       <AppTooltip v-if="itemRewards.length > 0" :text="itemRewardsSummaryTooltip">
@@ -250,7 +250,7 @@
     taskId: string;
     traderStandingRewards: TraderStanding[];
     skillRewards: SkillReward[];
-    traderUnlockReward?: TraderUnlock | null;
+    traderUnlockReward?: TraderUnlock | TraderUnlock[] | null;
     itemRewards: ItemReward[];
     offerUnlockRewards: OfferUnlock[];
     parentTasks: Task[];
@@ -261,6 +261,14 @@
   }>();
   const { t } = useI18n({ useScope: 'global' });
   const formatNumber = useLocaleNumberFormatter();
+
+  const displayedTraderUnlock = computed(() => {
+    if (Array.isArray(props.traderUnlockReward)) {
+      return props.traderUnlockReward.length > 0 ? props.traderUnlockReward[0] : null;
+    }
+    return props.traderUnlockReward || null;
+  });
+
   const rewardLinkClass =
     'text-primary-400 hover:text-primary-300 inline-flex items-center gap-1.5 text-xs';
   const rewardItemCardClass = [
@@ -275,7 +283,7 @@
     return (
       props.traderStandingRewards.length > 0 ||
       props.skillRewards.length > 0 ||
-      props.traderUnlockReward != null
+      displayedTraderUnlock.value != null
     );
   });
   const hasDetailedRewards = computed(() => {


### PR DESCRIPTION
The "Trader Unlock" reward is displaying for all tasks. It should only display for tasks that unlock a trader. This PR fixes the issue.

### Before
<img width="1469" height="1028" alt="image" src="https://github.com/user-attachments/assets/104c9dc8-6351-40a8-93ab-7209f5eb1822" />

### After
<img width="1464" height="1026" alt="image" src="https://github.com/user-attachments/assets/9d692611-8d96-48b4-9bb1-4241edd4b991" />
