### PR TITLE
fix: always restore original mode after tarkov.dev import failure

### DIFF
--- a/app/composables/__tests__/useTarkovDevImport.test.ts
+++ b/app/composables/__tests__/useTarkovDevImport.test.ts
@@ -201,6 +201,26 @@ describe('useTarkovDevImport', () => {
     expect(composable.importState.value).toBe('error');
     expect(composable.importError.value).toBe('Failed to apply import data');
   });
+  it('keeps success state when mode restoration fails', async () => {
+    const parsedData = createImportData();
+    mockParseTarkovDevProfile.mockReturnValue({
+      data: parsedData,
+      ok: true,
+    });
+    tarkovStore.getCurrentGameMode.mockReturnValue('pvp');
+    tarkovStore.switchGameMode
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error('restore failure'));
+    const composable = await loadComposable();
+    await composable.parseFile(createFile('{"aid":123}'));
+    await composable.confirmImport('pve');
+    expect(composable.importState.value).toBe('success');
+    expect(composable.importError.value).toBeNull();
+    expect(mockLogger.error).toHaveBeenCalledWith(
+      '[TarkovDevImport] Failed to restore original game mode:',
+      expect.any(Error)
+    );
+  });
   it('resets preview and errors back to idle', async () => {
     mockParseTarkovDevProfile.mockReturnValue({
       error: 'Invalid tarkov.dev profile format',

--- a/app/composables/useTarkovDevImport.ts
+++ b/app/composables/useTarkovDevImport.ts
@@ -88,7 +88,11 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
       logger.error('[TarkovDevImport] Import error:', e);
     } finally {
       if (shouldRestoreMode) {
-        await tarkovStore.switchGameMode(originalMode);
+        try {
+          await tarkovStore.switchGameMode(originalMode);
+        } catch (e) {
+          logger.error('[TarkovDevImport] Failed to restore original game mode:', e);
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary
- ensure `confirmImport` always restores the original game mode via `finally`
- preserve existing import success/error behavior
- add regression coverage for failure after switching to target mode

## Testing
- `npx vitest app/composables/__tests__/useTarkovDevImport.test.ts`
- `npm run format`

Closes #201

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed an issue where the game mode would not properly restore to its original setting if an import operation failed after switching modes.

* **Tests**
  * Added test coverage for import failure scenarios involving mode switching.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->