### PR TITLE
chore(deps): clear alerts and automate safe updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,11 +12,11 @@ updates:
       time: '03:00'
       timezone: America/New_York
     open-pull-requests-limit: 3
-    rebase-strategy: disabled
+    rebase-strategy: auto
     cooldown:
       semver-major-days: 30
       semver-minor-days: 7
-      semver-patch-days: 3
+      semver-patch-days: 1
     labels:
       - dependencies
       - javascript
@@ -125,7 +125,7 @@ updates:
       time: '05:00'
       timezone: America/New_York
     open-pull-requests-limit: 1
-    rebase-strategy: disabled
+    rebase-strategy: auto
     cooldown:
       semver-major-days: 30
       semver-minor-days: 14
@@ -171,7 +171,7 @@ updates:
       time: '04:00'
       timezone: America/New_York
     open-pull-requests-limit: 1
-    rebase-strategy: disabled
+    rebase-strategy: auto
     labels:
       - dependencies
       - ci

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,6 +24,11 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 **Trigger:** PR opened/updated/reopened
 **Jobs:** `PR Meta` (labels, size, commit validation, Lighthouse gating), `Lighthouse` (conditional on UI file changes or `ui`/`performance` labels)
 
+### Dependabot Auto Merge (`dependabot-auto-merge.yml`)
+
+**Trigger:** Dependabot PR opened/updated/reopened/ready for review
+**Jobs:** `Auto-merge safe Dependabot PR` (allowlist gate, wait for CI/security checks, squash merge)
+
 ### Stale (`stale.yml`)
 
 **Trigger:** Daily schedule
@@ -31,10 +36,11 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 
 ## Check Count
 
-| Context   | Checks                                                                            |
-| --------- | --------------------------------------------------------------------------------- |
-| PR        | ~7 (Validate, Supabase DB, Workers, PR Meta, Security Scan, CodeQL, Lighthouse\*) |
-| Main push | ~6 (Validate, Supabase DB, Workers, Security Scan, CodeQL, Release)               |
+| Context       | Checks                                                                            |
+| ------------- | --------------------------------------------------------------------------------- |
+| PR            | ~7 (Validate, Supabase DB, Workers, PR Meta, Security Scan, CodeQL, Lighthouse\*) |
+| Dependabot PR | ~8 (standard PR checks plus Dependabot Auto Merge when allowlisted)               |
+| Main push     | ~6 (Validate, Supabase DB, Workers, Security Scan, CodeQL, Release)               |
 
 \*Lighthouse runs only when the PR touches UI paths or already carries `performance`/`ui`
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,195 @@
+name: Dependabot Auto Merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  checks: read
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  auto-merge:
+    name: Auto-merge safe Dependabot PR
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      BASE_REF: ${{ github.event.pull_request.base.ref }}
+      GH_TOKEN: ${{ github.token }}
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+      HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - name: Gate Dependabot PR
+        id: gate
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          eligible=false
+
+          if [ "$BASE_REF" != "main" ]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Dependabot auto-merge only targets main."
+            exit 0
+          fi
+
+          if jq -e '.pull_request.draft' "$GITHUB_EVENT_PATH" >/dev/null; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Draft PRs are not auto-merged."
+            exit 0
+          fi
+
+          case "$HEAD_REF" in
+            dependabot/npm_and_yarn/lint-and-format-* | \
+            dependabot/npm_and_yarn/testing-tooling-* | \
+            dependabot/npm_and_yarn/tailwind-tooling-* | \
+            dependabot/npm_and_yarn/release-tooling-* | \
+            dependabot/github_actions/official-actions-* | \
+            dependabot/github_actions/third-party-actions-*)
+              eligible=true
+              ;;
+          esac
+
+          if [ "$eligible" != "true" ]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Dependabot group is outside the low-risk auto-merge allowlist."
+            exit 0
+          fi
+
+          invalid_files="$(
+            gh pr view "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json files \
+              --jq '.files[].path' |
+              while IFS= read -r file; do
+                case "$file" in
+                  package.json | \
+                  package-lock.json | \
+                  workers/api-gateway/package.json | \
+                  workers/api-gateway/package-lock.json | \
+                  .github/workflows/*.yml | \
+                  .github/workflows/*.yaml)
+                    ;;
+                  *)
+                    printf '%s\n' "$file"
+                    ;;
+                esac
+              done
+          )"
+
+          if [ -n "$invalid_files" ]; then
+            echo "eligible=false" >> "$GITHUB_OUTPUT"
+            echo "::notice::Dependabot PR changes files outside the auto-merge allowlist:"
+            printf '%s\n' "$invalid_files"
+            exit 0
+          fi
+
+          echo "eligible=true" >> "$GITHUB_OUTPUT"
+
+      - name: Wait for checks
+        if: steps.gate.outputs.eligible == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          expected_checks=(
+            "Validate"
+            "Supabase DB"
+            "Workers"
+            "PR Meta"
+            "Security Scan"
+            "CodeQL"
+          )
+
+          deadline=$((SECONDS + 1500))
+
+          while true; do
+            check_runs="$(
+              gh api \
+                "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?per_page=100" \
+                --jq '.check_runs | map(select(.name != "Auto-merge safe Dependabot PR"))'
+            )"
+
+            failing_count="$(
+              jq '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length' <<< "$check_runs"
+            )"
+
+            if [ "$failing_count" -gt 0 ]; then
+              jq -r '.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | "::error::\(.name) concluded \(.conclusion)"' <<< "$check_runs"
+              exit 1
+            fi
+
+            missing_checks=()
+            incomplete_checks=()
+            pending_count="$(
+              jq '[.[] | select(.status != "completed")] | length' <<< "$check_runs"
+            )"
+
+            for check_name in "${expected_checks[@]}"; do
+              matching_check="$(
+                jq --arg name "$check_name" '[.[] | select(.name == $name)]' <<< "$check_runs"
+              )"
+
+              if [ "$(jq 'length' <<< "$matching_check")" -eq 0 ]; then
+                missing_checks+=("$check_name")
+                continue
+              fi
+
+              incomplete_count="$(
+                jq '[.[] | select(.status != "completed")] | length' <<< "$matching_check"
+              )"
+
+              if [ "$incomplete_count" -gt 0 ]; then
+                incomplete_checks+=("$check_name")
+              fi
+            done
+
+            if [ "${#missing_checks[@]}" -eq 0 ] && [ "${#incomplete_checks[@]}" -eq 0 ] && [ "$pending_count" -eq 0 ]; then
+              echo "All checks completed."
+              break
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              printf '::error::Timed out waiting for checks. Missing: %s. Incomplete: %s. Pending: %s.\n' \
+                "${missing_checks[*]:-none}" \
+                "${incomplete_checks[*]:-none}" \
+                "$pending_count"
+              exit 1
+            fi
+
+            printf 'Waiting for checks. Missing: %s. Incomplete: %s. Pending: %s.\n' \
+              "${missing_checks[*]:-none}" \
+              "${incomplete_checks[*]:-none}" \
+              "$pending_count"
+            sleep 30
+          done
+
+      - name: Merge Dependabot PR
+        if: steps.gate.outputs.eligible == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          merge_state="$(
+            gh pr view "$PR_NUMBER" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json mergeStateStatus \
+              --jq '.mergeStateStatus'
+          )"
+
+          if [ "$merge_state" != "CLEAN" ]; then
+            echo "::error::PR merge state is $merge_state, not CLEAN."
+            exit 1
+          fi
+
+          gh pr merge "$PR_NUMBER" \
+            --repo "$GITHUB_REPOSITORY" \
+            --squash \
+            --delete-branch

--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.0.0"
+setups.@nuxt/test-utils="4.0.2"

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -12,6 +12,7 @@ Complete workflow automation setup for TarkovTracker with CI/CD pipelines, quali
 - Automated releases with semantic versioning
 - Pre-commit hooks for code quality
 - Dependency update automation via Dependabot
+- Conservative auto-merge for low-risk Dependabot updates
 
 ## GitHub Actions Workflows
 
@@ -69,7 +70,28 @@ Enhanced PR validation:
 - `conventional-commits` - Commit message validation
 - `lighthouse` - Performance checks (when `performance` label present)
 
-### 5. Stale Management (`.github/workflows/stale.yml`)
+### 5. Dependabot Auto Merge (`.github/workflows/dependabot-auto-merge.yml`)
+
+Merges known low-risk Dependabot PRs after the normal PR checks complete:
+
+**Auto-merged groups:**
+
+- lint and format tooling
+- testing tooling
+- tailwind tooling
+- release tooling
+- official GitHub Actions
+- third-party GitHub Actions minor/patch updates
+
+**Safety rules:**
+
+- Dependabot-only, `main`-targeted PRs only
+- No repository checkout in the privileged `pull_request_target` workflow
+- Only package lockfiles, package manifests, and workflow files are allowed
+- Runtime Nuxt, Cloudflare, TypeScript compiler, catch-all npm, and `.claude-plugin` updates stay manual
+- PR must be mergeable and all standard CI/security checks must finish without failures
+
+### 6. Stale Management (`.github/workflows/stale.yml`)
 
 Automatic stale issue/PR management:
 
@@ -78,7 +100,7 @@ Automatic stale issue/PR management:
 - Exempts issues: `pinned`, `security`, `enhancement` labels
 - Exempts PRs: `pinned`, `security`, `enhancement` labels
 
-### 6. Link Check (`.github/workflows/link-check.yml`)
+### 7. Link Check (`.github/workflows/link-check.yml`)
 
 Validates external links in documentation:
 
@@ -150,10 +172,11 @@ Automated via Dependabot (`.github/dependabot.yml`):
 - Monthly grouped GitHub Actions updates
 - Official GitHub Actions are allowed to take major updates so runtime migrations do not get stuck behind a minor/patch-only rule
 - Cooldown windows to avoid immediate churn from fresh releases
+- Patch cooldown is short so safe patch updates do not sit for a full week
 - Grouped minor/patch updates for low-risk tooling families
 - Version updates limited to direct dependencies; vulnerable transitives still surface through security updates
 - Maximum 3 concurrent npm PRs and 1 GitHub Actions PR
-- No automerge for version updates
+- Conservative auto-merge for allowlisted low-risk Dependabot groups after CI/security checks pass
 - Gitleaks runs via a pinned CLI download in CI with release checksum verification instead of the deprecated `gitleaks-action` runtime
 
 **Current package groups:**
@@ -171,9 +194,11 @@ Automated via Dependabot (`.github/dependabot.yml`):
 **Review strategy:**
 
 - Let Dependabot batch low-risk tooling updates for scheduled review windows
+- Let the auto-merge workflow clear allowlisted tooling/action PRs after checks pass
 - Keep major upgrades explicit
 - Allow official GitHub-maintained actions to take major updates when GitHub changes required action runtimes
 - Keep transitive lockfile churn out of version-update PRs unless GitHub raises a security fix
+- Keep Nuxt/runtime, Cloudflare deployment tooling, TypeScript compiler, catch-all npm, and `.claude-plugin` updates manual
 - Keep `.claude-plugin` updates out of the main app queue; review them monthly as isolated tooling maintenance
 - Review security PRs promptly; they remain separate from the scheduled version-update batches unless GitHub grouped security updates are enabled in repository settings
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@commitlint/cli": "^20.5.0",
         "@commitlint/config-conventional": "^20.5.0",
         "@nuxt/eslint": "^1.15.2",
-        "@nuxt/test-utils": "4.0.2",
+        "@nuxt/test-utils": "^4.0.2",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/git": "^10.0.1",
         "@semantic-release/npm": "^13.1.5",
@@ -9053,13 +9053,13 @@
       }
     },
     "node_modules/@unhead/vue": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.12.tgz",
-      "integrity": "sha512-zEWqg0nZM8acpuTZE40wkeUl8AhIe0tU0OkilVi1D4fmVjACrwoh5HP6aNqJ8kUnKsoy6D+R3Vi/O+fmdNGO7g==",
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/@unhead/vue/-/vue-2.1.13.tgz",
+      "integrity": "sha512-HYy0shaHRnLNW9r85gppO8IiGz0ONWVV3zGdlT8CQ0tbTwixznJCIiyqV4BSV1aIF1jJIye0pd1p/k6Eab8Z/A==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1",
-        "unhead": "2.1.12"
+        "unhead": "2.1.13"
       },
       "funding": {
         "url": "https://github.com/sponsors/harlan-zw"
@@ -18850,9 +18850,9 @@
       }
     },
     "node_modules/npm": {
-      "version": "11.12.1",
-      "resolved": "https://registry.npmjs.org/npm/-/npm-11.12.1.tgz",
-      "integrity": "sha512-zcoUuF1kezGSAo0CqtvoLXX3mkRqzuqYdL6Y5tdo8g69NVV3CkjQ6ZBhBgB4d7vGkPcV6TcvLi3GRKPDFX+xTA==",
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/npm/-/npm-11.13.0.tgz",
+      "integrity": "sha512-cRmhaghDWA1lFgl3Ug4/VxDJdPBK/U+tNtnrl9kXunFqhWw1x4xL5txkNn7qzPuVfvXOmXyjHpMwsuk2uisbkg==",
       "bundleDependencies": [
         "@isaacs/string-locale-compare",
         "@npmcli/arborist",
@@ -18931,7 +18931,7 @@
       ],
       "dependencies": {
         "@isaacs/string-locale-compare": "^1.1.0",
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/config": "^10.8.1",
         "@npmcli/fs": "^5.0.0",
         "@npmcli/map-workspaces": "^5.0.3",
@@ -18953,24 +18953,24 @@
         "hosted-git-info": "^9.0.2",
         "ini": "^6.0.0",
         "init-package-json": "^8.2.5",
-        "is-cidr": "^6.0.3",
+        "is-cidr": "^6.0.4",
         "json-parse-even-better-errors": "^5.0.0",
         "libnpmaccess": "^10.0.3",
-        "libnpmdiff": "^8.1.5",
-        "libnpmexec": "^10.2.5",
-        "libnpmfund": "^7.0.19",
+        "libnpmdiff": "^8.1.6",
+        "libnpmexec": "^10.2.6",
+        "libnpmfund": "^7.0.20",
         "libnpmorg": "^8.0.1",
-        "libnpmpack": "^9.1.5",
+        "libnpmpack": "^9.1.6",
         "libnpmpublish": "^11.1.3",
         "libnpmsearch": "^9.0.1",
         "libnpmteam": "^8.0.2",
         "libnpmversion": "^8.0.3",
         "make-fetch-happen": "^15.0.5",
-        "minimatch": "^10.2.4",
+        "minimatch": "^10.2.5",
         "minipass": "^7.1.3",
         "minipass-pipeline": "^1.2.4",
         "ms": "^2.1.2",
-        "node-gyp": "^12.2.0",
+        "node-gyp": "^12.3.0",
         "nopt": "^9.0.0",
         "npm-audit-report": "^7.0.0",
         "npm-install-checks": "^8.0.0",
@@ -18989,7 +18989,7 @@
         "spdx-expression-parse": "^4.0.0",
         "ssri": "^13.0.1",
         "supports-color": "^10.2.2",
-        "tar": "^7.5.11",
+        "tar": "^7.5.13",
         "text-table": "~0.2.0",
         "tiny-relative-date": "^2.0.2",
         "treeverse": "^3.0.0",
@@ -19085,7 +19085,7 @@
       }
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
-      "version": "9.4.2",
+      "version": "9.4.3",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
@@ -19336,7 +19336,7 @@
       }
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
@@ -19478,7 +19478,7 @@
       }
     },
     "node_modules/npm/node_modules/brace-expansion": {
-      "version": "5.0.4",
+      "version": "5.0.5",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -19547,7 +19547,7 @@
       }
     },
     "node_modules/npm/node_modules/cidr-regex": {
-      "version": "5.0.3",
+      "version": "5.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
@@ -19603,7 +19603,7 @@
       }
     },
     "node_modules/npm/node_modules/diff": {
-      "version": "8.0.3",
+      "version": "8.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
@@ -19779,12 +19779,12 @@
       }
     },
     "node_modules/npm/node_modules/is-cidr": {
-      "version": "6.0.3",
+      "version": "6.0.4",
       "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "cidr-regex": "^5.0.1"
+        "cidr-regex": "^5.0.4"
       },
       "engines": {
         "node": ">=20"
@@ -19852,12 +19852,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmdiff": {
-      "version": "8.1.5",
+      "version": "8.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/installed-package-contents": "^4.0.0",
         "binary-extensions": "^3.0.0",
         "diff": "^8.0.2",
@@ -19871,13 +19871,13 @@
       }
     },
     "node_modules/npm/node_modules/libnpmexec": {
-      "version": "10.2.5",
+      "version": "10.2.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
         "@gar/promise-retry": "^1.0.0",
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/package-json": "^7.0.0",
         "@npmcli/run-script": "^10.0.0",
         "ci-info": "^4.0.0",
@@ -19894,12 +19894,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmfund": {
-      "version": "7.0.19",
+      "version": "7.0.20",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2"
+        "@npmcli/arborist": "^9.4.3"
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
@@ -19919,12 +19919,12 @@
       }
     },
     "node_modules/npm/node_modules/libnpmpack": {
-      "version": "9.1.5",
+      "version": "9.1.6",
       "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
-        "@npmcli/arborist": "^9.4.2",
+        "@npmcli/arborist": "^9.4.3",
         "@npmcli/run-script": "^10.0.0",
         "npm-package-arg": "^13.0.0",
         "pacote": "^21.0.2"
@@ -19994,7 +19994,7 @@
       }
     },
     "node_modules/npm/node_modules/lru-cache": {
-      "version": "11.2.7",
+      "version": "11.3.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -20026,12 +20026,12 @@
       }
     },
     "node_modules/npm/node_modules/minimatch": {
-      "version": "10.2.4",
+      "version": "10.2.5",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^5.0.2"
+        "brace-expansion": "^5.0.5"
       },
       "engines": {
         "node": "18 || 20 || >=22"
@@ -20079,34 +20079,16 @@
       }
     },
     "node_modules/npm/node_modules/minipass-flush": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "dev": true,
       "inBundle": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "minipass": "^3.0.0"
+        "minipass": "^7.1.3"
       },
       "engines": {
-        "node": ">= 8"
+        "node": ">=16 || 14 >=14.17"
       }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
-      "version": "3.3.6",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/npm/node_modules/minipass-flush/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "inBundle": true,
-      "license": "ISC"
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
@@ -20187,7 +20169,7 @@
       }
     },
     "node_modules/npm/node_modules/node-gyp": {
-      "version": "12.2.0",
+      "version": "12.3.0",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20195,12 +20177,12 @@
         "env-paths": "^2.2.0",
         "exponential-backoff": "^3.1.1",
         "graceful-fs": "^4.2.6",
-        "make-fetch-happen": "^15.0.0",
         "nopt": "^9.0.0",
         "proc-log": "^6.0.0",
         "semver": "^7.3.5",
         "tar": "^7.5.4",
         "tinyglobby": "^0.2.12",
+        "undici": "^6.25.0",
         "which": "^6.0.0"
       },
       "bin": {
@@ -20647,7 +20629,7 @@
       }
     },
     "node_modules/npm/node_modules/tar": {
-      "version": "7.5.11",
+      "version": "7.5.13",
       "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
@@ -20675,13 +20657,13 @@
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
-      "version": "0.2.15",
+      "version": "0.2.16",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -20708,7 +20690,7 @@
       }
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.3",
+      "version": "4.0.4",
       "dev": true,
       "inBundle": true,
       "license": "MIT",
@@ -20740,6 +20722,15 @@
       },
       "engines": {
         "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/npm/node_modules/undici": {
+      "version": "6.25.0",
+      "dev": true,
+      "inBundle": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
       }
     },
     "node_modules/npm/node_modules/util-deprecate": {
@@ -26597,9 +26588,9 @@
       }
     },
     "node_modules/unhead": {
-      "version": "2.1.12",
-      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.12.tgz",
-      "integrity": "sha512-iTHdWD9ztTunOErtfUFk6Wr11BxvzumcYJ0CzaSCBUOEtg+DUZ9+gnE99i8QkLFT2q1rZD48BYYGXpOZVDLYkA==",
+      "version": "2.1.13",
+      "resolved": "https://registry.npmjs.org/unhead/-/unhead-2.1.13.tgz",
+      "integrity": "sha512-jO9M1sI6b2h/1KpIu4Jeu+ptumLmUKboRRLxys5pYHFeT+lqTzfNHbYUX9bxVDhC1FBszAGuWcUVlmvIPsah8Q==",
       "license": "MIT",
       "dependencies": {
         "hookable": "^6.0.1"
@@ -26609,9 +26600,9 @@
       }
     },
     "node_modules/unhead/node_modules/hookable": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.0.1.tgz",
-      "integrity": "sha512-uKGyY8BuzN/a5gvzvA+3FVWo0+wUjgtfSdnmjtrOVwQCZPHpHDH2WRO3VZSOeluYrHoDCiXFffZXs8Dj1ULWtw==",
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-6.1.1.tgz",
+      "integrity": "sha512-U9LYDy1CwhMCnprUfeAZWZGByVbhd54hwepegYTK7Pi5NvqEj63ifz5z+xukznehT7i6NIZRu89Ay1AZmRsLEQ==",
       "license": "MIT"
     },
     "node_modules/unicode-emoji-modifier-base": {
@@ -27262,9 +27253,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "__pinnedNotes": {
-    "@nuxt/test-utils": "Pinned to 4.0.0 on 2026-04-09 because 4.0.1 publishes vitest-environment-nuxt as workspace:* and 4.0.2 requires vitest-environment-nuxt@2.0.0, which is not published on npm. Remove after Nuxt republishes a fixed 4.x release.",
+    "@nuxt/test-utils": "Unpinned to ^4.0.2 on 2026-04-23 after vitest-environment-nuxt@2.0.0 was published and the upstream workspace dependency issue was fixed.",
     "@vueuse/core": "Previously pinned to 13.9.0 due to Nuxt/@nuxt/ui/reka-ui compatibility; updated to ^14.1.0 after upgrading Nuxt/@nuxt/ui.",
     "fast-xml-parser": "Pinned fast-xml-parser to the patched v5 line on 2026-02-18 to avoid potential v6 API regressions in @nuxtjs/sitemap dependency paths; remediation: remove this override after @nuxtjs/sitemap officially supports fast-xml-parser v6 and confirm sitemap generation in CI."
   },
@@ -35,7 +35,7 @@
     "@commitlint/cli": "^20.5.0",
     "@commitlint/config-conventional": "^20.5.0",
     "@nuxt/eslint": "^1.15.2",
-    "@nuxt/test-utils": "4.0.2",
+    "@nuxt/test-utils": "^4.0.2",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@semantic-release/npm": "^13.1.5",
@@ -75,7 +75,7 @@
   "name": "tarkovtracker-nuxt",
   "overrides": {
     "npm": {
-      ".": "^11.12.1",
+      ".": "^11.13.0",
       "picomatch": "^4.0.4"
     },
     "@tiptap/core": "3.14.0",
@@ -84,6 +84,7 @@
       "brace-expansion": "^1.1.13"
     },
     "fast-xml-parser": "^5.7.1",
+    "vite": "^7.3.2",
     "@nuxt/test-utils": {
       "h3-next": "npm:h3@2.0.1-rc.20",
       "srvx": "^0.11.15"
@@ -96,7 +97,7 @@
     "tar": "^7.5.13",
     "yaml": "^2.8.3"
   },
-  "packageManager": "npm@11.12.1",
+  "packageManager": "npm@11.13.0",
   "private": true,
   "scripts": {
     "build": "nuxt build",


### PR DESCRIPTION
## Summary
- merge the clean testing-tooling Dependabot update first (#302)
- clear remaining npm audit findings by updating unhead, npm nested deps, picomatch, and Vite via a narrow override
- re-enable Dependabot rebases, shorten root patch cooldown, and add a no-checkout auto-merge workflow for low-risk Dependabot groups
- update workflow/dependency automation docs

## Verification
- npm audit --package-lock-only --json
- npm run format
- npm run typecheck
- npm run test
- npm run build
- parsed dependabot-auto-merge.yml and bash -n checked embedded run blocks

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced automated dependency update handling with new safety verification steps before merging.
  * Updated development tooling and test framework versions.
* **Documentation**
  * Added documentation for automated dependency update workflows and safety requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->