### PR TITLE
ci: move workflows off node20 actions

### DIFF
--- a/.github/PROJECT_BOARD.md
+++ b/.github/PROJECT_BOARD.md
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Auto-label from issue template
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             # Auto-assign labels based on issue body content

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -180,9 +180,18 @@ updates:
     commit-message:
       prefix: chore(ci)
     groups:
-      github-actions:
+      official-actions:
         patterns:
-          - '*'
+          - actions/*
+          - github/codeql-action
+        update-types:
+          - major
+          - minor
+          - patch
+      third-party-actions:
+        patterns:
+          - lycheeverse/lychee-action
+          - treosh/lighthouse-ci-action
         update-types:
           - minor
           - patch

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 ### Security (`security.yml`)
 
 **Trigger:** Push to main/develop, PRs, weekly schedule
-**Jobs:** `Security Scan` (audit + gitleaks CLI), `CodeQL` (static analysis)
+**Jobs:** `Security Scan` (audit + checksum-verified Gitleaks CLI), `CodeQL` (static analysis)
 
 ### Release (`release.yml`)
 
@@ -40,7 +40,7 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 
 ## Secrets
 
-Workflow-specific secrets are not required for the Gitleaks step anymore. App build jobs still use the existing Nuxt/Supabase secrets configured for CI and release.
+Workflow-specific secrets are not required for the Gitleaks step anymore. The workflow downloads a pinned Gitleaks release and verifies its published checksum before scanning. App build jobs still use the existing Nuxt/Supabase secrets configured for CI and release.
 
 ## Commands
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,7 +12,7 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 ### Security (`security.yml`)
 
 **Trigger:** Push to main/develop, PRs, weekly schedule
-**Jobs:** `Security Scan` (audit + gitleaks), `CodeQL` (static analysis)
+**Jobs:** `Security Scan` (audit + gitleaks CLI), `CodeQL` (static analysis)
 
 ### Release (`release.yml`)
 
@@ -40,9 +40,7 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 
 ## Secrets
 
-```text
-GITLEAKS_LICENSE       - Gitleaks license key (optional)
-```
+Workflow-specific secrets are not required for the Gitleaks step anymore. App build jobs still use the existing Nuxt/Supabase secrets configured for CI and release.
 
 ## Commands
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,10 @@ jobs:
     name: Validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -47,7 +47,7 @@ jobs:
 
       - name: Upload build artifacts
         if: github.ref == 'refs/heads/main'
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: build-${{ github.sha }}
           path: dist
@@ -58,10 +58,10 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: .nvmrc
           cache: 'npm'

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -18,7 +18,7 @@ jobs:
   link-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Link Checker
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
@@ -41,7 +41,7 @@ jobs:
 
       - name: Upload Link Check Report
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
         with:
           name: link-check-report
           path: ./lychee/out.md

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -18,19 +18,19 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Auto-label PR
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/labeler@8558fd74291d67161a8a78ce36a881fa63b766a9
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Calculate and apply size label
         if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -87,7 +87,7 @@ jobs:
 
       - name: Detect Lighthouse scope
         id: lighthouse-gate
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b
+        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
         with:
           script: |
             const labels = context.payload.pull_request.labels.map(({ name }) => name);
@@ -107,7 +107,7 @@ jobs:
             console.log(`Lighthouse gate ${runLighthouse ? 'enabled' : 'skipped'}`);
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -128,10 +128,10 @@ jobs:
     env:
       API_ALLOWED_HOSTS: localhost,127.0.0.1
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: .nvmrc
           cache: 'npm'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,12 +21,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: .nvmrc
           cache: 'npm'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -37,18 +37,30 @@ jobs:
         run: npm outdated || true
 
       - name: Install Gitleaks CLI
+        shell: bash
         run: |
-          mkdir -p "$RUNNER_TEMP/gitleaks"
+          set -euo pipefail
+          archive="gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+          archive_path="$RUNNER_TEMP/$archive"
+          checksums_path="$RUNNER_TEMP/gitleaks_checksums.txt"
+          checksum_entry_path="$RUNNER_TEMP/gitleaks_checksum.txt"
+          install_dir="$RUNNER_TEMP/gitleaks"
+
+          mkdir -p "$install_dir"
           curl -sSfL \
-            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
-            -o "$RUNNER_TEMP/gitleaks.tar.gz"
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/${archive}" \
+            -o "$archive_path"
           curl -sSfL \
             "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" \
-            -o "$RUNNER_TEMP/gitleaks_checksums.txt"
-          grep "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" "$RUNNER_TEMP/gitleaks_checksums.txt" | \
-            sha256sum --check --status
-          tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP/gitleaks"
-          echo "$RUNNER_TEMP/gitleaks" >> "$GITHUB_PATH"
+            -o "$checksums_path"
+          awk -v archive="$archive" '$2 == archive { print }' "$checksums_path" > "$checksum_entry_path"
+          test -s "$checksum_entry_path"
+          (
+            cd "$RUNNER_TEMP"
+            sha256sum --check --strict "$checksum_entry_path"
+          )
+          tar -xzf "$archive_path" -C "$install_dir"
+          echo "$install_dir" >> "$GITHUB_PATH"
         env:
           GITLEAKS_VERSION: 8.30.1
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -14,12 +14,12 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
         with:
           node-version-file: .nvmrc
           cache: 'npm'
@@ -36,24 +36,47 @@ jobs:
       - name: Check for outdated dependencies
         run: npm outdated || true
 
-      - name: Check Gitleaks license
-        id: gitleaks-check
+      - name: Install Gitleaks CLI
         run: |
-          if [ -z "$GITLEAKS_LICENSE" ]; then
-            echo "::warning::GITLEAKS_LICENSE secret not configured - Gitleaks scan will be skipped"
-            echo "has-license=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "has-license=true" >> "$GITHUB_OUTPUT"
-          fi
+          mkdir -p "$RUNNER_TEMP/gitleaks"
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" \
+            -o "$RUNNER_TEMP/gitleaks.tar.gz"
+          curl -sSfL \
+            "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_checksums.txt" \
+            -o "$RUNNER_TEMP/gitleaks_checksums.txt"
+          grep "gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" "$RUNNER_TEMP/gitleaks_checksums.txt" | \
+            sha256sum --check --status
+          tar -xzf "$RUNNER_TEMP/gitleaks.tar.gz" -C "$RUNNER_TEMP/gitleaks"
+          echo "$RUNNER_TEMP/gitleaks" >> "$GITHUB_PATH"
         env:
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+          GITLEAKS_VERSION: 8.30.1
 
       - name: Gitleaks scan
-        if: steps.gitleaks-check.outputs.has-license == 'true'
-        uses: gitleaks/gitleaks-action@ff98106e4c7b2bc287b24eaf42907196329070c7
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+        id: gitleaks
+        continue-on-error: true
+        run: |
+          gitleaks git . \
+            --exit-code 1 \
+            --no-banner \
+            --redact \
+            --report-format sarif \
+            --report-path gitleaks.sarif
+
+      - name: Upload Gitleaks report
+        if: steps.gitleaks.outcome == 'failure'
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f
+        with:
+          name: gitleaks-report
+          path: gitleaks.sarif
+          if-no-files-found: ignore
+          retention-days: 7
+
+      - name: Fail on Gitleaks findings
+        if: steps.gitleaks.outcome == 'failure'
+        run: |
+          echo "::error::Gitleaks detected secrets. Review the gitleaks-report artifact."
+          exit 1
 
   codeql:
     name: CodeQL
@@ -63,7 +86,7 @@ jobs:
       actions: read
       contents: read
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@c10b8064de6f491fea524254123dbe5e09572f13
@@ -73,4 +96,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@c10b8064de6f491fea524254123dbe5e09572f13
-

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -12,7 +12,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
         with:
           stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
           stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.'
@@ -25,4 +25,3 @@ jobs:
           stale-pr-label: 'stale'
           exempt-issue-labels: 'pinned,security,enhancement'
           exempt-pr-labels: 'pinned,security,enhancement'
-

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -37,12 +37,6 @@ Weekly security audits:
 
 **Triggers:** Push to main/develop, all PRs, weekly (Sunday 00:00 UTC)
 
-**Required Secrets:**
-
-```text
-GITLEAKS_LICENSE (required for organization repos, free at gitleaks.io)
-```
-
 ### 3. Release Automation (`.github/workflows/release.yml`)
 
 Semantic versioning with automated releases:
@@ -153,11 +147,13 @@ Automated via Dependabot (`.github/dependabot.yml`):
 - Weekly npm update batches across the app root and `workers/api-gateway`
 - Monthly grouped npm batches for `.claude-plugin` MCP tooling
 - Monthly grouped GitHub Actions updates
+- Official GitHub Actions are allowed to take major updates so runtime migrations do not get stuck behind a minor/patch-only rule
 - Cooldown windows to avoid immediate churn from fresh releases
 - Grouped minor/patch updates for low-risk tooling families
 - Version updates limited to direct dependencies; vulnerable transitives still surface through security updates
 - Maximum 3 concurrent npm PRs and 1 GitHub Actions PR
 - No automerge for version updates
+- Gitleaks runs via the pinned CLI in CI instead of the deprecated `gitleaks-action` runtime
 
 **Current package groups:**
 
@@ -175,6 +171,7 @@ Automated via Dependabot (`.github/dependabot.yml`):
 
 - Let Dependabot batch low-risk tooling updates for scheduled review windows
 - Keep major upgrades explicit
+- Allow official GitHub-maintained actions to take major updates when GitHub changes required action runtimes
 - Keep transitive lockfile churn out of version-update PRs unless GitHub raises a security fix
 - Keep `.claude-plugin` updates out of the main app queue; review them monthly as isolated tooling maintenance
 - Review security PRs promptly; they remain separate from the scheduled version-update batches unless GitHub grouped security updates are enabled in repository settings

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -32,7 +32,7 @@ Weekly security audits:
 
 **Jobs:**
 
-- `security-scan` - npm audit (prod and all deps), outdated check, Gitleaks secret detection
+- `security-scan` - npm audit (prod and all deps), outdated check, checksum-verified Gitleaks secret detection
 - `codeql` - CodeQL static analysis
 
 **Triggers:** Push to main/develop, all PRs, weekly (Sunday 00:00 UTC)
@@ -153,7 +153,7 @@ Automated via Dependabot (`.github/dependabot.yml`):
 - Version updates limited to direct dependencies; vulnerable transitives still surface through security updates
 - Maximum 3 concurrent npm PRs and 1 GitHub Actions PR
 - No automerge for version updates
-- Gitleaks runs via the pinned CLI in CI instead of the deprecated `gitleaks-action` runtime
+- Gitleaks runs via a pinned CLI download in CI with release checksum verification instead of the deprecated `gitleaks-action` runtime
 
 **Current package groups:**
 


### PR DESCRIPTION
## Summary
- move GitHub-maintained workflow actions to Node 24-capable pinned SHAs
- replace gitleaks-action with a pinned gitleaks CLI install plus checksum verification and failure artifact upload
- let Dependabot propose major updates for official GitHub actions while keeping third-party action updates minor/patch only

## Validation
- npm ci
- npm run format
- git diff --check
- local gitleaks CLI download, checksum, version, and SARIF scan smoke test

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Gitleaks now runs via a pinned CLI with checksum verification, SARIF upload, and explicit failure reporting; workflow secret is no longer required.

* **Chores**
  * Updated GitHub Actions version pins across CI/CD and workflow examples.
  * Dependabot split action updates into specific groups, permitting major updates for official actions.

* **Documentation**
  * Workflow docs updated to reflect the checksum-verified Gitleaks flow and revised Dependabot policy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->