### PR TITLE
fix: preserve storyline progress in user_progress sanitizer

### DIFF
--- a/supabase/migrations/20260222120000_preserve_story_chapter_progress.sql
+++ b/supabase/migrations/20260222120000_preserve_story_chapter_progress.sql
@@ -33,7 +33,15 @@ AS $$
       'level',
       CASE
         WHEN jsonb_typeof(payload->'level') = 'number'
-        THEN to_jsonb(greatest(1, trunc((payload->>'level')::numeric)::int))
+        THEN to_jsonb(
+          greatest(
+            1,
+            least(
+              2147483647,
+              greatest(-2147483648, trunc((payload->>'level')::numeric))
+            )::int
+          )
+        )
         ELSE NULL
       END,
       'pmcFaction',
@@ -45,7 +53,18 @@ AS $$
       'prestigeLevel',
       CASE
         WHEN jsonb_typeof(payload->'prestigeLevel') = 'number'
-        THEN to_jsonb(least(6, greatest(0, trunc((payload->>'prestigeLevel')::numeric)::int)))
+        THEN to_jsonb(
+          least(
+            6,
+            greatest(
+              0,
+              least(
+                2147483647,
+                greatest(-2147483648, trunc((payload->>'prestigeLevel')::numeric))
+              )::int
+            )
+          )
+        )
         ELSE NULL
       END,
       'skillOffsets',
@@ -93,7 +112,12 @@ AS $$
       'xpOffset',
       CASE
         WHEN jsonb_typeof(payload->'xpOffset') = 'number'
-        THEN to_jsonb(trunc((payload->>'xpOffset')::numeric)::int)
+        THEN to_jsonb(
+          least(
+            2147483647,
+            greatest(-2147483648, trunc((payload->>'xpOffset')::numeric))
+          )::int
+        )
         ELSE NULL
       END
     )
@@ -103,7 +127,17 @@ $$;
 DO $$
 DECLARE
   sanitized jsonb;
+  expected_story_chapters jsonb;
 BEGIN
+  expected_story_chapters := jsonb_build_object(
+    'chapter-tour',
+    jsonb_build_object(
+      'complete',
+      true,
+      'objectives',
+      jsonb_build_object('objective-tour', jsonb_build_object('complete', true))
+    )
+  );
   sanitized := public.sanitize_user_progress_mode_data(
     jsonb_build_object(
       'displayName',
@@ -123,15 +157,7 @@ BEGIN
       'skills',
       jsonb_build_object('Endurance', 10),
       'storyChapters',
-      jsonb_build_object(
-        'chapter-tour',
-        jsonb_build_object(
-          'complete',
-          true,
-          'objectives',
-          jsonb_build_object('objective-tour', jsonb_build_object('complete', true))
-        )
-      ),
+      expected_story_chapters,
       'tarkovDevProfile',
       jsonb_build_object('aid', 12345, 'importedAt', 1730000000),
       'taskCompletions',
@@ -155,6 +181,11 @@ BEGIN
   IF jsonb_typeof(sanitized->'storyChapters') <> 'object' THEN
     RAISE EXCEPTION
       'sanitize_user_progress_mode_data regression: storyChapters object was not preserved';
+  END IF;
+
+  IF sanitized->'storyChapters' <> expected_story_chapters THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: storyChapters content was mutated';
   END IF;
 
   IF sanitized ? 'unexpected' THEN


### PR DESCRIPTION
## Summary
- fixes issue #186 root cause in Supabase sanitization trigger
- preserves `storyChapters` in `sanitize_user_progress_mode_data` instead of stripping it
- adds a migration regression assertion to fail if `storyChapters` is dropped

## Root Cause
`user_progress` writes pass through `sanitize_user_progress_mode_data`, which had an allowlist that omitted `storyChapters`. The POST succeeded, but this field was removed before persistence, so storyline progress reset after reload.

Closes #186

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation so story chapter progress is preserved and unknown keys are stripped, preventing regression of saved progress.

* **New Features**
  * Normalized user progress data: trimmed and limited display names, bounded levels/xp, and controlled currency-like fields to allowed values for more consistent profiles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->