### PR TITLE
Add required equipment to task overview

### DIFF
--- a/app/features/tasks/QuestEquipment.vue
+++ b/app/features/tasks/QuestEquipment.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <div class="mb-2 text-xs font-medium text-gray-400">
-      {{ $t('page.tasks.questcard.equipmentHeader', 'Required Equipment') }}
+      {{ $t('page.tasks.questcard.equipment_header') }}
     </div>
     <div class="mb-2 flex flex-wrap items-center gap-x-2 gap-y-1">
       <div v-for="item in equipment" :key="item.id" class="inline-block">

--- a/app/features/tasks/TaskCard.vue
+++ b/app/features/tasks/TaskCard.vue
@@ -78,125 +78,185 @@
               </span>
             </AppTooltip>
           </template>
-          <!-- Menu button -->
-          <AppTooltip v-if="isOurFaction" :text="t('page.tasks.questcard.more', 'More')">
-            <UButton
-              size="xs"
-              color="neutral"
-              variant="ghost"
-              class="shrink-0"
-              :aria-label="t('page.tasks.questcard.more', 'More')"
-              @click="openOverflowMenu"
-            >
-              <UIcon name="i-mdi-dots-horizontal" aria-hidden="true" class="h-5 w-5" />
-            </UButton>
-          </AppTooltip>
+          <template v-else-if="pendingParentTasks.length">
+            <span class="ml-2 inline-flex flex-wrap items-center gap-x-3 gap-y-1">
+              <AppTooltip
+                v-for="parent in displayedPendingParents"
+                :key="parent.id"
+                :text="getPendingParentTooltipText(parent)"
+              >
+                <span class="inline-flex items-center gap-1.5">
+                  <router-link
+                    :to="`/tasks?task=${parent.id}`"
+                    class="text-surface-200 text-[11px] underline decoration-white/30 underline-offset-2 hover:decoration-white/60"
+                  >
+                    <span class="truncate">{{ parent.name }}</span>
+                  </router-link>
+                  <span class="text-surface-500 text-[11px]">
+                    {{
+                      t(
+                        'page.tasks.questcard.requires_must_be',
+                        {
+                          status: formatRequirementExpectedStatuses(parent.expectedStatuses),
+                        },
+                        `must be ${formatRequirementExpectedStatuses(parent.expectedStatuses)}`
+                      )
+                    }}
+                  </span>
+                  <span class="inline-flex items-center gap-0.5 text-[10px] text-amber-400/80">
+                    <UIcon name="i-mdi-information-outline" class="h-3 w-3 shrink-0" />
+                    {{
+                      t(
+                        'page.tasks.questcard.requires_currently',
+                        {
+                          status: formatRequirementCurrentStatus(parent.currentStatus),
+                        },
+                        `currently ${formatRequirementCurrentStatus(parent.currentStatus)}`
+                      )
+                    }}
+                  </span>
+                </span>
+              </AppTooltip>
+              <span v-if="extraPendingParentsCount > 0" class="text-surface-500">
+                +{{ extraPendingParentsCount }}
+              </span>
+            </span>
+          </template>
+          <template v-else>
+            <span class="text-surface-300 ml-2">{{ lockedBefore }}</span>
+          </template>
+        </div>
+        <div
+          v-if="isFailed || isInvalid"
+          class="text-xs"
+          :class="isFailed ? 'text-error-300' : 'text-surface-300'"
+        >
+          <span :class="isFailed ? 'text-error-200/70' : 'text-surface-500'">
+            {{
+              isFailed
+                ? t('page.tasks.questcard.failed_because')
+                : t('page.tasks.questcard.blocked_because', 'Blocked because')
+            }}:
+          </span>
+          <template v-if="statusSources.length > 0">
+            <span class="ml-2 inline-flex flex-wrap items-center gap-x-3 gap-y-1">
+              <AppTooltip
+                v-for="source in statusSources"
+                :key="source.id"
+                :text="getStatusSourceTooltipText(source)"
+              >
+                <span class="inline-flex items-center gap-1.5">
+                  <router-link
+                    :to="`/tasks?task=${source.id}`"
+                    :class="
+                      isFailed
+                        ? 'text-error-200 decoration-error-400/40 hover:decoration-error-400/70'
+                        : 'text-surface-200 decoration-white/30 hover:decoration-white/60'
+                    "
+                    class="text-[11px] underline underline-offset-2"
+                  >
+                    {{ source.name }}
+                  </router-link>
+                  <span
+                    :class="isFailed ? 'text-error-300' : 'text-surface-400'"
+                    class="text-[11px]"
+                  >
+                    {{
+                      isFailed
+                        ? t(
+                            'page.tasks.questcard.failed_because_was',
+                            {
+                              status: formatRequirementExpectedStatuses(source.triggerStatuses),
+                            },
+                            `was ${formatRequirementExpectedStatuses(source.triggerStatuses)}`
+                          )
+                        : t(
+                            'page.tasks.questcard.blocked_because_was',
+                            {
+                              status: formatRequirementExpectedStatuses(source.triggerStatuses),
+                            },
+                            `was ${formatRequirementExpectedStatuses(source.triggerStatuses)}`
+                          )
+                    }}
+                  </span>
+                </span>
+              </AppTooltip>
+            </span>
+          </template>
+          <span v-else class="ml-2" :class="isFailed ? 'text-error-200/80' : 'text-surface-400'">
+            {{
+              isFailed
+                ? t('page.tasks.questcard.failed_because_unknown')
+                : t('page.tasks.questcard.blocked_because_unknown', 'Blocked by prerequisites')
+            }}
+          </span>
+        </div>
+        <div v-if="showNeededBy" class="text-surface-400 text-xs">
+          <span class="text-surface-500">
+            <UIcon name="i-mdi-account-multiple-outline" class="mr-1 inline h-4 w-4" />
+            {{
+              t(
+                'page.tasks.questcard.needed_by',
+                { names: neededByDisplayText },
+                `Needed by: ${neededByDisplayText}`
+              )
+            }}
+          </span>
         </div>
       </div>
-      <!-- 2) Top strip: Before (only show when there are pending prerequisites) -->
-      <div v-if="lockedBefore > 0" class="text-xs text-gray-400">
-        <span class="text-gray-500">{{ t('page.tasks.questcard.requires', 'Requires') }}:</span>
-        <template v-if="pendingParentTasks.length">
-          <span class="ml-2 inline-flex flex-wrap items-center gap-1.5">
-            <AppTooltip
-              v-for="parent in displayedPendingParents"
-              :key="parent.id"
-              :text="parent.name"
-            >
-              <router-link
-                :to="`/tasks?task=${parent.id}`"
-                class="inline-flex max-w-[16rem] items-center rounded-md border border-white/10 bg-white/5 px-2 py-0.5 text-[11px] text-gray-200 hover:bg-white/10"
-              >
-                <span class="truncate">{{ parent.name }}</span>
-              </router-link>
-            </AppTooltip>
-            <span v-if="extraPendingParentsCount > 0" class="text-gray-500">
-              +{{ extraPendingParentsCount }}
-            </span>
-          </span>
-        </template>
-        <template v-else>
-          <span class="ml-2 text-gray-300">{{ lockedBefore }}</span>
-        </template>
-      </div>
-      <div v-if="isFailed" class="text-xs text-red-300">
-        <span class="text-red-200/70">
-          {{ t('page.tasks.questcard.failedbecause', 'Failed because') }}:
-        </span>
-        <template v-if="failureSources.length > 0">
-          <span class="ml-2 inline-flex flex-wrap items-center gap-1.5">
-            <router-link
-              v-for="source in failureSources"
-              :key="source.id"
-              :to="`/tasks?task=${source.id}`"
-              class="inline-flex max-w-[16rem] items-center rounded-md border border-red-500/30 bg-red-500/10 px-2 py-0.5 text-[11px] text-red-200 hover:bg-red-500/20"
-            >
-              {{ source.name }}
-            </router-link>
-          </span>
-        </template>
-        <span v-else class="ml-2 text-red-200/80">
-          {{ t('page.tasks.questcard.failedbecauseunknown', 'Failed manually or data missing') }}
-        </span>
-      </div>
-      <div v-if="showNeededBy" class="text-xs text-gray-400">
-        <span class="text-gray-500">
-          <UIcon name="i-mdi-account-multiple-outline" class="mr-1 inline h-4 w-4" />
-          {{
-            t(
-              'page.tasks.questcard.neededby',
-              { names: neededByDisplayText },
-              `Needed by: ${neededByDisplayText}`
-            )
-          }}
-        </span>
-      </div>
-      <!-- 3) Body: objectives -->
-      <div class="space-y-3">
-        <QuestEquipment v-if="neededEquipment.length" :equipment="neededEquipment" />
-        <QuestKeys v-if="task?.neededKeys?.length" :needed-keys="task.neededKeys" />
-        <QuestObjectivesSkeleton
-          v-if="showObjectivesSkeleton"
-          :objectives="relevantViewObjectives"
-          :irrelevant-count="irrelevantObjectives.length"
-          :uncompleted-irrelevant="uncompletedIrrelevantObjectives.length"
-        />
-        <QuestObjectives
-          v-else
-          :objectives="relevantViewObjectives"
-          :irrelevant-count="irrelevantObjectives.length"
-          :uncompleted-irrelevant="uncompletedIrrelevantObjectives.length"
-        />
-      </div>
-      <!-- 4) Chain info -->
-      <div v-if="afterHasContent" class="text-xs text-gray-400">
-        <AppTooltip
-          v-if="unlocksNextCount > 0"
-          :text="
-            t(
-              'page.tasks.questcard.unlocksNextTooltip',
-              'Number of quests that become available after completing this task'
-            )
-          "
+      <!-- 2) Body: objectives (Full Width) -->
+      <div class="border-surface-700/50 border-t">
+        <div
+          class="hover:bg-surface-700/20 focus-visible:ring-primary-500/40 focus-visible:ring-offset-surface-900 flex cursor-pointer items-center justify-between rounded-sm transition-colors select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+          :class="compactClasses.objectivesToggle"
+          role="button"
+          tabindex="0"
+          :aria-expanded="objectivesVisible"
+          :aria-controls="`objectives-content-${task.id}`"
+          @click="toggleObjectivesVisibility"
+          @keydown.enter.prevent="toggleObjectivesVisibility"
+          @keydown.space.prevent="toggleObjectivesVisibility"
         >
-          <span class="cursor-help border-b border-dotted border-gray-500">
-            {{ t('page.tasks.questcard.unlocksNext', 'Unlocks next') }}: {{ unlocksNextCount }}
-          </span>
-        </AppTooltip>
-        <span v-if="unlocksNextCount > 0 && impactCount > 0" class="mx-2 text-gray-600">•</span>
-        <AppTooltip
-          v-if="impactCount > 0"
-          :text="
-            t(
-              'page.tasks.questcard.impactTooltip',
-              'Number of incomplete quests that depend on this task being completed'
-            )
-          "
+          <div class="text-surface-400 text-[10px] font-bold tracking-wider uppercase">
+            {{ t('page.tasks.questcard.objectives') }}
+          </div>
+          <UButton
+            icon="i-mdi-chevron-down"
+            variant="ghost"
+            color="neutral"
+            size="xs"
+            :class="{ 'rotate-180': objectivesVisible }"
+            class="pointer-events-none transition-transform duration-200"
+          />
+        </div>
+        <Transition
+          enter-active-class="transition duration-150 ease-out"
+          enter-from-class="opacity-0 -translate-y-1"
+          enter-to-class="opacity-100 translate-y-0"
+          leave-active-class="transition duration-100 ease-in"
+          leave-from-class="opacity-100 translate-y-0"
+          leave-to-class="opacity-0 -translate-y-1"
         >
-          <span class="cursor-help border-b border-dotted border-gray-500">
-            {{ t('page.tasks.questcard.impact', 'Impact') }}: {{ impactCount }}
-          </span>
-        </AppTooltip>
+          <div
+            v-if="objectivesVisible"
+            :id="`objectives-content-${task.id}`"
+            :class="[isCompact ? 'space-y-1.5' : 'space-y-3', compactClasses.objectivesBody]"
+          >
+            <QuestEquipment v-if="neededEquipment.length" :equipment="neededEquipment" />
+            <QuestObjectivesSkeleton
+              v-if="showObjectivesSkeleton"
+              :objectives="relevantViewObjectives"
+              :irrelevant-count="irrelevantObjectives.length"
+              :uncompleted-irrelevant="uncompletedIrrelevantObjectives.length"
+            />
+            <QuestObjectives
+              v-else
+              :objectives="relevantViewObjectives"
+              :irrelevant-count="irrelevantObjectives.length"
+              :uncompleted-irrelevant="uncompletedIrrelevantObjectives.length"
+            />
+          </div>
+        </Transition>
       </div>
     </div>
     <!-- 3) Rewards Summary Section (Fixed to bottom, Full Width) -->

--- a/app/locales/de.json5
+++ b/app/locales/de.json5
@@ -302,6 +302,7 @@
       },
       pinned_tasks_section: 'Angeheftete Aufgaben',
       questcard: {
+        equipment_header: 'Erforderliche ausrüstung',
         pin_task: 'Aufgabe anheften',
         unpin_task: 'Aufgabe lösen',
         level: 'Ebene: {count}',

--- a/app/locales/en.json5
+++ b/app/locales/en.json5
@@ -302,6 +302,7 @@
       },
       pinned_tasks_section: 'Pinned Tasks',
       questcard: {
+        equipment_header: 'Required equipment',
         pin_task: 'Pin task',
         unpin_task: 'Unpin task',
         level: 'Level: {count}',

--- a/app/locales/es.json5
+++ b/app/locales/es.json5
@@ -302,6 +302,7 @@
       },
       pinned_tasks_section: 'Misiones fijadas',
       questcard: {
+        equipment_header: 'Equipo requerido',
         pin_task: 'Fijar misión',
         unpin_task: 'Desfijar misión',
         level: 'Nivel requerido: {count}',

--- a/app/locales/fr.json5
+++ b/app/locales/fr.json5
@@ -302,6 +302,7 @@
       },
       pinned_tasks_section: 'Quêtes épinglées',
       questcard: {
+        equipment_header: 'Équipement requis',
         pin_task: 'Épingler la quête',
         unpin_task: 'Désépingler la quête',
         level: 'Niveau requis : {count}',

--- a/app/locales/ru.json5
+++ b/app/locales/ru.json5
@@ -302,6 +302,7 @@
       },
       pinned_tasks_section: 'Закреплённые задания',
       questcard: {
+        equipment_header: 'Необходимое оборудование',
         pin_task: 'Закрепить задание',
         unpin_task: 'Открепить задание',
         level: 'Требуемый уровень: {count}',

--- a/app/locales/uk.json5
+++ b/app/locales/uk.json5
@@ -302,6 +302,7 @@
       },
       pinned_tasks_section: 'Закріплені завдання',
       questcard: {
+        equipment_header: 'Необхідне спорядження',
         pin_task: 'Закріпити завдання',
         unpin_task: 'Відкріпити завдання',
         level: 'Потрібний рівень: {count}',

--- a/app/locales/zh.json5
+++ b/app/locales/zh.json5
@@ -302,6 +302,7 @@
       },
       pinned_tasks_section: '已固定任务',
       questcard: {
+        equipment_header: '所需设备',
         pin_task: '固定任务',
         unpin_task: '取消固定任务',
         level: '等级要求：{count}',


### PR DESCRIPTION
## Summary
Adds required special equipment (markers, cameras, jammers, etc.) to the task overview card.

## Changes
- Created a new component, QuestEquipment.vue, to display items and counts using the GameItem system.
- TaskCard.vue has been updated to calculate the remaining equipment from incomplete objectives, supporting the markerItem, plantItem and useItem types.
- The equipment section has been added to the task card body and positioned above 'Suggested Keys' for better visibility.
- Vertical stacking of the equipment and keys sections to prevent malformed layouts.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing feature)
- [ ] Refactoring (code restructuring without changing functionality)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Area(s) Affected
- [x] Frontend (UI/UX)
- [ ] Backend (Supabase/Nitro/Workers)
- [x] Tasks/Quests
- [ ] Team Features
- [ ] Hideout
- [ ] Maps
- [ ] Traders
- [ ] API
- [ ] i18n/Translations
- [ ] Other:

## Related Issues
- Closes #81 

## Testing
- [x] Tested locally
- [ ] Tested in production-like environment
- [ ] Added/updated unit tests
- [x] Manual testing performed

### Test Plan
1. Verified "Informed Means Arms" correctly displays 3 Wi-Fi Cameras.
2. Verified marker-based tasks (e.g., "BP Depot") display the correct number of MS2000 Markers.
3. Verified that completing objectives decreases the displayed equipment count or hides the section when no more equipment is needed.
4. Verified that tasks requiring both keys and equipment (e.g., "The Cult - Part 2") display both sections stacked correctly.

## Screenshots/Videos
<img width="892" height="681" alt="image" src="https://github.com/user-attachments/assets/fed79c52-753d-49e0-ab2a-8f3f79d9a692" />
<img width="1141" height="464" alt="image" src="https://github.com/user-attachments/assets/d65a9588-3edb-421a-8e66-e47ca9576c7f" />
<img width="1023" height="469" alt="image" src="https://github.com/user-attachments/assets/78a54110-31e7-471c-99a4-a50eba8414cf" />
<img width="1083" height="402" alt="image" src="https://github.com/user-attachments/assets/079b2cb6-b96c-4d77-87c1-c60ade03c9ed" />

## Checklist
- [x] My code follows the project's coding conventions (see CLAUDE.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated relevant documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes
In quests such as 'Hindsight 20/20' (674602307E3818D5BB069489) or 'Break the Deal' (675C085D59B0575973005F52), you have to stash a given calibre of ammo box (like 7.62x51). The first item on the list of valid items is shown.

 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Quest cards now display a required equipment section listing all necessary items with quantities needed to complete tasks
  * Added multilingual support with equipment translations in English, German, Spanish, French, Russian, Ukrainian, and Chinese
<!-- end of auto-generated comment: release notes by coderabbit.ai -->