### PR TITLE
Fix objective grouping regression (Collector spam) while keeping quest-item splits

### DIFF
--- a/app/features/tasks/__tests__/QuestObjectives.grouping.test.ts
+++ b/app/features/tasks/__tests__/QuestObjectives.grouping.test.ts
@@ -1,0 +1,142 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { defineComponent, ref, type PropType } from 'vue';
+import QuestObjectives from '@/features/tasks/QuestObjectives.vue';
+import type { TaskObjective } from '@/types/tarkov';
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({
+    locale: ref('en'),
+    t: (key: string) => key,
+  }),
+}));
+const TaskObjectiveItemGroupStub = defineComponent({
+  props: {
+    title: {
+      type: String,
+      required: true,
+    },
+    iconName: {
+      type: String,
+      required: true,
+    },
+    objectives: {
+      type: Array as PropType<TaskObjective[]>,
+      required: true,
+    },
+    optional: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  template: `<div
+    data-testid="group-row"
+    :data-title="title"
+    :data-icon="iconName"
+    :data-objective-ids="objectives.map((objective) => objective.id).join(',')"
+    :data-optional="String(optional)"
+  />`,
+});
+const TaskObjectiveStub = defineComponent({
+  props: {
+    objective: {
+      type: Object as PropType<TaskObjective>,
+      required: true,
+    },
+  },
+  template: '<div data-testid="solo-row" :data-objective-id="objective.id" />',
+});
+const mountComponent = (objectives: TaskObjective[]) => {
+  return mount(QuestObjectives, {
+    props: {
+      objectives,
+      irrelevantCount: 0,
+      uncompletedIrrelevant: 0,
+    },
+    global: {
+      stubs: {
+        'i18n-t': true,
+        TaskObjective: TaskObjectiveStub,
+        TaskObjectiveItemGroup: TaskObjectiveItemGroupStub,
+        UIcon: true,
+      },
+    },
+  });
+};
+describe('QuestObjectives item grouping', () => {
+  it('groups give-only objectives for normal items into one section', () => {
+    const wrapper = mountComponent([
+      {
+        id: 'give-a',
+        item: { id: 'item-a', name: 'Item A' },
+        optional: true,
+        type: 'giveItem',
+      },
+      {
+        id: 'give-b',
+        item: { id: 'item-b', name: 'Item B' },
+        optional: false,
+        type: 'giveItem',
+      },
+      {
+        description: 'Visit location',
+        id: 'visit-c',
+        type: 'visit',
+      },
+    ] as TaskObjective[]);
+    const groupRows = wrapper.findAll('[data-testid="group-row"]');
+    expect(groupRows).toHaveLength(1);
+    expect(groupRows[0]!.attributes('data-objective-ids')).toBe('give-a,give-b');
+    expect(groupRows[0]!.attributes('data-title')).toBe('page.tasks.questcard.hand_over');
+    expect(groupRows[0]!.attributes('data-optional')).toBe('false');
+    const soloRows = wrapper.findAll('[data-testid="solo-row"]');
+    expect(soloRows).toHaveLength(1);
+    expect(soloRows[0]!.attributes('data-objective-id')).toBe('visit-c');
+  });
+  it('keeps quest-item give-only objectives for different items in separate groups', () => {
+    const wrapper = mountComponent([
+      {
+        id: 'give-a',
+        questItem: { id: 'quest-a', name: 'Quest Item A' },
+        type: 'giveQuestItem',
+      },
+      {
+        id: 'give-b',
+        questItem: { id: 'quest-b', name: 'Quest Item B' },
+        type: 'giveQuestItem',
+      },
+    ] as TaskObjective[]);
+    const groupRows = wrapper.findAll('[data-testid="group-row"]');
+    expect(groupRows).toHaveLength(2);
+    expect(groupRows[0]!.attributes('data-objective-ids')).toBe('give-a');
+    expect(groupRows[1]!.attributes('data-objective-ids')).toBe('give-b');
+    expect(groupRows[0]!.attributes('data-title')).toBe('page.tasks.questcard.hand_over');
+    expect(groupRows[1]!.attributes('data-title')).toBe('page.tasks.questcard.hand_over');
+  });
+  it('keeps find and give objectives for the same item in one combined group', () => {
+    const wrapper = mountComponent([
+      {
+        foundInRaid: true,
+        id: 'find-a',
+        item: { id: 'item-a', name: 'Item A' },
+        optional: true,
+        type: 'findItem',
+      },
+      {
+        foundInRaid: true,
+        id: 'give-a',
+        item: { id: 'item-a', name: 'Item A' },
+        optional: true,
+        type: 'giveItem',
+      },
+    ] as TaskObjective[]);
+    const groupRows = wrapper.findAll('[data-testid="group-row"]');
+    expect(groupRows).toHaveLength(1);
+    expect(groupRows[0]!.attributes('data-objective-ids')).toBe('find-a,give-a');
+    expect(groupRows[0]!.attributes('data-title')).toBe(
+      'page.tasks.questcard.find_and_hand_over_fir'
+    );
+    expect(groupRows[0]!.attributes('data-icon')).toBe('mdi-package-variant-closed');
+    expect(groupRows[0]!.attributes('data-optional')).toBe('true');
+  });
+});


### PR DESCRIPTION
## Summary
- keep quest/task-specific objective pairs split by item (e.g. Vitamins - Part 1 containers)
- collapse normal hand-in objectives by category + FiR so Collector no longer renders repeated section headers
- keep the updated objective item row UX (full-width rows, key-style links, tarkov.dev icon link, compact icon + tooltip preview)

## Root cause
A previous fix grouped all item objectives by itemId, which corrected quest-item pair rendering but caused large normal hand-in tasks (Collector) to render one section header per item.

## Fix
- in `QuestObjectives.vue`, group key is now conditional:
  - quest items (`findQuestItem`/`giveQuestItem`): `quest:{itemId}:{category}:{fir}`
  - normal items: `{category}:{fir}`

## Tests
- updated/expanded `QuestObjectives.grouping.test.ts` coverage for:
  - normal give-only objectives grouped together
  - quest-item give-only objectives kept separate
  - same-item find+give remains combined

Closes #137


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced item previews with external Tarkov.dev links and detailed preview images.
  * Improved quest item grouping and organization within task objectives.

* **Style**
  * Refined layout and spacing for better visual organization of objective items and controls.

* **Tests**
  * Added comprehensive test coverage for objective grouping logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->