### PR TITLE
[codex] remove persisted tarkov import mode

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -128,6 +128,15 @@ const preferences = usePreferences();
 
 The app tracks PvP and PvE progress separately. Always consider both modes when working with progress data.
 
+### Tarkov.dev Import and Linking
+
+- Persist a single linked `tarkovUid` only.
+- Do not add or depend on a persisted linked-mode/imported-mode field.
+- Treat PvP/PvE choice for tarkov.dev imports as temporary UI state that decides where imported
+  progress is written.
+- Build tarkov.dev profile links from the currently viewed or selected mode to choose the
+  `regular` or `pve` URL slug.
+
 ### Team System
 
 Real-time sync via Supabase Broadcast. Team/token mutations run through Supabase Edge Functions.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,7 +7,7 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 ### CI (`ci.yml`)
 
 **Trigger:** Push to main/develop/wip branches, PRs
-**Jobs:** `Validate` (lint, typecheck, format, test, build), `Workers` (validate api-gateway)
+**Jobs:** `Validate` (lint, typecheck, format, test, build), `Supabase DB` (reset + lint local migrations), `Workers` (validate api-gateway)
 
 ### Security (`security.yml`)
 
@@ -31,12 +31,12 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 
 ## Check Count
 
-| Context | Checks |
-|---------|--------|
-| PR | ~6 (Validate, Workers, PR Meta, Security Scan, CodeQL, Lighthouse*) |
-| Main push | ~5 (Validate, Workers, Security Scan, CodeQL, Release) |
+| Context   | Checks                                                                            |
+| --------- | --------------------------------------------------------------------------------- |
+| PR        | ~7 (Validate, Supabase DB, Workers, PR Meta, Security Scan, CodeQL, Lighthouse\*) |
+| Main push | ~6 (Validate, Supabase DB, Workers, Security Scan, CodeQL, Release)               |
 
-*Lighthouse runs only when the PR touches UI paths or already carries `performance`/`ui`
+\*Lighthouse runs only when the PR touches UI paths or already carries `performance`/`ui`
 
 ## Secrets
 
@@ -56,6 +56,7 @@ Test workflows locally with [act](https://github.com/nektos/act):
 
 ```bash
 act -j validate
+act -j supabase-db
 act -j workers
 act -j pr-meta
 ```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -48,6 +48,7 @@ Workflow-specific secrets are not required for the Gitleaks step anymore. The wo
 gh run list              # List recent runs
 gh run view <run-id>     # View run details
 gh run watch             # Watch running workflow
+npm run supabase:check   # Validate local Supabase migration reset + lint
 ```
 
 ## Local Testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,24 @@ jobs:
           path: dist
           retention-days: 7
 
+  supabase-db:
+    name: Supabase DB
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+      - name: Setup Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: .nvmrc
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Validate Supabase migrations
+        run: npm run supabase:check
+
   workers:
     name: Workers
     needs: validate

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Run tests
         run: npm run test
 
+      - name: Validate Supabase migrations
+        run: npm run supabase:check
+
       - name: Build
         run: npm run build
         env:

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://www.gnu.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ The application will be available at `http://localhost:3000`.
 # Format code (Prettier + ESLint)
 npm run format
 
+# Validate Supabase migrations locally
+npm run supabase:check
+
 # Lint code
 npm run lint
 
@@ -103,6 +106,12 @@ npm run typecheck
 # Check for dependency updates
 npm run deps
 ```
+
+## Tarkov.dev Profile Cleanup
+
+The app now persists only the linked `tarkovUid` for tarkov.dev profiles. Legacy manual backups
+created before this cleanup may still contain imported profile snapshots. New imports ignore those
+legacy blobs, but regenerate backups after upgrading if you want future exports to be fully scrubbed.
 
 ## Production
 

--- a/app/composables/__tests__/useDataBackup.test.ts
+++ b/app/composables/__tests__/useDataBackup.test.ts
@@ -1221,7 +1221,7 @@ describe('useDataBackup', () => {
     it('ignores legacy tarkovUidMode metadata in backup payloads', async () => {
       const legacyBackup = {
         ...validBackup,
-        tarkovUidMode: 'pve',
+        tarkovUidMode: 'pvp',
       };
       const { parseBackupFile, confirmBackupImport } = await loadComposable();
       await parseBackupFile(createFile(JSON.stringify(legacyBackup)));

--- a/app/composables/__tests__/useDataBackup.test.ts
+++ b/app/composables/__tests__/useDataBackup.test.ts
@@ -1218,29 +1218,32 @@ describe('useDataBackup', () => {
       expect(mockState.tarkovUid).toBe(12345);
       expect(mockState.currentGameMode).toBe('pve');
     });
-    it('ignores legacy tarkovUidMode metadata in backup payloads', async () => {
-      const legacyBackup = {
-        ...validBackup,
-        tarkovUidMode: 'pvp',
-      };
-      const { parseBackupFile, confirmBackupImport } = await loadComposable();
-      await parseBackupFile(createFile(JSON.stringify(legacyBackup)));
-      await confirmBackupImport({ pvp: true, pve: true });
-      const patchFn = tarkovStore.$patch.mock.calls[0]![0] as (
-        state: Record<string, unknown>
-      ) => void;
-      const mockState = {
-        currentGameMode: 'pvp',
-        gameEdition: 1,
-        pvp: { level: 1, progressEpoch: 5 },
-        pve: { level: 1, progressEpoch: 7 },
-        tarkovUid: null,
-      };
-      patchFn(mockState);
-      expect(mockState.tarkovUid).toBe(12345);
-      expect(mockState.currentGameMode).toBe('pve');
-      expect(mockState).not.toHaveProperty('tarkovUidMode');
-    });
+    it.each(['pvp', 'pve'] as const)(
+      'ignores legacy tarkovUidMode=%s metadata in backup payloads',
+      async (legacyMode) => {
+        const legacyBackup = {
+          ...validBackup,
+          tarkovUidMode: legacyMode,
+        };
+        const { parseBackupFile, confirmBackupImport } = await loadComposable();
+        await parseBackupFile(createFile(JSON.stringify(legacyBackup)));
+        await confirmBackupImport({ pvp: true, pve: true });
+        const patchFn = tarkovStore.$patch.mock.calls[0]![0] as (
+          state: Record<string, unknown>
+        ) => void;
+        const mockState = {
+          currentGameMode: 'pvp',
+          gameEdition: 1,
+          pvp: { level: 1, progressEpoch: 5 },
+          pve: { level: 1, progressEpoch: 7 },
+          tarkovUid: null,
+        };
+        patchFn(mockState);
+        expect(mockState.tarkovUid).toBe(12345);
+        expect(mockState.currentGameMode).toBe('pve');
+        expect(mockState).not.toHaveProperty('tarkovUidMode');
+      }
+    );
     it('does nothing when not in preview state', async () => {
       const { confirmBackupImport } = await loadComposable();
       await confirmBackupImport({ pvp: true, pve: true });

--- a/app/composables/__tests__/useDataBackup.test.ts
+++ b/app/composables/__tests__/useDataBackup.test.ts
@@ -423,22 +423,6 @@ describe('useDataBackup', () => {
   });
   describe('exportDebugSnapshot', () => {
     it('exports a sanitized debug snapshot without auth secrets or player identifiers', async () => {
-      tarkovStore.$state.pvp.tarkovDevProfile = {
-        achievements: {},
-        importedAt: 1700000010000,
-        mastering: [],
-        pmcStats: {
-          Avatar_URL: 'https://example.com/avatar.png',
-          NickName: 'SensitiveNick',
-          player_id: 'pmc-player-1',
-        },
-        profileUpdatedAt: 1700000011000,
-        scavStats: {
-          accountId: 'account-77',
-          display_name: 'SensitiveScav',
-          UserName: 'scav-user-1',
-        },
-      };
       localStorage.setItem(
         STORAGE_KEYS.progress,
         JSON.stringify({
@@ -541,11 +525,6 @@ describe('useDataBackup', () => {
         expect(debugText).not.toContain('token-secret');
         expect(debugText).not.toContain('user-123');
         expect(debugText).not.toContain('teammate-1');
-        expect(debugText).not.toContain('SensitiveNick');
-        expect(debugText).not.toContain('pmc-player-1');
-        expect(debugText).not.toContain('SensitiveScav');
-        expect(debugText).not.toContain('scav-user-1');
-        expect(debugText).not.toContain('account-77');
         expect(revokeObjectURLSpy).toHaveBeenCalledWith('blob:test-debug-url');
         expect(clickSpy).toHaveBeenCalledOnce();
       } finally {
@@ -1238,6 +1217,29 @@ describe('useDataBackup', () => {
       expect(mockState.gameEdition).toBe(3);
       expect(mockState.tarkovUid).toBe(12345);
       expect(mockState.currentGameMode).toBe('pve');
+    });
+    it('ignores legacy tarkovUidMode metadata in backup payloads', async () => {
+      const legacyBackup = {
+        ...validBackup,
+        tarkovUidMode: 'pve',
+      };
+      const { parseBackupFile, confirmBackupImport } = await loadComposable();
+      await parseBackupFile(createFile(JSON.stringify(legacyBackup)));
+      await confirmBackupImport({ pvp: true, pve: true });
+      const patchFn = tarkovStore.$patch.mock.calls[0]![0] as (
+        state: Record<string, unknown>
+      ) => void;
+      const mockState = {
+        currentGameMode: 'pvp',
+        gameEdition: 1,
+        pvp: { level: 1, progressEpoch: 5 },
+        pve: { level: 1, progressEpoch: 7 },
+        tarkovUid: null,
+      };
+      patchFn(mockState);
+      expect(mockState.tarkovUid).toBe(12345);
+      expect(mockState.currentGameMode).toBe('pve');
+      expect(mockState).not.toHaveProperty('tarkovUidMode');
     });
     it('does nothing when not in preview state', async () => {
       const { confirmBackupImport } = await loadComposable();

--- a/app/composables/__tests__/useTarkovDevImport.test.ts
+++ b/app/composables/__tests__/useTarkovDevImport.test.ts
@@ -161,6 +161,18 @@ describe('useTarkovDevImport', () => {
     await composable.confirmImport('pvp');
     expect(tarkovStore.setGameEdition).toHaveBeenCalledWith(4);
   });
+  it('defaults to level 1 when totalXP is zero', async () => {
+    const parsedData = createImportData({ totalXP: 0 });
+    mockParseTarkovDevProfile.mockReturnValue({
+      data: parsedData,
+      ok: true,
+    });
+    const composable = await loadComposable();
+    await composable.parseFile(createFile('{"aid":123}'));
+    await composable.confirmImport('pvp');
+    expect(mockSetTotalXP).toHaveBeenCalledWith(0);
+    expect(tarkovStore.setLevel).toHaveBeenCalledWith(1);
+  });
   it('sets error state when applying import data throws', async () => {
     const parsedData = createImportData();
     mockParseTarkovDevProfile.mockReturnValue({

--- a/app/composables/__tests__/useTarkovDevImport.test.ts
+++ b/app/composables/__tests__/useTarkovDevImport.test.ts
@@ -3,6 +3,7 @@ import type { GameMode } from '@/utils/constants';
 import type { TarkovDevImportResult } from '@/utils/tarkovDevProfileParser';
 const mockParseTarkovDevProfile = vi.fn();
 const mockSetTotalSkillLevel = vi.fn();
+const mockSetTotalXP = vi.fn();
 const mockLogger = {
   debug: vi.fn(),
   error: vi.fn(),
@@ -17,7 +18,6 @@ const tarkovStore = {
   setPMCFaction: vi.fn(),
   setPrestigeLevel: vi.fn(),
   syncPvpPrestigeLevel: vi.fn(),
-  setTarkovDevProfile: vi.fn(),
   setTarkovUid: vi.fn(),
   switchGameMode: vi.fn(),
 };
@@ -28,19 +28,18 @@ const metadataStore = {
     { exp: 2500, level: 12 },
   ],
 };
-const preferencesStore = {
-  setUseAutomaticLevelCalculation: vi.fn(),
-};
 vi.mock('@/composables/useSkillCalculation', () => ({
   useSkillCalculation: () => ({
     setTotalSkillLevel: mockSetTotalSkillLevel,
   }),
 }));
+vi.mock('@/composables/useXpCalculation', () => ({
+  useXpCalculation: () => ({
+    setTotalXP: mockSetTotalXP,
+  }),
+}));
 vi.mock('@/stores/useMetadata', () => ({
   useMetadataStore: () => metadataStore,
-}));
-vi.mock('@/stores/usePreferences', () => ({
-  usePreferencesStore: () => preferencesStore,
 }));
 vi.mock('@/stores/useTarkov', () => ({
   useTarkovStore: () => tarkovStore,
@@ -58,14 +57,6 @@ const createImportData = (
   gameEditionGuess: 4,
   pmcFaction: 'USEC',
   prestigeLevel: 2,
-  rawProfile: {
-    achievements: {},
-    importedAt: 1,
-    mastering: [],
-    pmcStats: null,
-    profileUpdatedAt: 2,
-    scavStats: null,
-  },
   skills: {
     Endurance: 10,
     Strength: 15,
@@ -150,12 +141,11 @@ describe('useTarkovDevImport', () => {
     expect(switchModeOrder).toBeDefined();
     expect(setPrestigeOrder).toBeDefined();
     expect(switchModeOrder!).toBeLessThan(setPrestigeOrder!);
-    expect(preferencesStore.setUseAutomaticLevelCalculation).toHaveBeenCalledWith(false);
+    expect(mockSetTotalXP).toHaveBeenCalledWith(parsedData.totalXP);
     expect(tarkovStore.setLevel).toHaveBeenCalledWith(12);
     expect(mockSetTotalSkillLevel).toHaveBeenCalledWith('Endurance', 10);
     expect(mockSetTotalSkillLevel).toHaveBeenCalledWith('Strength', 15);
     expect(tarkovStore.setGameEdition).toHaveBeenCalledWith(6);
-    expect(tarkovStore.setTarkovDevProfile).toHaveBeenCalledWith(parsedData.rawProfile);
     expect(tarkovStore.switchGameMode).toHaveBeenNthCalledWith(2, 'pvp');
     expect(composable.importState.value).toBe('success');
     expect(composable.importError.value).toBeNull();

--- a/app/composables/useDataBackup.ts
+++ b/app/composables/useDataBackup.ts
@@ -14,8 +14,8 @@ import {
   usePreferencesStore,
 } from '@/stores/usePreferences';
 import { useTarkovStore } from '@/stores/useTarkov';
-import { MAX_SKILL_LEVEL } from '@/utils/constants';
 import { logger } from '@/utils/logger';
+import { sanitizeOwnedProgressData, sanitizeOwnedUserState } from '@/utils/progressSanitizers';
 import { LEGACY_STORAGE_KEYS, STORAGE_KEYS } from '@/utils/storageKeys';
 import { parseUserScopedStorage } from '@/utils/userScopedStorage';
 const BACKUP_FORMAT = 'tarkovtracker-backup' as const;
@@ -136,30 +136,10 @@ const ALLOWED_PROGRESS_KEYS = new Set([
   'progressEpoch',
   'skillOffsets',
   'storyChapters',
-  'tarkovDevProfile',
 ]);
 const VALID_FACTIONS = new Set<Faction>(['USEC', 'BEAR']);
-const PII_DEBUG_KEYS = new Set([
-  'accountid',
-  'aid',
-  'avatarurl',
-  'displayname',
-  'email',
-  'memberid',
-  'nickname',
-  'photourl',
-  'picture',
-  'playerid',
-  'profileid',
-  'uid',
-  'userid',
-  'username',
-]);
 function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
-}
-function normalizeDebugKey(key: string): string {
-  return key.replace(/[^a-z0-9]/gi, '').toLowerCase();
 }
 function getDefaultTaskFilterSettings(): TaskFilterSettings {
   return {
@@ -234,75 +214,9 @@ function sanitizeProgressData(
       stripped[key] = raw[key];
     }
   }
-  const level =
-    typeof stripped.level === 'number' && Number.isFinite(stripped.level)
-      ? Math.max(1, Math.trunc(stripped.level))
-      : 1;
-  const prestigeLevel =
-    typeof stripped.prestigeLevel === 'number' && Number.isFinite(stripped.prestigeLevel)
-      ? Math.max(0, Math.min(6, Math.trunc(stripped.prestigeLevel)))
-      : 0;
-  const progressEpoch =
-    typeof stripped.progressEpoch === 'number' && Number.isFinite(stripped.progressEpoch)
-      ? Math.max(0, Math.trunc(stripped.progressEpoch))
-      : 0;
-  const xpOffset =
-    typeof stripped.xpOffset === 'number' && Number.isFinite(stripped.xpOffset)
-      ? Math.trunc(stripped.xpOffset)
-      : 0;
-  const displayName =
-    typeof stripped.displayName === 'string'
-      ? stripped.displayName.trim().slice(0, 64) || null
-      : null;
-  const skills = isPlainObject(stripped.skills)
-    ? { ...(stripped.skills as Record<string, number>) }
-    : {};
-  for (const [key, val] of Object.entries(skills)) {
-    if (typeof val !== 'number' || !Number.isFinite(val)) {
-      skills[key] = 0;
-    } else {
-      skills[key] = Math.max(0, Math.min(MAX_SKILL_LEVEL, val));
-    }
-  }
   return {
     ok: true,
-    data: {
-      level,
-      pmcFaction: stripped.pmcFaction as Faction,
-      displayName,
-      xpOffset,
-      taskCompletions: isPlainObject(stripped.taskCompletions)
-        ? (stripped.taskCompletions as UserProgressData['taskCompletions'])
-        : {},
-      taskObjectives: isPlainObject(stripped.taskObjectives)
-        ? (stripped.taskObjectives as UserProgressData['taskObjectives'])
-        : {},
-      hideoutParts: isPlainObject(stripped.hideoutParts)
-        ? (stripped.hideoutParts as UserProgressData['hideoutParts'])
-        : {},
-      hideoutModules: isPlainObject(stripped.hideoutModules)
-        ? (stripped.hideoutModules as UserProgressData['hideoutModules'])
-        : {},
-      traders: isPlainObject(stripped.traders)
-        ? (stripped.traders as UserProgressData['traders'])
-        : {},
-      skills,
-      prestigeLevel,
-      progressEpoch,
-      skillOffsets: isPlainObject(stripped.skillOffsets)
-        ? (stripped.skillOffsets as UserProgressData['skillOffsets'])
-        : {},
-      storyChapters: isPlainObject(stripped.storyChapters)
-        ? (stripped.storyChapters as UserProgressData['storyChapters'])
-        : {},
-      ...(isPlainObject(stripped.tarkovDevProfile) &&
-      typeof (stripped.tarkovDevProfile as Record<string, unknown>).importedAt === 'number'
-        ? {
-            tarkovDevProfile:
-              stripped.tarkovDevProfile as unknown as UserProgressData['tarkovDevProfile'],
-          }
-        : {}),
-    },
+    data: sanitizeOwnedProgressData(stripped),
   };
 }
 function validateBackup(json: unknown):
@@ -373,7 +287,7 @@ function buildPreview(
 }
 function stripInternalSyncMetadata(data: UserProgressData): UserProgressData {
   const { apiUpdateHistory: _, lastApiUpdate: __, ...rest } = data;
-  return rest as UserProgressData;
+  return sanitizeOwnedProgressData(rest);
 }
 async function fingerprintValue(value: string | number | null | undefined): Promise<string | null> {
   if (value === null || value === undefined || value === '') {
@@ -397,22 +311,6 @@ async function fingerprintValue(value: string | number | null | undefined): Prom
     hash = Math.imul(hash, 16777619);
   }
   return `fnv1a:${(hash >>> 0).toString(16).padStart(8, '0')}`;
-}
-function sanitizeDebugObject<T>(value: T): T {
-  if (Array.isArray(value)) {
-    return value.map((item) => sanitizeDebugObject(item)) as T;
-  }
-  if (!isPlainObject(value)) {
-    return value;
-  }
-  return Object.fromEntries(
-    Object.entries(value).map(([key, entryValue]) => {
-      if (PII_DEBUG_KEYS.has(normalizeDebugKey(key))) {
-        return [key, null];
-      }
-      return [key, sanitizeDebugObject(entryValue)];
-    })
-  ) as T;
 }
 async function sanitizeTaskUserView(value: string | null): Promise<string | null> {
   if (!value || value === 'all' || value === 'self') {
@@ -478,16 +376,13 @@ function normalizePreferencesForDebug(value: unknown): PersistedPreferencesState
 function sanitizeProgressForDebug(data: UserProgressData): UserProgressData {
   const sanitizedData = stripInternalSyncMetadata(cloneStateSnapshot(data));
   sanitizedData.displayName = null;
-  if (sanitizedData.tarkovDevProfile) {
-    sanitizedData.tarkovDevProfile = sanitizeDebugObject(sanitizedData.tarkovDevProfile);
-  }
   return sanitizedData;
 }
 async function sanitizeTarkovStateForDebug(state: unknown): Promise<UserState> {
   if (!isPlainObject(state)) {
     throw new Error('Persisted progress state must be an object');
   }
-  const clonedState = migrateToGameModeStructure(cloneStateSnapshot(state));
+  const clonedState = sanitizeOwnedUserState(migrateToGameModeStructure(cloneStateSnapshot(state)));
   clonedState.tarkovUid = null;
   clonedState.pvp = sanitizeProgressForDebug(clonedState.pvp);
   clonedState.pve = sanitizeProgressForDebug(clonedState.pve);

--- a/app/composables/useTarkovDevImport.ts
+++ b/app/composables/useTarkovDevImport.ts
@@ -1,6 +1,6 @@
 import { useSkillCalculation } from '@/composables/useSkillCalculation';
+import { useXpCalculation } from '@/composables/useXpCalculation';
 import { useMetadataStore } from '@/stores/useMetadata';
-import { usePreferencesStore } from '@/stores/usePreferences';
 import { useTarkovStore } from '@/stores/useTarkov';
 import { logger } from '@/utils/logger';
 import { parseTarkovDevProfile, type TarkovDevImportResult } from '@/utils/tarkovDevProfileParser';
@@ -17,8 +17,8 @@ export interface UseTarkovDevImportReturn {
 export function useTarkovDevImport(): UseTarkovDevImportReturn {
   const tarkovStore = useTarkovStore();
   const metadataStore = useMetadataStore();
-  const preferencesStore = usePreferencesStore();
   const { setTotalSkillLevel } = useSkillCalculation();
+  const { setTotalXP } = useXpCalculation();
   const importState = ref<ImportState>('idle');
   const previewData = ref<TarkovDevImportResult | null>(null);
   const importError = ref<string | null>(null);
@@ -55,10 +55,10 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
     const originalMode = tarkovStore.getCurrentGameMode();
     const shouldRestoreMode = targetMode !== originalMode;
     try {
-      tarkovStore.setTarkovUid(data.tarkovUid);
       if (shouldRestoreMode) {
         await tarkovStore.switchGameMode(targetMode);
       }
+      tarkovStore.setTarkovUid(data.tarkovUid);
       tarkovStore.setPMCFaction(data.pmcFaction);
       tarkovStore.setDisplayName(data.displayName);
       tarkovStore.setPrestigeLevel(data.prestigeLevel);
@@ -71,7 +71,7 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
           break;
         }
       }
-      preferencesStore.setUseAutomaticLevelCalculation(false);
+      setTotalXP(data.totalXP);
       tarkovStore.setLevel(derivedLevel);
       for (const [skillId, level] of Object.entries(data.skills)) {
         setTotalSkillLevel(skillId, level);
@@ -80,7 +80,6 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
       if (edition !== null && edition !== undefined) {
         tarkovStore.setGameEdition(edition);
       }
-      tarkovStore.setTarkovDevProfile(data.rawProfile);
       importState.value = 'success';
     } catch (e) {
       importState.value = 'error';

--- a/app/features/profile/ProfileProgression.vue
+++ b/app/features/profile/ProfileProgression.vue
@@ -252,6 +252,7 @@
   import { logger } from '@/utils/logger';
   import { computeInvalidProgress } from '@/utils/progressInvalidation';
   import { orderedStoryObjectives } from '@/utils/storylineObjectives';
+  import { buildTarkovDevProfileUrl } from '@/utils/tarkovDevProfileUrl';
   import { getCompletionFlags, type RawTaskCompletion } from '@/utils/taskStatus';
   import { filterTasksByTypeSettings, type TaskTypeFilterOptions } from '@/utils/taskTypeFilters';
   import type {
@@ -576,11 +577,8 @@
   });
   const modeFaction = computed(() => modeData.value.pmcFaction ?? 'USEC');
   const tarkovDevProfileUrl = computed(() => {
-    if (isViewingSharedProfile.value) return null;
-    const uid = tarkovStore.getTarkovUid();
-    if (!uid) return null;
-    const modeSlug = selectedMode.value === GAME_MODES.PVE ? 'pve' : 'regular';
-    return `https://tarkov.dev/players/${modeSlug}/${uid}`;
+    if (isViewingSharedProfile.value) return undefined;
+    return buildTarkovDevProfileUrl(tarkovStore.getTarkovUid(), selectedMode.value);
   });
   const profileLevel = computed(() => {
     if (isViewingCurrentMode.value && preferencesStore.getUseAutomaticLevelCalculation) {

--- a/app/features/settings/DataManagementCard.vue
+++ b/app/features/settings/DataManagementCard.vue
@@ -688,6 +688,7 @@
   import { useTarkovStore } from '@/stores/useTarkov';
   import { GAME_MODES, type GameMode } from '@/utils/constants';
   import { logger } from '@/utils/logger';
+  import { buildTarkovDevProfileUrl } from '@/utils/tarkovDevProfileUrl';
   const { t } = useI18n({ useScope: 'global' });
   const toast = useToast();
   const tarkovStore = useTarkovStore();
@@ -793,23 +794,8 @@
   );
   const tarkovUid = computed(() => tarkovStore.getTarkovUid());
   const isLinked = computed(() => tarkovUid.value !== null);
-  const linkedProfileMode = computed<GameMode | null>(() => {
-    const pvpImportedAt = tarkovStore.getPvPProgressData().tarkovDevProfile?.importedAt;
-    const pveImportedAt = tarkovStore.getPvEProgressData().tarkovDevProfile?.importedAt;
-    const hasPvpImport = typeof pvpImportedAt === 'number' && Number.isFinite(pvpImportedAt);
-    const hasPveImport = typeof pveImportedAt === 'number' && Number.isFinite(pveImportedAt);
-    if (hasPvpImport && hasPveImport) {
-      return pveImportedAt > pvpImportedAt ? GAME_MODES.PVE : GAME_MODES.PVP;
-    }
-    if (hasPvpImport) return GAME_MODES.PVP;
-    if (hasPveImport) return GAME_MODES.PVE;
-    return null;
-  });
   const tarkovDevProfileUrl = computed(() => {
-    const mode =
-      linkedProfileMode.value ?? tarkovStore.getCurrentGameMode() ?? tarkovDevTargetMode.value;
-    const modeSlug = mode === GAME_MODES.PVE ? 'pve' : 'regular';
-    return `https://tarkov.dev/players/${modeSlug}/${tarkovUid.value}`;
+    return buildTarkovDevProfileUrl(tarkovUid.value, tarkovStore.getCurrentGameMode());
   });
   const previewLevel = computed(() => {
     if (!tarkovDevPreview.value) return 1;

--- a/app/features/settings/__tests__/DataManagementCard.test.ts
+++ b/app/features/settings/__tests__/DataManagementCard.test.ts
@@ -274,13 +274,14 @@ describe('DataManagementCard', () => {
     asVm<{ resetTarkovDevImport: () => void }>(wrapper.vm).resetTarkovDevImport();
     expect(tarkovDevFns.reset).toHaveBeenCalledTimes(1);
   });
-  it('builds linked tarkov.dev url from the current mode', () => {
-    tarkovStoreState.currentMode = 'pve';
+  it.each([
+    { expected: 'https://tarkov.dev/players/regular/123456', mode: 'pvp' as const },
+    { expected: 'https://tarkov.dev/players/pve/123456', mode: 'pve' as const },
+  ])('builds linked tarkov.dev url from the current mode ($mode)', ({ mode, expected }) => {
+    tarkovStoreState.currentMode = mode;
     tarkovStoreState.tarkovUid = 123456;
     const wrapper = createWrapper();
-    expect(asVm<{ tarkovDevProfileUrl: string }>(wrapper.vm).tarkovDevProfileUrl).toBe(
-      'https://tarkov.dev/players/pve/123456'
-    );
+    expect(asVm<{ tarkovDevProfileUrl: string }>(wrapper.vm).tarkovDevProfileUrl).toBe(expected);
   });
   it('forwards EFT logs confirmation using current target mode', async () => {
     tarkovStoreState.currentMode = 'pve';

--- a/app/features/settings/__tests__/DataManagementCard.test.ts
+++ b/app/features/settings/__tests__/DataManagementCard.test.ts
@@ -274,6 +274,14 @@ describe('DataManagementCard', () => {
     asVm<{ resetTarkovDevImport: () => void }>(wrapper.vm).resetTarkovDevImport();
     expect(tarkovDevFns.reset).toHaveBeenCalledTimes(1);
   });
+  it('builds linked tarkov.dev url from the current mode', () => {
+    tarkovStoreState.currentMode = 'pve';
+    tarkovStoreState.tarkovUid = 123456;
+    const wrapper = createWrapper();
+    expect(asVm<{ tarkovDevProfileUrl: string }>(wrapper.vm).tarkovDevProfileUrl).toBe(
+      'https://tarkov.dev/players/pve/123456'
+    );
+  });
   it('forwards EFT logs confirmation using current target mode', async () => {
     tarkovStoreState.currentMode = 'pve';
     const wrapper = createWrapper();

--- a/app/stores/__tests__/progressState.test.ts
+++ b/app/stores/__tests__/progressState.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
-import { actions, getters, type UserState } from '@/stores/progressState';
+import {
+  actions,
+  getters,
+  migrateToGameModeStructure,
+  type UserState,
+} from '@/stores/progressState';
 const createBaseState = (): UserState =>
   ({
     currentGameMode: 'pvp',
@@ -76,5 +81,33 @@ describe('progressState storyline timestamps', () => {
     } finally {
       nowSpy.mockRestore();
     }
+  });
+});
+describe('migrateToGameModeStructure', () => {
+  it('preserves linked uid while stripping legacy tarkov.dev payloads', () => {
+    const migrated = migrateToGameModeStructure({
+      currentGameMode: 'pvp',
+      gameEdition: 4,
+      tarkovUid: 67890,
+      pvp: {
+        level: 20,
+        pmcFaction: 'USEC',
+        tarkovDevProfile: {
+          aid: 12345,
+          importedAt: 111,
+        },
+      },
+      pve: {
+        level: 12,
+        pmcFaction: 'BEAR',
+        tarkovDevProfile: {
+          aid: 67890,
+          importedAt: 222,
+        },
+      },
+    });
+    expect(migrated.tarkovUid).toBe(67890);
+    expect(migrated.pvp).not.toHaveProperty('tarkovDevProfile');
+    expect(migrated.pve).not.toHaveProperty('tarkovDevProfile');
   });
 });

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -1390,6 +1390,40 @@ describe('useTarkov sync integration', () => {
     });
     expect(showApiUpdated).toHaveBeenCalledTimes(2);
   });
+  it('avoids overlapping deprecated remote cleanup writes during realtime sync', async () => {
+    single.mockResolvedValue({
+      data: createRemoteRow(),
+      error: null,
+    });
+    let pendingUpsertResolve: (value: { error: null }) => void = () => {};
+    const pendingUpsert = new Promise<{ error: null }>((resolve) => {
+      pendingUpsertResolve = resolve;
+    });
+    upsert.mockImplementationOnce(() => pendingUpsert);
+    await initializeTarkovSync();
+    const callback = getRealtimeCallback();
+    expect(callback).toBeTypeOf('function');
+    upsert.mockClear();
+    const payload = {
+      current_game_mode: 'pvp',
+      game_edition: 1,
+      tarkov_uid: null,
+      pvp_data: withLegacyTarkovDevProfile(progressWithLevel(2), 12345),
+      pve_data: progressWithLevel(1),
+      updated_at: '2000-01-01T00:00:00.000Z',
+    };
+    callback?.({
+      new: payload,
+      old: {},
+    });
+    callback?.({
+      new: payload,
+      old: {},
+    });
+    expect(upsert).toHaveBeenCalledTimes(1);
+    pendingUpsertResolve({ error: null });
+    await waitForBackgroundTasks();
+  });
   it('shows load_failed and aborts sync for multi-provider account with no progress row', async () => {
     supabaseContext.user.providers = ['discord', 'google'];
     single.mockResolvedValue({

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -1424,6 +1424,99 @@ describe('useTarkov sync integration', () => {
     pendingUpsertResolve({ error: null });
     await waitForBackgroundTasks();
   });
+  it('backs off deprecated remote cleanup retries after repeated failures and retries again later', async () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(new Date('2026-04-22T12:00:00.000Z'));
+      single.mockResolvedValue({
+        data: createRemoteRow(),
+        error: null,
+      });
+      await initializeTarkovSync();
+      const callback = getRealtimeCallback();
+      expect(callback).toBeTypeOf('function');
+      upsert.mockClear();
+      upsert
+        .mockResolvedValueOnce({ error: { message: 'cleanup failed 1' } })
+        .mockResolvedValueOnce({ error: { message: 'cleanup failed 2' } })
+        .mockResolvedValueOnce({ error: { message: 'cleanup failed 3' } })
+        .mockResolvedValueOnce({ error: null });
+      const payload = {
+        current_game_mode: 'pvp',
+        game_edition: 1,
+        tarkov_uid: null,
+        pvp_data: withLegacyTarkovDevProfile(progressWithLevel(2), 12345),
+        pve_data: progressWithLevel(1),
+        updated_at: '2000-01-01T00:00:00.000Z',
+      };
+      callback?.({ new: payload, old: {} });
+      await waitForBackgroundTasks();
+      expect(upsert).toHaveBeenCalledTimes(1);
+      vi.setSystemTime(Date.now() + 3000);
+      callback?.({ new: payload, old: {} });
+      await waitForBackgroundTasks();
+      expect(upsert).toHaveBeenCalledTimes(2);
+      vi.setSystemTime(Date.now() + 3000);
+      callback?.({ new: payload, old: {} });
+      await waitForBackgroundTasks();
+      expect(upsert).toHaveBeenCalledTimes(3);
+      vi.setSystemTime(Date.now() + 3000);
+      callback?.({ new: payload, old: {} });
+      await waitForBackgroundTasks();
+      expect(upsert).toHaveBeenCalledTimes(3);
+      vi.setSystemTime(Date.now() + 30000);
+      callback?.({ new: payload, old: {} });
+      await waitForBackgroundTasks();
+      expect(upsert).toHaveBeenCalledTimes(4);
+      expect(loggerMock.debug).toHaveBeenCalledWith(
+        '[TarkovStore] Cleaned deprecated remote progress payload'
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+  it('skips deprecated remote cleanup writes after session invalidation', async () => {
+    single.mockResolvedValue({
+      data: createRemoteRow(),
+      error: null,
+    });
+    await initializeTarkovSync();
+    const callback = getRealtimeCallback();
+    expect(callback).toBeTypeOf('function');
+    upsert.mockClear();
+    supabaseContext.user.loggedIn = false;
+    supabaseContext.user.id = null;
+    callback?.({
+      new: {
+        current_game_mode: 'pvp',
+        game_edition: 1,
+        tarkov_uid: null,
+        pvp_data: withLegacyTarkovDevProfile(progressWithLevel(2), 12345),
+        pve_data: progressWithLevel(1),
+        updated_at: '2000-01-01T00:00:00.000Z',
+      },
+      old: {},
+    });
+    await waitForBackgroundTasks();
+    expect(upsert).not.toHaveBeenCalled();
+  });
+  it('aborts initialization when post-load cleanup persistence fails', async () => {
+    single.mockResolvedValue({
+      data: createRemoteRow({
+        pvp_data: withLegacyTarkovDevProfile(progressWithLevel(7), 12345),
+      }),
+      error: null,
+    });
+    upsert.mockResolvedValueOnce({
+      error: { message: 'post-load cleanup failed' },
+    });
+    await expect(initializeTarkovSync()).rejects.toThrow('post-load cleanup failed');
+    expect(useSupabaseSyncMock).not.toHaveBeenCalled();
+    expect(loggerMock.error).toHaveBeenCalledWith(
+      '[TarkovStore] Failed to persist post-load data migration/repair:',
+      expect.objectContaining({ message: 'post-load cleanup failed' })
+    );
+  });
   it('shows load_failed and aborts sync for multi-provider account with no progress row', async () => {
     supabaseContext.user.providers = ['discord', 'google'];
     single.mockResolvedValue({

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -269,6 +269,14 @@ const progressWithItemCounts = (
 const cloneProgress = (value: UserProgressData): UserProgressData => {
   return JSON.parse(JSON.stringify(value)) as UserProgressData;
 };
+const withLegacyTarkovDevProfile = (value: UserProgressData, aid: number): UserProgressData => {
+  return Object.assign(cloneProgress(value), {
+    tarkovDevProfile: {
+      aid,
+      importedAt: 123,
+    },
+  }) as UserProgressData;
+};
 const waitForBackgroundTasks = async () => {
   await Promise.resolve();
   await Promise.resolve();
@@ -974,6 +982,50 @@ describe('useTarkov sync integration', () => {
     });
     await initializeTarkovSync();
     expect(upsert).not.toHaveBeenCalled();
+  });
+  it('rewrites sanitized progress locally and remotely when deprecated tarkov.dev payloads remain', async () => {
+    const legacyPersistedState = {
+      ...structuredClone(defaultState),
+      pvp: withLegacyTarkovDevProfile(progressWithLevel(1), 12345),
+      pve: withLegacyTarkovDevProfile(progressWithLevel(1), 67890),
+    };
+    localStorage.setItem(
+      STORAGE_KEYS.progress,
+      JSON.stringify({
+        _timestamp: Date.parse('2026-02-01T00:00:00.000Z'),
+        _userId: 'user-1',
+        data: legacyPersistedState,
+      })
+    );
+    single.mockResolvedValue({
+      data: createRemoteRow({
+        pvp_data: withLegacyTarkovDevProfile(progressWithLevel(7), 12345),
+        pve_data: withLegacyTarkovDevProfile(progressWithLevel(3), 67890),
+      }),
+      error: null,
+    });
+    const store = useTarkovStore();
+    await initializeTarkovSync();
+    const persistedSnapshot = JSON.parse(localStorage.getItem(STORAGE_KEYS.progress) || '{}') as {
+      data?: typeof defaultState;
+    };
+    expect(upsert).toHaveBeenCalled();
+    const lastUpsertCall = upsert.mock.calls.at(-1);
+    if (!lastUpsertCall) {
+      throw new Error('Expected an upsert payload');
+    }
+    const lastUpsertPayload = lastUpsertCall.at(0) as unknown as {
+      pve_data?: Record<string, unknown>;
+      pvp_data?: Record<string, unknown>;
+    };
+    expect(lastUpsertPayload.pvp_data).not.toHaveProperty('tarkovDevProfile');
+    expect(lastUpsertPayload.pve_data).not.toHaveProperty('tarkovDevProfile');
+    expect(persistedSnapshot.data?.pvp).not.toHaveProperty('tarkovDevProfile');
+    expect(persistedSnapshot.data?.pve).not.toHaveProperty('tarkovDevProfile');
+    expect(store.pvp).not.toHaveProperty('tarkovDevProfile');
+    expect(store.pve).not.toHaveProperty('tarkovDevProfile');
+    expect(store.pvp.level).toBe(7);
+    expect(store.pve.level).toBe(3);
   });
   it('aborts initialization when owned-local upsert fails', async () => {
     setLocalProgress(10);

--- a/app/stores/progressState.ts
+++ b/app/stores/progressState.ts
@@ -15,6 +15,7 @@
  * @module stores/userProgressState
  */
 import { GAME_MODES, type GameMode } from '@/utils/constants';
+import { sanitizeOwnedProgressData } from '@/utils/progressSanitizers';
 import {
   isTaskComplete as isTaskCompletionComplete,
   isTaskFailed as isTaskCompletionFailed,
@@ -65,21 +66,12 @@ export function migrateToGameModeStructure(legacyData: unknown): UserState {
     'pve' in legacyData
   ) {
     const data = legacyData as Record<string, unknown>;
-    // Ensure the structure is complete
-    const pvpData = {
-      ...defaultProgressData,
-      ...(data.pvp as Record<string, unknown>),
-    };
-    const pveData = {
-      ...defaultProgressData,
-      ...(data.pve as Record<string, unknown>),
-    };
     return {
       currentGameMode: (data.currentGameMode as GameMode) || GAME_MODES.PVP,
       gameEdition: (data.gameEdition as number) || defaultState.gameEdition,
       tarkovUid: (data.tarkovUid as number | null) ?? null,
-      pvp: pvpData,
-      pve: pveData,
+      pvp: sanitizeOwnedProgressData(data.pvp),
+      pve: sanitizeOwnedProgressData(data.pve),
     };
   }
   // Handle partial migration case - has currentGameMode but missing pvp/pve structure
@@ -90,56 +82,21 @@ export function migrateToGameModeStructure(legacyData: unknown): UserState {
     !('pvp' in legacyData && !('pve' in legacyData))
   ) {
     const data = legacyData as Record<string, unknown>;
-    // This is a partially migrated state, use the existing data as legacy format
-    const migratedProgressData: UserProgressData = {
-      level: (data.level as number) || defaultProgressData.level,
-      pmcFaction: (data.pmcFaction as 'USEC' | 'BEAR') || defaultProgressData.pmcFaction,
-      displayName: (data.displayName as string) || defaultProgressData.displayName,
-      xpOffset: (data.xpOffset as number) || defaultProgressData.xpOffset,
-      taskCompletions: (data.taskCompletions as UserProgressData['taskCompletions']) || {},
-      taskObjectives: (data.taskObjectives as UserProgressData['taskObjectives']) || {},
-      hideoutParts: (data.hideoutParts as UserProgressData['hideoutParts']) || {},
-      hideoutModules: (data.hideoutModules as UserProgressData['hideoutModules']) || {},
-      traders: (data.traders as UserProgressData['traders']) || {},
-      skills: (data.skills as UserProgressData['skills']) || {},
-      prestigeLevel: (data.prestigeLevel as number) || defaultProgressData.prestigeLevel,
-      progressEpoch: (data.progressEpoch as number) || defaultProgressData.progressEpoch,
-      skillOffsets: (data.skillOffsets as UserProgressData['skillOffsets']) || {},
-      storyChapters: (data.storyChapters as UserProgressData['storyChapters']) || {},
-      apiUpdateHistory: (data.apiUpdateHistory as UserProgressData['apiUpdateHistory']) || [],
-    };
     return {
       currentGameMode: data.currentGameMode as GameMode,
       gameEdition: (data.gameEdition as number) || defaultState.gameEdition,
       tarkovUid: (data.tarkovUid as number | null) ?? null,
-      pvp: migratedProgressData,
+      pvp: sanitizeOwnedProgressData(data),
       pve: structuredClone(defaultProgressData),
     };
   }
   // Create new structure with migrated data from legacy format
   const data = (legacyData as Record<string, unknown>) || {};
-  const migratedProgressData: UserProgressData = {
-    level: (data.level as number) || defaultProgressData.level,
-    pmcFaction: (data.pmcFaction as 'USEC' | 'BEAR') || defaultProgressData.pmcFaction,
-    displayName: (data.displayName as string) || defaultProgressData.displayName,
-    xpOffset: (data.xpOffset as number) || defaultProgressData.xpOffset,
-    taskCompletions: (data.taskCompletions as UserProgressData['taskCompletions']) || {},
-    taskObjectives: (data.taskObjectives as UserProgressData['taskObjectives']) || {},
-    hideoutParts: (data.hideoutParts as UserProgressData['hideoutParts']) || {},
-    hideoutModules: (data.hideoutModules as UserProgressData['hideoutModules']) || {},
-    traders: (data.traders as UserProgressData['traders']) || {},
-    skills: (data.skills as UserProgressData['skills']) || {},
-    prestigeLevel: (data.prestigeLevel as number) || defaultProgressData.prestigeLevel,
-    progressEpoch: (data.progressEpoch as number) || defaultProgressData.progressEpoch,
-    skillOffsets: (data.skillOffsets as UserProgressData['skillOffsets']) || {},
-    storyChapters: (data.storyChapters as UserProgressData['storyChapters']) || {},
-    apiUpdateHistory: (data.apiUpdateHistory as UserProgressData['apiUpdateHistory']) || [],
-  };
   return {
     currentGameMode: GAME_MODES.PVP, // Default to PvP for existing users
     gameEdition: (data.gameEdition as number) || defaultState.gameEdition,
-    tarkovUid: null,
-    pvp: migratedProgressData,
+    tarkovUid: (data.tarkovUid as number | null) ?? null,
+    pvp: sanitizeOwnedProgressData(data),
     pve: structuredClone(defaultProgressData),
   };
 }
@@ -221,7 +178,6 @@ export const getters = {
     getCurrentData(state)?.skillOffsets?.[skillName] ?? 0,
   getAllSkillOffsets: (state: UserState) => () => getCurrentData(state)?.skillOffsets ?? {},
   getTarkovUid: (state: UserState) => () => state.tarkovUid ?? null,
-  getTarkovDevProfile: (state: UserState) => () => getCurrentData(state)?.tarkovDevProfile ?? null,
   isStoryChapterComplete: (state: UserState) => (chapterId: string) =>
     getCurrentData(state)?.storyChapters?.[chapterId]?.complete ?? false,
   isStoryObjectiveComplete: (state: UserState) => (chapterId: string, objectiveId: string) =>
@@ -421,10 +377,6 @@ export const actions = {
   },
   setTarkovUid(this: UserState, uid: number | null) {
     this.tarkovUid = uid;
-  },
-  setTarkovDevProfile(this: UserState, profile: UserProgressData['tarkovDevProfile']) {
-    const currentData = getCurrentData(this);
-    currentData.tarkovDevProfile = profile;
   },
   setStoryChapterComplete(this: UserState, chapterId: string) {
     updateObjective(this, 'storyChapters', chapterId, {

--- a/app/stores/tarkov/localStorage.ts
+++ b/app/stores/tarkov/localStorage.ts
@@ -1,8 +1,9 @@
+import { migrateToGameModeStructure, type UserState } from '@/stores/progressState';
 import { clearProgressStorage } from '@/utils/clientStorage';
 import { logger } from '@/utils/logger';
+import { sanitizeOwnedUserState } from '@/utils/progressSanitizers';
 import { LEGACY_STORAGE_KEYS, STORAGE_KEYS } from '@/utils/storageKeys';
 import { parseUserScopedStorage } from '@/utils/userScopedStorage';
-import type { UserState } from '@/stores/progressState';
 export type PersistedProgressSnapshot = {
   state: UserState;
   storedUserId: string | null;
@@ -78,14 +79,14 @@ export const parsePersistedProgressState = (
       return null;
     }
     return {
-      state: wrapped.data,
+      state: sanitizeOwnedUserState(migrateToGameModeStructure(wrapped.data)),
       storedUserId: wrapped._userId,
       timestamp: wrapped._timestamp ?? null,
     };
   }
   try {
     return {
-      state: JSON.parse(rawValue) as UserState,
+      state: sanitizeOwnedUserState(migrateToGameModeStructure(JSON.parse(rawValue) as UserState)),
       storedUserId: null,
       timestamp: null,
     };
@@ -112,11 +113,12 @@ export const patchStoreState = (
   store: { $patch: (fn: (state: UserState) => void) => void },
   snapshot: UserState
 ) => {
+  const sanitizedSnapshot = sanitizeOwnedUserState(snapshot);
   store.$patch((state) => {
-    state.currentGameMode = snapshot.currentGameMode;
-    state.gameEdition = snapshot.gameEdition;
-    state.tarkovUid = snapshot.tarkovUid;
-    state.pvp = snapshot.pvp;
-    state.pve = snapshot.pve;
+    state.currentGameMode = sanitizedSnapshot.currentGameMode;
+    state.gameEdition = sanitizedSnapshot.gameEdition;
+    state.tarkovUid = sanitizedSnapshot.tarkovUid;
+    state.pvp = sanitizedSnapshot.pvp;
+    state.pve = sanitizedSnapshot.pve;
   });
 };

--- a/app/stores/tarkov/localStorage.ts
+++ b/app/stores/tarkov/localStorage.ts
@@ -1,10 +1,14 @@
 import { migrateToGameModeStructure, type UserState } from '@/stores/progressState';
 import { clearProgressStorage } from '@/utils/clientStorage';
 import { logger } from '@/utils/logger';
-import { sanitizeOwnedUserState } from '@/utils/progressSanitizers';
+import {
+  hasDeprecatedTarkovDevProfileData,
+  sanitizeOwnedUserState,
+} from '@/utils/progressSanitizers';
 import { LEGACY_STORAGE_KEYS, STORAGE_KEYS } from '@/utils/storageKeys';
 import { parseUserScopedStorage } from '@/utils/userScopedStorage';
 export type PersistedProgressSnapshot = {
+  hadDeprecatedProgressData: boolean;
   state: UserState;
   storedUserId: string | null;
   timestamp: number | null;
@@ -75,18 +79,22 @@ export const parsePersistedProgressState = (
   }
   const wrapped = parseUserScopedStorage<UserState>(rawValue);
   if (wrapped) {
+    const hadDeprecatedProgressData = hasDeprecatedTarkovDevProfileData(wrapped.data);
     if (wrapped._userId !== userId) {
       return null;
     }
     return {
+      hadDeprecatedProgressData,
       state: sanitizeOwnedUserState(migrateToGameModeStructure(wrapped.data)),
       storedUserId: wrapped._userId,
       timestamp: wrapped._timestamp ?? null,
     };
   }
   try {
+    const parsed = JSON.parse(rawValue) as UserState;
     return {
-      state: sanitizeOwnedUserState(migrateToGameModeStructure(JSON.parse(rawValue) as UserState)),
+      hadDeprecatedProgressData: hasDeprecatedTarkovDevProfileData(parsed),
+      state: sanitizeOwnedUserState(migrateToGameModeStructure(parsed)),
       storedUserId: null,
       timestamp: null,
     };

--- a/app/stores/tarkov/progressMerge.ts
+++ b/app/stores/tarkov/progressMerge.ts
@@ -6,6 +6,7 @@ import {
   type UserState,
 } from '@/stores/progressState';
 import { GAME_MODES, type GameMode } from '@/utils/constants';
+import { sanitizeOwnedProgressData } from '@/utils/progressSanitizers';
 import type { RawTaskCompletion } from '@/utils/taskStatus';
 const API_UPDATE_HISTORY_LIMIT = 50;
 type CountableEntry = { count?: number; complete?: boolean; timestamp?: number };
@@ -37,8 +38,8 @@ export const buildUpsertPayload = (
   current_game_mode: state.currentGameMode || GAME_MODES.PVP,
   game_edition: state.gameEdition || defaultState.gameEdition,
   tarkov_uid: state.tarkovUid ?? null,
-  pvp_data: partial?.pvp_data ?? state.pvp ?? defaultState.pvp,
-  pve_data: partial?.pve_data ?? state.pve ?? defaultState.pve,
+  pvp_data: sanitizeOwnedProgressData(partial?.pvp_data ?? state.pvp ?? defaultState.pvp),
+  pve_data: sanitizeOwnedProgressData(partial?.pve_data ?? state.pve ?? defaultState.pve),
 });
 export const toProgressEpoch = (modeData: UserProgressData | undefined): number => {
   if (
@@ -279,18 +280,6 @@ export function mergeProgressData(
     if (!normalizedRemote) return normalizedLocal;
     return normalizedRemote.at >= normalizedLocal.at ? normalizedRemote : normalizedLocal;
   };
-  const resolveTarkovDevProfile = (
-    localProfile?: UserProgressData['tarkovDevProfile'],
-    remoteProfile?: UserProgressData['tarkovDevProfile']
-  ): UserProgressData['tarkovDevProfile'] => {
-    if (!localProfile) return remoteProfile;
-    if (!remoteProfile) return localProfile;
-    const localImportedAt =
-      typeof localProfile.importedAt === 'number' ? localProfile.importedAt : 0;
-    const remoteImportedAt =
-      typeof remoteProfile.importedAt === 'number' ? remoteProfile.importedAt : 0;
-    return remoteImportedAt >= localImportedAt ? remoteProfile : localProfile;
-  };
   const mergedState: UserProgressData = {
     ...local,
     ...remote,
@@ -302,7 +291,6 @@ export function mergeProgressData(
     xpOffset: remote.xpOffset !== undefined ? remote.xpOffset : local.xpOffset,
     lastApiUpdate: resolveApiUpdate(local.lastApiUpdate, remote.lastApiUpdate),
     apiUpdateHistory: mergeApiUpdateHistory(local, remote),
-    tarkovDevProfile: resolveTarkovDevProfile(local.tarkovDevProfile, remote.tarkovDevProfile),
     taskCompletions: (() => {
       const allKeys = new Set([
         ...Object.keys(local.taskCompletions || {}),

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -1172,6 +1172,8 @@ export function resetTarkovSync(
   syncUserId = null;
   shownLocalIgnoreReasons.clear();
   lastLocalSyncTime = 0;
+  deprecatedRemoteCleanupInFlight = false;
+  lastDeprecatedRemoteCleanupAttemptAt = 0;
   recentLocalSyncTimes.length = 0;
   lastApiUpdateIds.pvp = null;
   lastApiUpdateIds.pve = null;
@@ -1629,6 +1631,8 @@ export async function initializeTarkovSync() {
 // Realtime channel for multi-device sync
 let realtimeChannel: unknown = null;
 let lastLocalSyncTime = 0; // Track when we last synced locally to filter self-origin updates
+let deprecatedRemoteCleanupInFlight = false;
+let lastDeprecatedRemoteCleanupAttemptAt = 0;
 const recentLocalSyncTimes: number[] = [];
 const recordLocalSyncTime = () => {
   const now = Date.now();
@@ -1863,15 +1867,33 @@ function setupRealtimeListener() {
           pve: merged.pve ?? localState.pve,
         };
         const cleanupDeprecatedRemoteProgress = async () => {
+          if (deprecatedRemoteCleanupInFlight) {
+            return;
+          }
+          const now = Date.now();
+          if (
+            lastDeprecatedRemoteCleanupAttemptAt > 0 &&
+            now - lastDeprecatedRemoteCleanupAttemptAt < SELF_ORIGIN_THRESHOLD_MS
+          ) {
+            return;
+          }
+          deprecatedRemoteCleanupInFlight = true;
+          lastDeprecatedRemoteCleanupAttemptAt = now;
           recordLocalSyncTime();
-          const { error } = await $supabase.client
-            .from('user_progress')
-            .upsert(buildUpsertPayload(currentUserId, nextState));
-          if (error) {
-            logger.error(
-              '[TarkovStore] Failed to clean deprecated remote progress payload:',
-              error
-            );
+          try {
+            const { error } = await $supabase.client
+              .from('user_progress')
+              .upsert(buildUpsertPayload(currentUserId, nextState));
+            if (error) {
+              logger.error(
+                '[TarkovStore] Failed to clean deprecated remote progress payload:',
+                error
+              );
+              return;
+            }
+            lastDeprecatedRemoteCleanupAttemptAt = 0;
+          } finally {
+            deprecatedRemoteCleanupInFlight = false;
           }
         };
         const stateUnchanged = deepEqual(nextState, localState);

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -58,7 +58,11 @@ import { useMetadataStore } from '@/stores/useMetadata';
 import { delay } from '@/utils/async';
 import { GAME_MODES, MANUAL_FAIL_TASK_IDS, type GameMode } from '@/utils/constants';
 import { logger } from '@/utils/logger';
-import { sanitizeOwnedProgressData, sanitizeOwnedUserState } from '@/utils/progressSanitizers';
+import {
+  hasDeprecatedTarkovDevProfileData,
+  sanitizeOwnedProgressData,
+  sanitizeOwnedUserState,
+} from '@/utils/progressSanitizers';
 import { STORAGE_KEYS } from '@/utils/storageKeys';
 import { getCompletionFlags, type RawTaskCompletion } from '@/utils/taskStatus';
 import {
@@ -308,16 +312,10 @@ const tarkovActions = {
     const { $supabase } = useNuxtApp();
     if ($supabase.user.loggedIn && $supabase.user.id) {
       try {
-        const completeState = {
-          user_id: $supabase.user.id,
-          current_game_mode: mode,
-          game_edition: this.gameEdition,
-          tarkov_uid: this.tarkovUid ?? null,
-          pvp_data: this.pvp,
-          pve_data: this.pve,
-        };
         recordLocalSyncTime(); // Track for self-origin filtering
-        await $supabase.client.from('user_progress').upsert(completeState);
+        await $supabase.client
+          .from('user_progress')
+          .upsert(buildUpsertPayload($supabase.user.id, this.$state));
       } catch (error) {
         logger.error('Error syncing gamemode to backend:', error);
       }
@@ -341,14 +339,9 @@ const tarkovActions = {
       if ($supabase.user.loggedIn && $supabase.user.id) {
         try {
           recordLocalSyncTime(); // Track for self-origin filtering
-          await $supabase.client.from('user_progress').upsert({
-            user_id: $supabase.user.id,
-            current_game_mode: this.currentGameMode,
-            game_edition: this.gameEdition,
-            tarkov_uid: this.tarkovUid ?? null,
-            pvp_data: this.pvp,
-            pve_data: this.pve,
-          });
+          await $supabase.client
+            .from('user_progress')
+            .upsert(buildUpsertPayload($supabase.user.id, this.$state));
         } catch (error) {
           logger.error('Error saving migrated data to Supabase:', error);
         }
@@ -358,14 +351,9 @@ const tarkovActions = {
       if ($supabase.user.loggedIn && $supabase.user.id) {
         try {
           recordLocalSyncTime();
-          await $supabase.client.from('user_progress').upsert({
-            user_id: $supabase.user.id,
-            current_game_mode: this.currentGameMode,
-            game_edition: this.gameEdition,
-            tarkov_uid: this.tarkovUid ?? null,
-            pvp_data: this.pvp,
-            pve_data: this.pve,
-          });
+          await $supabase.client
+            .from('user_progress')
+            .upsert(buildUpsertPayload($supabase.user.id, this.$state));
         } catch (error) {
           logger.error('Error saving task completion migration to Supabase:', error);
         }
@@ -986,8 +974,9 @@ export const useTarkovStore = defineStore('swapTarkov', {
       serialize: (state: StateTree) => {
         const now = Date.now();
         const currentUserId = getCurrentSupabaseUserId();
+        const sanitizedState = sanitizeOwnedUserState(state as UserState);
         const serialized = serializeUserScopedStorage(
-          cloneStateSnapshot(state as UserState),
+          cloneStateSnapshot(sanitizedState),
           currentUserId,
           now
         );
@@ -1065,11 +1054,13 @@ export const useTarkovStore = defineStore('swapTarkov', {
                 currentUserId,
               });
             }
-            return JSON.parse(value) as UserState;
+            return sanitizeOwnedUserState(
+              migrateToGameModeStructure(JSON.parse(value) as UserState)
+            );
           }
           const storedUserId = wrapped._userId;
           if (storedUserId === currentUserId) {
-            return wrapped.data;
+            return sanitizeOwnedUserState(migrateToGameModeStructure(wrapped.data));
           }
           if (storedUserId && currentUserId && storedUserId !== currentUserId) {
             logger.warn(
@@ -1271,10 +1262,15 @@ export async function initializeTarkovSync() {
       timestamp: number | null = null
     ) => {
       if (typeof window === 'undefined') return;
+      const sanitizedState = sanitizeOwnedUserState(state);
       if (
         !safeSetItem(
           STORAGE_KEYS.progress,
-          serializeUserScopedStorage(cloneStateSnapshot(state), userId, timestamp ?? Date.now())
+          serializeUserScopedStorage(
+            cloneStateSnapshot(sanitizedState),
+            userId,
+            timestamp ?? Date.now()
+          )
         )
       ) {
         logger.warn('[TarkovStore] Could not persist local ownership metadata');
@@ -1290,12 +1286,18 @@ export async function initializeTarkovSync() {
         state.pve = freshState.pve;
       });
     };
-    const loadData = async (): Promise<{ ok: boolean; hadRemoteData: boolean }> => {
+    const loadData = async (): Promise<{
+      hadRemoteData: boolean;
+      needsRemoteCleanup: boolean;
+      ok: boolean;
+    }> => {
       const localMeta = getLocalStorageMeta();
       const storedUserId = localMeta?.storedUserId ?? null;
       const localTimestamp = localMeta?.timestamp ?? null;
       const hasLocalPersistence = Boolean(localMeta);
       let resolvedLocalState: UserState | null = null;
+      let shouldPersistSanitizedLocalState = hasDeprecatedTarkovDevProfileData(tarkovStore.$state);
+      let needsRemoteCleanup = false;
       if (storedUserId && storedUserId !== currentUserId) {
         logger.warn('[TarkovStore] Local progress belongs to a different user; clearing');
         clearActiveProgressStorage();
@@ -1309,6 +1311,7 @@ export async function initializeTarkovSync() {
         patchStoreState(tarkovStore, localState);
       }
       if (preservedLocalSnapshot) {
+        shouldPersistSanitizedLocalState ||= preservedLocalSnapshot.hadDeprecatedProgressData;
         localState = sanitizeOwnedUserState(preservedLocalSnapshot.state);
         hasLocalProgress = hasProgress(localState);
         if (!deepEqual(localState, tarkovStore.$state)) {
@@ -1319,6 +1322,7 @@ export async function initializeTarkovSync() {
           readPersistedProgressState(currentUserId) ??
           (storedUserId !== currentUserId ? readPersistedProgressState(storedUserId) : null);
         if (persistedLocalState) {
+          shouldPersistSanitizedLocalState ||= persistedLocalState.hadDeprecatedProgressData;
           localState = persistedLocalState.state;
           hasLocalProgress = hasProgress(localState);
           if (hasLocalProgress) {
@@ -1381,7 +1385,7 @@ export async function initializeTarkovSync() {
       // Handle query errors (but not "no rows" which is expected for new users)
       if (error && error.code !== 'PGRST116') {
         logger.error('[TarkovStore] Error loading data from Supabase:', error);
-        return { ok: false, hadRemoteData };
+        return { hadRemoteData, needsRemoteCleanup, ok: false };
       }
       // Normalize Supabase data with defaults for safety
       const normalizedRemote = data
@@ -1398,6 +1402,10 @@ export async function initializeTarkovSync() {
       if (data) {
         const remoteUpdatedAt = data.updated_at ? Date.parse(data.updated_at) : null;
         const localOwnedByUser = storedUserId === currentUserId;
+        const remoteHadDeprecatedProgressData = hasDeprecatedTarkovDevProfileData({
+          pvp: data.pvp_data,
+          pve: data.pve_data,
+        });
         if (hasLocalProgress && !localOwnedByUser && storedUserId === null) {
           notifyLocalIgnored('guest');
         }
@@ -1426,22 +1434,24 @@ export async function initializeTarkovSync() {
               .upsert(buildUpsertPayload(currentUserId, resolvedState));
             if (upsertError) {
               logger.error('[TarkovStore] Error syncing merged progress to Supabase:', upsertError);
-              return { ok: false, hadRemoteData };
+              return { hadRemoteData, needsRemoteCleanup, ok: false };
             }
           } else {
             logger.debug('[TarkovStore] Startup sync resolved to existing remote state');
+            needsRemoteCleanup = remoteHadDeprecatedProgressData;
           }
           if (!deepEqual(resolvedState, localState)) {
             tarkovStore.$patch((state) => {
               state.currentGameMode = resolvedState.currentGameMode;
               state.gameEdition = resolvedState.gameEdition;
               state.tarkovUid = resolvedState.tarkovUid;
-              state.pvp = { ...state.pvp, ...resolvedState.pvp };
-              state.pve = { ...state.pve, ...resolvedState.pve };
+              state.pvp = resolvedState.pvp;
+              state.pve = resolvedState.pve;
             });
           }
           resolvedLocalState = resolvedState;
         } else {
+          needsRemoteCleanup = remoteHadDeprecatedProgressData;
           logger.debug('[TarkovStore] Loading data from Supabase (user exists in DB)');
           tarkovStore.$patch((state) => {
             state.currentGameMode = normalizedRemote?.currentGameMode ?? state.currentGameMode;
@@ -1452,33 +1462,21 @@ export async function initializeTarkovSync() {
             ) {
               state.tarkovUid = normalizedRemote.tarkovUid;
             }
-            state.pvp = normalizedRemote?.pvp
-              ? { ...state.pvp, ...normalizedRemote.pvp }
-              : state.pvp;
-            state.pve = normalizedRemote?.pve
-              ? { ...state.pve, ...normalizedRemote.pve }
-              : state.pve;
+            state.pvp = normalizedRemote?.pvp ?? state.pvp;
+            state.pve = normalizedRemote?.pve ?? state.pve;
           });
           resolvedLocalState = normalizedRemote!;
         }
       } else if (hasLocalProgress && hasLocalPersistence) {
         // No Supabase record at all, but localStorage has progress - migrate it
         logger.debug('[TarkovStore] Migrating localStorage data to Supabase');
-        const migrateData = {
-          user_id: $supabase.user.id,
-          current_game_mode: localState.currentGameMode || GAME_MODES.PVP,
-          game_edition: localState.gameEdition || defaultState.gameEdition,
-          tarkov_uid: localState.tarkovUid ?? null,
-          pvp_data: localState.pvp || defaultState.pvp,
-          pve_data: localState.pve || defaultState.pve,
-        };
         recordLocalSyncTime(); // Track for self-origin filtering
         const { error: upsertError } = await $supabase.client
           .from('user_progress')
-          .upsert(migrateData);
+          .upsert(buildUpsertPayload(currentUserId, localState));
         if (upsertError) {
           logger.error('[TarkovStore] Error migrating local data to Supabase:', upsertError);
-          return { ok: false, hadRemoteData };
+          return { hadRemoteData, needsRemoteCleanup, ok: false };
         }
         logger.debug('[TarkovStore] Migration complete');
         resolvedLocalState = localState;
@@ -1511,7 +1509,7 @@ export async function initializeTarkovSync() {
           resetStoreToDefault();
           // Notify user of the issue
           toastI18n.showLoadFailed();
-          return { ok: false, hadRemoteData: false };
+          return { hadRemoteData: false, needsRemoteCleanup, ok: false };
         }
         // All safety checks passed - truly new user (or old account, first login)
         logger.debug('[TarkovStore] New user - no existing progress found', {
@@ -1519,11 +1517,15 @@ export async function initializeTarkovSync() {
           linkedProviders,
         });
       }
-      if (currentUserId && storedUserId === null && hasLocalPersistence && resolvedLocalState) {
-        persistLocalOwnership(currentUserId, resolvedLocalState, localTimestamp);
+      if (
+        currentUserId &&
+        hasLocalPersistence &&
+        (shouldPersistSanitizedLocalState || (storedUserId === null && resolvedLocalState))
+      ) {
+        persistLocalOwnership(currentUserId, resolvedLocalState ?? localState, localTimestamp);
       }
       logger.debug('[TarkovStore] Initial load complete');
-      return { ok: true, hadRemoteData };
+      return { hadRemoteData, needsRemoteCleanup, ok: true };
     };
     // Wait for data load to complete BEFORE enabling sync
     // This prevents race conditions and overwriting server data with empty local state
@@ -1548,17 +1550,12 @@ export async function initializeTarkovSync() {
       failedRepairResult.pveRepaired > 0 ||
       completedObjectivesRepairResult.pvpRepaired > 0 ||
       completedObjectivesRepairResult.pveRepaired > 0;
-    if (hasCompletionSchemaMigration || hasRepairChanges) {
+    if (hasCompletionSchemaMigration || hasRepairChanges || loadResult.needsRemoteCleanup) {
       try {
         recordLocalSyncTime();
-        await $supabase.client.from('user_progress').upsert({
-          user_id: $supabase.user.id,
-          current_game_mode: tarkovStore.currentGameMode,
-          game_edition: tarkovStore.gameEdition,
-          tarkov_uid: tarkovStore.tarkovUid ?? null,
-          pvp_data: tarkovStore.pvp,
-          pve_data: tarkovStore.pve,
-        });
+        await $supabase.client
+          .from('user_progress')
+          .upsert(buildUpsertPayload(currentUserId, tarkovStore.$state));
       } catch (error) {
         logger.error('[TarkovStore] Failed to persist post-load data migration/repair:', error);
       }
@@ -1809,7 +1806,8 @@ function setupRealtimeListener() {
   const tarkovStore = useTarkovStore();
   const metadataStore = useMetadataStore();
   const toastI18n = useToastI18n();
-  if (!$supabase.user.loggedIn || !$supabase.user.id) return;
+  const currentUserId = $supabase.user.id;
+  if (!$supabase.user.loggedIn || !currentUserId) return;
   // Clean up existing channel if any
   if (realtimeChannel) {
     $supabase.client.removeChannel(
@@ -1819,14 +1817,14 @@ function setupRealtimeListener() {
   }
   logger.debug('[TarkovStore] Setting up realtime listener for multi-device sync');
   realtimeChannel = $supabase.client
-    .channel(`user_progress_${$supabase.user.id}`)
+    .channel(`user_progress_${currentUserId}`)
     .on(
       'postgres_changes' as const,
       {
         event: 'UPDATE',
         schema: 'public',
         table: 'user_progress',
-        filter: `user_id=eq.${$supabase.user.id}`,
+        filter: `user_id=eq.${currentUserId}`,
       },
       (payload: { new: unknown; old: unknown }) => {
         const remoteData = payload.new as {
@@ -1840,6 +1838,10 @@ function setupRealtimeListener() {
         const parsedUpdateTime = remoteData.updated_at ? Date.parse(remoteData.updated_at) : NaN;
         const updateTime = Number.isNaN(parsedUpdateTime) ? Date.now() : parsedUpdateTime;
         const timeSinceLastSync = updateTime - lastLocalSyncTime;
+        const remoteHadDeprecatedProgressData = hasDeprecatedTarkovDevProfileData({
+          pvp: remoteData.pvp_data,
+          pve: remoteData.pve_data,
+        });
         // Get current local state
         const localState = sanitizeOwnedUserState(tarkovStore.$state);
         // Merge remote changes with local state
@@ -1860,8 +1862,23 @@ function setupRealtimeListener() {
           pvp: merged.pvp ?? localState.pvp,
           pve: merged.pve ?? localState.pve,
         };
+        const cleanupDeprecatedRemoteProgress = async () => {
+          recordLocalSyncTime();
+          const { error } = await $supabase.client
+            .from('user_progress')
+            .upsert(buildUpsertPayload(currentUserId, nextState));
+          if (error) {
+            logger.error(
+              '[TarkovStore] Failed to clean deprecated remote progress payload:',
+              error
+            );
+          }
+        };
         const stateUnchanged = deepEqual(nextState, localState);
         const isLikelySelfOrigin = isLikelySelfOriginUpdate(updateTime);
+        if (remoteHadDeprecatedProgressData) {
+          void cleanupDeprecatedRemoteProgress();
+        }
         if (isLikelySelfOrigin && stateUnchanged) {
           logger.debug('[TarkovStore] Ignoring realtime update - likely self-origin', {
             timeSinceLastSync,
@@ -1899,8 +1916,8 @@ function setupRealtimeListener() {
           state.currentGameMode = nextState.currentGameMode;
           state.gameEdition = nextState.gameEdition;
           state.tarkovUid = nextState.tarkovUid;
-          state.pvp = { ...state.pvp, ...nextState.pvp };
-          state.pve = { ...state.pve, ...nextState.pve };
+          state.pvp = nextState.pvp;
+          state.pve = nextState.pve;
         });
         setTimeout(() => {
           const currentController = getSyncController();

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -58,6 +58,7 @@ import { useMetadataStore } from '@/stores/useMetadata';
 import { delay } from '@/utils/async';
 import { GAME_MODES, MANUAL_FAIL_TASK_IDS, type GameMode } from '@/utils/constants';
 import { logger } from '@/utils/logger';
+import { sanitizeOwnedProgressData, sanitizeOwnedUserState } from '@/utils/progressSanitizers';
 import { STORAGE_KEYS } from '@/utils/storageKeys';
 import { getCompletionFlags, type RawTaskCompletion } from '@/utils/taskStatus';
 import {
@@ -1302,10 +1303,13 @@ export async function initializeTarkovSync() {
         notifyLocalIgnored('other_account');
       }
       // Get current localStorage state (loaded by persist plugin)
-      let localState = tarkovStore.$state;
+      let localState = sanitizeOwnedUserState(tarkovStore.$state);
       let hasLocalProgress = hasProgress(localState);
+      if (!deepEqual(localState, tarkovStore.$state)) {
+        patchStoreState(tarkovStore, localState);
+      }
       if (preservedLocalSnapshot) {
-        localState = preservedLocalSnapshot.state;
+        localState = sanitizeOwnedUserState(preservedLocalSnapshot.state);
         hasLocalProgress = hasProgress(localState);
         if (!deepEqual(localState, tarkovStore.$state)) {
           patchStoreState(tarkovStore, localState);
@@ -1381,13 +1385,13 @@ export async function initializeTarkovSync() {
       }
       // Normalize Supabase data with defaults for safety
       const normalizedRemote = data
-        ? ({
+        ? sanitizeOwnedUserState({
             currentGameMode: coerceGameMode(data.current_game_mode),
             gameEdition: data.game_edition || defaultState.gameEdition,
             tarkovUid: data.tarkov_uid ?? null,
-            pvp: { ...defaultState.pvp, ...(data.pvp_data || {}) },
-            pve: { ...defaultState.pve, ...(data.pve_data || {}) },
-          } as UserState)
+            pvp: data.pvp_data,
+            pve: data.pve_data,
+          })
         : null;
       const remoteScore = normalizedRemote ? progressScore(normalizedRemote) : 0;
       const localScore = progressScore(localState);
@@ -1589,16 +1593,17 @@ export async function initializeTarkovSync() {
           }
           // Track sync time for self-origin filtering in realtime listener
           recordLocalSyncTime();
+          const sanitizedUserState = sanitizeOwnedUserState(userState);
           return {
             user_id: $supabase.user.id,
-            current_game_mode: userState.currentGameMode || GAME_MODES.PVP,
+            current_game_mode: sanitizedUserState.currentGameMode || GAME_MODES.PVP,
             game_edition:
-              typeof userState.gameEdition === 'string'
-                ? parseInt(userState.gameEdition)
-                : userState.gameEdition,
-            tarkov_uid: userState.tarkovUid ?? null,
-            pvp_data: userState.pvp || {},
-            pve_data: userState.pve || {},
+              typeof sanitizedUserState.gameEdition === 'string'
+                ? parseInt(sanitizedUserState.gameEdition)
+                : sanitizedUserState.gameEdition,
+            tarkov_uid: sanitizedUserState.tarkovUid ?? null,
+            pvp_data: sanitizedUserState.pvp,
+            pve_data: sanitizedUserState.pve,
           };
         },
       });
@@ -1836,15 +1841,15 @@ function setupRealtimeListener() {
         const updateTime = Number.isNaN(parsedUpdateTime) ? Date.now() : parsedUpdateTime;
         const timeSinceLastSync = updateTime - lastLocalSyncTime;
         // Get current local state
-        const localState = tarkovStore.$state;
+        const localState = sanitizeOwnedUserState(tarkovStore.$state);
         // Merge remote changes with local state
         const merged: Partial<UserState> = {
           currentGameMode: remoteData.current_game_mode
             ? coerceGameMode(remoteData.current_game_mode)
             : localState.currentGameMode,
           gameEdition: remoteData.game_edition || localState.gameEdition,
-          pvp: mergeProgressData(localState.pvp, remoteData.pvp_data),
-          pve: mergeProgressData(localState.pve, remoteData.pve_data),
+          pvp: mergeProgressData(localState.pvp, sanitizeOwnedProgressData(remoteData.pvp_data)),
+          pve: mergeProgressData(localState.pve, sanitizeOwnedProgressData(remoteData.pve_data)),
         };
         const nextState: UserState = {
           currentGameMode: merged.currentGameMode ?? localState.currentGameMode,

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -80,6 +80,8 @@ const QUOTA_SAFETY_BUFFER_BYTES = 512 * 1024;
 const SYNC_DEBOUNCE_MS = 5000;
 const SELF_ORIGIN_THRESHOLD_MS = 3000;
 const RECENT_LOCAL_SYNC_HISTORY_SIZE = 20;
+const DEPRECATED_REMOTE_CLEANUP_FAST_RETRY_LIMIT = 3;
+const DEPRECATED_REMOTE_CLEANUP_FAILURE_BACKOFF_MS = 30000;
 const SYNC_RESUME_DELAY_MS = 1000;
 const RESET_SETTLE_DELAY_MS = 100;
 const API_UPDATE_FRESHNESS_MS = 30000;
@@ -1174,6 +1176,7 @@ export function resetTarkovSync(
   lastLocalSyncTime = 0;
   deprecatedRemoteCleanupInFlight = false;
   lastDeprecatedRemoteCleanupAttemptAt = 0;
+  deprecatedRemoteCleanupFailureCount = 0;
   recentLocalSyncTimes.length = 0;
   lastApiUpdateIds.pvp = null;
   lastApiUpdateIds.pve = null;
@@ -1438,6 +1441,7 @@ export async function initializeTarkovSync() {
               logger.error('[TarkovStore] Error syncing merged progress to Supabase:', upsertError);
               return { hadRemoteData, needsRemoteCleanup, ok: false };
             }
+            needsRemoteCleanup = false;
           } else {
             logger.debug('[TarkovStore] Startup sync resolved to existing remote state');
             needsRemoteCleanup = remoteHadDeprecatedProgressData;
@@ -1555,11 +1559,15 @@ export async function initializeTarkovSync() {
     if (hasCompletionSchemaMigration || hasRepairChanges || loadResult.needsRemoteCleanup) {
       try {
         recordLocalSyncTime();
-        await $supabase.client
+        const { error: upsertError } = await $supabase.client
           .from('user_progress')
           .upsert(buildUpsertPayload(currentUserId, tarkovStore.$state));
+        if (upsertError) {
+          throw upsertError;
+        }
       } catch (error) {
         logger.error('[TarkovStore] Failed to persist post-load data migration/repair:', error);
+        throw error;
       }
     }
     const startSync = () => {
@@ -1633,6 +1641,7 @@ let realtimeChannel: unknown = null;
 let lastLocalSyncTime = 0; // Track when we last synced locally to filter self-origin updates
 let deprecatedRemoteCleanupInFlight = false;
 let lastDeprecatedRemoteCleanupAttemptAt = 0;
+let deprecatedRemoteCleanupFailureCount = 0;
 const recentLocalSyncTimes: number[] = [];
 const recordLocalSyncTime = () => {
   const now = Date.now();
@@ -1648,6 +1657,10 @@ const isLikelySelfOriginUpdate = (updateTime: number) => {
     return Math.abs(updateTime - syncTime) < SELF_ORIGIN_THRESHOLD_MS;
   });
 };
+const getDeprecatedRemoteCleanupCooldownMs = () =>
+  deprecatedRemoteCleanupFailureCount >= DEPRECATED_REMOTE_CLEANUP_FAST_RETRY_LIMIT
+    ? DEPRECATED_REMOTE_CLEANUP_FAILURE_BACKOFF_MS
+    : SELF_ORIGIN_THRESHOLD_MS;
 const lastApiUpdateIds: { pvp: string | null; pve: string | null } = { pvp: null, pve: null };
 const getToastTranslator = (): ToastTranslate => {
   try {
@@ -1870,10 +1883,14 @@ function setupRealtimeListener() {
           if (deprecatedRemoteCleanupInFlight) {
             return;
           }
+          if (!$supabase.user.loggedIn || $supabase.user.id !== currentUserId) {
+            return;
+          }
           const now = Date.now();
+          const cleanupCooldownMs = getDeprecatedRemoteCleanupCooldownMs();
           if (
             lastDeprecatedRemoteCleanupAttemptAt > 0 &&
-            now - lastDeprecatedRemoteCleanupAttemptAt < SELF_ORIGIN_THRESHOLD_MS
+            now - lastDeprecatedRemoteCleanupAttemptAt < cleanupCooldownMs
           ) {
             return;
           }
@@ -1885,13 +1902,20 @@ function setupRealtimeListener() {
               .from('user_progress')
               .upsert(buildUpsertPayload(currentUserId, nextState));
             if (error) {
+              deprecatedRemoteCleanupFailureCount += 1;
               logger.error(
                 '[TarkovStore] Failed to clean deprecated remote progress payload:',
+                {
+                  cooldownMs: getDeprecatedRemoteCleanupCooldownMs(),
+                  failureCount: deprecatedRemoteCleanupFailureCount,
+                },
                 error
               );
               return;
             }
+            deprecatedRemoteCleanupFailureCount = 0;
             lastDeprecatedRemoteCleanupAttemptAt = 0;
+            logger.debug('[TarkovStore] Cleaned deprecated remote progress payload');
           } finally {
             deprecatedRemoteCleanupInFlight = false;
           }

--- a/app/types/progress.ts
+++ b/app/types/progress.ts
@@ -32,14 +32,6 @@ export interface TraderProgress {
   level: number;
   reputation: number;
 }
-export interface TarkovDevProfileData {
-  pmcStats: Record<string, unknown> | null;
-  scavStats: Record<string, unknown> | null;
-  achievements: Record<string, number>;
-  mastering: Array<{ Id: string; Progress: number; Kills?: number }>;
-  importedAt: number;
-  profileUpdatedAt: number;
-}
 export interface UserProgressData {
   level: number;
   pmcFaction: 'USEC' | 'BEAR';
@@ -63,5 +55,4 @@ export interface UserProgressData {
   };
   lastApiUpdate?: ApiUpdateMeta;
   apiUpdateHistory?: ApiUpdateMeta[];
-  tarkovDevProfile?: TarkovDevProfileData;
 }

--- a/app/utils/__tests__/progressSanitizers.test.ts
+++ b/app/utils/__tests__/progressSanitizers.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest';
 import { MAX_SKILL_LEVEL } from '@/utils/constants';
-import { sanitizeOwnedProgressData, sanitizeOwnedUserState } from '@/utils/progressSanitizers';
+import {
+  hasDeprecatedTarkovDevProfileData,
+  sanitizeOwnedProgressData,
+  sanitizeOwnedUserState,
+} from '@/utils/progressSanitizers';
 describe('sanitizeOwnedProgressData', () => {
   it('drops legacy tarkov.dev payloads while preserving canonical fields', () => {
     const result = sanitizeOwnedProgressData({
@@ -121,5 +125,36 @@ describe('sanitizeOwnedUserState', () => {
     expect(result.tarkovUid).toBe(67890);
     expect(result.pvp).not.toHaveProperty('tarkovDevProfile');
     expect(result.pve).not.toHaveProperty('tarkovDevProfile');
+  });
+});
+describe('hasDeprecatedTarkovDevProfileData', () => {
+  it('detects deprecated tarkov.dev payloads in both legacy and per-mode shapes', () => {
+    expect(
+      hasDeprecatedTarkovDevProfileData({
+        tarkovDevProfile: {
+          aid: 12345,
+        },
+      })
+    ).toBe(true);
+    expect(
+      hasDeprecatedTarkovDevProfileData({
+        pvp: {
+          tarkovDevProfile: {
+            aid: 12345,
+          },
+        },
+        pve: {},
+      })
+    ).toBe(true);
+    expect(
+      hasDeprecatedTarkovDevProfileData({
+        pvp: {
+          level: 12,
+        },
+        pve: {
+          level: 8,
+        },
+      })
+    ).toBe(false);
   });
 });

--- a/app/utils/__tests__/progressSanitizers.test.ts
+++ b/app/utils/__tests__/progressSanitizers.test.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_SKILL_LEVEL } from '@/utils/constants';
+import { sanitizeOwnedProgressData, sanitizeOwnedUserState } from '@/utils/progressSanitizers';
+describe('sanitizeOwnedProgressData', () => {
+  it('drops legacy tarkov.dev payloads while preserving canonical fields', () => {
+    const result = sanitizeOwnedProgressData({
+      apiUpdateHistory: [{ at: 100, id: 'update-1', source: 'api' }],
+      displayName: '  Test Player  ',
+      level: 24,
+      pmcFaction: 'USEC',
+      prestigeLevel: 2,
+      progressEpoch: 5,
+      skillOffsets: { Endurance: 3 },
+      skills: { Endurance: 10 },
+      tarkovDevProfile: {
+        achievements: { foo: 1 },
+        importedAt: 123,
+      },
+      taskCompletions: {
+        task: { complete: true, timestamp: 1000 },
+      },
+      xpOffset: 321,
+    });
+    expect(result).toEqual({
+      apiUpdateHistory: [{ at: 100, id: 'update-1', source: 'api' }],
+      displayName: 'Test Player',
+      hideoutModules: {},
+      hideoutParts: {},
+      level: 24,
+      pmcFaction: 'USEC',
+      prestigeLevel: 2,
+      progressEpoch: 5,
+      skillOffsets: { Endurance: 3 },
+      skills: { Endurance: 10 },
+      storyChapters: {},
+      taskCompletions: {
+        task: { complete: true, timestamp: 1000 },
+      },
+      taskObjectives: {},
+      traders: {},
+      xpOffset: 321,
+    });
+  });
+  it('clamps skill values to the allowed range', () => {
+    const result = sanitizeOwnedProgressData({
+      skills: { Endurance: 100, Strength: -5 },
+    });
+    expect(result.skills).toEqual({
+      Endurance: MAX_SKILL_LEVEL,
+      Strength: 0,
+    });
+  });
+  it('returns the default sanitized state for nullish input', () => {
+    const nullResult = sanitizeOwnedProgressData(null);
+    const undefinedResult = sanitizeOwnedProgressData(undefined);
+    expect(nullResult).toMatchObject({
+      apiUpdateHistory: [],
+      displayName: null,
+      level: 1,
+      pmcFaction: 'USEC',
+      skills: {},
+      taskCompletions: {},
+      xpOffset: 0,
+    });
+    expect(undefinedResult).toMatchObject({
+      apiUpdateHistory: [],
+      displayName: null,
+      level: 1,
+      pmcFaction: 'USEC',
+      skills: {},
+      taskCompletions: {},
+      xpOffset: 0,
+    });
+  });
+});
+describe('sanitizeOwnedUserState', () => {
+  it('normalizes top-level user state and per-mode payloads', () => {
+    const result = sanitizeOwnedUserState({
+      currentGameMode: 'pve',
+      gameEdition: '5',
+      pvp: {
+        level: 0,
+        pmcFaction: 'BEAR',
+      },
+      pve: {
+        displayName: ' Runner ',
+        level: 15,
+        pmcFaction: 'USEC',
+      },
+      tarkovUid: 12345,
+    });
+    expect(result.currentGameMode).toBe('pve');
+    expect(result.gameEdition).toBe(5);
+    expect(result.tarkovUid).toBe(12345);
+    expect(result.pvp.level).toBe(1);
+    expect(result.pvp.pmcFaction).toBe('BEAR');
+    expect(result.pve.displayName).toBe('Runner');
+    expect(result.pve.level).toBe(15);
+  });
+  it('preserves linked uid while stripping legacy tarkov.dev payloads', () => {
+    const result = sanitizeOwnedUserState({
+      currentGameMode: 'pvp',
+      tarkovUid: 67890,
+      pvp: {
+        level: 20,
+        pmcFaction: 'USEC',
+        tarkovDevProfile: {
+          aid: 12345,
+          importedAt: 111,
+        },
+      },
+      pve: {
+        level: 12,
+        pmcFaction: 'BEAR',
+        tarkovDevProfile: {
+          aid: 67890,
+          importedAt: 222,
+        },
+      },
+    });
+    expect(result.tarkovUid).toBe(67890);
+    expect(result.pvp).not.toHaveProperty('tarkovDevProfile');
+    expect(result.pve).not.toHaveProperty('tarkovDevProfile');
+  });
+});

--- a/app/utils/__tests__/tarkovDevProfileParser.test.ts
+++ b/app/utils/__tests__/tarkovDevProfileParser.test.ts
@@ -69,6 +69,7 @@ describe('parseTarkovDevProfile', () => {
     expect(result.data.pmcFaction).toBe('USEC');
     expect(result.data.totalXP).toBe(217726);
     expect(result.data.prestigeLevel).toBe(0);
+    expect(result.data).not.toHaveProperty('rawProfile');
   });
   it('computes skill levels from Progress / 100 floored', () => {
     const result = parseTarkovDevProfile(buildValidProfile());
@@ -225,48 +226,5 @@ describe('parseTarkovDevProfile', () => {
     expect(result.ok).toBe(false);
     if (result.ok) return;
     expect(result.error).toBeTruthy();
-  });
-  it('includes rawProfile with importedAt timestamp', () => {
-    const before = Date.now();
-    const result = parseTarkovDevProfile(buildValidProfile());
-    const after = Date.now();
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.rawProfile.importedAt).toBeGreaterThanOrEqual(before);
-    expect(result.data.rawProfile.importedAt).toBeLessThanOrEqual(after);
-  });
-  it('handles missing optional rawProfile fields gracefully', () => {
-    const result = parseTarkovDevProfile(buildValidProfile());
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.rawProfile.achievements).toEqual({});
-    expect(result.data.rawProfile.mastering).toEqual([]);
-  });
-  it('filters non-number values from achievements', () => {
-    const profile = buildValidProfile({
-      achievements: { valid: 1234567890, bad_string: 'not-a-number', bad_null: null },
-    });
-    const result = parseTarkovDevProfile(profile);
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.rawProfile.achievements).toEqual({ valid: 1234567890 });
-  });
-  it('filters malformed mastering entries', () => {
-    const profile = buildValidProfile({
-      mastering: [
-        { Id: 'weapon1', Progress: 500 },
-        { bad: true },
-        'not-an-object',
-        { Id: 123, Progress: 100 },
-        { Id: 'weapon2', Progress: 200, Kills: 10 },
-      ],
-    });
-    const result = parseTarkovDevProfile(profile);
-    expect(result.ok).toBe(true);
-    if (!result.ok) return;
-    expect(result.data.rawProfile.mastering).toEqual([
-      { Id: 'weapon1', Progress: 500 },
-      { Id: 'weapon2', Progress: 200, Kills: 10 },
-    ]);
   });
 });

--- a/app/utils/__tests__/tarkovDevProfileUrl.test.ts
+++ b/app/utils/__tests__/tarkovDevProfileUrl.test.ts
@@ -12,5 +12,7 @@ describe('buildTarkovDevProfileUrl', () => {
   it('returns undefined for missing or invalid uid values', () => {
     expect(buildTarkovDevProfileUrl(null, 'pvp')).toBeUndefined();
     expect(buildTarkovDevProfileUrl(0, 'pve')).toBeUndefined();
+    expect(buildTarkovDevProfileUrl(Number.NaN, 'pvp')).toBeUndefined();
+    expect(buildTarkovDevProfileUrl(Number.POSITIVE_INFINITY, 'pve')).toBeUndefined();
   });
 });

--- a/app/utils/__tests__/tarkovDevProfileUrl.test.ts
+++ b/app/utils/__tests__/tarkovDevProfileUrl.test.ts
@@ -11,6 +11,7 @@ describe('buildTarkovDevProfileUrl', () => {
   });
   it('returns undefined for missing or invalid uid values', () => {
     expect(buildTarkovDevProfileUrl(null, 'pvp')).toBeUndefined();
+    expect(buildTarkovDevProfileUrl(-1, 'pve')).toBeUndefined();
     expect(buildTarkovDevProfileUrl(0, 'pve')).toBeUndefined();
     expect(buildTarkovDevProfileUrl(Number.NaN, 'pvp')).toBeUndefined();
     expect(buildTarkovDevProfileUrl(Number.POSITIVE_INFINITY, 'pve')).toBeUndefined();

--- a/app/utils/__tests__/tarkovDevProfileUrl.test.ts
+++ b/app/utils/__tests__/tarkovDevProfileUrl.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { buildTarkovDevProfileUrl } from '@/utils/tarkovDevProfileUrl';
+describe('buildTarkovDevProfileUrl', () => {
+  it('builds a regular profile URL for pvp mode', () => {
+    expect(buildTarkovDevProfileUrl(123456, 'pvp')).toBe(
+      'https://tarkov.dev/players/regular/123456'
+    );
+  });
+  it('builds a pve profile URL for pve mode', () => {
+    expect(buildTarkovDevProfileUrl(123456, 'pve')).toBe('https://tarkov.dev/players/pve/123456');
+  });
+  it('returns undefined for missing or invalid uid values', () => {
+    expect(buildTarkovDevProfileUrl(null, 'pvp')).toBeUndefined();
+    expect(buildTarkovDevProfileUrl(0, 'pve')).toBeUndefined();
+  });
+});

--- a/app/utils/progressSanitizers.ts
+++ b/app/utils/progressSanitizers.ts
@@ -259,6 +259,17 @@ const sanitizeTarkovUid = (value: unknown): number | null => {
   const normalized = Math.trunc(uid);
   return Number.isSafeInteger(normalized) && normalized > 0 ? normalized : null;
 };
+export const hasDeprecatedTarkovDevProfileData = (value: unknown): boolean => {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (Object.prototype.hasOwnProperty.call(value, 'tarkovDevProfile')) {
+    return true;
+  }
+  return (
+    hasDeprecatedTarkovDevProfileData(value.pvp) || hasDeprecatedTarkovDevProfileData(value.pve)
+  );
+};
 export const sanitizeOwnedProgressData = (value: unknown): UserProgressData => {
   const sanitized: UserProgressData = createDefaultOwnedProgressData();
   if (!isRecord(value)) {

--- a/app/utils/progressSanitizers.ts
+++ b/app/utils/progressSanitizers.ts
@@ -270,6 +270,8 @@ export const hasDeprecatedTarkovDevProfileData = (value: unknown): boolean => {
     hasDeprecatedTarkovDevProfileData(value.pvp) || hasDeprecatedTarkovDevProfileData(value.pve)
   );
 };
+// Keep this canonical sanitizer aligned with the persisted DB sanitizer in the
+// tarkovDevProfile cleanup migration when changing stored progress fields.
 export const sanitizeOwnedProgressData = (value: unknown): UserProgressData => {
   const sanitized: UserProgressData = createDefaultOwnedProgressData();
   if (!isRecord(value)) {

--- a/app/utils/progressSanitizers.ts
+++ b/app/utils/progressSanitizers.ts
@@ -1,4 +1,5 @@
-import type { UserState } from '@/stores/progressState';
+import { GAME_MODES, MAX_SKILL_LEVEL, type GameMode } from '@/utils/constants';
+import type { ApiTaskUpdate, ApiUpdateMeta, UserState } from '@/stores/progressState';
 type UserProgressData = UserState['pvp'];
 export const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === 'object' && !Array.isArray(value));
@@ -172,6 +173,158 @@ export const sanitizeStoryChaptersMap = (value: unknown): UserProgressData['stor
     }
   }
   return sanitized;
+};
+const API_UPDATE_HISTORY_LIMIT = 50;
+const createDefaultOwnedProgressData = (): UserProgressData => ({
+  level: 1,
+  pmcFaction: 'USEC',
+  displayName: null,
+  xpOffset: 0,
+  taskObjectives: {},
+  taskCompletions: {},
+  hideoutParts: {},
+  hideoutModules: {},
+  traders: {},
+  skills: {},
+  prestigeLevel: 0,
+  progressEpoch: 0,
+  skillOffsets: {},
+  storyChapters: {},
+  apiUpdateHistory: [],
+});
+const sanitizeApiTaskUpdates = (value: unknown): ApiTaskUpdate[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  return value.filter(
+    (entry): entry is ApiTaskUpdate =>
+      isRecord(entry) &&
+      typeof entry.id === 'string' &&
+      ['completed', 'failed', 'uncompleted'].includes(entry.state as string)
+  );
+};
+export const sanitizeApiUpdateMeta = (value: unknown): ApiUpdateMeta | undefined => {
+  if (!isRecord(value)) {
+    return undefined;
+  }
+  const at = toFiniteNumber(value.at);
+  if (value.source !== 'api' || typeof value.id !== 'string' || !value.id || at === null) {
+    return undefined;
+  }
+  const tasks = sanitizeApiTaskUpdates(value.tasks);
+  return {
+    at: Math.max(0, Math.trunc(at)),
+    id: value.id,
+    source: 'api',
+    ...(tasks.length > 0 ? { tasks } : {}),
+  };
+};
+export const sanitizeApiUpdateHistory = (value: unknown): ApiUpdateMeta[] => {
+  if (!Array.isArray(value)) {
+    return [];
+  }
+  const deduped = new Map<string, ApiUpdateMeta>();
+  for (const entry of value) {
+    const normalized = sanitizeApiUpdateMeta(entry);
+    if (!normalized) {
+      continue;
+    }
+    const existing = deduped.get(normalized.id);
+    if (!existing || normalized.at >= existing.at) {
+      deduped.set(normalized.id, normalized);
+    }
+  }
+  return Array.from(deduped.values())
+    .sort((left, right) => right.at - left.at)
+    .slice(0, API_UPDATE_HISTORY_LIMIT);
+};
+const sanitizeGameMode = (value: unknown): GameMode => {
+  return value === GAME_MODES.PVE ? GAME_MODES.PVE : GAME_MODES.PVP;
+};
+const sanitizeGameEdition = (value: unknown): number => {
+  const edition =
+    typeof value === 'string' && value.trim() !== ''
+      ? toFiniteNumber(Number(value))
+      : toFiniteNumber(value);
+  if (edition === null) {
+    return 1;
+  }
+  return Math.max(1, Math.min(6, Math.trunc(edition)));
+};
+const sanitizeTarkovUid = (value: unknown): number | null => {
+  const uid = toFiniteNumber(value);
+  if (uid === null) {
+    return null;
+  }
+  const normalized = Math.trunc(uid);
+  return Number.isSafeInteger(normalized) && normalized > 0 ? normalized : null;
+};
+export const sanitizeOwnedProgressData = (value: unknown): UserProgressData => {
+  const sanitized: UserProgressData = createDefaultOwnedProgressData();
+  if (!isRecord(value)) {
+    return sanitized;
+  }
+  const level = toFiniteNumber(value.level);
+  const xpOffset = toFiniteNumber(value.xpOffset);
+  const prestigeLevel = toFiniteNumber(value.prestigeLevel);
+  const progressEpoch = toFiniteNumber(value.progressEpoch);
+  const lastApiUpdate = sanitizeApiUpdateMeta(value.lastApiUpdate);
+  sanitized.displayName = sanitizeDisplayName(value.displayName);
+  sanitized.hideoutModules = sanitizeHideoutModuleMap(value.hideoutModules);
+  sanitized.hideoutParts = sanitizeObjectiveProgressMap(value.hideoutParts);
+  sanitized.pmcFaction = sanitizeFaction(value.pmcFaction);
+  sanitized.skillOffsets = sanitizeNumberMap(value.skillOffsets);
+  sanitized.skills = Object.fromEntries(
+    Object.entries(sanitizeNumberMap(value.skills)).map(([skillName, level]) => [
+      skillName,
+      Math.max(0, Math.min(MAX_SKILL_LEVEL, level)),
+    ])
+  );
+  sanitized.storyChapters = sanitizeStoryChaptersMap(value.storyChapters);
+  sanitized.taskCompletions = sanitizeTaskCompletionMap(value.taskCompletions);
+  sanitized.taskObjectives = sanitizeObjectiveProgressMap(value.taskObjectives);
+  sanitized.traders = sanitizeTraderMap(value.traders);
+  sanitized.apiUpdateHistory = sanitizeApiUpdateHistory(value.apiUpdateHistory);
+  if (level !== null) {
+    sanitized.level = Math.max(1, Math.trunc(level));
+  }
+  if (xpOffset !== null) {
+    sanitized.xpOffset = Math.trunc(xpOffset);
+  }
+  if (prestigeLevel !== null) {
+    sanitized.prestigeLevel = Math.max(0, Math.min(6, Math.trunc(prestigeLevel)));
+  }
+  if (progressEpoch !== null) {
+    sanitized.progressEpoch = Math.max(0, Math.trunc(progressEpoch));
+  }
+  if (lastApiUpdate) {
+    sanitized.lastApiUpdate = lastApiUpdate;
+    if (!sanitized.apiUpdateHistory.some((entry) => entry.id === lastApiUpdate.id)) {
+      sanitized.apiUpdateHistory = sanitizeApiUpdateHistory([
+        lastApiUpdate,
+        ...sanitized.apiUpdateHistory,
+      ]);
+    }
+  }
+  return sanitized;
+};
+export const sanitizeOwnedUserState = (value: unknown): UserState => {
+  if (!isRecord(value)) {
+    return {
+      currentGameMode: GAME_MODES.PVP,
+      gameEdition: 1,
+      tarkovUid: null,
+      pvp: createDefaultOwnedProgressData(),
+      pve: createDefaultOwnedProgressData(),
+    };
+  }
+  return {
+    currentGameMode: sanitizeGameMode(value.currentGameMode),
+    gameEdition: sanitizeGameEdition(value.gameEdition),
+    tarkovUid: sanitizeTarkovUid(value.tarkovUid),
+    pvp: sanitizeOwnedProgressData(value.pvp),
+    pve: sanitizeOwnedProgressData(value.pve),
+  };
 };
 export const sanitizeTeammateProgressData = (value: unknown): Partial<UserProgressData> => {
   if (!isRecord(value)) {

--- a/app/utils/tarkovDevProfileParser.ts
+++ b/app/utils/tarkovDevProfileParser.ts
@@ -9,14 +9,6 @@ export interface TarkovDevImportResult {
   prestigeLevel: number;
   skills: Record<string, number>;
   gameEditionGuess: number | null;
-  rawProfile: {
-    pmcStats: Record<string, unknown> | null;
-    scavStats: Record<string, unknown> | null;
-    achievements: Record<string, number>;
-    mastering: Array<{ Id: string; Progress: number; Kills?: number }>;
-    importedAt: number;
-    profileUpdatedAt: number;
-  };
 }
 export type ParseResult = { ok: true; data: TarkovDevImportResult } | { ok: false; error: string };
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -80,7 +72,6 @@ export function parseTarkovDevProfile(data: unknown): ParseResult {
   }
   const prestigeRaw = typeof data.info.prestigeLevel === 'number' ? data.info.prestigeLevel : 0;
   const prestigeLevel = Math.max(0, Math.min(6, Math.floor(prestigeRaw)));
-  const rawData = data as Record<string, unknown>;
   return {
     ok: true,
     data: {
@@ -91,26 +82,6 @@ export function parseTarkovDevProfile(data: unknown): ParseResult {
       prestigeLevel,
       skills,
       gameEditionGuess: mapMemberCategoryToEdition(data.info.memberCategory),
-      rawProfile: {
-        pmcStats: isRecord(rawData.pmcStats) ? (rawData.pmcStats as Record<string, unknown>) : null,
-        scavStats: isRecord(rawData.scavStats)
-          ? (rawData.scavStats as Record<string, unknown>)
-          : null,
-        achievements: isRecord(rawData.achievements)
-          ? (Object.fromEntries(
-              Object.entries(rawData.achievements).filter(([, v]) => typeof v === 'number')
-            ) as Record<string, number>)
-          : {},
-        mastering: Array.isArray(rawData.mastering)
-          ? rawData.mastering.filter(
-              (item): item is { Id: string; Progress: number; Kills?: number } =>
-                isRecord(item) && typeof item.Id === 'string' && typeof item.Progress === 'number'
-            )
-          : [],
-        importedAt: Date.now(),
-        profileUpdatedAt:
-          typeof rawData.profileUpdatedAt === 'number' ? rawData.profileUpdatedAt : Date.now(),
-      },
     },
   };
 }

--- a/app/utils/tarkovDevProfileUrl.ts
+++ b/app/utils/tarkovDevProfileUrl.ts
@@ -1,0 +1,11 @@
+import { GAME_MODES, type GameMode } from '@/utils/constants';
+export const buildTarkovDevProfileUrl = (
+  tarkovUid: number | null,
+  mode: GameMode | null | undefined
+) => {
+  if (tarkovUid === null || !Number.isFinite(tarkovUid) || tarkovUid <= 0) {
+    return undefined;
+  }
+  const modeSlug = mode === GAME_MODES.PVE ? 'pve' : 'regular';
+  return `https://tarkov.dev/players/${modeSlug}/${tarkovUid}`;
+};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -143,6 +143,19 @@ Manages user progress data with dual game mode support (PvP/PvE).
 - Multi-device conflict resolution
 - Data migration for legacy formats
 - Task repair mechanisms
+- Stores a single linked `tarkovUid` for tarkov.dev profiles
+- Treats import target mode as import-time UI state, not persisted account metadata
+
+#### Tarkov.dev Linking and Importing
+
+- A linked tarkov.dev account is represented by a single persisted `tarkovUid`.
+- The app does **not** persist a long-lived "linked mode" or "imported mode" field.
+- Tarkov.dev imports always ask the user which mode to write into and default that choice to the
+  current active mode.
+- Tarkov.dev links use the currently viewed or selected mode only to choose the URL slug:
+  `regular` for PvP, `pve` for PvE.
+- Legacy embedded `tarkovDevProfile` payloads are sanitized out of stored progress data and should
+  not be reintroduced as long-lived state.
 
 #### useMetadataStore (Game Data)
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -135,6 +135,7 @@ Run formatting before committing:
 
 ```bash
 npm run format
+npm run supabase:check
 ```
 
 ## Testing
@@ -147,6 +148,9 @@ npx vitest run
 
 # Watch mode (default)
 npx vitest
+
+# Validate local Supabase migrations
+npm run supabase:check
 
 # API Gateway tests
 npm run test:api-gateway

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -221,6 +221,16 @@ Recommended mappings:
 1. Create store file in `app/stores/`
 2. If persisted, configure persistence options
 
+### Tarkov.dev Import and Linking Rules
+
+- Persist only the linked `tarkovUid`.
+- Do not add a persisted `tarkovUidMode`, linked-mode field, or imported-mode field.
+- Import target mode is chosen in the import UI and is temporary action state only.
+- When generating tarkov.dev links, use the currently viewed or selected mode to choose the URL
+  slug instead of storing import metadata.
+- Old backup files may still contain legacy import-mode metadata; new code should ignore it rather
+  than restore it into state.
+
 ### Adding a New API Endpoint
 
 1. Create route file in `app/server/api/`

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,7 +4,7 @@ This is the consolidated source of truth for the TarkovTracker Nuxt 4 applicatio
 
 ## 1. Project Standards & Philosophy
 
-- **Framework**: Nuxt ^4.2.1 (SPA mode, `app/` directory, Node 22).
+- **Framework**: Nuxt ^4.2.1 (SPA mode, `app/` directory, Node >=24.12.0).
 - **Frontend**: Vue 3 SFCs (`<script setup lang="ts">`), Pinia state, @nuxt/ui v4, Tailwind CSS v4.
 - **Backend**: Supabase (Auth, DB, Realtime) + Cloudflare Workers (public API gateway).
 - **Styling**: Strictly use Tailwind v4 theme layer (`@theme {}`). No hex colors or legacy UI patterns.
@@ -30,12 +30,13 @@ This is the consolidated source of truth for the TarkovTracker Nuxt 4 applicatio
 ## 4. Security & Operations
 
 - **Security**: Origin-check middleware (`tarkovtracker.org`) + per-user mutation rate limiting in Supabase Edge Functions. Public API rate limiting stays at the Cloudflare edge. HMAC signing for critical endpoints.
-- **Commands**: `npm run dev` (dev), `npm run build` (prod), `npx vitest` (test), `npm run lint` (lint).
+- **Commands**: `npm run dev` (dev), `npm run build` (prod), `npx vitest` (test), `npm run lint` (lint), `npm run supabase:check` (local migration reset + lint).
 - **Runbook**: [`docs/runbook.md`](./runbook.md) contains required env vars, deploy checks, and incident recovery.
 - **Deployment**:
   - Frontend: Automated via Cloudflare Pages on push.
   - Functions: `supabase functions deploy [name]`.
   - Public API worker: `cd workers/api-gateway && npx wrangler deploy`.
+- **Release Note**: Legacy manual backups created before the tarkov.dev profile cleanup may still contain old imported profile snapshots. New imports ignore them, but users who want fully scrubbed backup files should regenerate exports after upgrading.
 - **Troubleshooting**: Check Supabase Dashboard for Edge Function logs and Cloudflare logs for the public API worker.
 
 --- DO NOT TOUCH ANY OF THIS FILE CONENT BELOW HERE, IT IS MANUALLY MAINTAINED ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -24,6 +24,7 @@ This is the consolidated source of truth for the TarkovTracker Nuxt 4 applicatio
 
 - **Team System**: Supabase Edge Functions handle team/token mutations with per-user rate limits. Real-time updates via Supabase Broadcast (<200ms). Teammate profiles are fetched via a Nitro server route using service roles to bypass RLS.
 - **XP & Level System**: Dynamic calculation from tasks. Stores `xpOffset` (difference between calculated and actual XP) to maintain accuracy across manual adjustments.
+- **Tarkov.dev Linking**: The app persists one linked `tarkovUid`. Import destination mode is chosen at import time and is not stored as durable account metadata. Profile URLs use the current/viewed mode only to switch between `regular` and `pve`.
 - **i18n**: 6 languages managed in [`app/locales/*.json5`](../app/locales/). Missing keys fallback to raw strings.
 
 ## 4. Security & Operations

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -44,6 +44,7 @@ Semantic versioning with automated releases:
 **Jobs:**
 
 - Runs tests and build
+- Validates local Supabase migrations with `npm run supabase:check`
 - Generates changelog from conventional commits
 - Creates GitHub releases
 - Updates version in package.json

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -26,18 +26,23 @@
 2. `npm run lint`
 3. `npm run typecheck`
 4. `npm run test`
-5. `npm run build`
-6. `npm audit --omit=dev`
+5. `npm run supabase:check`
+6. `npm run build`
+7. `npm audit --omit=dev`
+8. For the tarkov.dev profile cleanup rollout, snapshot `public.user_progress` before applying the
+   destructive cleanup migration.
 
 ## Deployment
 
-1. Merge to `main` and verify CI workflow `Validate` and `Workers` jobs are green.
+1. Merge to `main` and verify CI workflow `Validate`, `Supabase DB`, and `Workers` jobs are green.
 2. Confirm Cloudflare Pages and Cloudflare Workers Git deployments completed for `main`.
 3. Confirm workers are serving the expected revision:
    - `workers/api-gateway`
 4. Smoke test:
    - `https://tarkovtracker.org`
    - `https://api.tarkovtracker.org/health`
+5. If the tarkov.dev profile cleanup migration shipped, note that old manual backups may still
+   contain historic imported profile snapshots until users regenerate them.
 
 ## Incident Triage
 

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "prepare": "husky || true",
     "preview": "nuxt preview",
     "setup": "bash scripts/setup-dev-environment.sh",
+    "supabase:check": "bash scripts/check-supabase-db.sh",
     "supabase:types": "supabase gen types typescript --linked > supabase/functions/_shared/database.types.ts",
     "test": "vitest run --reporter=default --maxWorkers=2",
     "test:watch": "vitest --watch",

--- a/scripts/check-supabase-db.sh
+++ b/scripts/check-supabase-db.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cleanup() {
+  npx supabase stop --no-backup >/dev/null 2>&1 || true
+}
+
+trap cleanup EXIT
+
+npx supabase db start
+npx supabase db reset --no-seed
+npx supabase db lint --schema public --fail-on error

--- a/scripts/check-supabase-db.sh
+++ b/scripts/check-supabase-db.sh
@@ -1,12 +1,20 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+started_local_stack=false
+
 cleanup() {
-  npx supabase stop --no-backup >/dev/null 2>&1 || true
+  if [ "${started_local_stack}" = true ]; then
+    npx supabase stop --no-backup >/dev/null 2>&1 || true
+  fi
 }
 
 trap cleanup EXIT
 
-npx supabase db start
+if ! npx supabase status >/dev/null 2>&1; then
+  npx supabase db start
+  started_local_stack=true
+fi
+
 npx supabase db reset --no-seed
 npx supabase db lint --schema public --fail-on error

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -507,6 +507,7 @@ export type Database = {
           created_at: string | null
           current_game_mode: string | null
           game_edition: number | null
+          tarkov_uid: number | null
           pve_data: Json | null
           pvp_data: Json | null
           updated_at: string | null
@@ -516,6 +517,7 @@ export type Database = {
           created_at?: string | null
           current_game_mode?: string | null
           game_edition?: number | null
+          tarkov_uid?: number | null
           pve_data?: Json | null
           pvp_data?: Json | null
           updated_at?: string | null
@@ -525,6 +527,7 @@ export type Database = {
           created_at?: string | null
           current_game_mode?: string | null
           game_edition?: number | null
+          tarkov_uid?: number | null
           pve_data?: Json | null
           pvp_data?: Json | null
           updated_at?: string | null

--- a/supabase/migrations/20251205171031_enable_realtime_user_progress_dup_1.sql
+++ b/supabase/migrations/20251205171031_enable_realtime_user_progress_dup_1.sql
@@ -1,5 +1,13 @@
 -- Enable Realtime on user_progress table for team sync
 -- This allows teammates to receive real-time updates when other team members update their progress
 
--- Add user_progress table to the realtime publication
-ALTER PUBLICATION supabase_realtime ADD TABLE public.user_progress;;
+-- Add user_progress table to the realtime publication (idempotent)
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_publication_tables
+    WHERE pubname = 'supabase_realtime' AND tablename = 'user_progress'
+  ) THEN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.user_progress;
+  END IF;
+END $$;

--- a/supabase/migrations/20251205171557_enable_realtime_user_progress_dup_2.sql
+++ b/supabase/migrations/20251205171557_enable_realtime_user_progress_dup_2.sql
@@ -10,4 +10,4 @@ BEGIN
   ) THEN
     ALTER PUBLICATION supabase_realtime ADD TABLE public.user_progress;
   END IF;
-END $$;;
+END $$;

--- a/supabase/migrations/20260409120000_remove_tarkovdev_profile_from_progress.sql
+++ b/supabase/migrations/20260409120000_remove_tarkovdev_profile_from_progress.sql
@@ -103,7 +103,20 @@ AS $$
       'skills',
       CASE
         WHEN jsonb_typeof(payload->'skills') = 'object'
-        THEN payload->'skills'
+        THEN (
+          SELECT COALESCE(
+            jsonb_object_agg(
+              skill.key,
+              CASE
+                WHEN skill.value ~ '^-?[0-9]+(\.[0-9]+)?$'
+                THEN to_jsonb(least(51, greatest(0, trunc((skill.value)::numeric)::int)))
+                ELSE to_jsonb(0)
+              END
+            ),
+            '{}'::jsonb
+          )
+          FROM jsonb_each_text(payload->'skills') AS skill(key, value)
+        )
         ELSE '{}'::jsonb
       END,
       'storyChapters',
@@ -178,6 +191,33 @@ BEGIN
   IF sanitized ? 'tarkovDevProfile' THEN
     RAISE EXCEPTION
       'sanitize_user_progress_mode_data regression: tarkovDevProfile should not be preserved';
+  END IF;
+
+  IF sanitized->'skills'->>'Endurance' <> '10' THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: in-range skills should be preserved';
+  END IF;
+
+  sanitized := public.sanitize_user_progress_mode_data(
+    jsonb_build_object(
+      'skills',
+      jsonb_build_object('Endurance', 99, 'Strength', -5, 'Intellect', 'bad')
+    )
+  );
+
+  IF sanitized->'skills'->>'Endurance' <> '51' THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: high skill values should be clamped';
+  END IF;
+
+  IF sanitized->'skills'->>'Strength' <> '0' THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: negative skill values should be clamped';
+  END IF;
+
+  IF sanitized->'skills'->>'Intellect' <> '0' THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: invalid skill values should normalize to 0';
   END IF;
 END;
 $$;

--- a/supabase/migrations/20260409120000_remove_tarkovdev_profile_from_progress.sql
+++ b/supabase/migrations/20260409120000_remove_tarkovdev_profile_from_progress.sql
@@ -1,8 +1,133 @@
+-- Keep this persisted cleanup aligned with app/utils/progressSanitizers.ts when
+-- changing the canonical stored progress shape.
+CREATE OR REPLACE FUNCTION public.sanitize_user_progress_api_task_updates(payload jsonb)
+RETURNS jsonb
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+  SELECT COALESCE(
+    jsonb_agg(
+      jsonb_build_object(
+        'id', entry.value->>'id',
+        'state', entry.value->>'state'
+      )
+    ),
+    '[]'::jsonb
+  )
+  FROM jsonb_array_elements(
+    CASE
+      WHEN jsonb_typeof(payload) = 'array' THEN payload
+      ELSE '[]'::jsonb
+    END
+  ) AS entry(value)
+  WHERE
+    jsonb_typeof(entry.value) = 'object'
+    AND jsonb_typeof(entry.value->'id') = 'string'
+    AND nullif(entry.value->>'id', '') IS NOT NULL
+    AND entry.value->>'state' IN ('completed', 'failed', 'uncompleted');
+$$;
+
+CREATE OR REPLACE FUNCTION public.sanitize_user_progress_api_update_meta(payload jsonb)
+RETURNS jsonb
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+  WITH sanitized_tasks AS (
+    SELECT public.sanitize_user_progress_api_task_updates(payload->'tasks') AS value
+  )
+  SELECT
+    CASE
+      WHEN
+        jsonb_typeof(payload) = 'object'
+        AND payload->>'source' = 'api'
+        AND jsonb_typeof(payload->'id') = 'string'
+        AND nullif(payload->>'id', '') IS NOT NULL
+        AND jsonb_typeof(payload->'at') = 'number'
+      THEN jsonb_strip_nulls(
+        jsonb_build_object(
+          'at',
+          to_jsonb(
+            greatest(
+              0,
+              least(
+                2147483647,
+                greatest(-2147483648, trunc((payload->>'at')::numeric))
+              )::int
+            )
+          ),
+          'id', payload->>'id',
+          'source', 'api',
+          'tasks',
+          CASE
+            WHEN jsonb_array_length((SELECT value FROM sanitized_tasks)) > 0
+            THEN (SELECT value FROM sanitized_tasks)
+            ELSE NULL
+          END
+        )
+      )
+      ELSE NULL
+    END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.sanitize_user_progress_api_update_history(payload jsonb)
+RETURNS jsonb
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+  WITH sanitized_entries AS (
+    SELECT public.sanitize_user_progress_api_update_meta(entry.value) AS value
+    FROM jsonb_array_elements(
+      CASE
+        WHEN jsonb_typeof(payload) = 'array' THEN payload
+        ELSE '[]'::jsonb
+      END
+    ) AS entry(value)
+  ),
+  deduped_entries AS (
+    SELECT DISTINCT ON (value->>'id') value
+    FROM sanitized_entries
+    WHERE value IS NOT NULL
+    ORDER BY value->>'id', ((value->>'at')::int) DESC
+  ),
+  ordered_entries AS (
+    SELECT value
+    FROM deduped_entries
+    ORDER BY ((value->>'at')::int) DESC
+    LIMIT 50
+  )
+  SELECT COALESCE(jsonb_agg(value), '[]'::jsonb)
+  FROM ordered_entries;
+$$;
+
 CREATE OR REPLACE FUNCTION public.sanitize_user_progress_mode_data(payload jsonb)
 RETURNS jsonb
 LANGUAGE SQL
 IMMUTABLE
 AS $$
+  WITH sanitized_last_api_update AS (
+    SELECT public.sanitize_user_progress_api_update_meta(payload->'lastApiUpdate') AS value
+  ),
+  sanitized_api_update_history AS (
+    SELECT public.sanitize_user_progress_api_update_history(
+      CASE
+        WHEN (SELECT value FROM sanitized_last_api_update) IS NOT NULL
+          AND NOT EXISTS (
+            SELECT 1
+            FROM jsonb_array_elements(
+              public.sanitize_user_progress_api_update_history(payload->'apiUpdateHistory')
+            ) AS entry(value)
+            WHERE entry.value->>'id' = (SELECT value->>'id' FROM sanitized_last_api_update)
+          )
+        THEN jsonb_build_array((SELECT value FROM sanitized_last_api_update))
+          || CASE
+            WHEN jsonb_typeof(payload->'apiUpdateHistory') = 'array'
+            THEN payload->'apiUpdateHistory'
+            ELSE '[]'::jsonb
+          END
+        ELSE payload->'apiUpdateHistory'
+      END
+    ) AS value
+  )
   SELECT jsonb_strip_nulls(
     jsonb_build_object(
       'displayName',
@@ -25,24 +150,9 @@ AS $$
         ELSE '{}'::jsonb
       END,
       'lastApiUpdate',
-      CASE
-        WHEN jsonb_typeof(payload->'lastApiUpdate') = 'object'
-        THEN payload->'lastApiUpdate'
-        ELSE NULL
-      END,
+      (SELECT value FROM sanitized_last_api_update),
       'apiUpdateHistory',
-      CASE
-        WHEN jsonb_typeof(payload->'apiUpdateHistory') = 'array'
-        THEN (
-          SELECT COALESCE(jsonb_agg(entry.value), '[]'::jsonb)
-          FROM (
-            SELECT value
-            FROM jsonb_array_elements(payload->'apiUpdateHistory')
-            LIMIT 50
-          ) AS entry
-        )
-        ELSE '[]'::jsonb
-      END,
+      (SELECT value FROM sanitized_api_update_history),
       'level',
       CASE
         WHEN jsonb_typeof(payload->'level') = 'number'
@@ -166,6 +276,13 @@ BEGIN
     jsonb_build_object(
       'displayName',
       '  Cleanup Tester  ',
+      'lastApiUpdate',
+      jsonb_build_object(
+        'at', 90,
+        'id', 'update-2',
+        'source', 'api',
+        'tasks', jsonb_build_array(jsonb_build_object('id', 'task-2', 'state', 'completed'))
+      ),
       'level',
       7,
       'pmcFaction',
@@ -174,6 +291,23 @@ BEGIN
       2,
       'progressEpoch',
       3,
+      'apiUpdateHistory',
+      jsonb_build_array(
+        jsonb_build_object('at', 100, 'id', 'update-1', 'source', 'api'),
+        jsonb_build_object('at', 80, 'id', 'update-2', 'source', 'api'),
+        jsonb_build_object(
+          'at',
+          120,
+          'id',
+          'update-1',
+          'source',
+          'api',
+          'tasks',
+          jsonb_build_array(jsonb_build_object('id', 'task-1', 'state', 'failed'))
+        ),
+        jsonb_build_object('id', '', 'source', 'api', 'at', 10),
+        jsonb_build_object('id', 'update-3', 'source', 'manual', 'at', 70)
+      ),
       'skills',
       jsonb_build_object('Endurance', 10),
       'tarkovDevProfile',
@@ -196,6 +330,26 @@ BEGIN
   IF sanitized->'skills'->>'Endurance' <> '10' THEN
     RAISE EXCEPTION
       'sanitize_user_progress_mode_data regression: in-range skills should be preserved';
+  END IF;
+
+  IF sanitized->'lastApiUpdate'->>'id' <> 'update-2' THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: lastApiUpdate should be validated and preserved';
+  END IF;
+
+  IF sanitized->'apiUpdateHistory'->0->>'id' <> 'update-1' THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: apiUpdateHistory should prefer the newest duplicate entry';
+  END IF;
+
+  IF sanitized->'apiUpdateHistory'->1->>'id' <> 'update-2' THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: apiUpdateHistory should preserve valid entry order';
+  END IF;
+
+  IF jsonb_array_length(sanitized->'apiUpdateHistory') <> 2 THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: apiUpdateHistory should discard invalid entries';
   END IF;
 
   sanitized := public.sanitize_user_progress_mode_data(
@@ -222,10 +376,29 @@ BEGIN
 END;
 $$;
 
-UPDATE public.user_progress
-SET
-  pvp_data = public.sanitize_user_progress_mode_data(COALESCE(pvp_data, '{}'::jsonb)),
-  pve_data = public.sanitize_user_progress_mode_data(COALESCE(pve_data, '{}'::jsonb))
-WHERE
-  COALESCE(pvp_data, '{}'::jsonb) ? 'tarkovDevProfile'
-  OR COALESCE(pve_data, '{}'::jsonb) ? 'tarkovDevProfile';
+DO $$
+DECLARE
+  rows_updated integer := 0;
+BEGIN
+  LOOP
+    WITH batch AS (
+      SELECT ctid
+      FROM public.user_progress
+      WHERE
+        COALESCE(pvp_data, '{}'::jsonb) ? 'tarkovDevProfile'
+        OR COALESCE(pve_data, '{}'::jsonb) ? 'tarkovDevProfile'
+      LIMIT 500
+    )
+    UPDATE public.user_progress AS up
+    SET
+      pvp_data = public.sanitize_user_progress_mode_data(COALESCE(up.pvp_data, '{}'::jsonb)),
+      pve_data = public.sanitize_user_progress_mode_data(COALESCE(up.pve_data, '{}'::jsonb))
+    FROM batch
+    WHERE up.ctid = batch.ctid;
+
+    GET DIAGNOSTICS rows_updated = ROW_COUNT;
+    EXIT WHEN rows_updated = 0;
+    PERFORM pg_sleep(0.05);
+  END LOOP;
+END;
+$$;

--- a/supabase/migrations/20260409120000_remove_tarkovdev_profile_from_progress.sql
+++ b/supabase/migrations/20260409120000_remove_tarkovdev_profile_from_progress.sql
@@ -1,0 +1,191 @@
+CREATE OR REPLACE FUNCTION public.sanitize_user_progress_mode_data(payload jsonb)
+RETURNS jsonb
+LANGUAGE SQL
+IMMUTABLE
+AS $$
+  SELECT jsonb_strip_nulls(
+    jsonb_build_object(
+      'displayName',
+      CASE
+        WHEN jsonb_typeof(payload->'displayName') = 'string'
+          AND nullif(btrim(payload->>'displayName'), '') IS NOT NULL
+        THEN to_jsonb(left(btrim(payload->>'displayName'), 64))
+        ELSE NULL
+      END,
+      'hideoutModules',
+      CASE
+        WHEN jsonb_typeof(payload->'hideoutModules') = 'object'
+        THEN payload->'hideoutModules'
+        ELSE '{}'::jsonb
+      END,
+      'hideoutParts',
+      CASE
+        WHEN jsonb_typeof(payload->'hideoutParts') = 'object'
+        THEN payload->'hideoutParts'
+        ELSE '{}'::jsonb
+      END,
+      'lastApiUpdate',
+      CASE
+        WHEN jsonb_typeof(payload->'lastApiUpdate') = 'object'
+        THEN payload->'lastApiUpdate'
+        ELSE NULL
+      END,
+      'apiUpdateHistory',
+      CASE
+        WHEN jsonb_typeof(payload->'apiUpdateHistory') = 'array'
+        THEN (
+          SELECT COALESCE(jsonb_agg(entry.value), '[]'::jsonb)
+          FROM (
+            SELECT value
+            FROM jsonb_array_elements(payload->'apiUpdateHistory')
+            LIMIT 50
+          ) AS entry
+        )
+        ELSE '[]'::jsonb
+      END,
+      'level',
+      CASE
+        WHEN jsonb_typeof(payload->'level') = 'number'
+        THEN to_jsonb(
+          greatest(
+            1,
+            least(
+              2147483647,
+              greatest(-2147483648, trunc((payload->>'level')::numeric))
+            )::int
+          )
+        )
+        ELSE NULL
+      END,
+      'pmcFaction',
+      CASE
+        WHEN payload->>'pmcFaction' IN ('BEAR', 'USEC')
+        THEN to_jsonb(payload->>'pmcFaction')
+        ELSE NULL
+      END,
+      'prestigeLevel',
+      CASE
+        WHEN jsonb_typeof(payload->'prestigeLevel') = 'number'
+        THEN to_jsonb(
+          least(
+            6,
+            greatest(
+              0,
+              least(
+                2147483647,
+                greatest(-2147483648, trunc((payload->>'prestigeLevel')::numeric))
+              )::int
+            )
+          )
+        )
+        ELSE NULL
+      END,
+      'progressEpoch',
+      CASE
+        WHEN jsonb_typeof(payload->'progressEpoch') = 'number'
+        THEN to_jsonb(
+          greatest(
+            0,
+            least(
+              2147483647,
+              greatest(-2147483648, trunc((payload->>'progressEpoch')::numeric))
+            )::int
+          )
+        )
+        ELSE to_jsonb(0)
+      END,
+      'skillOffsets',
+      CASE
+        WHEN jsonb_typeof(payload->'skillOffsets') = 'object'
+        THEN payload->'skillOffsets'
+        ELSE '{}'::jsonb
+      END,
+      'skills',
+      CASE
+        WHEN jsonb_typeof(payload->'skills') = 'object'
+        THEN payload->'skills'
+        ELSE '{}'::jsonb
+      END,
+      'storyChapters',
+      CASE
+        WHEN jsonb_typeof(payload->'storyChapters') = 'object'
+        THEN payload->'storyChapters'
+        ELSE '{}'::jsonb
+      END,
+      'taskCompletions',
+      CASE
+        WHEN jsonb_typeof(payload->'taskCompletions') = 'object'
+        THEN payload->'taskCompletions'
+        ELSE '{}'::jsonb
+      END,
+      'taskObjectives',
+      CASE
+        WHEN jsonb_typeof(payload->'taskObjectives') = 'object'
+        THEN payload->'taskObjectives'
+        ELSE '{}'::jsonb
+      END,
+      'traders',
+      CASE
+        WHEN jsonb_typeof(payload->'traders') = 'object'
+        THEN payload->'traders'
+        ELSE '{}'::jsonb
+      END,
+      'xpOffset',
+      CASE
+        WHEN jsonb_typeof(payload->'xpOffset') = 'number'
+        THEN to_jsonb(
+          least(
+            2147483647,
+            greatest(-2147483648, trunc((payload->>'xpOffset')::numeric))
+          )::int
+        )
+        ELSE NULL
+      END
+    )
+  );
+$$;
+
+DO $$
+DECLARE
+  sanitized jsonb;
+BEGIN
+  sanitized := public.sanitize_user_progress_mode_data(
+    jsonb_build_object(
+      'displayName',
+      '  Cleanup Tester  ',
+      'level',
+      7,
+      'pmcFaction',
+      'USEC',
+      'prestigeLevel',
+      2,
+      'progressEpoch',
+      3,
+      'skills',
+      jsonb_build_object('Endurance', 10),
+      'tarkovDevProfile',
+      jsonb_build_object('aid', 12345, 'importedAt', 1730000000),
+      'taskCompletions',
+      jsonb_build_object('task', jsonb_build_object('complete', true))
+    )
+  );
+
+  IF sanitized->>'displayName' <> 'Cleanup Tester' THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: displayName not trimmed as expected';
+  END IF;
+
+  IF sanitized ? 'tarkovDevProfile' THEN
+    RAISE EXCEPTION
+      'sanitize_user_progress_mode_data regression: tarkovDevProfile should not be preserved';
+  END IF;
+END;
+$$;
+
+UPDATE public.user_progress
+SET
+  pvp_data = public.sanitize_user_progress_mode_data(COALESCE(pvp_data, '{}'::jsonb)),
+  pve_data = public.sanitize_user_progress_mode_data(COALESCE(pve_data, '{}'::jsonb))
+WHERE
+  COALESCE(pvp_data, '{}'::jsonb) ? 'tarkovDevProfile'
+  OR COALESCE(pve_data, '{}'::jsonb) ? 'tarkovDevProfile';

--- a/workers/api-gateway/package-lock.json
+++ b/workers/api-gateway/package-lock.json
@@ -9,12 +9,12 @@
       "version": "1.0.0",
       "devDependencies": {
         "@apidevtools/swagger-parser": "^12.1.0",
-        "@cloudflare/workers-types": "^4.20260405.1",
+        "@cloudflare/workers-types": "^4.20260409.1",
         "@types/node": "^25.5.2",
         "openapi-types": "^12.1.3",
         "tsx": "^4.21.0",
         "typescript": "^6.0.2",
-        "wrangler": "^4.80.0"
+        "wrangler": "^4.81.0"
       }
     },
     "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -96,9 +96,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260401.1.tgz",
-      "integrity": "sha512-ZSmceM70jH6k+/62VkEcmMNzrpr4kSctkX5Lsgqv38KktfhPY/hsh75y1lRoPWS3H3kgMa4p2pUSlidZR1u2hw==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260415.1.tgz",
+      "integrity": "sha512-dsxaKsQm3LnPGNPEdsRv09QN3Y4DqCw7kX5j6noKqbAtro2jTr95sVlYM1jUxZ5FkOl1f7SXgaKKB9t5H5Nkbg==",
       "cpu": [
         "x64"
       ],
@@ -113,9 +113,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260401.1.tgz",
-      "integrity": "sha512-7UKWF+IUZ3NXMVPsDg8Cjg0r58b+uYlfvs5Yt8bvtU+geCtW4P2MxRHmRSEo8SryckXOJjb/b8tcncgCykFu8g==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260415.1.tgz",
+      "integrity": "sha512-+JgSgVA49KyKteHRA1SnonE4Zn5Ei5zdAp5FQMxFmXI8qulZw4Hl7safXxRyK4i9sTO8gl7TFOKO5Q64VPvSDQ==",
       "cpu": [
         "arm64"
       ],
@@ -130,9 +130,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260401.1.tgz",
-      "integrity": "sha512-MDWUH/0bvL/l9aauN8zEddyYOXId1OueqrUCXXENNJ95R/lSmF6OgGVuXaYhoIhxQkNiEJ/0NOlnVYj9mJq4dw==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260415.1.tgz",
+      "integrity": "sha512-tU+9pwsqCy8afOVlGtiWrWQc/fedQK4SRm4KPIAt+zOiQWDxWASm6YGBUJis5c648WN80yz47qnmdDi8DQNOcA==",
       "cpu": [
         "x64"
       ],
@@ -147,9 +147,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260401.1.tgz",
-      "integrity": "sha512-UgkzpMzVWM/bwbo3vjCTg2aoKfGcUhiEoQoDdo6RGWvbHRJyLVZ4VQCG9ZcISiztkiS2ICCoYOtPy6M/lV6Gcw==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260415.1.tgz",
+      "integrity": "sha512-bR9uITnV19r5NQ14xnypi2xHXu2iQvfYV8cVgx0JouFUmWwTEEAwFVojDdssGq93VHX9hr/pi2IRUZeegbYBog==",
       "cpu": [
         "arm64"
       ],
@@ -164,9 +164,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260401.1.tgz",
-      "integrity": "sha512-HBLzcQF5iF4Qv20tQ++pG7xs3OsCnaIbc+GAi6fmhUKZhvmzvml/jwrQzLJ+MPm0cQo41K5OO/U3T4S8tvJetQ==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260415.1.tgz",
+      "integrity": "sha512-4NuMLlerI0Ijua3Ir8HXQ+qyNvCUDEG5gDco5Om+sAiK6rnWiz+aGoSlbB8W16yW9QAgzCstbmXLiVknUBflfQ==",
       "cpu": [
         "x64"
       ],
@@ -181,9 +181,9 @@
       }
     },
     "node_modules/@cloudflare/workers-types": {
-      "version": "4.20260405.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260405.1.tgz",
-      "integrity": "sha512-PokTmySa+D6MY01R1UfYH48korsN462NK/fl3aw47Hg7XuLuSo/RTpjT0vtWaJhJoFY5tHGOBBIbDcIc8wltLg==",
+      "version": "4.20260418.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workers-types/-/workers-types-4.20260418.1.tgz",
+      "integrity": "sha512-bywXb2XmeSqrLCQYipcupLneqx015YhhNWz2v9b9iatpe8Cg551vP7ZuD5S2a6GfBka0dDnO70kIBiBvFglcrg==",
       "dev": true,
       "license": "MIT OR Apache-2.0"
     },
@@ -201,9 +201,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -1449,16 +1449,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260401.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260401.0.tgz",
-      "integrity": "sha512-lngHPzZFN9sxYG/mhzvnWiBMNVAN5MsO/7g32ttJ07rymtiK/ZBalODTKb8Od+BQdlU5DOR4CjVt9NydjnUyYg==",
+      "version": "4.20260415.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260415.0.tgz",
+      "integrity": "sha512-JoExRWN4YBI2luA5BoSMFEgi8rQWXUGzo3mtE+58VXCLV3jj/Xnk5Yeqs/IXWz8Es5GJIaq6BtsixDvAxXSIng==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "^0.34.5",
-        "undici": "7.24.4",
-        "workerd": "1.20260401.1",
+        "undici": "7.24.8",
+        "workerd": "1.20260415.1",
         "ws": "8.18.0",
         "youch": "4.1.0-beta.10"
       },
@@ -1624,9 +1624,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.4.tgz",
-      "integrity": "sha512-BM/JzwwaRXxrLdElV2Uo6cTLEjhSb3WXboncJamZ15NgUURmvlXvxa6xkwIOILIjPNo9i8ku136ZvWV0Uly8+w==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1651,9 +1651,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260401.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260401.1.tgz",
-      "integrity": "sha512-mUYCd+ohaWJWF5nhDzxugWaAD/DM8Dw0ze3B7bu8JaA7S70+XQJXcvcvwE8C4qGcxSdCyqjsrFzqxKubECDwzg==",
+      "version": "1.20260415.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260415.1.tgz",
+      "integrity": "sha512-phyPjRnx+mQDfkhN9ENPioL1L0SdhYs4S0YmJK/xF9Oga+ykNfdSy1MHnsOj8yqnOV96zcVQMx32dJ0r3pq0jQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1664,17 +1664,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260401.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260401.1",
-        "@cloudflare/workerd-linux-64": "1.20260401.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260401.1",
-        "@cloudflare/workerd-windows-64": "1.20260401.1"
+        "@cloudflare/workerd-darwin-64": "1.20260415.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260415.1",
+        "@cloudflare/workerd-linux-64": "1.20260415.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260415.1",
+        "@cloudflare/workerd-windows-64": "1.20260415.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.80.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.80.0.tgz",
-      "integrity": "sha512-2ZKF7uPeOZy65BGk3YfvqBCPo/xH1MrAlMmH9mVP+tCNBrTUMnwOHSj1HrZHgR8LttkAqhko0fGz+I4ax1rzyQ==",
+      "version": "4.83.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.83.0.tgz",
+      "integrity": "sha512-gw5g3LCiuAqVWxaoKY6+quE0HzAUEFb/FV3oAlNkE1ttd4XP3FiV91XDkkzUCcdqxS4WjhQvPhIDBNdhEi8P0A==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
@@ -1682,10 +1682,10 @@
         "@cloudflare/unenv-preset": "2.16.0",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.27.3",
-        "miniflare": "4.20260401.0",
+        "miniflare": "4.20260415.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260401.1"
+        "workerd": "1.20260415.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
@@ -1698,7 +1698,7 @@
         "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20260401.1"
+        "@cloudflare/workers-types": "^4.20260415.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {


### PR DESCRIPTION
## Summary

- remove persisted tarkov.dev import-mode metadata and keep only the linked `tarkovUid`
- treat PvP/PvE choice as import-time UI state while sharing tarkov.dev profile URL generation across settings and profile views
- simplify backup, sync, and sanitizer handling around legacy tarkov.dev profile data
- document the updated import/linking contract and add regression coverage
- add the SQL cleanup migration that actually strips embedded `tarkovDevProfile` payloads from stored progress JSON

## Why

The app only needs the linked tarkov.dev UID as durable account state. Persisting the mode used during a past import added unnecessary long-lived state, created migration complexity, and drifted from the actual product behavior where links should follow the current/viewed mode.

## Impact

- imports still default to the active mode but no longer persist that mode afterward
- profile/settings links now stay consistent and derive the `regular` vs `pve` slug from the current mode
- old backups with legacy mode metadata are accepted and ignored safely
- legacy embedded tarkov.dev payloads are sanitized out of stored progress data

## Validation

- `npm run format`
- `npm run typecheck`
- `npx vitest app/utils/__tests__/progressSanitizers.test.ts app/utils/__tests__/tarkovDevProfileParser.test.ts app/utils/__tests__/tarkovDevProfileUrl.test.ts app/stores/__tests__/progressState.test.ts app/composables/__tests__/useTarkovDevImport.test.ts app/composables/__tests__/useDataBackup.test.ts app/features/settings/__tests__/DataManagementCard.test.ts app/stores/__tests__/useTarkov.sync.integration.test.ts app/stores/__tests__/useTarkov.prestigePvP.test.ts app/stores/__tests__/useTarkov.syncPvpPrestigeLevel.test.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Removed legacy tarkov.dev profile blobs from stored backups/sync; tightened sanitization and validation of imported progress.

* **New Features**
  * Persist a single linked Tarkov UID; profile links use the currently viewed mode (regular vs pve); import target mode is transient UI state.

* **Documentation**
  * Docs and contributor guides updated; note that old backups may contain legacy data and should be regenerated after upgrade.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->