### PR TITLE
[codex] fix Promise delays and map popup race

### DIFF
--- a/app/components/ui/__tests__/PageHelpSpotlight.test.ts
+++ b/app/components/ui/__tests__/PageHelpSpotlight.test.ts
@@ -75,7 +75,9 @@ const mountComponent = async (steps: HelpStep[] = defaultSteps) => {
 };
 const flushUi = async (wrapper: Awaited<ReturnType<typeof mountComponent>>) => {
   await wrapper.vm.$nextTick();
-  await new Promise((resolve) => window.setTimeout(resolve, 0));
+  await new Promise((resolve) => {
+    window.setTimeout(resolve, 0);
+  });
   await wrapper.vm.$nextTick();
 };
 const findBodyButton = (label: string) =>

--- a/app/composables/__tests__/useMapObjectivePopup.test.ts
+++ b/app/composables/__tests__/useMapObjectivePopup.test.ts
@@ -15,13 +15,22 @@ const createMetadataStore = (
   objectiveMaps,
 });
 const createPreferencesStore = (mapView = 'customs') => {
-  let taskMapView = mapView;
+  const normalizeMapView = (value: unknown): string => {
+    const candidate =
+      typeof value === 'string'
+        ? value
+        : value && typeof value === 'object' && 'value' in value
+          ? (value as { value?: unknown }).value
+          : null;
+    return typeof candidate === 'string' && candidate.length > 0 ? candidate : 'all';
+  };
+  let taskMapView = normalizeMapView(mapView);
   return {
     get getTaskMapView() {
-      return taskMapView;
+      return normalizeMapView(taskMapView);
     },
     setTaskMapView: vi.fn((nextMapView: string) => {
-      taskMapView = nextMapView;
+      taskMapView = normalizeMapView(nextMapView);
     }),
   };
 };

--- a/app/composables/__tests__/useMapObjectivePopup.test.ts
+++ b/app/composables/__tests__/useMapObjectivePopup.test.ts
@@ -14,10 +14,17 @@ const createMetadataStore = (
   objectives,
   objectiveMaps,
 });
-const createPreferencesStore = (mapView = 'customs') => ({
-  getTaskMapView: mapView,
-  setTaskMapView: vi.fn(),
-});
+const createPreferencesStore = (mapView = 'customs') => {
+  let taskMapView = mapView;
+  return {
+    get getTaskMapView() {
+      return taskMapView;
+    },
+    setTaskMapView: vi.fn((nextMapView: string) => {
+      taskMapView = nextMapView;
+    }),
+  };
+};
 const mockSetup = (options?: {
   objectives?: Parameters<typeof createMetadataStore>[0];
   objectiveMaps?: Parameters<typeof createMetadataStore>[1];
@@ -185,6 +192,34 @@ describe('useMapObjectivePopup', () => {
       const { result, wrapper } = await setupComposable(mocks);
       await result.jumpToMapObjective('obj-1');
       expect(mocks.preferencesStore.setTaskMapView).not.toHaveBeenCalled();
+      result.cleanup();
+      wrapper.unmount();
+    });
+    it('ignores stale delayed jumps when a newer objective is selected', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: false });
+      const mocks = mockSetup({
+        objectives: [
+          { id: 'obj-a', taskId: 'task-1' },
+          { id: 'obj-b', taskId: 'task-1' },
+        ],
+        objectiveMaps: {
+          'task-1': [
+            { objectiveID: 'obj-a', mapID: 'woods' },
+            { objectiveID: 'obj-b', mapID: 'woods' },
+          ],
+        },
+        mapView: 'customs',
+        activateResult: true,
+      });
+      const { result, wrapper } = await setupComposable(mocks);
+      const firstJump = result.jumpToMapObjective('obj-a');
+      const secondJump = result.jumpToMapObjective('obj-b');
+      await secondJump;
+      expect(mocks.activateObjectivePopup).toHaveBeenCalledTimes(1);
+      expect(mocks.activateObjectivePopup).toHaveBeenCalledWith('obj-b');
+      await vi.advanceTimersByTimeAsync(100);
+      await firstJump;
+      expect(mocks.activateObjectivePopup).toHaveBeenCalledTimes(1);
       result.cleanup();
       wrapper.unmount();
     });

--- a/app/composables/useMapObjectivePopup.ts
+++ b/app/composables/useMapObjectivePopup.ts
@@ -89,7 +89,9 @@ export function useMapObjectivePopup({
       preferencesStore.setTaskMapView(targetMapId);
       await nextTick();
       if (!isMounted.value) return;
-      await new Promise((resolve) => setTimeout(resolve, MAP_POPUP_POST_RERENDER_DELAY));
+      await new Promise((resolve) => {
+        setTimeout(resolve, MAP_POPUP_POST_RERENDER_DELAY);
+      });
       if (!isMounted.value) return;
     }
     const isNearTop = window.scrollY < NEAR_TOP_SCROLL_THRESHOLD;

--- a/app/composables/useMapObjectivePopup.ts
+++ b/app/composables/useMapObjectivePopup.ts
@@ -26,6 +26,7 @@ export function useMapObjectivePopup({
   const metadataStore = useMetadataStore();
   const preferencesStore = usePreferencesStore();
   const isMounted = ref(true);
+  let mapJumpRequestId = 0;
   let jumpToMapTimeoutId: ReturnType<typeof setTimeout> | null = null;
   const popupActivateTimers = ref<ReturnType<typeof setTimeout>[]>([]);
   const clearPopupActivateTimers = () => {
@@ -79,6 +80,7 @@ export function useMapObjectivePopup({
     window.scrollTo({ top: 0, behavior: 'smooth' });
   };
   const jumpToMapObjective = async (objectiveId: string) => {
+    const requestId = (mapJumpRequestId += 1);
     if (jumpToMapTimeoutId) {
       clearTimeout(jumpToMapTimeoutId);
       jumpToMapTimeoutId = null;
@@ -88,11 +90,11 @@ export function useMapObjectivePopup({
     if (targetMapId && targetMapId !== currentMapId) {
       preferencesStore.setTaskMapView(targetMapId);
       await nextTick();
-      if (!isMounted.value) return;
+      if (!isMounted.value || requestId !== mapJumpRequestId) return;
       await new Promise((resolve) => {
         setTimeout(resolve, MAP_POPUP_POST_RERENDER_DELAY);
       });
-      if (!isMounted.value) return;
+      if (!isMounted.value || requestId !== mapJumpRequestId) return;
     }
     const isNearTop = window.scrollY < NEAR_TOP_SCROLL_THRESHOLD;
     if (!isNearTop) {
@@ -104,7 +106,7 @@ export function useMapObjectivePopup({
     }
     jumpToMapTimeoutId = setTimeout(() => {
       jumpToMapTimeoutId = null;
-      if (!isMounted.value) return;
+      if (!isMounted.value || requestId !== mapJumpRequestId) return;
       activateObjectivePopupWithRetry(objectiveId);
     }, SCROLL_TO_MAP_POPUP_DELAY);
   };

--- a/app/composables/useTaskDeepLink.ts
+++ b/app/composables/useTaskDeepLink.ts
@@ -149,7 +149,9 @@ export function useTaskDeepLink({
         return true;
       }
       if (attempt < maxAttempts - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 25));
+        await new Promise((resolve) => {
+          setTimeout(resolve, 25);
+        });
       }
     }
     return filteredTasks.value.some((task) => task.id === taskId);
@@ -162,7 +164,9 @@ export function useTaskDeepLink({
         return taskElement;
       }
       if (attempt < maxAttempts - 1) {
-        await new Promise((resolve) => setTimeout(resolve, 25));
+        await new Promise((resolve) => {
+          setTimeout(resolve, 25);
+        });
       }
     }
     return document.getElementById(`task-${taskId}`);

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -92,7 +92,9 @@
           callbackError.message
         );
       }
-      await new Promise((resolve) => setTimeout(resolve, AUTH_CALLBACK_HASH_SETTLE_TIMEOUT_MS));
+      await new Promise((resolve) => {
+        setTimeout(resolve, AUTH_CALLBACK_HASH_SETTLE_TIMEOUT_MS);
+      });
       await $supabase.ready();
       if ($supabase.user.loggedIn) {
         return { authenticated: true as const };

--- a/app/plugins/metadata.client.ts
+++ b/app/plugins/metadata.client.ts
@@ -47,7 +47,9 @@ export default defineNuxtPlugin((nuxtApp) => {
           `[MetadataPlugin] Background initialization failed (attempt ${attempt}/${MAX_ATTEMPTS}). Retrying in ${delay}ms...`,
           err
         );
-        await new Promise((resolve) => setTimeout(resolve, delay));
+        await new Promise((resolve) => {
+          setTimeout(resolve, delay);
+        });
         return initializeWithRetry(attempt + 1);
       }
       // Final failure handling after all retries

--- a/app/server/utils/streamerKappa.ts
+++ b/app/server/utils/streamerKappa.ts
@@ -155,7 +155,6 @@ export const computeStreamerKappaMetrics = ({
     taskCompletions: normalizeTaskCompletionsForInvalidation(taskCompletions),
     tasks: relevantTasks,
   });
-  const eligibleKappaTaskIds = new Set<string>();
   const eligibleCollectorTaskIds = new Set<string>();
   let totalKappaTasks = 0;
   let completedKappaTasks = 0;
@@ -172,14 +171,12 @@ export const computeStreamerKappaMetrics = ({
     if (successful) {
       totalKappaTasks += 1;
       completedKappaTasks += 1;
-      eligibleKappaTaskIds.add(task.id);
       continue;
     }
     if (failed || invalid) {
       continue;
     }
     totalKappaTasks += 1;
-    eligibleKappaTaskIds.add(task.id);
   }
   const mergedKappaItems = mergeKappaItemRequirements(
     neededItemTaskObjectives,

--- a/app/server/utils/tarkovFetcher.ts
+++ b/app/server/utils/tarkovFetcher.ts
@@ -34,7 +34,12 @@ export function createTarkovFetcher<T = unknown>(
   const { maxRetries = 3, timeoutMs = 30000, allowPartialData = false, deps } = options;
   const fetcher = deps?.fetcher ?? ($fetch as TarkovFetcherRequest);
   const fetcherLogger = deps?.logger ?? logger;
-  const sleep = deps?.sleep ?? ((ms: number) => new Promise((resolve) => setTimeout(resolve, ms)));
+  const sleep =
+    deps?.sleep ??
+    ((ms: number) =>
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, ms);
+      }));
   const safeMaxRetries = Number.isFinite(maxRetries) ? Math.max(1, Math.floor(maxRetries)) : 3;
   const safeTimeoutMs = Number.isFinite(timeoutMs) ? Math.max(1000, Math.floor(timeoutMs)) : 30000;
   return async () => {

--- a/app/types/vue.d.ts
+++ b/app/types/vue.d.ts
@@ -1,6 +1,5 @@
 declare module '*.vue' {
   import type { DefineComponent } from 'vue';
-  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
-  const component: DefineComponent<{}, {}, unknown>;
+  const component: DefineComponent<Record<string, never>, Record<string, never>, unknown>;
   export default component;
 }

--- a/supabase/functions/account-delete-reconcile/index.ts
+++ b/supabase/functions/account-delete-reconcile/index.ts
@@ -61,7 +61,10 @@ interface ReconcileRequest {
   dryRun?: boolean;
 }
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
 
 const getErrorMessage = (error: unknown) => {
   if (typeof error === 'string') return error;
@@ -161,7 +164,9 @@ const cleanupUserData = async (supabase: TypedSupabaseClient, userId: string) =>
     promise
       .then(({ error }) => ({ tableKey, error }))
       .catch((error) => {
-        throw { tableKey, error };
+        const tableError = new Error(`Failed to delete ${tableKey} rows`);
+        Object.assign(tableError, { cause: error, tableKey });
+        throw tableError;
       })
   );
 
@@ -173,10 +178,10 @@ const cleanupUserData = async (supabase: TypedSupabaseClient, userId: string) =>
       }
       continue;
     }
-    const reason = result.reason as { tableKey?: string; error?: unknown };
+    const reason = result.reason as { cause?: unknown; tableKey?: string };
     const tableKey = typeof reason?.tableKey === 'string' ? reason.tableKey : 'unknown';
     const error =
-      reason && typeof reason === 'object' && 'error' in reason ? reason.error : reason;
+      reason && typeof reason === 'object' && 'cause' in reason ? reason.cause : reason;
     cleanupErrors[tableKey] = getErrorMessage(error);
   }
 

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -57,7 +57,10 @@ interface TypedSupabaseClient {
   rpc(fn: string, args?: Record<string, unknown>): Promise<{ data: unknown; error: unknown }>;
 }
 
-const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
 
 const getErrorMessage = (error: unknown) => {
   if (typeof error === 'string') return error;


### PR DESCRIPTION
## **User description**
## Summary
- Fix promise delay wrappers so Promise executors do not return timer handles
- Remove unused Kappa task tracking state from streamer metrics
- Wrap Supabase reconcile table cleanup failures in real Error instances and tighten the Vue SFC shim type

## Why
AntCode reported a broad set of antipatterns. The noisy or intentional findings were left alone; this PR applies the validated, low-risk fixes that improve correctness and type hygiene.

## Validation
- npm run format
- npm run typecheck
- npx vitest run app/server/utils/__tests__/streamerKappa.test.ts app/server/utils/__tests__/tarkovFetcher.test.ts app/composables/__tests__/useTaskDeepLink.test.ts app/composables/__tests__/useMapObjectivePopup.test.ts app/plugins/__tests__/metadata.client.test.ts app/components/ui/__tests__/PageHelpSpotlight.test.ts app/pages/__tests__/auth-callback.page.test.ts --reporter=default --maxWorkers=2
- CodeRabbit review: 0 issues


___

## **CodeAnt-AI Description**
**Prevent older map jumps from opening the wrong popup**

### What Changed
- When a user selects a new map objective, the app now ignores earlier delayed jumps so the popup opens for the latest selection instead of a stale one.
- Login, task deep-link, metadata refresh, and account cleanup waits now pause cleanly without returning timer handles.
- Account deletion cleanup now shows direct per-table failure messages when a delete step fails.
- Vue components now use a stricter default empty-props shape.

### Impact
`✅ Fewer stale map popup jumps`
`✅ Clearer account deletion failure messages`
`✅ More reliable login and task deep-link timing`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=8Hq_ul8RiT9OexB3WleD87l8hdC2F3aDsFYctVhM1kI&org=tarkovtracker-org)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
