### PR TITLE
[codex] Move API tokens into settings API tab

### DIFF
--- a/app/features/settings/ApiTokensCard.vue
+++ b/app/features/settings/ApiTokensCard.vue
@@ -1,0 +1,29 @@
+<template>
+  <GenericCard
+    icon="i-mdi-api"
+    icon-color="secondary"
+    highlight-color="secondary"
+    :fill-height="false"
+    :title="$t('page.settings.card.apitokens.title')"
+    title-classes="text-lg font-semibold"
+  >
+    <template #content>
+      <div class="relative px-4 py-4">
+        <ApiTokens v-if="isLoggedIn" />
+        <UAlert
+          v-else
+          color="warning"
+          variant="soft"
+          icon="i-mdi-lock"
+          :title="$t('page.settings.card.apitokens.not_logged_in')"
+        />
+      </div>
+    </template>
+  </GenericCard>
+</template>
+<script setup lang="ts">
+  import GenericCard from '@/components/ui/GenericCard.vue';
+  import ApiTokens from '@/features/settings/ApiTokens.vue';
+  const { $supabase } = useNuxtApp();
+  const isLoggedIn = computed(() => Boolean($supabase?.user?.loggedIn));
+</script>

--- a/app/features/settings/__tests__/ApiTokensCard.test.ts
+++ b/app/features/settings/__tests__/ApiTokensCard.test.ts
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ApiTokensCard from '@/features/settings/ApiTokensCard.vue';
+const mockState = {
+  isLoggedIn: false,
+};
+mockNuxtImport('useNuxtApp', () => () => ({
+  $supabase: {
+    user: {
+      get loggedIn() {
+        return mockState.isLoggedIn;
+      },
+    },
+  },
+}));
+describe('ApiTokensCard', () => {
+  beforeEach(() => {
+    mockState.isLoggedIn = false;
+    vi.clearAllMocks();
+  });
+  const createWrapper = () =>
+    mount(ApiTokensCard, {
+      global: {
+        mocks: { $t: (key: string) => key },
+        stubs: {
+          ApiTokens: { template: '<div data-testid="api-tokens" />' },
+          GenericCard: {
+            template: '<section><slot name="content" /></section>',
+          },
+          UAlert: {
+            props: ['title'],
+            template: '<div data-testid="login-warning">{{ title }}</div>',
+          },
+        },
+      },
+    });
+  it('shows api tokens when logged in', () => {
+    mockState.isLoggedIn = true;
+    const wrapper = createWrapper();
+    expect(wrapper.find('[data-testid="api-tokens"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="login-warning"]').exists()).toBe(false);
+  });
+  it('shows the login warning when logged out', () => {
+    const wrapper = createWrapper();
+    expect(wrapper.find('[data-testid="api-tokens"]').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="login-warning"]').text()).toBe(
+      'page.settings.card.apitokens.not_logged_in'
+    );
+  });
+});

--- a/app/locales/de.json5
+++ b/app/locales/de.json5
@@ -1398,6 +1398,7 @@
       progression: 'Fortschritt',
       preferences: 'Präferenzen',
       data_management: 'Datenverwaltung',
+      api: 'API',
     },
     density: {
       compact: 'Kompakt',

--- a/app/locales/en.json5
+++ b/app/locales/en.json5
@@ -1398,6 +1398,7 @@
       progression: 'Progression',
       preferences: 'Preferences',
       data_management: 'Data Management',
+      api: 'API',
     },
     density: {
       compact: 'Compact',

--- a/app/locales/es.json5
+++ b/app/locales/es.json5
@@ -1398,6 +1398,7 @@
       progression: 'Progreso',
       preferences: 'Preferencias',
       data_management: 'Gestión de datos',
+      api: 'API',
     },
     density: {
       compact: 'Compacta',

--- a/app/locales/fr.json5
+++ b/app/locales/fr.json5
@@ -1398,6 +1398,7 @@
       progression: 'Progression',
       preferences: 'Préférences',
       data_management: 'Gestion des données',
+      api: 'API',
     },
     density: {
       compact: 'Compact',

--- a/app/locales/ru.json5
+++ b/app/locales/ru.json5
@@ -1398,6 +1398,7 @@
       progression: 'Прогресс',
       preferences: 'Предпочтения',
       data_management: 'Управление данными',
+      api: 'API',
     },
     density: {
       compact: 'Компактная',

--- a/app/locales/uk.json5
+++ b/app/locales/uk.json5
@@ -1398,6 +1398,7 @@
       progression: 'Прогрес',
       preferences: 'Параметри',
       data_management: 'Керування даними',
+      api: 'API',
     },
     density: {
       compact: 'Компактна',

--- a/app/locales/zh.json5
+++ b/app/locales/zh.json5
@@ -1398,6 +1398,7 @@
       progression: '进度',
       preferences: '偏好',
       data_management: '数据管理',
+      api: 'API',
     },
     density: {
       compact: '紧凑',

--- a/app/pages/__tests__/account.page.test.ts
+++ b/app/pages/__tests__/account.page.test.ts
@@ -56,17 +56,15 @@ describe('account page', () => {
         mocks: { $t: (key: string) => key },
         stubs: {
           AccountDeletionCard: true,
-          ApiTokens: true,
-          GenericCard: true,
           NuxtLink: { template: '<a><slot /></a>' },
           PrivacyCard: { template: '<div data-testid="privacy-card" />' },
           ProfileSharingCard: true,
-          UAlert: true,
           UIcon: true,
         },
       },
     });
     expect(wrapper.find('[data-testid="privacy-card"]').exists()).toBe(true);
+    expect(wrapper.text()).not.toContain('page.settings.card.apitokens.title');
   });
   it('shows admin link when user is admin', () => {
     mockState.isAdmin = true;
@@ -76,12 +74,9 @@ describe('account page', () => {
         mocks: { $t: (key: string) => key },
         stubs: {
           AccountDeletionCard: true,
-          ApiTokens: true,
-          GenericCard: true,
           NuxtLink: { template: '<a><slot /></a>', props: ['to'] },
           PrivacyCard: true,
           ProfileSharingCard: true,
-          UAlert: true,
           UIcon: true,
         },
       },
@@ -96,12 +91,9 @@ describe('account page', () => {
         mocks: { $t: (key: string) => key },
         stubs: {
           AccountDeletionCard: true,
-          ApiTokens: true,
-          GenericCard: true,
           NuxtLink: { template: '<a><slot /></a>' },
           PrivacyCard: true,
           ProfileSharingCard: true,
-          UAlert: true,
           UIcon: true,
         },
       },

--- a/app/pages/__tests__/settings.page.test.ts
+++ b/app/pages/__tests__/settings.page.test.ts
@@ -97,8 +97,8 @@ vi.mock('vue-i18n', async (importOriginal) => ({
   }),
 }));
 const defaultGlobalStubs = {
+  ApiTokensCard: { template: '<div data-testid="api-tokens-card" />' },
   DataManagementCard: { template: '<div data-testid="data-management-card" />' },
-  ApiTokens: true,
   DisplayNameCard: {
     data: () => ({
       localValue: '',
@@ -240,6 +240,15 @@ describe('settings page', () => {
       expect(wrapper.find('[data-testid="data-management-card"]').exists()).toBe(true);
       expect(wrapper.find('#settings-progression').exists()).toBe(false);
     });
+    it('opens the api tab from the route hash', async () => {
+      configureMockState({ routeHash: '#api' });
+      const wrapper = mount(SettingsPage, {
+        global: globalConfig,
+      });
+      await vi.dynamicImportSettled();
+      expect(wrapper.find('[data-testid="api-tokens-card"]').exists()).toBe(true);
+      expect(wrapper.find('#settings-progression').exists()).toBe(false);
+    });
     it('keeps skill deep links on the progression tab', async () => {
       configureMockState({ routeHash: '#settings-skills' });
       const wrapper = mount(SettingsPage, {
@@ -256,6 +265,17 @@ describe('settings page', () => {
       await wrapper.get('[data-testid="tab-preferences"]').trigger('click');
       expect(mockFns.routerReplace).toHaveBeenCalledWith({
         hash: '#settings-preferences',
+        path: '/settings',
+        query: {},
+      });
+    });
+    it('updates the route hash when selecting the api tab', async () => {
+      const wrapper = mount(SettingsPage, {
+        global: globalConfig,
+      });
+      await wrapper.get('[data-testid="tab-api"]').trigger('click');
+      expect(mockFns.routerReplace).toHaveBeenCalledWith({
+        hash: '#api',
         path: '/settings',
         query: {},
       });

--- a/app/pages/account.vue
+++ b/app/pages/account.vue
@@ -3,27 +3,6 @@
     <div class="mx-auto max-w-5xl space-y-4">
       <ProfileSharingCard />
       <PrivacyCard />
-      <GenericCard
-        icon="mdi-key-chain"
-        icon-color="secondary"
-        highlight-color="secondary"
-        :fill-height="false"
-        :title="$t('page.settings.card.apitokens.title')"
-        title-classes="text-lg font-semibold"
-      >
-        <template #content>
-          <div class="relative px-4 py-4">
-            <ApiTokens v-if="isLoggedIn" />
-            <UAlert
-              v-else
-              color="warning"
-              variant="soft"
-              icon="i-mdi-lock"
-              :title="$t('page.settings.card.apitokens.not_logged_in')"
-            />
-          </div>
-        </template>
-      </GenericCard>
       <AccountDeletionCard />
       <div v-if="isAdmin" class="flex justify-center pt-4">
         <NuxtLink
@@ -38,9 +17,7 @@
   </div>
 </template>
 <script setup lang="ts">
-  import GenericCard from '@/components/ui/GenericCard.vue';
   import AccountDeletionCard from '@/features/settings/AccountDeletionCard.vue';
-  import ApiTokens from '@/features/settings/ApiTokens.vue';
   import PrivacyCard from '@/features/settings/PrivacyCard.vue';
   import ProfileSharingCard from '@/features/settings/ProfileSharingCard.vue';
   import { useSystemStore, useSystemStoreWithSupabase } from '@/stores/useSystemStore';
@@ -51,9 +28,7 @@
       'Manage your TarkovTracker account options, sharing visibility, and data controls.',
     robots: 'noindex, nofollow',
   });
-  const { $supabase } = useNuxtApp();
   const { hasInitiallyLoaded } = useSystemStoreWithSupabase();
-  const isLoggedIn = computed(() => Boolean($supabase?.user?.loggedIn));
   const systemStore = useSystemStore();
   const isAdmin = computed(() => hasInitiallyLoaded.value && systemStore.isAdmin);
 </script>

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -64,6 +64,16 @@
             >
               <DataManagementCard />
             </section>
+            <section
+              v-if="visitedTabs.api"
+              v-show="activeTab === 'api'"
+              id="api"
+              class="scroll-mt-24 space-y-4"
+              role="tabpanel"
+              :aria-label="$t('settings.tabs.api')"
+            >
+              <ApiTokensCard />
+            </section>
           </div>
         </div>
       </div>
@@ -71,6 +81,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import ApiTokensCard from '@/features/settings/ApiTokensCard.vue';
   import DataManagementCard from '@/features/settings/DataManagementCard.vue';
   import DisplayNameCard from '@/features/settings/DisplayNameCard.vue';
   import ExperienceCard from '@/features/settings/ExperienceCard.vue';
@@ -88,12 +99,13 @@
   const { t } = useI18n({ useScope: 'global' });
   const route = useRoute();
   const router = useRouter();
-  type SettingsTabId = 'progression' | 'preferences' | 'data-management';
-  const settingsTabIds = ['progression', 'preferences', 'data-management'] as const;
+  type SettingsTabId = 'progression' | 'preferences' | 'data-management' | 'api';
+  const settingsTabIds = ['progression', 'preferences', 'data-management', 'api'] as const;
   const settingsTabHashes: Record<SettingsTabId, string> = {
     progression: '#settings-progression',
     preferences: '#settings-preferences',
     'data-management': '#settings-data-management',
+    api: '#api',
   };
   const nestedTabHashes: Record<string, SettingsTabId> = {
     '#settings-skills': 'progression',
@@ -125,11 +137,17 @@
       label: t('settings.tabs.data_management'),
       icon: 'i-mdi-database-cog-outline',
     },
+    {
+      value: 'api',
+      label: t('settings.tabs.api'),
+      icon: 'i-mdi-api',
+    },
   ]);
   const visitedTabs = reactive<Record<SettingsTabId, boolean>>({
     progression: false,
     preferences: false,
     'data-management': false,
+    api: false,
   });
   const mobileTabsUi: TabsProps['ui'] = {
     root: 'w-full',


### PR DESCRIPTION
## What changed

- Moves API token management from `/account` into a dedicated `/settings#api` tab.
- Adds `ApiTokensCard` as a small wrapper around the existing `ApiTokens` behavior.
- Keeps existing token create/load/revoke logic unchanged.
- Adds the API tab locale label across all locale files.
- Updates account/settings page tests and adds wrapper coverage.

## Why

The account route was carrying API token management even though this fits better as a dedicated Settings tab. The new tab also uses the cleaner `/settings#api` hash instead of repeating `settings` after the fragment.

## Validation

- `npx vitest app/pages/__tests__/settings.page.test.ts app/pages/__tests__/account.page.test.ts app/features/settings/__tests__/ApiTokensCard.test.ts app/features/settings/__tests__/ApiTokens.test.ts`
- `npm run format`
- `npm run typecheck`
- Browser smoke check at `/settings#api`

Note: validation ran in a mirrored `/tmp` clone because the sibling worktree has no `node_modules` and Vite temp config writes hit sandbox read-only behavior there.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new "API" tab in the Settings page displaying API tokens for logged-in users, with a login prompt for non-authenticated users.
  * Moved API token management functionality from the Account page to the Settings page.

* **Documentation**
  * Added multi-language translation support for the new API tab (English, German, Spanish, French, Russian, Ukrainian, and Chinese).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->