### PR TITLE
fix(ui): close TT-102 OAuth loading lifecycle bug

### DIFF
--- a/app/composables/__tests__/useOAuthLogin.test.ts
+++ b/app/composables/__tests__/useOAuthLogin.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import type { OAuthProvider } from '@/composables/useOAuthLogin';
+const { loggerMock, mockSignInWithOAuth } = vi.hoisted(() => ({
+  loggerMock: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+  mockSignInWithOAuth: vi.fn(),
+}));
+mockNuxtImport('useNuxtApp', () => () => ({
+  $supabase: {
+    signInWithOAuth: mockSignInWithOAuth,
+  },
+}));
+vi.mock('@/utils/logger', () => ({
+  logger: loggerMock,
+}));
+const createLoadingState = () =>
+  ref<Record<OAuthProvider, boolean>>({
+    twitch: false,
+    discord: false,
+    google: false,
+    github: false,
+  });
+const buildCallbackUrl = () => 'https://tarkovtracker.test/auth/callback';
+describe('useOAuthLogin', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('keeps loading active when popup lifecycle is managed externally', async () => {
+    mockSignInWithOAuth.mockResolvedValueOnce({ url: 'https://oauth.test/login' });
+    const openPopupOrRedirect = vi.fn(() => true);
+    const loading = createLoadingState();
+    const { useOAuthLogin } = await import('@/composables/useOAuthLogin');
+    const { signInWithProvider } = useOAuthLogin({
+      buildCallbackUrl,
+      loading,
+      openPopupOrRedirect,
+    });
+    await signInWithProvider('discord');
+    expect(mockSignInWithOAuth).toHaveBeenCalledWith('discord', {
+      skipBrowserRedirect: true,
+      redirectTo: 'https://tarkovtracker.test/auth/callback',
+    });
+    expect(openPopupOrRedirect).toHaveBeenCalledWith('https://oauth.test/login', 'discord');
+    expect(loading.value.discord).toBe(true);
+  });
+  it('clears loading on success when no OAuth URL is returned', async () => {
+    mockSignInWithOAuth.mockResolvedValueOnce({});
+    const openPopupOrRedirect = vi.fn(() => true);
+    const loading = createLoadingState();
+    const { useOAuthLogin } = await import('@/composables/useOAuthLogin');
+    const { signInWithProvider } = useOAuthLogin({
+      buildCallbackUrl,
+      loading,
+      openPopupOrRedirect,
+    });
+    await signInWithProvider('google');
+    expect(openPopupOrRedirect).not.toHaveBeenCalled();
+    expect(loading.value.google).toBe(false);
+  });
+  it('clears loading when popup flow is cancelled', async () => {
+    mockSignInWithOAuth.mockResolvedValueOnce({ url: 'https://oauth.test/login' });
+    const openPopupOrRedirect = vi.fn(() => false);
+    const loading = createLoadingState();
+    const { useOAuthLogin } = await import('@/composables/useOAuthLogin');
+    const { signInWithProvider } = useOAuthLogin({
+      buildCallbackUrl,
+      loading,
+      openPopupOrRedirect,
+    });
+    await signInWithProvider('github');
+    expect(openPopupOrRedirect).toHaveBeenCalledWith('https://oauth.test/login', 'github');
+    expect(loading.value.github).toBe(false);
+  });
+  it('clears loading and logs when OAuth request fails', async () => {
+    const oauthError = new Error('oauth failed');
+    mockSignInWithOAuth.mockRejectedValueOnce(oauthError);
+    const openPopupOrRedirect = vi.fn(() => true);
+    const loading = createLoadingState();
+    const { useOAuthLogin } = await import('@/composables/useOAuthLogin');
+    const { signInWithProvider } = useOAuthLogin({
+      buildCallbackUrl,
+      loading,
+      openPopupOrRedirect,
+    });
+    await signInWithProvider('twitch');
+    expect(openPopupOrRedirect).not.toHaveBeenCalled();
+    expect(loading.value.twitch).toBe(false);
+    expect(loggerMock.error).toHaveBeenCalledWith('[Login] Twitch sign in error:', oauthError);
+  });
+});

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -239,9 +239,9 @@
   const openPopupOrRedirect = (
     url: string,
     provider: 'twitch' | 'discord' | 'google' | 'github'
-  ) => {
+  ): boolean => {
     if (loginPageUnmounted) {
-      return;
+      return false;
     }
     const width = 600;
     const height = 700;
@@ -256,7 +256,7 @@
       );
     } catch {
       fallbackToRedirect(url, provider);
-      return;
+      return true;
     }
     const isPopupClosed = () => {
       try {
@@ -268,7 +268,7 @@
     };
     if (isPopupClosed()) {
       fallbackToRedirect(url, provider);
-      return;
+      return true;
     }
     let didCleanup = false;
     const isOAuthSuccessMessage = (event: MessageEvent) => {
@@ -358,6 +358,7 @@
     };
     activePopupCleanups.add(cleanup);
     window.addEventListener('message', messageHandler);
+    return true;
   };
   const { signInWithProvider } = useOAuthLogin({
     buildCallbackUrl,


### PR DESCRIPTION
## Summary\n- fix OAuth provider loading lifecycle so buttons always clear on non-managed exits\n- delegate loading lifecycle only when popup/redirect flow explicitly reports external management\n- add composable tests for success, failure, and cancellation paths\n\n## Issue\nCloses #202\n\n## Validation\n- 
> tarkovtracker-nuxt@1.13.6 format
> prettier --write "app/**/*.{js,ts,tsx,vue,json,json5,css,scss,md}" "docs/**/*.{md,markdown}" "nuxt.config.ts" "app/app.config.ts" "vitest.config.ts" "vitest.happy-dom.config.ts" "vitest.nuxt.config.ts" "vitest.shared.ts" "tests/test-setup.ts" && NODE_ENV=development nuxt prepare && eslint app --fix

app/app.config.ts 42ms (unchanged)
app/app.vue 46ms (unchanged)
app/assets/css/tailwind.css 74ms (unchanged)
app/components/SelectMenuFixed.vue 26ms (unchanged)
app/components/ui/AppTooltip.vue 14ms (unchanged)
app/components/ui/BackToTop.vue 11ms (unchanged)
app/components/ui/ContextMenu.vue 15ms (unchanged)
app/components/ui/ContextMenuItem.vue 13ms (unchanged)
app/components/ui/DiscordIcon.vue 9ms (unchanged)
app/components/ui/GameItem.vue 59ms (unchanged)
app/components/ui/GenericCard.vue 26ms (unchanged)
app/components/ui/RefreshButton.vue 7ms (unchanged)
app/composables/__tests__/useAppInitialization.test.ts 12ms (unchanged)
app/composables/__tests__/useCountEditController.test.ts 11ms (unchanged)
app/composables/__tests__/useDashboardStats.test.ts 31ms (unchanged)
app/composables/__tests__/useDataBackup.test.ts 28ms (unchanged)
app/composables/__tests__/useEdgeFunctions.test.ts 7ms (unchanged)
app/composables/__tests__/useEftLogsImport.test.ts 17ms (unchanged)
app/composables/__tests__/useGraphBuilder.test.ts 7ms (unchanged)
app/composables/__tests__/useHideoutFiltering.test.ts 12ms (unchanged)
app/composables/__tests__/useHideoutRouteSync.test.ts 8ms (unchanged)
app/composables/__tests__/useHideoutStationStatus.test.ts 10ms (unchanged)
app/composables/__tests__/useInfiniteScroll.test.ts 9ms (unchanged)
app/composables/__tests__/useItemDistribution.test.ts 27ms (unchanged)
app/composables/__tests__/useLeafletMap.test.ts 41ms (unchanged)
app/composables/__tests__/useMapObjectivePopup.test.ts 18ms (unchanged)
app/composables/__tests__/useNeededItems.test.ts 24ms (unchanged)
app/composables/__tests__/useNeededItemsRouteSync.test.ts 10ms (unchanged)
app/composables/__tests__/useOAuthLogin.test.ts 8ms (unchanged)
app/composables/__tests__/useRouteFilters.test.ts 12ms (unchanged)
app/composables/__tests__/useSkillCalculation.test.ts 10ms (unchanged)
app/composables/__tests__/useSupabaseSync.test.ts 9ms (unchanged)
app/composables/__tests__/useTarkovDevImport.test.ts 11ms (unchanged)
app/composables/__tests__/useTarkovTime.test.ts 6ms (unchanged)
app/composables/__tests__/useTaskActions.test.ts 14ms (unchanged)
app/composables/__tests__/useTaskDeepLink.test.ts 8ms (unchanged)
app/composables/__tests__/useTaskFiltering.test.ts 28ms (unchanged)
app/composables/__tests__/useTaskGraphData.test.ts 6ms (unchanged)
app/composables/__tests__/useTaskNotification.test.ts 7ms (unchanged)
app/composables/__tests__/useTaskRouteSync.test.ts 8ms (unchanged)
app/composables/__tests__/useToastI18n.test.ts 5ms (unchanged)
app/composables/__tests__/useXpCalculation.test.ts 7ms (unchanged)
app/composables/api/useEdgeFunctions.ts 14ms (unchanged)
app/composables/i18nHelpers.ts 6ms (unchanged)
app/composables/supabase/useSupabaseListener.ts 12ms (unchanged)
app/composables/supabase/useSupabaseSync.ts 16ms (unchanged)
app/composables/useAppInitialization.ts 5ms (unchanged)
app/composables/useCopyToClipboard.ts 5ms (unchanged)
app/composables/useCountEditController.ts 5ms (unchanged)
app/composables/useCraftableItem.ts 7ms (unchanged)
app/composables/useDashboardStats.ts 16ms (unchanged)
app/composables/useDataBackup.ts 15ms (unchanged)
app/composables/useEftLogsImport.ts 18ms (unchanged)
app/composables/useGraphBuilder.ts 14ms (unchanged)
app/composables/useHideoutFiltering.ts 7ms (unchanged)
app/composables/useHideoutRouteSync.ts 4ms (unchanged)
app/composables/useHideoutStationStatus.ts 5ms (unchanged)
app/composables/useInfiniteScroll.ts 10ms (unchanged)
app/composables/useItemDistribution.ts 9ms (unchanged)
app/composables/useItemRowIntersection.ts 4ms (unchanged)
app/composables/useLeafletMap.ts 39ms (unchanged)
app/composables/useMapObjectivePopup.ts 6ms (unchanged)
app/composables/useMapResize.ts 6ms (unchanged)
app/composables/useNeededItems.ts 19ms (unchanged)
app/composables/useNeededItemsRouteSync.ts 4ms (unchanged)
app/composables/useNeededItemsSettingsDrawer.ts 4ms (unchanged)
app/composables/useNeededItemsSorting.ts 6ms (unchanged)
app/composables/useOAuthConsent.ts 7ms (unchanged)
app/composables/useOAuthLogin.ts 4ms (unchanged)
app/composables/usePrereqModal.ts 4ms (unchanged)
app/composables/useRouteFilters.ts 7ms (unchanged)
app/composables/useSafeToast.ts 3ms (unchanged)
app/composables/useSharedBreakpoints.ts 3ms (unchanged)
app/composables/useSkillCalculation.ts 12ms (unchanged)
app/composables/useStorylineChapters.ts 7ms (unchanged)
app/composables/useTarkovDevImport.ts 6ms (unchanged)
app/composables/useTarkovTime.ts 4ms (unchanged)
app/composables/useTaskActions.ts 8ms (unchanged)
app/composables/useTaskCardLinks.ts 6ms (unchanged)
app/composables/useTaskDeepLink.ts 10ms (unchanged)
app/composables/useTaskFiltering.ts 33ms (unchanged)
app/composables/useTaskGraphData.ts 10ms (unchanged)
app/composables/useTaskNotification.ts 8ms (unchanged)
app/composables/useTaskRepair.ts 7ms (unchanged)
app/composables/useTaskRouteSync.ts 9ms (unchanged)
app/composables/useTaskSettingsDrawer.ts 4ms (unchanged)
app/composables/useTaskState.ts 4ms (unchanged)
app/composables/useToastI18n.ts 5ms (unchanged)
app/composables/useXpCalculation.ts 7ms (unchanged)
app/data/maps-overrides.json 1ms (unchanged)
app/data/maps.json 3ms (unchanged)
app/data/storyObjectiveLinks.ts 4ms (unchanged)
app/error.vue 7ms (unchanged)
app/features/admin/AdminAuditLog.vue 18ms (unchanged)
app/features/admin/AdminCacheCard.vue 19ms (unchanged)
app/features/dashboard/__tests__/DashboardProgressCard.test.ts 9ms (unchanged)
app/features/dashboard/DashboardChangelog.vue 34ms (unchanged)
app/features/dashboard/DashboardMilestoneCard.vue 9ms (unchanged)
app/features/dashboard/DashboardProgressCard.vue 15ms (unchanged)
app/features/dashboard/DashboardTraderCard.vue 27ms (unchanged)
app/features/dashboard/progressCard.ts 3ms (unchanged)
app/features/dashboard/ReputationInput.vue 9ms (unchanged)
app/features/drawer/DrawerGameSettings.vue 15ms (unchanged)
app/features/drawer/DrawerItem.vue 10ms (unchanged)
app/features/drawer/DrawerItemContent.vue 17ms (unchanged)
app/features/drawer/DrawerItemIcon.vue 8ms (unchanged)
app/features/drawer/DrawerLevel.vue 24ms (unchanged)
app/features/drawer/DrawerLinks.vue 9ms (unchanged)
app/features/hideout/HideoutCard.vue 47ms (unchanged)
app/features/hideout/HideoutRequirement.vue 32ms (unchanged)
app/features/hideout/StationLink.vue 8ms (unchanged)
app/features/maps/__tests__/LeafletMap.test.ts 14ms (unchanged)
app/features/maps/__tests__/LeafletObjectiveTooltip.test.ts 8ms (unchanged)
app/features/maps/__tests__/MapRequiredItemsSummary.test.ts 9ms (unchanged)
app/features/maps/LeafletMap.vue 92ms (unchanged)
app/features/maps/LeafletObjectiveTooltip.vue 19ms (unchanged)
app/features/maps/MapRequiredItemsSummary.vue 13ms (unchanged)
app/features/neededitems/__tests__/neededItemFilters.test.ts 8ms (unchanged)
app/features/neededitems/__tests__/neededitems-constants.test.ts 6ms (unchanged)
app/features/neededitems/__tests__/NeededItemsFilterBar.test.ts 7ms (unchanged)
app/features/neededitems/ItemCountControls.vue 13ms (unchanged)
app/features/neededitems/ItemIndicators.vue 10ms (unchanged)
app/features/neededitems/neededitem-keys.ts 5ms (unchanged)
app/features/neededitems/NeededItem.vue 18ms (unchanged)
app/features/neededitems/neededItemFilters.ts 5ms (unchanged)
app/features/neededitems/NeededItemGroupedCard.vue 23ms (unchanged)
app/features/neededitems/NeededItemGroupedInputControls.vue 18ms (unchanged)
app/features/neededitems/NeededItemGroupedModal.vue 33ms (unchanged)
app/features/neededitems/NeededItemRow.vue 42ms (unchanged)
app/features/neededitems/neededitems-constants.ts 5ms (unchanged)
app/features/neededitems/NeededItemsFilterBar.vue 33ms (unchanged)
app/features/neededitems/NeededItemSmallCard.vue 25ms (unchanged)
app/features/neededitems/NeededItemsSettingsDrawer.vue 22ms (unchanged)
app/features/neededitems/RequirementInfo.vue 7ms (unchanged)
app/features/neededitems/TeamNeedsDisplay.vue 7ms (unchanged)
app/features/profile/__tests__/kappaProjectionHelpers.test.ts 9ms (unchanged)
app/features/profile/__tests__/profileStats.test.ts 6ms (unchanged)
app/features/profile/__tests__/ProfileStorylineTab.test.ts 6ms (unchanged)
app/features/profile/kappaProjectionHelpers.ts 5ms (unchanged)
app/features/profile/ProfileHideoutTab.vue 10ms (unchanged)
app/features/profile/ProfileOverviewTab.vue 22ms (unchanged)
app/features/profile/ProfileProgression.vue 68ms (unchanged)
app/features/profile/profileStats.ts 5ms (unchanged)
app/features/profile/ProfileStorylineTab.vue 27ms (unchanged)
app/features/profile/ProfileTasksTab.vue 23ms (unchanged)
app/features/profile/profileTypes.ts 4ms (unchanged)
app/features/settings/__tests__/DataManagementCard.test.ts 13ms (unchanged)
app/features/settings/__tests__/DisplayNameCard.test.ts 7ms (unchanged)
app/features/settings/__tests__/ResetProgressSection.test.ts 8ms (unchanged)
app/features/settings/__tests__/SkillsCard.test.ts 11ms (unchanged)
app/features/settings/AccountDeletionCard.vue 39ms (unchanged)
app/features/settings/ApiTokens.vue 37ms (unchanged)
app/features/settings/DataManagementCard.vue 59ms (unchanged)
app/features/settings/DisplayNameCard.vue 9ms (unchanged)
app/features/settings/ExperienceCard.vue 11ms (unchanged)
app/features/settings/GameModeToggle.vue 8ms (unchanged)
app/features/settings/MapSettingsCard.vue 12ms (unchanged)
app/features/settings/PrivacyCard.vue 7ms (unchanged)
app/features/settings/ProfileSharingCard.vue 12ms (unchanged)
app/features/settings/ResetProgressSection.vue 17ms (unchanged)
app/features/settings/SkillsCard.vue 28ms (unchanged)
app/features/settings/TaskDisplayCard.vue 11ms (unchanged)
app/features/storyline/components/ChapterCard.vue 22ms (unchanged)
app/features/tasks/__tests__/ObjectiveCountControls.test.ts 7ms (unchanged)
app/features/tasks/__tests__/QuestObjectives.grouping.test.ts 8ms (unchanged)
app/features/tasks/__tests__/task-objective-equipment.test.ts 8ms (unchanged)
app/features/tasks/__tests__/task-objective-item-overrides.test.ts 4ms (unchanged)
app/features/tasks/__tests__/task-requirement-helpers.test.ts 5ms (unchanged)
app/features/tasks/__tests__/TaskCard.actionButtonState.test.ts 5ms (unchanged)
app/features/tasks/__tests__/TaskCard.categorizedObjectives.test.ts 15ms (unchanged)
app/features/tasks/__tests__/TaskCard.objectivesVisibility.test.ts 7ms (unchanged)
app/features/tasks/__tests__/TaskFilterBar.test.ts 15ms (unchanged)
app/features/tasks/AdvancedTasksSection.vue 8ms (unchanged)
app/features/tasks/CardDisplaySection.vue 9ms (unchanged)
app/features/tasks/FilterBarSection.vue 7ms (unchanged)
app/features/tasks/MapTaskVisibilityNotice.vue 6ms (unchanged)
app/features/tasks/ObjectiveCountControls.vue 13ms (unchanged)
app/features/tasks/ObjectiveRequiredItems.vue 34ms (unchanged)
app/features/tasks/QuestObjectives.vue 16ms (unchanged)
app/features/tasks/QuestObjectivesSkeleton.vue 5ms (unchanged)
app/features/tasks/task-objective-constants.ts 3ms (unchanged)
app/features/tasks/task-objective-equipment.ts 5ms (unchanged)
app/features/tasks/task-objective-helpers.ts 5ms (unchanged)
app/features/tasks/task-objective-item-overrides.ts 3ms (unchanged)
app/features/tasks/task-requirement-helpers.ts 5ms (unchanged)
app/features/tasks/TaskCard.vue 70ms (unchanged)
app/features/tasks/TaskCardActions.vue 9ms (unchanged)
app/features/tasks/TaskCardBackground.vue 7ms (unchanged)
app/features/tasks/TaskCardBadges.vue 15ms (unchanged)
app/features/tasks/TaskCardHeader.vue 13ms (unchanged)
app/features/tasks/TaskCardRewards.vue 38ms (unchanged)
app/features/tasks/TaskEmptyState.vue 5ms (unchanged)
app/features/tasks/TaskFilterBar.vue 48ms (unchanged)
app/features/tasks/TaskFiltersSection.vue 11ms (unchanged)
app/features/tasks/TaskGraphNode.vue 13ms (unchanged)
app/features/tasks/TaskGraphView.vue 34ms (unchanged)
app/features/tasks/TaskLink.vue 10ms (unchanged)
app/features/tasks/TaskLoadingState.vue 6ms (unchanged)
app/features/tasks/TaskObjective.vue 26ms (unchanged)
app/features/tasks/TaskObjectiveItemGroup.vue 33ms (unchanged)
app/features/tasks/taskObjectiveTypes.ts 4ms (unchanged)
app/features/tasks/TaskSettingsDrawer.vue 23ms (unchanged)
app/features/tasks/types.ts 4ms (unchanged)
app/features/team/__tests__/MyTeam.test.ts 15ms (unchanged)
app/features/team/__tests__/TeamOptions.test.ts 8ms (unchanged)
app/features/team/MyTeam.vue 20ms (unchanged)
app/features/team/TeamInvite.vue 11ms (unchanged)
app/features/team/TeamMemberCard.vue 14ms (unchanged)
app/features/team/TeamMembers.vue 7ms (unchanged)
app/features/team/TeamOptions.vue 14ms (unchanged)
app/i18n.config.ts 2ms (unchanged)
app/layouts/default.vue 6ms (unchanged)
app/locales/de.json5 14ms (unchanged)
app/locales/en.json5 9ms (unchanged)
app/locales/es.json5 10ms (unchanged)
app/locales/fr.json5 11ms (unchanged)
app/locales/ru.json5 11ms (unchanged)
app/locales/uk.json5 11ms (unchanged)
app/locales/zh.json5 12ms (unchanged)
app/middleware/__tests__/auth.test.ts 5ms (unchanged)
app/middleware/admin.ts 5ms (unchanged)
app/middleware/auth.ts 3ms (unchanged)
app/pages/__tests__/account.page.test.ts 6ms (unchanged)
app/pages/__tests__/hideout.page.test.ts 7ms (unchanged)
app/pages/__tests__/index.page.test.ts 14ms (unchanged)
app/pages/__tests__/neededitems.page.test.ts 10ms (unchanged)
app/pages/__tests__/settings.page.test.ts 8ms (unchanged)
app/pages/__tests__/tasks.page.test.ts 16ms (unchanged)
app/pages/account.vue 6ms (unchanged)
app/pages/admin.vue 6ms (unchanged)
app/pages/auth/callback.vue 6ms (unchanged)
app/pages/changelog.vue 19ms (unchanged)
app/pages/credits.vue 11ms (unchanged)
app/pages/hideout.vue 27ms (unchanged)
app/pages/index.vue 22ms (unchanged)
app/pages/login.vue 17ms (unchanged)
app/pages/needed-items.vue 29ms (unchanged)
app/pages/neededitems.vue 3ms (unchanged)
app/pages/not-found.vue 4ms (unchanged)
app/pages/oauth/consent.vue 14ms (unchanged)
app/pages/privacy.vue 20ms (unchanged)
app/pages/profile.vue 2ms (unchanged)
app/pages/profile/[userId]/[mode].vue 5ms (unchanged)
app/pages/settings.vue 8ms (unchanged)
app/pages/storyline.vue 10ms (unchanged)
app/pages/streamer-tools.vue 70ms (unchanged)
app/pages/tasks.vue 43ms (unchanged)
app/pages/team.vue 5ms (unchanged)
app/pages/terms-of-service.vue 29ms (unchanged)
app/plugins/__tests__/zz.preferences-sync.client.test.ts 7ms (unchanged)
app/plugins/00.storage-version.client.ts 5ms (unchanged)
app/plugins/01.pinia.client.ts 3ms (unchanged)
app/plugins/02.error-monitoring.client.ts 4ms (unchanged)
app/plugins/i18n.client.ts 5ms (unchanged)
app/plugins/metadata.client.ts 4ms (unchanged)
app/plugins/store-initializer.ts 5ms (unchanged)
app/plugins/supabase.client.ts 9ms (unchanged)
app/plugins/zz.preferences-sync.client.ts 9ms (unchanged)
app/server/api/changelog.get.ts 26ms (unchanged)
app/server/api/profile/__tests__/shared-profile.test.ts 16ms (unchanged)
app/server/api/profile/[userId]/[mode].get.ts 25ms (unchanged)
app/server/api/streamer/__tests__/kappa.test.ts 11ms (unchanged)
app/server/api/streamer/[userId]/[mode]/kappa.get.ts 17ms (unchanged)
app/server/api/tarkov/__tests__/handlers.test.ts 20ms (unchanged)
app/server/api/tarkov/bootstrap.get.ts 5ms (unchanged)
app/server/api/tarkov/cache-meta.get.ts 8ms (unchanged)
app/server/api/tarkov/hideout.get.ts 5ms (unchanged)
app/server/api/tarkov/items-lite.get.ts 5ms (unchanged)
app/server/api/tarkov/items.get.ts 4ms (unchanged)
app/server/api/tarkov/map-spawns.get.ts 5ms (unchanged)
app/server/api/tarkov/prestige.get.ts 5ms (unchanged)
app/server/api/tarkov/tasks-core.get.ts 5ms (unchanged)
app/server/api/tarkov/tasks-objectives.get.ts 5ms (unchanged)
app/server/api/tarkov/tasks-rewards.get.ts 5ms (unchanged)
app/server/api/team/__tests__/members.test.ts 15ms (unchanged)
app/server/api/team/members.ts 14ms (unchanged)
app/server/middleware/__tests__/api-protection.test.ts 12ms (unchanged)
app/server/middleware/api-protection.ts 11ms (unchanged)
app/server/routes/overlay/kappa/__tests__/route.test.ts 9ms (unchanged)
app/server/routes/overlay/kappa/[userId]/[mode].get.ts 15ms (unchanged)
app/server/utils/__tests__/edgeCache.test.ts 6ms (unchanged)
app/server/utils/__tests__/objectiveTypeInferrer.test.ts 7ms (unchanged)
app/server/utils/__tests__/overlay.test.ts 7ms (unchanged)
app/server/utils/__tests__/streamerKappa.test.ts 7ms (unchanged)
app/server/utils/__tests__/tarkov-cache-config.test.ts 5ms (unchanged)
app/server/utils/deepMerge.ts 5ms (unchanged)
app/server/utils/edgeCache.ts 13ms (unchanged)
app/server/utils/graphql-validation.ts 7ms (unchanged)
app/server/utils/language-helpers.ts 4ms (unchanged)
app/server/utils/logger.ts 7ms (unchanged)
app/server/utils/objectiveTypeInferrer.ts 7ms (unchanged)
app/server/utils/overlay.ts 17ms (unchanged)
app/server/utils/sharedEdgeStore.ts 8ms (unchanged)
app/server/utils/streamerKappa.ts 10ms (unchanged)
app/server/utils/tarkov-cache-config.ts 5ms (unchanged)
app/server/utils/tarkov-queries.ts 4ms (unchanged)
app/server/utils/tarkov-sanitization.ts 5ms (unchanged)
app/shell/__tests__/AppBar.test.ts 14ms (unchanged)
app/shell/__tests__/LoadingScreen.test.ts 7ms (unchanged)
app/shell/AppBar.vue 21ms (unchanged)
app/shell/AppFooter.vue 6ms (unchanged)
app/shell/LoadingScreen.vue 10ms (unchanged)
app/shell/NavDrawer.vue 11ms (unchanged)
app/stores/__tests__/progressState.test.ts 5ms (unchanged)
app/stores/__tests__/teammate_flow.test.ts 5ms (unchanged)
app/stores/__tests__/useMetadata.fetchEditionsData.test.ts 6ms (unchanged)
app/stores/__tests__/useMetadata.prestigeTaskMap.test.ts 8ms (unchanged)
app/stores/__tests__/useMetadata.taskObjectivesHydration.test.ts 7ms (unchanged)
app/stores/__tests__/useMetadataCachePurge.test.ts 6ms (unchanged)
app/stores/__tests__/usePreferences.test.ts 39ms (unchanged)
app/stores/__tests__/useProgress.test.ts 7ms (unchanged)
app/stores/__tests__/useSystemStore.test.ts 7ms (unchanged)
app/stores/__tests__/useTarkov.failedRepair.test.ts 9ms (unchanged)
app/stores/__tests__/useTarkov.hideoutPrereqs.test.ts 4ms (unchanged)
app/stores/__tests__/useTarkov.mergeProgressData.test.ts 5ms (unchanged)
app/stores/__tests__/useTarkov.sync.integration.test.ts 17ms (unchanged)
app/stores/__tests__/useTarkov.syncToasts.test.ts 4ms (unchanged)
app/stores/__tests__/useTeamStore.test.ts 19ms (unchanged)
app/stores/progressState.ts 20ms (unchanged)
app/stores/useApp.ts 3ms (unchanged)
app/stores/useMetadata.ts 65ms (unchanged)
app/stores/usePreferences.ts 17ms (unchanged)
app/stores/useProgress.ts 31ms (unchanged)
app/stores/useSystemStore.ts 7ms (unchanged)
app/stores/useTarkov.ts 65ms (unchanged)
app/stores/useTeamStore.ts 17ms (unchanged)
app/stores/utils/gameMode.ts 4ms (unchanged)
app/types/__tests__/taskSort.test.ts 4ms (unchanged)
app/types/api.ts 4ms (unchanged)
app/types/changelog.ts 3ms (unchanged)
app/types/edge.ts 3ms (unchanged)
app/types/env.d.ts 0ms (unchanged)
app/types/json5.d.ts 3ms (unchanged)
app/types/supabase-plugin.d.ts 3ms (unchanged)
app/types/tarkov.ts 11ms (unchanged)
app/types/taskFilter.ts 4ms (unchanged)
app/types/taskSort.ts 3ms (unchanged)
app/types/team.ts 3ms (unchanged)
app/types/theme.ts 2ms (unchanged)
app/types/ui.ts 2ms (unchanged)
app/types/vue.d.ts 3ms (unchanged)
app/utils/__tests__/constants.test.ts 4ms (unchanged)
app/utils/__tests__/debounce.test.ts 7ms (unchanged)
app/utils/__tests__/eftLogQuestParser.test.ts 7ms (unchanged)
app/utils/__tests__/factionIcons.test.ts 4ms (unchanged)
app/utils/__tests__/fuzzySearch.test.ts 4ms (unchanged)
app/utils/__tests__/mapClustering.test.ts 6ms (unchanged)
app/utils/__tests__/mapCoordinates.test.ts 9ms (unchanged)
app/utils/__tests__/oauthConsent.test.ts 5ms (unchanged)
app/utils/__tests__/progressInvalidation.test.ts 7ms (unchanged)
app/utils/__tests__/redirect.test.ts 4ms (unchanged)
app/utils/__tests__/skillHelpers.test.ts 8ms (unchanged)
app/utils/__tests__/tarkovDevProfileParser.test.ts 12ms (unchanged)
app/utils/__tests__/taskImpact.test.ts 5ms (unchanged)
app/utils/__tests__/taskRequiredKeys.test.ts 9ms (unchanged)
app/utils/__tests__/taskSorter.test.ts 10ms (unchanged)
app/utils/__tests__/taskStatus.test.ts 6ms (unchanged)
app/utils/__tests__/taskTypeFilters.test.ts 9ms (unchanged)
app/utils/async.ts 4ms (unchanged)
app/utils/changelog.ts 6ms (unchanged)
app/utils/constants.ts 8ms (unchanged)
app/utils/dataMigrationService.ts 17ms (unchanged)
app/utils/debounce.ts 4ms (unchanged)
app/utils/editionHelpers.ts 4ms (unchanged)
app/utils/eftLogQuestParser.ts 16ms (unchanged)
app/utils/errors.ts 4ms (unchanged)
app/utils/factionIcons.ts 3ms (unchanged)
app/utils/formatters.ts 4ms (unchanged)
app/utils/fuzzySearch.ts 4ms (unchanged)
app/utils/graphHelpers.ts 7ms (unchanged)
app/utils/locales.ts 3ms (unchanged)
app/utils/logger.ts 7ms (unchanged)
app/utils/mapClustering.ts 4ms (unchanged)
app/utils/mapCoordinates.ts 10ms (unchanged)
app/utils/mapTime.ts 3ms (unchanged)
app/utils/oauthConsent.ts 5ms (unchanged)
app/utils/perf.ts 5ms (unchanged)
app/utils/progressInvalidation.ts 7ms (unchanged)
app/utils/progressSanitizers.ts 7ms (unchanged)
app/utils/redirect.ts 4ms (unchanged)
app/utils/routeHelpers.ts 3ms (unchanged)
app/utils/skillHelpers.ts 5ms (unchanged)
app/utils/storageKeys.ts 6ms (unchanged)
app/utils/storeHelpers.ts 10ms (unchanged)
app/utils/storylineObjectives.ts 6ms (unchanged)
app/utils/tarkovCache.ts 14ms (unchanged)
app/utils/tarkovDevProfileParser.ts 8ms (unchanged)
app/utils/tarkovKeyHelpers.ts 4ms (unchanged)
app/utils/tarkovUrls.ts 4ms (unchanged)
app/utils/taskFilterNormalization.ts 4ms (unchanged)
app/utils/taskGraphLayout.ts 16ms (unchanged)
app/utils/taskImpact.ts 4ms (unchanged)
app/utils/taskNormalization.ts 3ms (unchanged)
app/utils/taskProgress.ts 6ms (unchanged)
app/utils/taskRequiredKeys.ts 5ms (unchanged)
app/utils/taskSorter.ts 9ms (unchanged)
app/utils/taskStatus.ts 3ms (unchanged)
app/utils/taskTypeFilters.ts 4ms (unchanged)
app/utils/theme-colors.ts 6ms (unchanged)
app/utils/userHydration.ts 6ms (unchanged)
docs/API.md 25ms (unchanged)
docs/ARCHITECTURE.md 30ms (unchanged)
docs/CONTRIBUTING.md 11ms (unchanged)
docs/plans/2026-02-15-kappa-projection-fix-design.md 4ms (unchanged)
docs/plans/2026-02-15-kappa-projection-fix.md 21ms (unchanged)
docs/plans/2026-02-15-settings-redesign-design.md 4ms (unchanged)
docs/plans/2026-02-15-settings-redesign.md 45ms (unchanged)
docs/plans/2026-02-17-storyline-objectives-design.md 6ms (unchanged)
docs/plans/2026-02-17-storyline-objectives-plan.md 36ms (unchanged)
docs/plans/2026-02-17-storyline-tab-design.md 3ms (unchanged)
docs/plans/2026-02-17-storyline-tab-plan.md 37ms (unchanged)
docs/plans/2026-02-18-data-export-import-design.md 5ms (unchanged)
docs/plans/2026-02-18-data-export-import-plan.md 89ms (unchanged)
docs/README.md 7ms (unchanged)
docs/runbook.md 3ms (unchanged)
docs/WORKFLOW_AUTOMATION.md 13ms (unchanged)
nuxt.config.ts 6ms (unchanged)
vitest.config.ts 2ms (unchanged)
vitest.happy-dom.config.ts 1ms (unchanged)
vitest.nuxt.config.ts 1ms (unchanged)
vitest.shared.ts 1ms (unchanged)
tests/test-setup.ts 5ms (unchanged)
ℹ Nuxt Icon server bundle mode is set to remote
│
◆  Types generated in .nuxt.\n- 
 RUN  v4.0.18 /home/lab/TarkovTracker

 ✓ app/composables/__tests__/useOAuthLogin.test.ts (4 tests) 7ms

 Test Files  1 passed (1)
      Tests  4 passed (4)
   Start at  13:44:37
   Duration  1.29s (transform 751ms, setup 69ms, import 1.02s, tests 7ms, environment 124ms)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test suite for OAuth login functionality, covering popup behavior, redirects, error scenarios, and loading state management across multiple providers.

* **Refactor**
  * Enhanced OAuth authentication flow handling to improve popup and redirect operations with better state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->