### PR TITLE
[codex] Remove stale SelectMenu width overrides

### DIFF
--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -90,7 +90,8 @@ const uiConfig = {
       trailing: 'shrink-0 text-surface-400',
       value: 'text-surface-100',
       placeholder: 'text-surface-500',
-      content: 'bg-surface-900 border border-surface-700 rounded-lg shadow-xl z-[9999] min-w-fit',
+      content:
+        'bg-surface-900 border border-surface-700 rounded-lg shadow-xl z-[9999] max-w-[90vw] min-w-fit overflow-auto',
       viewport: 'p-1 max-h-60 overflow-y-auto',
       group: '',
       empty: 'px-3 py-2 text-sm text-surface-500 text-center',
@@ -100,7 +101,7 @@ const uiConfig = {
       itemLeadingIcon: 'text-surface-400 shrink-0',
       itemLeadingAvatar: 'shrink-0',
       itemLeadingChip: 'shrink-0',
-      itemLabel: 'whitespace-nowrap',
+      itemLabel: 'break-words whitespace-normal',
       itemTrailing: 'ms-auto',
       itemTrailingIcon: 'text-surface-400 shrink-0',
     },

--- a/app/app.config.ts
+++ b/app/app.config.ts
@@ -90,8 +90,7 @@ const uiConfig = {
       trailing: 'shrink-0 text-surface-400',
       value: 'text-surface-100',
       placeholder: 'text-surface-500',
-      content:
-        'bg-surface-900 border border-surface-700 rounded-lg shadow-xl z-[9999] !w-[var(--reka-combobox-trigger-width)]',
+      content: 'bg-surface-900 border border-surface-700 rounded-lg shadow-xl z-[9999] min-w-fit',
       viewport: 'p-1 max-h-60 overflow-y-auto',
       group: '',
       empty: 'px-3 py-2 text-sm text-surface-500 text-center',

--- a/app/assets/css/tailwind.css
+++ b/app/assets/css/tailwind.css
@@ -706,37 +706,6 @@ html.no-smooth-scroll {
 }
 /* Text colors now use warm surface tokens (see @theme --color-surface-*) */
 
-/* Nuxt UI v4 USelectMenu (Reka combobox) locks content width to the trigger; override to fit widest option. */
-/* TODO: Remove these overrides when Nuxt UI v4 fixes trigger-width content sizing.
-   Track: https://github.com/tarkovtracker-org/TarkovTracker/issues/157
-   Condition: Remove once Nuxt UI v4 stops forcing trigger-width sizing (fix or opt-out prop). */
-[id^='reka-combobox-content'][data-slot='content'] {
-  --reka-combobox-trigger-width: max-content !important;
-  min-width: var(--reka-popper-anchor-width);
-  max-width: none;
-}
-
-[id^='reka-combobox-content'][data-slot='content'] [data-slot='viewport'] {
-  width: max-content;
-  min-width: 100%;
-  max-width: none;
-  overflow-x: visible;
-}
-
-[id^='reka-combobox-content'][data-slot='content'] [data-slot='group'] {
-  width: max-content;
-  min-width: 100%;
-}
-
-[id^='reka-combobox-content'][data-slot='content'] [data-slot='item'] {
-  white-space: nowrap;
-}
-
-[id^='reka-combobox-content'][data-slot='content'] [data-slot='itemLabel'] {
-  white-space: nowrap;
-  display: inline-block;
-}
-
 /* Restore pointer cursor on interactive elements (reset by Tailwind preflight) */
 button:not(:disabled),
 [role='button']:not([disabled]):not([aria-disabled='true']),

--- a/app/components/SelectMenuFixed.vue
+++ b/app/components/SelectMenuFixed.vue
@@ -56,8 +56,7 @@
     trailing: 'shrink-0 text-surface-400',
     value: 'text-surface-100',
     placeholder: 'text-surface-500',
-    content:
-      'bg-surface-900 border border-surface-700 rounded-lg shadow-xl z-[9999] !w-[var(--reka-combobox-trigger-width)]',
+    content: 'bg-surface-900 border border-surface-700 rounded-lg shadow-xl z-[9999] min-w-fit',
     viewport: 'p-1 max-h-60 overflow-y-auto',
     item: 'px-3 py-2 text-sm cursor-pointer transition-colors rounded text-surface-300 data-[highlighted]:bg-surface-800 data-[highlighted]:text-white data-[state=checked]:bg-surface-700 data-[state=checked]:text-white data-[state=checked]:font-medium',
     itemLabel: 'whitespace-nowrap',

--- a/app/components/SelectMenuFixed.vue
+++ b/app/components/SelectMenuFixed.vue
@@ -56,10 +56,11 @@
     trailing: 'shrink-0 text-surface-400',
     value: 'text-surface-100',
     placeholder: 'text-surface-500',
-    content: 'bg-surface-900 border border-surface-700 rounded-lg shadow-xl z-[9999] min-w-fit',
+    content:
+      'bg-surface-900 border border-surface-700 rounded-lg shadow-xl z-[9999] max-w-[90vw] min-w-fit overflow-auto',
     viewport: 'p-1 max-h-60 overflow-y-auto',
     item: 'px-3 py-2 text-sm cursor-pointer transition-colors rounded text-surface-300 data-[highlighted]:bg-surface-800 data-[highlighted]:text-white data-[state=checked]:bg-surface-700 data-[state=checked]:text-white data-[state=checked]:font-medium',
-    itemLabel: 'whitespace-nowrap',
+    itemLabel: 'break-words whitespace-normal',
     itemTrailingIcon: 'text-surface-400 shrink-0',
   };
   const mergedUi = computed(() => {


### PR DESCRIPTION
## Summary

- Replaces the SelectMenu trigger-width override with Nuxt UI's scoped `min-w-fit` content slot.
- Removes the stale global Reka combobox CSS workaround and its #157 TODO.

## Why

Issue #157 tracked temporary global overrides added because Nuxt UI v4 forced combobox content to match the trigger width. Nuxt UI now documents `ui.content: 'min-w-fit'` for full content width, so this can be handled in the SelectMenu theme/wrapper instead of global CSS.

## Validation

- `npm run format`
- `npm run typecheck`
- Dev server + Playwright smoke on `/settings` Game Edition SelectMenu

Addresses #157


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Dropdown menus now size naturally instead of being forced to match the trigger, restoring expected library behavior and improving layout on small viewports.
* **Style**
  * Option labels now wrap to multiple lines and dropdowns support internal scrolling, improving readability for long items.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->