### PR TITLE
[codex] Add never-stale escape for stale auto-close

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -49,7 +49,7 @@ All area labels use `#c2e0c6` (light green) for visual grouping.
 | ------------------ | --------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
 | `good-first-issue` | `#7057ff` | Good for newcomers                 | Simple, well-defined issues that can be completed in isolation without deep knowledge                 |
 | `help-wanted`      | `#008672` | Community help needed              | Well-scoped issues that welcome community contributions but may require broader context or experience |
-| `never-stale`      | `#5319e7` | Keep open when stale               | Long-lived backlog issues/PRs that should receive stale reminders but never be auto-closed            |
+| `never-stale`      | `#5319e7` | Never auto-close from stale        | Long-lived backlog issues/PRs that may be marked stale for review but must not be auto-closed         |
 | `upstream`         | `#e99695` | Issue belongs in data-overlay repo | Quest/item data issues that need fixes in the data-overlay repository                                 |
 
 ## Label Usage Guidelines

--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -24,32 +24,33 @@ GitHub's native **Issue Types** feature replaces type labels. Each issue must ha
 
 All area labels use `#c2e0c6` (light green) for visual grouping.
 
-| Label | Description | Examples |
-|-------|-------------|----------|
-| `area:ui` | Vue components, pages, styling | Component bugs, layout issues, Tailwind CSS, responsive design |
-| `area:api` | Nitro server routes, workers, API endpoints | Server routes in `app/server/api/`, Cloudflare Workers, GraphQL proxy |
-| `area:database` | Supabase schema, migrations, queries | Database schema, Postgres queries, migrations, RLS policies |
-| `area:auth` | Authentication and authorization | Login/logout, Supabase Auth, permissions, session management |
-| `area:realtime` | Team sync, Supabase broadcasts | Team features, real-time sync, Supabase Realtime, broadcasts |
-| `area:i18n` | Translations and localization | Language files, translation keys, i18n system, locale switching |
+| Label           | Description                                 | Examples                                                              |
+| --------------- | ------------------------------------------- | --------------------------------------------------------------------- |
+| `area:ui`       | Vue components, pages, styling              | Component bugs, layout issues, Tailwind CSS, responsive design        |
+| `area:api`      | Nitro server routes, workers, API endpoints | Server routes in `app/server/api/`, Cloudflare Workers, GraphQL proxy |
+| `area:database` | Supabase schema, migrations, queries        | Database schema, Postgres queries, migrations, RLS policies           |
+| `area:auth`     | Authentication and authorization            | Login/logout, Supabase Auth, permissions, session management          |
+| `area:realtime` | Team sync, Supabase broadcasts              | Team features, real-time sync, Supabase Realtime, broadcasts          |
+| `area:i18n`     | Translations and localization               | Language files, translation keys, i18n system, locale switching       |
 
 **Note:** Issues can have multiple area labels if they affect multiple systems (e.g., `area:ui` + `area:realtime` for team page display issues).
 
 ### Priority Labels (How urgent)
 
-| Label | Color | Description | When to Use |
-|-------|-------|-------------|-------------|
-| `priority:high` | `#d93f0b` | Important features/bugs | Critical bugs, security issues, data loss, blocking issues, important features |
-| `priority:medium` | `#fbca04` | Normal priority | Standard bugs and features (default) |
-| `priority:low` | `#0e8a16` | Nice to have | Minor improvements, edge cases, quality-of-life enhancements |
+| Label             | Color     | Description             | When to Use                                                                    |
+| ----------------- | --------- | ----------------------- | ------------------------------------------------------------------------------ |
+| `priority:high`   | `#d93f0b` | Important features/bugs | Critical bugs, security issues, data loss, blocking issues, important features |
+| `priority:medium` | `#fbca04` | Normal priority         | Standard bugs and features (default)                                           |
+| `priority:low`    | `#0e8a16` | Nice to have            | Minor improvements, edge cases, quality-of-life enhancements                   |
 
 ### Special Labels
 
-| Label | Color | Description | When to Use |
-|-------|-------|-------------|-------------|
-| `good-first-issue` | `#7057ff` | Good for newcomers | Simple, well-defined issues that can be completed in isolation without deep knowledge |
-| `help-wanted` | `#008672` | Community help needed | Well-scoped issues that welcome community contributions but may require broader context or experience |
-| `upstream` | `#e99695` | Issue belongs in data-overlay repo | Quest/item data issues that need fixes in the data-overlay repository |
+| Label              | Color     | Description                        | When to Use                                                                                           |
+| ------------------ | --------- | ---------------------------------- | ----------------------------------------------------------------------------------------------------- |
+| `good-first-issue` | `#7057ff` | Good for newcomers                 | Simple, well-defined issues that can be completed in isolation without deep knowledge                 |
+| `help-wanted`      | `#008672` | Community help needed              | Well-scoped issues that welcome community contributions but may require broader context or experience |
+| `never-stale`      | `#5319e7` | Keep open when stale               | Long-lived backlog issues/PRs that should receive stale reminders but never be auto-closed            |
+| `upstream`         | `#e99695` | Issue belongs in data-overlay repo | Quest/item data issues that need fixes in the data-overlay repository                                 |
 
 ## Label Usage Guidelines
 
@@ -144,14 +145,14 @@ Labels: (none needed, Dependabot handles these)
 
 These are **NOT** labels - they're handled by GitHub Project columns:
 
-| ❌ Don't Use Label | ✅ Use Project Column Instead |
-|-------------------|-------------------------------|
-| ~~needs-info~~ | **Waiting for Info** column |
-| ~~blocked~~ | **Blocked** column |
-| ~~in-progress~~ | **In Progress** column |
-| ~~ready-for-review~~ | **In Review** column |
-| ~~duplicate~~ | Close with comment linking to original |
-| ~~wontfix~~ | Close with explanation in comment |
+| ❌ Don't Use Label   | ✅ Use Project Column Instead          |
+| -------------------- | -------------------------------------- |
+| ~~needs-info~~       | **Waiting for Info** column            |
+| ~~blocked~~          | **Blocked** column                     |
+| ~~in-progress~~      | **In Progress** column                 |
+| ~~ready-for-review~~ | **In Review** column                   |
+| ~~duplicate~~        | Close with comment linking to original |
+| ~~wontfix~~          | Close with explanation in comment      |
 
 ### Automated Labeling
 
@@ -177,6 +178,7 @@ These are **NOT** labels - they're handled by GitHub Project columns:
 5. Add special labels if appropriate:
    - `good-first-issue` for simple, well-defined issues
    - `help-wanted` for community contributions
+   - `never-stale` for long-lived backlog work that should not auto-close
    - `upstream` if it's a data issue → close with comment
 
    **Note**: Prefer `help-wanted` over `good-first-issue` unless the issue is truly first-time contributor safe.
@@ -207,17 +209,20 @@ When someone reports incorrect quest requirements, missing items, wrong item pro
 
 ## Quick Reference
 
-**Total Labels: 12** (down from 31!)
+**Total Labels: 13** (down from 31!)
 
 **By Category:**
+
 - Area: 6 labels (area:ui, area:api, area:database, area:auth, area:realtime, area:i18n)
 - Priority: 3 labels (priority:high, priority:medium, priority:low)
-- Special: 3 labels (good-first-issue, help-wanted, upstream)
+- Special: 4 labels (good-first-issue, help-wanted, never-stale, upstream)
 
 **Issue Types (not labels): 5**
+
 - bug, feature, enhancement, dependencies, documentation
 
 **Most Common Patterns:**
+
 - Issue Type: `bug` + Labels: `area:ui, priority:medium`
 - Issue Type: `enhancement` + Labels: `area:ui, priority:low`
 - Issue Type: `feature` + Labels: `area:api, priority:high`

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,7 +37,7 @@ the current floors as long-term targets.
 ### Stale (`stale.yml`)
 
 **Trigger:** Daily schedule
-**Jobs:** Mark and close stale issues/PRs
+**Jobs:** Mark and close stale PRs; issues are excluded from stale automation
 
 ## Check Count
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -37,7 +37,7 @@ the current floors as long-term targets.
 ### Stale (`stale.yml`)
 
 **Trigger:** Daily schedule
-**Jobs:** Mark and close stale PRs; issues are excluded from stale automation
+**Jobs:** Mark inactive issues/PRs stale, then close stale items unless labeled `never-stale`
 
 ## Check Count
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,23 +6,43 @@ on:
   workflow_dispatch:
 
 jobs:
-  stale:
+  stale-reminder:
     runs-on: ubuntu-latest
     permissions:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
+      - name: Mark inactive issues and PRs
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
         with:
-          stale-issue-message: 'This issue has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs. Thank you for your contributions.'
-          stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.'
-          close-issue-message: 'This issue was closed because it has been stalled for 14 days with no activity.'
-          close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity.'
-          days-before-issue-stale: -1
-          days-before-issue-close: -1
-          days-before-pr-stale: 60
-          days-before-pr-close: 14
+          stale-issue-message: 'This issue has been inactive for 60 days. Please review whether it is already addressed, should be prioritized, or needs a status update. Add the `never-stale` label if it should remain open without auto-close.'
+          stale-pr-message: 'This PR has been inactive for 60 days. Please review whether it is still needed, blocked, ready to close, or needs a status update. Add the `never-stale` label if it should remain open without auto-close.'
+          days-before-stale: 60
+          days-before-close: -1
           operations-per-run: 100
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-pr-labels: 'pinned,security,enhancement'
+          exempt-issue-labels: 'pinned,security'
+          exempt-pr-labels: 'pinned,security'
+
+  stale-close:
+    runs-on: ubuntu-latest
+    needs: stale-reminder
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Close stale items unless protected
+        uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f
+        with:
+          close-issue-message: 'This issue was closed because it has been stalled for 14 days with no activity after being marked stale.'
+          close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity after being marked stale.'
+          days-before-stale: -1
+          days-before-close: 14
+          operations-per-run: 100
+          stale-issue-label: 'stale'
+          stale-pr-label: 'stale'
+          any-of-issue-labels: 'stale'
+          any-of-pr-labels: 'stale'
+          exempt-issue-labels: 'pinned,security,never-stale'
+          exempt-pr-labels: 'pinned,security,never-stale'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,10 +18,11 @@ jobs:
           stale-pr-message: 'This PR has been automatically marked as stale because it has not had recent activity. It will be closed if no further activity occurs.'
           close-issue-message: 'This issue was closed because it has been stalled for 14 days with no activity.'
           close-pr-message: 'This PR was closed because it has been stalled for 14 days with no activity.'
-          days-before-stale: 60
-          days-before-close: 14
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
           operations-per-run: 100
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'
-          exempt-issue-labels: 'pinned,security,enhancement'
           exempt-pr-labels: 'pinned,security,enhancement'

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -93,12 +93,13 @@ Merges known low-risk Dependabot PRs after the normal PR checks complete:
 
 ### 6. Stale Management (`.github/workflows/stale.yml`)
 
-Automatic stale PR management:
+Automatic stale issue/PR management:
 
-- Does not mark or close issues as stale
-- Marks PRs stale after 60 days
-- Closes stale PRs after 14 days
-- Exempts PRs: `pinned`, `security`, `enhancement` labels
+- Marks issues/PRs stale after 60 days and leaves a review reminder
+- Closes stale issues/PRs after 14 more days
+- Add `never-stale` to issues/PRs that should keep stale reminders but never auto-close
+- Exempts issues/PRs from stale reminders and closing: `pinned`, `security`
+- Exempts issues/PRs from auto-close only: `never-stale`
 
 ### 7. Link Check (`.github/workflows/link-check.yml`)
 

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -93,11 +93,11 @@ Merges known low-risk Dependabot PRs after the normal PR checks complete:
 
 ### 6. Stale Management (`.github/workflows/stale.yml`)
 
-Automatic stale issue/PR management:
+Automatic stale PR management:
 
-- Marks issues/PRs stale after 60 days
-- Closes stale items after 14 days
-- Exempts issues: `pinned`, `security`, `enhancement` labels
+- Does not mark or close issues as stale
+- Marks PRs stale after 60 days
+- Closes stale PRs after 14 days
 - Exempts PRs: `pinned`, `security`, `enhancement` labels
 
 ### 7. Link Check (`.github/workflows/link-check.yml`)


### PR DESCRIPTION
## Summary
Adds a protected stale path so inactive issues and PRs still get review reminders, while selected long-lived backlog items can be protected from automatic closure.

## Changes
- Split stale automation into reminder and close jobs.
- Added `never-stale` as the opt-out label for stale auto-close.
- Documented `never-stale` in the label guide and workflow docs.
- Clarified the `never-stale` label wording after CodeRabbit feedback.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing feature)
- [ ] Refactoring (code restructuring without changing functionality)
- [x] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Area(s) Affected
- [ ] Frontend (UI/UX)
- [ ] Backend (Supabase/Nitro/Workers)
- [ ] Tasks/Quests
- [ ] Team Features
- [ ] Hideout
- [ ] Maps
- [ ] Traders
- [ ] API
- [ ] i18n/Translations
- [x] Other: GitHub Actions and repository workflow docs

## Related Issues
- Related to stale backlog cleanup: #89, #102, #104, #106, #107, #108, #122, #123, #124, #128, #135, #188, #189

## Testing
- [x] Tested locally
- [ ] Tested in production-like environment
- [ ] Added/updated unit tests
- [x] Manual testing performed

### Test Plan
1. Ran `npm run format`.
2. Verified `never-stale` exists on GitHub with the updated description.
3. Verified closed issues with the `stale` label return an empty list.
4. Verified PR checks after pushing the branch.

## Screenshots/Videos
Not applicable.

## Checklist
- [x] My code follows the project coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated relevant documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes
Live repository cleanup was also done: stale-closed feature backlog issues were reopened, the `stale` label was removed from rescued issues, `never-stale` was created, and it was applied to the long-lived backlog items listed above.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `never-stale` label to prevent automatic closing of important long-lived issues and pull requests

* **Documentation**
  * Updated stale management docs to a two-stage process: mark as stale after 60 days, then auto-close 14 days later if still stale
  * Clarified label exemption rules and maintainer triage guidance for `pinned`, `security`, and `never-stale`
<!-- end of auto-generated comment: release notes by coderabbit.ai -->