### PR TITLE
fix(settings): support decimal skill input/offset handling

### DIFF
--- a/app/composables/useSkillCalculation.ts
+++ b/app/composables/useSkillCalculation.ts
@@ -110,9 +110,10 @@ export function useSkillCalculation() {
       );
       return false;
     }
-    const validatedLevel = Math.min(MAX_SKILL_LEVEL, Math.max(0, Math.floor(totalLevel)));
+    const validatedLevel = Math.min(MAX_SKILL_LEVEL, Math.max(0, totalLevel));
+    const normalizedLevel = Number(validatedLevel.toFixed(2));
     const questLevel = calculatedQuestSkills.value[skillName] || 0;
-    const offset = validatedLevel - questLevel;
+    const offset = Number((normalizedLevel - questLevel).toFixed(2));
     tarkovStore.setSkillOffset(skillName, offset);
     return true;
   };

--- a/app/features/settings/SkillsCard.vue
+++ b/app/features/settings/SkillsCard.vue
@@ -129,7 +129,7 @@
                 :id="`skill-input-${skill.name}`"
                 :model-value="getSkillLevel(skill.name)"
                 type="text"
-                inputmode="numeric"
+                inputmode="decimal"
                 :min="0"
                 placeholder="0"
                 size="sm"
@@ -254,8 +254,17 @@
       setTotalSkillLevel(skillName, 0);
       return;
     }
-    const numValue = typeof value === 'string' ? parseInt(value, 10) : value;
-    if (!isNaN(numValue) && numValue >= 0) {
+    if (typeof value === 'string') {
+      const trimmedValue = value.trim();
+      if (trimmedValue === '.' || trimmedValue.endsWith('.')) {
+        return;
+      }
+      if (!/^\d*\.?\d{0,2}$/.test(trimmedValue)) {
+        return;
+      }
+    }
+    const numValue = typeof value === 'string' ? Number(value) : value;
+    if (Number.isFinite(numValue) && numValue >= 0) {
       const clampedValue = Math.min(Math.max(numValue, 0), MAX_SKILL_LEVEL);
       setTotalSkillLevel(skillName, clampedValue);
     }
@@ -264,7 +273,7 @@
     if (e.ctrlKey || e.metaKey) {
       return;
     }
-    if (['-', '+', 'e', '.'].includes(e.key)) {
+    if (['-', '+', 'e'].includes(e.key)) {
       e.preventDefault();
       return;
     }
@@ -291,9 +300,9 @@
     const selectionStart = target.selectionStart ?? 0;
     const selectionEnd = target.selectionEnd ?? currentVal.length;
     const nextValStr = currentVal.slice(0, selectionStart) + e.key + currentVal.slice(selectionEnd);
-    const nextVal = parseInt(nextValStr, 10);
-    const isNumeric = /^\d+$/.test(nextValStr);
-    if (!isNumeric || isNaN(nextVal) || nextVal > MAX_SKILL_LEVEL) {
+    const nextVal = parseFloat(nextValStr);
+    const isNumeric = /^\d*\.?\d{0,2}$/.test(nextValStr);
+    if (!isNumeric || Number.isNaN(nextVal) || nextVal > MAX_SKILL_LEVEL) {
       e.preventDefault();
       showSkillLimitToast();
     }
@@ -317,8 +326,8 @@
     e.preventDefault();
     const pastedText = e.clipboardData?.getData('text');
     if (!pastedText) return;
-    const numVal = parseInt(pastedText, 10);
-    if (!isNaN(numVal)) {
+    const numVal = Number(pastedText.trim());
+    if (Number.isFinite(numVal)) {
       const clamped = Math.min(Math.max(numVal, 0), MAX_SKILL_LEVEL);
       setTotalSkillLevel(skillName, clamped);
     }

--- a/app/features/settings/__tests__/SkillsCard.test.ts
+++ b/app/features/settings/__tests__/SkillsCard.test.ts
@@ -44,7 +44,7 @@ mockNuxtImport('useToast', () => () => ({
 const _GenericCard = { template: '<div><slot name="content" /></div>' };
 const UInput = {
   template:
-    '<input type="text" @keydown="$emit(\'keydown\', $event)" @input="$emit(\'update:model-value\', $event.target.value)" />',
+    '<input type="text" :value="modelValue" @keydown="$emit(\'keydown\', $event)" @input="$emit(\'update:model-value\', $event.target.value)" />',
   props: ['modelValue'],
 };
 const _UButton = { template: '<button />' };
@@ -124,7 +124,22 @@ describe('SkillsCard', () => {
     inputEl.selectionStart = 2;
     inputEl.selectionEnd = 2;
     await dispatchKey('.', '10.');
-    expect(inputEl.value).toBe('10');
+    expect(inputEl.value).toBe('10.');
+    expect(setTotalSkillLevel).not.toHaveBeenCalled();
+    await dispatchKey('5', '10.5');
+    expect(inputEl.value).toBe('10.5');
+    expect(setTotalSkillLevel).toHaveBeenCalledWith('Strength', 10.5);
+    setTotalSkillLevel.mockClear();
+    inputEl.selectionStart = inputEl.value.length;
+    inputEl.selectionEnd = inputEl.value.length;
+    await dispatchKey('5', '10.55');
+    expect(inputEl.value).toBe('10.55');
+    expect(setTotalSkillLevel).toHaveBeenCalledWith('Strength', 10.55);
+    setTotalSkillLevel.mockClear();
+    inputEl.selectionStart = inputEl.value.length;
+    inputEl.selectionEnd = inputEl.value.length;
+    await dispatchKey('5', '10.555');
+    expect(inputEl.value).toBe('10.55');
     expect(setTotalSkillLevel).not.toHaveBeenCalled();
     setTotalSkillLevel.mockClear();
     inputEl.value = '';
@@ -171,5 +186,21 @@ describe('SkillsCard', () => {
     };
     await input.trigger('keydown', eventLength);
     expect(eventLength.preventDefault).toHaveBeenCalled();
+  });
+  it('allows edits when displayed value is fractional', async () => {
+    const wrapper = createWrapper({
+      getSkillLevel: () => 1.5,
+      setTotalSkillLevel: vi.fn(() => true),
+    });
+    const input = wrapper.find('input');
+    const inputEl = input.element as HTMLInputElement;
+    inputEl.selectionStart = inputEl.value.length;
+    inputEl.selectionEnd = inputEl.value.length;
+    const event = {
+      key: '1',
+      preventDefault: vi.fn(),
+    };
+    await input.trigger('keydown', event);
+    expect(event.preventDefault).not.toHaveBeenCalled();
   });
 });

--- a/app/stores/progressState.ts
+++ b/app/stores/progressState.ts
@@ -306,7 +306,7 @@ export const actions = {
     if (!currentData.skillOffsets) {
       currentData.skillOffsets = {};
     }
-    currentData.skillOffsets[skillName] = Number.isFinite(offset) ? Math.trunc(offset) : 0;
+    currentData.skillOffsets[skillName] = Number.isFinite(offset) ? offset : 0;
   },
   resetSkillOffset(this: UserState, skillName: string) {
     const currentData = getCurrentData(this);


### PR DESCRIPTION
## Summary
- preserve fractional skill offsets instead of truncating them
- support decimal skill input in Settings skills card
- limit manual skill input precision to 2 decimal places
- add regression tests for decimal quest rewards and decimal typing behavior

## Validation
- npx vitest
- npm run build
- npm run format

Fixes #159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Skills can now be configured with decimal precision (up to two decimal places)
  * Input fields now accept fractional skill values with real-time validation

* **Bug Fixes**
  * Improved accuracy in skill offset and experience calculations by preserving decimal precision

<!-- end of auto-generated comment: release notes by coderabbit.ai -->