### PR TITLE
ci: fix dependabot auto-merge gate

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -184,10 +184,14 @@ jobs:
               --jq '.mergeStateStatus'
           )"
 
-          if [ "$merge_state" != "CLEAN" ]; then
-            echo "::error::PR merge state is $merge_state, not CLEAN."
-            exit 1
-          fi
+          case "$merge_state" in
+            CLEAN | UNSTABLE)
+              ;;
+            *)
+              echo "::error::PR merge state is $merge_state, not mergeable."
+              exit 1
+              ;;
+          esac
 
           gh pr merge "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \


### PR DESCRIPTION
## Summary
- allow the Dependabot auto-merge workflow to proceed when GitHub reports UNSTABLE because the auto-merge check itself is still pending
- keep blocking non-mergeable states such as DIRTY, BLOCKED, BEHIND, or UNKNOWN

## Verification
- npx prettier --check .github/workflows/dependabot-auto-merge.yml
- parsed dependabot-auto-merge.yml and bash -n checked embedded run blocks

## Context
The first real run on #305 failed after all normal checks passed because mergeStateStatus was UNSTABLE while this workflow's own check was still pending.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Dependabot merge automation to allow automatic merging under additional branch status conditions, enabling more flexible dependency update processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->