### PR TITLE
[codex] add CodeAnt coverage upload

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,7 +7,7 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 ### CI (`ci.yml`)
 
 **Trigger:** Push to main/develop/wip branches, PRs
-**Jobs:** `Validate` (lint, typecheck, format, test, build), `Supabase DB` (reset + lint local migrations), `Workers` (validate api-gateway)
+**Jobs:** `Validate` (lint, typecheck, format, coverage, CodeAnt upload, build), `Supabase DB` (reset + lint local migrations), `Workers` (validate api-gateway)
 
 ### Security (`security.yml`)
 
@@ -51,7 +51,7 @@ the current floors as long-term targets.
 
 ## Secrets
 
-Workflow-specific secrets are not required for the Gitleaks step anymore. The workflow downloads a pinned Gitleaks release and verifies its published checksum before scanning. App build jobs still use the existing Nuxt/Supabase secrets configured for CI and release.
+Workflow-specific secrets are not required for the Gitleaks step anymore. The workflow downloads a pinned Gitleaks release and verifies its published checksum before scanning. App build jobs still use the existing Nuxt/Supabase secrets configured for CI and release. CodeAnt coverage upload requires `ACCESS_TOKEN_GITHUB` with the repository access documented by CodeAnt.
 
 ## Commands
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,18 @@ jobs:
       - name: Test with coverage
         run: npm run test:coverage
 
+      - name: Check CodeAnt token
+        id: codeant-token
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        run: |
+          if [ -n "$CODEANT_ACCESS_TOKEN" ]; then
+            echo "available=true" >> "$GITHUB_OUTPUT"
+          fi
+        env:
+          CODEANT_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_GITHUB }}
+
       - name: Upload coverage to CodeAnt AI
-        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.secret_source == 'Actions'
+        if: steps.codeant-token.outputs.available == 'true'
         uses: CodeAnt-AI/codeant-coverage-action@0d670ed6f27284867ef4373f2a9a568a5aeffce2
         with:
           access_token: ${{ secrets.ACCESS_TOKEN_GITHUB }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,25 @@ jobs:
 
       - name: Upload coverage to CodeAnt AI
         if: steps.codeant-token.outputs.available == 'true'
-        uses: CodeAnt-AI/codeant-coverage-action@0d670ed6f27284867ef4373f2a9a568a5aeffce2
-        with:
-          access_token: ${{ secrets.ACCESS_TOKEN_GITHUB }}
-          coverage_file: coverage/cobertura-coverage.xml
+        env:
+          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_GITHUB }}
+          COVERAGE_FILE: coverage/cobertura-coverage.xml
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          curl -sS -X GET "https://api.codeant.ai/pr/analysis/coverage/script/get" \
+            --output upload_coverage.sh.b64
+          base64 -d upload_coverage.sh.b64 > upload_coverage.sh
+          chmod +x upload_coverage.sh
+          commit_id="${PR_HEAD_SHA:-$GITHUB_SHA}"
+          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+          bash upload_coverage.sh \
+            -t "$ACCESS_TOKEN" \
+            -r "$GITHUB_REPOSITORY" \
+            -c "$commit_id" \
+            -f "$COVERAGE_FILE" \
+            -p github \
+            -b "$branch" \
+            -u "https://github.com"
 
       - name: Build
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Upload coverage to CodeAnt AI
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) && github.secret_source == 'Actions'
         uses: CodeAnt-AI/codeant-coverage-action@0d670ed6f27284867ef4373f2a9a568a5aeffce2
         with:
           access_token: ${{ secrets.ACCESS_TOKEN_GITHUB }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,15 @@ jobs:
       - name: Format check
         run: npm run format:check
 
-      - name: Test
-        run: npm run test
+      - name: Test with coverage
+        run: npm run test:coverage
+
+      - name: Upload coverage to CodeAnt AI
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: CodeAnt-AI/codeant-coverage-action@0d670ed6f27284867ef4373f2a9a568a5aeffce2
+        with:
+          access_token: ${{ secrets.ACCESS_TOKEN_GITHUB }}
+          coverage_file: coverage/cobertura-coverage.xml
 
       - name: Build
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .nuxt
 .nitro
 .cache
+coverage
 dist
 .wrangler
 .claude

--- a/package.json
+++ b/package.json
@@ -115,6 +115,7 @@
     "supabase:check": "bash scripts/check-supabase-db.sh",
     "supabase:types": "supabase gen types typescript --linked > supabase/functions/_shared/database.types.ts",
     "test": "vitest run --reporter=default --maxWorkers=2",
+    "test:coverage": "vitest run --coverage --reporter=default --maxWorkers=2",
     "test:watch": "vitest --watch",
     "test:api-gateway": "vitest --config workers/api-gateway/vitest.config.ts",
     "validate:openapi": "npm --prefix workers/api-gateway run validate:openapi"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,12 +25,14 @@ export default defineVitestConfig({
     fileParallelism: false,
     maxConcurrency: 1,
     testTimeout: 30000,
+    hookTimeout: 60000,
     watch: false,
     reporters: ['default'],
     passWithNoTests: false,
     coverage: {
       provider: 'v8',
-      reporter: ['text', 'json-summary', 'lcov'],
+      reportsDirectory: './coverage',
+      reporter: ['text', 'json-summary', 'lcov', 'cobertura'],
       include: ['app/**/*.{ts,vue}'],
       exclude: ['app/**/*.d.ts', 'app/**/__tests__/**'],
       thresholds: {


### PR DESCRIPTION
## Summary
Configure CI to generate Vitest coverage and upload Cobertura XML to CodeAnt AI for Code Quality coverage reporting.

## Changes
- Add `test:coverage` for local and CI coverage runs.
- Emit `coverage/cobertura-coverage.xml` from Vitest for CodeAnt.
- Upload coverage from CI with the `ACCESS_TOKEN_GITHUB` secret when repository secrets are available.
- Skip CodeAnt upload for fork/Dependabot-style PR contexts without Actions secrets.
- Ignore generated `coverage` output and document the workflow secret.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing feature)
- [ ] Refactoring (code restructuring without changing functionality)
- [x] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Area(s) Affected
- [ ] Frontend (UI/UX)
- [ ] Backend (Supabase/Nitro/Workers)
- [ ] Tasks/Quests
- [ ] Team Features
- [ ] Hideout
- [ ] Maps
- [ ] Traders
- [ ] API
- [ ] i18n/Translations
- [x] Other: CI/CD, test coverage reporting

## Related Issues
- None

## Testing
- [x] Tested locally
- [x] Tested in production-like environment
- [ ] Added/updated unit tests
- [ ] Manual testing performed

### Test Plan
1. Ran `npm run format`.
2. Ran `npm run typecheck`.
3. Ran `npm run test:coverage` and confirmed `coverage/cobertura-coverage.xml` is generated.
4. Parsed `.github/workflows/ci.yml` as YAML after review fixes.
5. Checked PR CI status and review threads.

## Screenshots/Videos
Not applicable.

## Checklist
- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated relevant documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes
The CodeAnt upload uses CodeAnt's coverage-upload script endpoint inline in CI instead of adding a third-party `uses:` action. The upload step first checks whether `ACCESS_TOKEN_GITHUB` is available, so Dependabot and fork PRs do not fail when repository secrets are unavailable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Integrated automated test coverage reporting with optional upload to CodeAnt.

* **Chores**
  * CI now runs coverage-aware tests and conditionally publishes coverage when upload credentials are present.
  * Added a test:coverage script and extended test configuration to emit Cobertura, LCOV, JSON-summary and text reports.
  * .gitignore updated to exclude coverage artifacts.

* **Documentation**
  * CI docs updated with coverage upload requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->