### PR TITLE
Added short name to the search field lookup in needed items page

### DIFF
--- a/app/pages/neededitems.vue
+++ b/app/pages/neededitems.vue
@@ -255,8 +255,8 @@
         const itemName = itemObj?.name;
         const itemShortName = itemObj?.shortName;
         if (
-          itemName?.toLowerCase().includes(searchLower) ||
-          itemShortName?.toLowerCase().includes(searchLower)
+          itemName?.toLowerCase()?.includes(searchLower) ||
+          itemShortName?.toLowerCase()?.includes(searchLower)
         ) {
           return true;
         }


### PR DESCRIPTION
Items can be found by short name now in needed items page.
<img width="433" height="367" alt="image" src="https://github.com/user-attachments/assets/5b0c31bf-a935-4c44-b0c7-9782f05ced41" />
