### PR TITLE
refactor(search): enhance multi-token search functionality for items and tasks

### DIFF
--- a/app/pages/neededitems.vue
+++ b/app/pages/neededitems.vue
@@ -430,8 +430,6 @@
         return task?.kappaRequired === true;
       });
     }
-    // Filter by search - multi-token search across item name, task name, and hideout station
-    // e.g., "gas analyzer lavatory" finds gas analyzers needed for Lavatory
     if (search.value) {
       const tokens = splitSearchTokens(search.value);
       if (tokens.length > 0) {

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -504,7 +504,6 @@
       logger.error('[Tasks] Debounced search update failed:', error);
     });
   });
-  // Split search into tokens for multi-word matching (e.g., "punisher 5" matches "The Punisher - Part 5")
   const searchTokens = computed(() => splitSearchTokens(debouncedSearch.value));
   // Cache lowercase task names to avoid repeated toLowerCase() calls in filter
   type TaskWithLowerName = Task & { _lowerName: string };

--- a/app/utils/__tests__/search.test.ts
+++ b/app/utils/__tests__/search.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeSearchString, splitSearchTokens } from '@/utils/search';
+describe('normalizeSearchString', () => {
+  it('converts to lowercase', () => {
+    expect(normalizeSearchString('HELLO')).toBe('hello');
+    expect(normalizeSearchString('HeLLo WoRLd')).toBe('hello world');
+  });
+  it('trims whitespace', () => {
+    expect(normalizeSearchString('  hello  ')).toBe('hello');
+    expect(normalizeSearchString('\thello\n')).toBe('hello');
+  });
+  it('handles empty string', () => {
+    expect(normalizeSearchString('')).toBe('');
+    expect(normalizeSearchString('   ')).toBe('');
+  });
+});
+describe('splitSearchTokens', () => {
+  it('splits on whitespace', () => {
+    expect(splitSearchTokens('punisher 5')).toEqual(['punisher', '5']);
+    expect(splitSearchTokens('gas analyzer')).toEqual(['gas', 'analyzer']);
+  });
+  it('handles multiple spaces', () => {
+    expect(splitSearchTokens('  gas  analyzer  ')).toEqual(['gas', 'analyzer']);
+  });
+  it('normalizes input', () => {
+    expect(splitSearchTokens('PUNISHER 5')).toEqual(['punisher', '5']);
+    expect(splitSearchTokens('  GAS  Analyzer  ')).toEqual(['gas', 'analyzer']);
+  });
+  it('returns empty array for empty input', () => {
+    expect(splitSearchTokens('')).toEqual([]);
+    expect(splitSearchTokens('   ')).toEqual([]);
+  });
+  it('handles single token', () => {
+    expect(splitSearchTokens('punisher')).toEqual(['punisher']);
+  });
+});

--- a/app/utils/search.ts
+++ b/app/utils/search.ts
@@ -1,27 +1,6 @@
-/**
- * Utility functions for search string processing.
- * Used across multiple pages (tasks, neededitems) for consistent multi-token search behavior.
- */
-/**
- * Normalizes a search string by converting to lowercase and trimming whitespace.
- * @param search - The raw search input string
- * @returns Normalized search string
- */
 export function normalizeSearchString(search: string): string {
   return search.toLowerCase().trim();
 }
-/**
- * Splits a search string into individual tokens for multi-word matching.
- * Tokens are separated by whitespace and empty tokens are filtered out.
- *
- * @example
- * splitSearchTokens('punisher 5') // returns ['punisher', '5']
- * splitSearchTokens('  gas  analyzer  ') // returns ['gas', 'analyzer']
- * splitSearchTokens('') // returns []
- *
- * @param search - The search string to tokenize (should already be normalized)
- * @returns Array of non-empty tokens
- */
 export function splitSearchTokens(search: string): string[] {
   const normalized = normalizeSearchString(search);
   if (!normalized) return [];


### PR DESCRIPTION
## Summary

Improved search functionality on both Tasks and Needed Items pages to support **multi-token matching**.

## Changes

### Tasks Page (`/tasks`)

**Before:** Single substring match - search query had to appear exactly as typed in the task name.
- ❌ `"punisher 5"` → No results (literal string "punisher 5" doesn't exist in "The Punisher - Part 5")
- ✅ `"punisher - part 5"` → The Punisher - Part 5

**After:** Multi-token search - query is split by whitespace, all tokens must be present in the task name.
- ✅ `"punisher 5"` → The Punisher - Part 5
- ✅ `"punisher 1"` → The Punisher - Part 1
- ✅ `"delivery past"` → Delivery from the Past

### Needed Items Page (`/neededitems`)

**Before:** Single substring match checked against separate fields (item name, short name, task name, station name).
- ❌ `"gas analyzer lavatory"` → No results (no single field contains the full substring)
- ✅ `"gas analyzer"` → Gas Analyzers (all sources)

**After:** Multi-token search across all combined searchable fields (item name, short name, task name, hideout station name/level).
- ✅ `"gas analyzer lavatory"` → Gas Analyzers needed for Lavatory
- ✅ `"flash drive skier"` → Flash drives needed for Skier tasks
- ✅ `"workbench 3"` → Items needed for Workbench level 3
- ✅ `"salewa therapist"` → Salewas needed for Therapist tasks

## Technical Details

- Search queries are split by whitespace into tokens
- All tokens must be present in the searchable text (AND logic)
- Case-insensitive matching
- Empty tokens are filtered out