### PR TITLE
Fix incorrect task counts when filtering Lightkeeper-required tasks

### DIFF
--- a/app/composables/__tests__/useTaskFiltering.test.ts
+++ b/app/composables/__tests__/useTaskFiltering.test.ts
@@ -290,6 +290,25 @@ describe('useTaskFiltering', () => {
     const counts = taskFiltering.calculateStatusCounts('self');
     expect(counts.all).toBe(2);
   });
+  it('calculateStatusCounts includes dual-tag tasks when filtering by Lightkeeper only', async () => {
+    const { taskFiltering, preferencesStore, metadataStore, progressStore } = await setup();
+    metadataStore.tasks.push({
+      id: 'task-kappa-lightkeeper',
+      name: 'Kappa Lightkeeper Task',
+      factionName: 'Any',
+      kappaRequired: true,
+      lightkeeperRequired: true,
+      trader: { id: 'trader-1', name: 'Trader One' },
+    });
+    progressStore.unlockedTasks['task-kappa-lightkeeper'] = { self: true };
+    progressStore.tasksCompletions['task-kappa-lightkeeper'] = { self: false };
+    preferencesStore.getHideNonKappaTasks = true;
+    preferencesStore.getShowLightkeeperTasks = true;
+    preferencesStore.getShowNonSpecialTasks = false;
+    const counts = taskFiltering.calculateStatusCounts('self');
+    expect(counts.all).toBe(2);
+    expect(counts.available).toBe(2);
+  });
   it('calculateTraderCounts respects task type settings', async () => {
     const { taskFiltering, preferencesStore } = await setup();
     const allCounts = taskFiltering.calculateTraderCounts('self', 'all');
@@ -301,6 +320,25 @@ describe('useTaskFiltering', () => {
     const kappaCounts = taskFiltering.calculateTraderCounts('self', 'all');
     expect(kappaCounts['trader-1']).toBe(1);
     expect(kappaCounts['trader-2']).toBeUndefined();
+  });
+  it('calculateTraderCounts includes dual-tag tasks when filtering by Lightkeeper only', async () => {
+    const { taskFiltering, preferencesStore, metadataStore, progressStore } = await setup();
+    metadataStore.tasks.push({
+      id: 'task-kappa-lightkeeper',
+      name: 'Kappa Lightkeeper Task',
+      factionName: 'Any',
+      kappaRequired: true,
+      lightkeeperRequired: true,
+      trader: { id: 'trader-1', name: 'Trader One' },
+    });
+    progressStore.unlockedTasks['task-kappa-lightkeeper'] = { self: true };
+    progressStore.tasksCompletions['task-kappa-lightkeeper'] = { self: false };
+    preferencesStore.getHideNonKappaTasks = true;
+    preferencesStore.getShowLightkeeperTasks = true;
+    preferencesStore.getShowNonSpecialTasks = false;
+    const counts = taskFiltering.calculateTraderCounts('self', 'all');
+    expect(counts['trader-1']).toBe(1);
+    expect(counts['trader-2']).toBe(1);
   });
   it('sorts impact using filtered successors when enforcement is enabled', async () => {
     const { taskFiltering, preferencesStore } = await setup();

--- a/app/composables/useTaskFiltering.ts
+++ b/app/composables/useTaskFiltering.ts
@@ -891,13 +891,12 @@ export function useTaskFiltering() {
       const isKappaRequired = task.kappaRequired === true;
       const isLightkeeperRequired = task.lightkeeperRequired === true;
       const isNonSpecial = !isKappaRequired && !isLightkeeperRequired;
-      if (
-        hasTypeSelection &&
-        ((isKappaRequired && !showKappa) ||
-          (isLightkeeperRequired && !showLightkeeper) ||
-          (isNonSpecial && !showNonSpecial))
-      ) {
-        continue;
+      if (hasTypeSelection) {
+        const matchesTaskType =
+          (isKappaRequired && showKappa) ||
+          (isLightkeeperRequired && showLightkeeper) ||
+          (isNonSpecial && showNonSpecial);
+        if (!matchesTaskType) continue;
       }
       if (onlyTasksWithRequiredKeys && !taskHasRequiredKeys(task)) {
         continue;
@@ -997,13 +996,12 @@ export function useTaskFiltering() {
       const isKappaRequired = task.kappaRequired === true;
       const isLightkeeperRequired = task.lightkeeperRequired === true;
       const isNonSpecial = !isKappaRequired && !isLightkeeperRequired;
-      if (
-        hasTypeSelection &&
-        ((isKappaRequired && !showKappa) ||
-          (isLightkeeperRequired && !showLightkeeper) ||
-          (isNonSpecial && !showNonSpecial))
-      ) {
-        continue;
+      if (hasTypeSelection) {
+        const matchesTaskType =
+          (isKappaRequired && showKappa) ||
+          (isLightkeeperRequired && showLightkeeper) ||
+          (isNonSpecial && showNonSpecial);
+        if (!matchesTaskType) continue;
       }
       if (onlyTasksWithRequiredKeys && !taskHasRequiredKeys(task)) {
         continue;


### PR DESCRIPTION
## Summary
- fix task status/trader count filtering to use inclusive task-type matching
- align count logic with the task list filter behavior for mixed-tag tasks
- add regression tests for Lightkeeper-only filtering with dual-tag (Kappa + Lightkeeper) tasks

## Validation
- npx vitest app/composables/__tests__/useTaskFiltering.test.ts
- npm run format

Closes #190

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added tests to verify task filtering correctly handles tasks with multiple tags across different filter types.

* **Refactor**
  * Improved filtering logic clarity with simplified control flow while maintaining existing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->