### PR TITLE
[codex] Harden progress sync, imports, and API safety

### DIFF
--- a/app/composables/useAppInitialization.ts
+++ b/app/composables/useAppInitialization.ts
@@ -60,14 +60,19 @@ export function useAppInitialization() {
   const resetTarkovState = (reason: string, previousUserId: string | null = null) => {
     resetTarkovStoreForSessionTransition(previousUserId, reason);
   };
-  const startSyncIfNeeded = async (expectedUserId?: string) => {
+  const startSyncIfNeeded = async (expectedUserId?: string, expectedToken?: number) => {
     const authenticatedUserId = getAuthenticatedUserId();
     if (expectedUserId && authenticatedUserId !== expectedUserId) return;
+    if (expectedToken !== undefined && expectedToken !== authChangeToken) return;
     if (!authenticatedUserId || syncStarted) return;
     syncStarted = true;
     try {
       await initializeTarkovSync();
       if (expectedUserId && getAuthenticatedUserId() !== expectedUserId) {
+        syncStarted = false;
+        return;
+      }
+      if (expectedToken !== undefined && expectedToken !== authChangeToken) {
         syncStarted = false;
       }
     } catch (error) {
@@ -112,7 +117,7 @@ export function useAppInitialization() {
         syncStarted = false;
         migrationAttempted = false;
       }
-      await startSyncIfNeeded(userId);
+      await startSyncIfNeeded(userId, token);
       if (token !== authChangeToken) return;
       await runMigrationIfNeeded(userId);
     },

--- a/app/composables/useAppInitialization.ts
+++ b/app/composables/useAppInitialization.ts
@@ -54,28 +54,36 @@ export function useAppInitialization() {
   };
   let syncStarted = false;
   let migrationAttempted = false;
+  let authChangeToken = 0;
   // resetTarkovState keeps the existing (reason, previousUserId) call signature while forwarding
   // to resetTarkovStoreForSessionTransition(previousUserId, reason).
   const resetTarkovState = (reason: string, previousUserId: string | null = null) => {
     resetTarkovStoreForSessionTransition(previousUserId, reason);
   };
-  const startSyncIfNeeded = async () => {
+  const startSyncIfNeeded = async (expectedUserId?: string) => {
     const authenticatedUserId = getAuthenticatedUserId();
+    if (expectedUserId && authenticatedUserId !== expectedUserId) return;
     if (!authenticatedUserId || syncStarted) return;
     syncStarted = true;
     try {
       await initializeTarkovSync();
+      if (expectedUserId && getAuthenticatedUserId() !== expectedUserId) {
+        syncStarted = false;
+      }
     } catch (error) {
       syncStarted = false;
       logger.error('[useAppInitialization] Error initializing Supabase sync:', error);
       showLoadFailed();
     }
   };
-  const runMigrationIfNeeded = async () => {
-    if (!getAuthenticatedUserId() || migrationAttempted) return;
+  const runMigrationIfNeeded = async (expectedUserId?: string) => {
+    const authenticatedUserId = getAuthenticatedUserId();
+    if (expectedUserId && authenticatedUserId !== expectedUserId) return;
+    if (!authenticatedUserId || migrationAttempted) return;
     try {
       const store = useTarkovStore();
       await store.migrateDataIfNeeded?.();
+      if (expectedUserId && getAuthenticatedUserId() !== expectedUserId) return;
       migrationAttempted = true;
     } catch (error) {
       migrationAttempted = false;
@@ -87,6 +95,7 @@ export function useAppInitialization() {
   watch(
     () => [$supabase.user.loggedIn, $supabase.user.id] as const,
     async ([loggedIn, userId], previous) => {
+      const token = ++authChangeToken;
       const [prevLoggedIn, prevUserId] = previous ?? [false, null];
       if (!loggedIn || !userId) {
         if (prevLoggedIn && prevUserId) {
@@ -103,8 +112,9 @@ export function useAppInitialization() {
         syncStarted = false;
         migrationAttempted = false;
       }
-      await startSyncIfNeeded();
-      await runMigrationIfNeeded();
+      await startSyncIfNeeded(userId);
+      if (token !== authChangeToken) return;
+      await runMigrationIfNeeded(userId);
     },
     { immediate: true }
   );

--- a/app/composables/useAppInitialization.ts
+++ b/app/composables/useAppInitialization.ts
@@ -55,8 +55,6 @@ export function useAppInitialization() {
   let syncStarted = false;
   let migrationAttempted = false;
   let authChangeToken = 0;
-  // resetTarkovState keeps the existing (reason, previousUserId) call signature while forwarding
-  // to resetTarkovStoreForSessionTransition(previousUserId, reason).
   const resetTarkovState = (reason: string, previousUserId: string | null = null) => {
     resetTarkovStoreForSessionTransition(previousUserId, reason);
   };
@@ -81,14 +79,16 @@ export function useAppInitialization() {
       showLoadFailed();
     }
   };
-  const runMigrationIfNeeded = async (expectedUserId?: string) => {
+  const runMigrationIfNeeded = async (expectedUserId?: string, expectedToken?: number) => {
     const authenticatedUserId = getAuthenticatedUserId();
     if (expectedUserId && authenticatedUserId !== expectedUserId) return;
+    if (expectedToken !== undefined && expectedToken !== authChangeToken) return;
     if (!authenticatedUserId || migrationAttempted) return;
     try {
       const store = useTarkovStore();
       await store.migrateDataIfNeeded?.();
       if (expectedUserId && getAuthenticatedUserId() !== expectedUserId) return;
+      if (expectedToken !== undefined && expectedToken !== authChangeToken) return;
       migrationAttempted = true;
     } catch (error) {
       migrationAttempted = false;
@@ -119,7 +119,7 @@ export function useAppInitialization() {
       }
       await startSyncIfNeeded(userId, token);
       if (token !== authChangeToken) return;
-      await runMigrationIfNeeded(userId);
+      await runMigrationIfNeeded(userId, token);
     },
     { immediate: true }
   );

--- a/app/composables/useEftLogsImport.ts
+++ b/app/composables/useEftLogsImport.ts
@@ -193,6 +193,7 @@ export function useEftLogsImport(): UseEftLogsImportReturn {
   const selectedVersions = ref<string[]>([]);
   const sourceFileName = ref(t('settings.log_import.selected_files'));
   const scannedEntriesCount = ref(0);
+  let parseFilesRequestId = 0;
   function getTaskIds(): string[] {
     return metadataStore.tasks.map((task) => task.id);
   }
@@ -217,6 +218,7 @@ export function useEftLogsImport(): UseEftLogsImportReturn {
     importError.value = null;
   }
   function reset(): void {
+    parseFilesRequestId++;
     importState.value = 'idle';
     previewData.value = null;
     importError.value = null;
@@ -226,6 +228,8 @@ export function useEftLogsImport(): UseEftLogsImportReturn {
     scannedEntriesCount.value = 0;
   }
   async function parseFiles(files: File[]): Promise<void> {
+    const requestId = ++parseFilesRequestId;
+    const isActiveRequest = () => requestId === parseFilesRequestId;
     importState.value = 'idle';
     previewData.value = null;
     importError.value = null;
@@ -246,6 +250,7 @@ export function useEftLogsImport(): UseEftLogsImportReturn {
         ensureImportFileSize(file);
         if (isZipFile(file)) {
           const zipSource = await readZipLogs(file);
+          if (!isActiveRequest()) return;
           scannedEntries += zipSource.scanned;
           importFiles.push(...zipSource.files);
           continue;
@@ -255,14 +260,17 @@ export function useEftLogsImport(): UseEftLogsImportReturn {
       if (rawLogFiles.length > 0) {
         if (rawLogFiles.length === 1) {
           const singleSource = await readSingleLogFile(rawLogFiles[0]!);
+          if (!isActiveRequest()) return;
           scannedEntries += singleSource.scanned;
           importFiles.push(...singleSource.files);
         } else {
           const rawSource = await readRawImportLogFiles(rawLogFiles);
+          if (!isActiveRequest()) return;
           scannedEntries += rawSource.scanned;
           importFiles.push(...rawSource.files);
         }
       }
+      if (!isActiveRequest()) return;
       if (importFiles.length === 0) {
         importState.value = 'error';
         importError.value = t('settings.log_import.errors.no_notification_logs_found');
@@ -299,6 +307,7 @@ export function useEftLogsImport(): UseEftLogsImportReturn {
       previewData.value = buildPreviewData(taskIds);
       importState.value = 'preview';
     } catch (error) {
+      if (!isActiveRequest()) return;
       importState.value = 'error';
       importError.value = normalizeErrorMessage(error, t);
       logger.error('[EftLogsImport] Parse error:', error);

--- a/app/composables/useTarkovDevImport.ts
+++ b/app/composables/useTarkovDevImport.ts
@@ -28,7 +28,9 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
   const importState = ref<ImportState>('idle');
   const previewData = ref<TarkovDevImportResult | null>(null);
   const importError = ref<string | null>(null);
+  let profileUrlRequestId = 0;
   function reset(): void {
+    profileUrlRequestId++;
     importState.value = 'idle';
     previewData.value = null;
     importError.value = null;
@@ -64,9 +66,11 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
     }
   }
   async function parseProfileUrl(profileUrl: string): Promise<TarkovDevProfileSource | null> {
+    const requestId = ++profileUrlRequestId;
     importError.value = null;
     const source = resolveTarkovDevProfileSource(profileUrl);
     if (!source.ok) {
+      if (requestId !== profileUrlRequestId) return null;
       importState.value = 'error';
       previewData.value = null;
       importError.value = source.error;
@@ -78,8 +82,10 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
       const json = await $fetch<unknown>('/api/tarkov-dev/profile', {
         query: { url: source.data.profileJsonUrl },
       });
+      if (requestId !== profileUrlRequestId) return null;
       return applyProfilePayload(json) ? source.data : null;
     } catch (e) {
+      if (requestId !== profileUrlRequestId) return null;
       importState.value = 'error';
       importError.value =
         'Unable to fetch Tarkov.dev profile. Open the profile on Tarkov.dev, then try again.';

--- a/app/composables/useTarkovDevImport.ts
+++ b/app/composables/useTarkovDevImport.ts
@@ -54,13 +54,16 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
     return true;
   }
   async function parseFile(file: File): Promise<void> {
-    profileUrlRequestId++;
+    const requestId = ++profileUrlRequestId;
     importState.value = 'loading';
     previewData.value = null;
     importError.value = null;
     try {
-      applyProfilePayload(JSON.parse(await file.text()));
+      const text = await file.text();
+      if (requestId !== profileUrlRequestId) return;
+      applyProfilePayload(JSON.parse(text));
     } catch (e) {
+      if (requestId !== profileUrlRequestId) return;
       importState.value = 'error';
       importError.value = 'Failed to read or parse JSON file';
       logger.error('[TarkovDevImport] Parse error:', e);

--- a/app/composables/useTarkovDevImport.ts
+++ b/app/composables/useTarkovDevImport.ts
@@ -54,6 +54,7 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
     return true;
   }
   async function parseFile(file: File): Promise<void> {
+    profileUrlRequestId++;
     importState.value = 'loading';
     previewData.value = null;
     importError.value = null;

--- a/app/locales/cs.json
+++ b/app/locales/cs.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Podmínky služby",
       "popup_blocked_title": "Blokované vyskakovací okno",
       "popup_blocked_description": "Váš prohlížeč zablokoval přihlašovací okno. Probíhá přesměrování nyní...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Přihlášení se nezdařilo",
       "error_description": "Ověření bylo zrušeno nebo se nezdařilo. Zkuste to prosím znovu.",
       "success_title": "Přihlášen",

--- a/app/locales/de.json
+++ b/app/locales/de.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Nutzungsbedingungen",
       "popup_blocked_title": "Popup blockiert",
       "popup_blocked_description": "Dein Browser hat das Anmeldefenster blockiert. Du wirst jetzt weitergeleitet...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Angemeldet",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Terms of Service",
       "popup_blocked_title": "Popup Blocked",
       "popup_blocked_description": "Your browser blocked the sign-in window. Redirecting you now...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Signed in",

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Términos de servicio",
       "popup_blocked_title": "Popup bloqueado",
       "popup_blocked_description": "Tu navegador bloqueó la ventana de inicio de sesión. Redirigiendo ahora...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Sesión iniciada",

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Conditions d'utilisation",
       "popup_blocked_title": "Popup bloqué",
       "popup_blocked_description": "Votre navigateur a bloqué la fenêtre de connexion. Redirection en cours...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Connecté",

--- a/app/locales/it.json
+++ b/app/locales/it.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Terms of Service",
       "popup_blocked_title": "Popup Blocked",
       "popup_blocked_description": "Your browser blocked the sign-in window. Redirecting you now...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Signed in",

--- a/app/locales/ko.json
+++ b/app/locales/ko.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Terms of Service",
       "popup_blocked_title": "Popup Blocked",
       "popup_blocked_description": "Your browser blocked the sign-in window. Redirecting you now...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Signed in",

--- a/app/locales/pl.json
+++ b/app/locales/pl.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Terms of Service",
       "popup_blocked_title": "Popup Blocked",
       "popup_blocked_description": "Your browser blocked the sign-in window. Redirecting you now...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Signed in",

--- a/app/locales/pt.json
+++ b/app/locales/pt.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Terms of Service",
       "popup_blocked_title": "Popup Blocked",
       "popup_blocked_description": "Your browser blocked the sign-in window. Redirecting you now...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Signed in",

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Условия использования",
       "popup_blocked_title": "Всплывающее окно заблокировано",
       "popup_blocked_description": "Ваш браузер заблокировал окно входа. Перенаправляем...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Не удалось войти",
       "error_description": "Авторизация была отменена или не удалась. Пожалуйста, попробуйте снова.",
       "success_title": "Вход выполнен",

--- a/app/locales/uk.json
+++ b/app/locales/uk.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "Умови використання",
       "popup_blocked_title": "Спливаюче вікно заблоковано",
       "popup_blocked_description": "Ваш браузер заблокував вікно входу. Перенаправляємо...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Вхід виконано",

--- a/app/locales/zh.json
+++ b/app/locales/zh.json
@@ -1078,6 +1078,8 @@
       "terms_of_service": "服务条款",
       "popup_blocked_title": "弹出窗口被阻止",
       "popup_blocked_description": "你的浏览器阻止了登录窗口。正在为你重定向...",
+      "authenticating": "Authenticating...",
+      "authenticating_description": "Please wait while we complete your sign in.",
       "error_title": "Sign-in failed",
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "已登录",

--- a/app/pages/auth/callback.vue
+++ b/app/pages/auth/callback.vue
@@ -6,8 +6,8 @@
     >
       <div class="flex flex-col items-center space-y-3 text-center">
         <UIcon name="i-heroicons-arrow-path" class="text-primary-500 h-10 w-10 animate-spin" />
-        <h2 class="text-surface-50 text-lg font-semibold">Authenticating...</h2>
-        <p class="text-surface-300 text-sm">Please wait while we complete your sign in.</p>
+        <h2 class="text-surface-50 text-lg font-semibold">{{ t('page.login.authenticating') }}</h2>
+        <p class="text-surface-300 text-sm">{{ t('page.login.authenticating_description') }}</p>
       </div>
     </UCard>
   </div>

--- a/app/server/api/team/__tests__/members.test.ts
+++ b/app/server/api/team/__tests__/members.test.ts
@@ -122,9 +122,7 @@ describe('Team Members API', () => {
       runtimeConfig.supabaseUrl = '';
       mockGetQuery.mockReturnValue({ teamId: 'team-456' });
       const { default: handler } = await import('@/server/api/team/members');
-      await expect(handler(mockEvent as H3Event)).rejects.toThrow(
-        'Missing required environment variables'
-      );
+      await expect(handler(mockEvent as H3Event)).rejects.toThrow('Service configuration error');
     });
     it('should allow missing supabaseServiceKey when auth header exists', async () => {
       runtimeConfig.supabaseServiceKey = '';
@@ -161,9 +159,7 @@ describe('Team Members API', () => {
       runtimeConfig.supabaseAnonKey = '';
       mockGetQuery.mockReturnValue({ teamId: 'team-456' });
       const { default: handler } = await import('@/server/api/team/members');
-      await expect(handler(mockEvent as H3Event)).rejects.toThrow(
-        'Missing required environment variables'
-      );
+      await expect(handler(mockEvent as H3Event)).rejects.toThrow('Service configuration error');
     });
   });
   describe('Team membership validation', () => {

--- a/app/server/api/team/members.ts
+++ b/app/server/api/team/members.ts
@@ -186,8 +186,7 @@ export default defineEventHandler(async (event) => {
   ) {
     throw createError({
       statusCode: 500,
-      statusMessage:
-        '[team/members] Missing required environment variables: SUPABASE_URL and SUPABASE_ANON_KEY must both be set',
+      statusMessage: 'Service configuration error',
     });
   }
   const teamId = (getQuery(event).teamId as string | undefined)?.trim();

--- a/app/server/middleware/api-protection.ts
+++ b/app/server/middleware/api-protection.ts
@@ -41,6 +41,9 @@ function routeMatchesPattern(route: string, pattern: string): boolean {
 function isPublicRoute(pathname: string, publicRoutes: string[]): boolean {
   return publicRoutes.some((pattern) => routeMatchesPattern(pathname, pattern));
 }
+function isAlwaysProtectedRoute(pathname: string): boolean {
+  return pathname === '/api/tarkov/cache-meta';
+}
 function ipInRange(clientIp: string, range: string): boolean {
   try {
     const addr = ipaddr.process(clientIp);
@@ -288,7 +291,7 @@ export default defineEventHandler(async (event) => {
     setResponseStatus(event, 204);
     return '';
   }
-  const isPublic = isPublicRoute(pathname, publicRoutes);
+  const isPublic = !isAlwaysProtectedRoute(pathname) && isPublicRoute(pathname, publicRoutes);
   if (requireAuth && !isPublic) {
     const authHeader = getRequestHeader(event, 'authorization');
     const supabaseUrl = config.supabaseUrl as string;

--- a/app/server/middleware/api-protection.ts
+++ b/app/server/middleware/api-protection.ts
@@ -42,7 +42,8 @@ function isPublicRoute(pathname: string, publicRoutes: string[]): boolean {
   return publicRoutes.some((pattern) => routeMatchesPattern(pathname, pattern));
 }
 function isAlwaysProtectedRoute(pathname: string): boolean {
-  return pathname === '/api/tarkov/cache-meta';
+  const normalized = pathname.replace(/\/+$/, '');
+  return normalized === '/api/tarkov/cache-meta';
 }
 function ipInRange(clientIp: string, range: string): boolean {
   try {

--- a/app/server/utils/__tests__/edgeCache.test.ts
+++ b/app/server/utils/__tests__/edgeCache.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { H3Event, createError, setResponseHeaders } from 'h3';
 let appUrl: string | undefined;
+let publicCacheBypassEnabled = false;
 vi.mock('#imports', () => ({
   useRuntimeConfig: () => ({
+    publicCacheBypassEnabled,
     public: {
       appUrl,
     },
@@ -44,6 +46,7 @@ describe('edgeCache', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     appUrl = undefined;
+    publicCacheBypassEnabled = false;
   });
   it('falls back to default cache host when appUrl is localhost', async () => {
     appUrl = 'http://localhost:3000';
@@ -91,7 +94,24 @@ describe('edgeCache', () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(cacheSpy.put).toHaveBeenCalledTimes(1);
   });
-  it('bypasses cache and skips writes when bypass header is set', async () => {
+  it('ignores public bypass headers unless bypass is enabled', async () => {
+    const fetcher = vi.fn(async () => ({ data: { items: [{ id: 'fresh' }] } }));
+    const event = createEvent({ 'x-bypass-cache': 'true' });
+    const { edgeCache } = await import('@/server/utils/edgeCache');
+    await edgeCache(event, 'items-en', fetcher, 60, {
+      cacheKeyPrefix: 'tarkov',
+      deps: {
+        createErrorFn,
+        setResponseHeadersFn: setHeaders,
+      },
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(cacheSpy.match).toHaveBeenCalledTimes(1);
+    expect(cacheSpy.put).toHaveBeenCalledTimes(1);
+  });
+  it('bypasses cache and skips writes when operator bypass is enabled', async () => {
+    publicCacheBypassEnabled = true;
+    process.env.NUXT_PUBLIC_CACHE_BYPASS_ENABLED = 'true';
     const fetcher = vi.fn(async () => ({ data: { items: [{ id: 'fresh' }] } }));
     const event = createEvent({ 'x-bypass-cache': 'true' });
     const { edgeCache } = await import('@/server/utils/edgeCache');
@@ -105,6 +125,7 @@ describe('edgeCache', () => {
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(cacheSpy.match).not.toHaveBeenCalled();
     expect(cacheSpy.put).not.toHaveBeenCalled();
+    delete process.env.NUXT_PUBLIC_CACHE_BYPASS_ENABLED;
   });
   it('sanitizes error details in thrown status message', async () => {
     const event = createEvent();

--- a/app/server/utils/edgeCache.ts
+++ b/app/server/utils/edgeCache.ts
@@ -85,6 +85,12 @@ function resolveAppUrl(deps?: EdgeCacheDependencies): string | undefined {
   return undefined;
 }
 export function shouldBypassCache(event: H3Event): boolean {
+  const config = useRuntimeConfig(event);
+  const bypassEnabled =
+    config.publicCacheBypassEnabled === true ||
+    String(config.publicCacheBypassEnabled) === 'true' ||
+    process.env.NUXT_PUBLIC_CACHE_BYPASS_ENABLED === 'true';
+  if (!bypassEnabled) return false;
   const headerValue =
     event.node?.req?.headers?.['x-bypass-cache'] ?? event.node?.req?.headers?.['x-cache-bypass'];
   if (isTruthyFlag(headerValue)) return true;

--- a/app/server/utils/logger.ts
+++ b/app/server/utils/logger.ts
@@ -67,7 +67,7 @@ function resolveLogSinkUrl(): string {
     const runtimeConfig = useRuntimeConfig();
     const runtimeSink = runtimeConfig?.logSinkUrl;
     if (typeof runtimeSink === 'string' && runtimeSink.trim().length > 0) {
-      cachedLogSinkUrl = runtimeSink.trim();
+      cachedLogSinkUrl = normalizeFetchTargetUrl(runtimeSink.trim());
       return cachedLogSinkUrl;
     }
   } catch {
@@ -75,8 +75,17 @@ function resolveLogSinkUrl(): string {
     return cachedLogSinkUrl;
   }
   const envSink = process.env.LOG_SINK_URL;
-  cachedLogSinkUrl = typeof envSink === 'string' ? envSink.trim() : '';
+  cachedLogSinkUrl = typeof envSink === 'string' ? normalizeFetchTargetUrl(envSink.trim()) : '';
   return cachedLogSinkUrl;
+}
+function normalizeFetchTargetUrl(value: string): string {
+  if (!value) return '';
+  try {
+    const url = new URL(value);
+    return url.protocol === 'https:' ? url.toString() : '';
+  } catch {
+    return '';
+  }
 }
 function sendServerLog(level: LogLevel, source: string, args: unknown[]): void {
   const sinkUrl = resolveLogSinkUrl();

--- a/app/server/utils/logger.ts
+++ b/app/server/utils/logger.ts
@@ -67,8 +67,11 @@ function resolveLogSinkUrl(): string {
     const runtimeConfig = useRuntimeConfig();
     const runtimeSink = runtimeConfig?.logSinkUrl;
     if (typeof runtimeSink === 'string' && runtimeSink.trim().length > 0) {
-      cachedLogSinkUrl = normalizeFetchTargetUrl(runtimeSink.trim());
-      return cachedLogSinkUrl;
+      const normalizedRuntimeSink = normalizeFetchTargetUrl(runtimeSink.trim());
+      if (normalizedRuntimeSink) {
+        cachedLogSinkUrl = normalizedRuntimeSink;
+        return cachedLogSinkUrl;
+      }
     }
   } catch {
     cachedLogSinkUrl = '';

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -55,9 +55,18 @@ const OVERLAY_CACHE_TTL = 3600000; // 1 hour in milliseconds
 const FETCH_TIMEOUT_MS = 5000; // 5 seconds
 // GitHub raw URL for the overlay
 // Note: Using raw.githubusercontent.com directly until jsDelivr cache propagates
-const OVERLAY_URL =
-  process.env.OVERLAY_URL?.trim() ||
+const DEFAULT_OVERLAY_URL =
   'https://raw.githubusercontent.com/tarkovtracker-org/tarkov-data-overlay/main/dist/overlay.json';
+function resolveOverlayUrl(value: string | undefined): string {
+  const candidate = value?.trim() || DEFAULT_OVERLAY_URL;
+  try {
+    const url = new URL(candidate);
+    return url.protocol === 'https:' ? url.toString() : DEFAULT_OVERLAY_URL;
+  } catch {
+    return DEFAULT_OVERLAY_URL;
+  }
+}
+const OVERLAY_URL = resolveOverlayUrl(process.env.OVERLAY_URL);
 const OVERLAY_CACHE_BUSTER = process.env.OVERLAY_CACHE_BUSTER?.trim();
 const OVERLAY_URL_WITH_BUSTER = OVERLAY_CACHE_BUSTER
   ? `${OVERLAY_URL}${OVERLAY_URL.includes('?') ? '&' : '?'}v=${encodeURIComponent(

--- a/app/stores/progressState.ts
+++ b/app/stores/progressState.ts
@@ -89,11 +89,7 @@ export function migrateToGameModeStructure(legacyData: unknown): UserState {
       currentGameMode: data.currentGameMode === GAME_MODES.PVE ? GAME_MODES.PVE : GAME_MODES.PVP,
       gameEdition: (data.gameEdition as number) || defaultState.gameEdition,
       tarkovUid: (data.tarkovUid as number | null) ?? null,
-      pvp: hasPvp
-        ? sanitizeOwnedProgressData(data.pvp)
-        : !hasPve
-          ? migratedLegacy
-          : structuredClone(defaultProgressData),
+      pvp: hasPvp ? sanitizeOwnedProgressData(data.pvp) : migratedLegacy,
       pve: hasPve ? sanitizeOwnedProgressData(data.pve) : structuredClone(defaultProgressData),
     };
   }

--- a/app/stores/progressState.ts
+++ b/app/stores/progressState.ts
@@ -79,7 +79,7 @@ export function migrateToGameModeStructure(legacyData: unknown): UserState {
     legacyData &&
     typeof legacyData === 'object' &&
     'currentGameMode' in legacyData &&
-    !('pvp' in legacyData && !('pve' in legacyData))
+    (!('pvp' in legacyData) || !('pve' in legacyData))
   ) {
     const data = legacyData as Record<string, unknown>;
     return {

--- a/app/stores/progressState.ts
+++ b/app/stores/progressState.ts
@@ -82,12 +82,19 @@ export function migrateToGameModeStructure(legacyData: unknown): UserState {
     (!('pvp' in legacyData) || !('pve' in legacyData))
   ) {
     const data = legacyData as Record<string, unknown>;
+    const hasPvp = 'pvp' in data;
+    const hasPve = 'pve' in data;
+    const migratedLegacy = sanitizeOwnedProgressData(data);
     return {
-      currentGameMode: data.currentGameMode as GameMode,
+      currentGameMode: data.currentGameMode === GAME_MODES.PVE ? GAME_MODES.PVE : GAME_MODES.PVP,
       gameEdition: (data.gameEdition as number) || defaultState.gameEdition,
       tarkovUid: (data.tarkovUid as number | null) ?? null,
-      pvp: sanitizeOwnedProgressData(data),
-      pve: structuredClone(defaultProgressData),
+      pvp: hasPvp
+        ? sanitizeOwnedProgressData(data.pvp)
+        : !hasPve
+          ? migratedLegacy
+          : structuredClone(defaultProgressData),
+      pve: hasPve ? sanitizeOwnedProgressData(data.pve) : structuredClone(defaultProgressData),
     };
   }
   // Create new structure with migrated data from legacy format

--- a/app/stores/tarkov/progressMerge.ts
+++ b/app/stores/tarkov/progressMerge.ts
@@ -10,6 +10,7 @@ import { sanitizeOwnedProgressData } from '@/utils/progressSanitizers';
 import type { RawTaskCompletion } from '@/utils/taskStatus';
 const API_UPDATE_HISTORY_LIMIT = 50;
 type CountableEntry = { count?: number; complete?: boolean; timestamp?: number };
+type HideoutModuleEntry = UserProgressData['hideoutModules'][string];
 type StoryChapterEntry = UserProgressData['storyChapters'][string];
 type StoryObjectiveEntry = NonNullable<StoryChapterEntry['objectives']>[string];
 type TimestampedCompletionEntry = { complete?: boolean; timestamp?: number };
@@ -109,6 +110,23 @@ export const mergeStoryChapterProgress = (
       mergedChapter.objectives = mergedObjectives;
     }
     merged[chapterId] = mergedChapter;
+  }
+  return merged;
+};
+const mergeHideoutModules = (
+  local: UserProgressData['hideoutModules'] | undefined,
+  remote: UserProgressData['hideoutModules'] | undefined
+): UserProgressData['hideoutModules'] => {
+  const allModuleIds = new Set([...Object.keys(local || {}), ...Object.keys(remote || {})]);
+  const merged: UserProgressData['hideoutModules'] = {};
+  for (const moduleId of allModuleIds) {
+    const resolved = mergeTimestampedCompletion<HideoutModuleEntry>(
+      local?.[moduleId],
+      remote?.[moduleId]
+    );
+    if (resolved) {
+      merged[moduleId] = resolved;
+    }
   }
   return merged;
 };
@@ -239,15 +257,15 @@ export function mergeProgressData(
   remote: UserProgressData | undefined
 ): UserProgressData {
   if (!local && !remote) return {} as UserProgressData;
-  if (!local) return remote!;
-  if (!remote) return local;
+  if (!local) return structuredClone(remote!);
+  if (!remote) return structuredClone(local);
   const localEpoch = toProgressEpoch(local);
   const remoteEpoch = toProgressEpoch(remote);
   if (remoteEpoch > localEpoch) {
-    return { ...remote, progressEpoch: remoteEpoch };
+    return { ...structuredClone(remote), progressEpoch: remoteEpoch };
   }
   if (localEpoch > remoteEpoch) {
-    return { ...local, progressEpoch: localEpoch };
+    return { ...structuredClone(local), progressEpoch: localEpoch };
   }
   const mergeTaskCompletion = (
     localComp: RawTaskCompletion,
@@ -309,7 +327,7 @@ export function mergeProgressData(
       return merged;
     })(),
     taskObjectives: mergeCountableObjects(local.taskObjectives, remote.taskObjectives),
-    hideoutModules: { ...local.hideoutModules, ...remote.hideoutModules },
+    hideoutModules: mergeHideoutModules(local.hideoutModules, remote.hideoutModules),
     hideoutParts: mergeCountableObjects(local.hideoutParts, remote.hideoutParts),
     storyChapters: mergeStoryChapterProgress(local.storyChapters, remote.storyChapters),
     traders: {

--- a/app/stores/useProgress.ts
+++ b/app/stores/useProgress.ts
@@ -14,6 +14,7 @@ import {
 import { logger } from '@/utils/logger';
 import { perfEnd, perfStart } from '@/utils/perf';
 import { computeInvalidProgress } from '@/utils/progressInvalidation';
+import { createDefaultOwnedProgressData } from '@/utils/progressSanitizers';
 import {
   getCompletionFlags,
   getTaskStatusFromFlags,
@@ -26,10 +27,11 @@ import type { UserProgressData, UserState } from '@/stores/progressState';
 import type { GameEdition, Task, TaskRequirement } from '@/types/tarkov';
 import type { Store } from 'pinia';
 function getGameModeData(store: Store<string, UserState> | undefined): UserProgressData {
-  if (!store) return {} as UserProgressData;
-  const currentGameMode = store.$state.currentGameMode || GAME_MODES.PVP;
-  const gameModeState = store.$state[currentGameMode as keyof UserState];
-  return (gameModeState || store.$state) as UserProgressData;
+  if (!store) return createDefaultOwnedProgressData();
+  const currentGameMode = store.$state.currentGameMode;
+  if (currentGameMode === GAME_MODES.PVP) return store.$state.pvp;
+  if (currentGameMode === GAME_MODES.PVE) return store.$state.pve;
+  return createDefaultOwnedProgressData();
 }
 type TeamStoresMap = Record<string, Store<string, UserState>>;
 type CompletionsMap = Record<string, Record<string, boolean>>;
@@ -136,7 +138,7 @@ export const useProgressStore = defineStore('progress', () => {
       const store = visibleTeamStores.value[teamId];
       for (const trader of metadataStore.traders) {
         const currentData = getGameModeData(store);
-        levels[teamId]![trader.id] = currentData?.level ?? 0;
+        levels[teamId]![trader.id] = currentData.traders?.[trader.id]?.level ?? 0;
       }
     }
     perfEnd(perfTimer, { traders: metadataStore.traders.length });

--- a/app/stores/useProgress.ts
+++ b/app/stores/useProgress.ts
@@ -29,9 +29,13 @@ import type { Store } from 'pinia';
 function getGameModeData(store: Store<string, UserState> | undefined): UserProgressData {
   if (!store) return createDefaultOwnedProgressData();
   const currentGameMode = store.$state.currentGameMode;
-  if (currentGameMode === GAME_MODES.PVP) return store.$state.pvp;
-  if (currentGameMode === GAME_MODES.PVE) return store.$state.pve;
-  return createDefaultOwnedProgressData();
+  const modeData =
+    currentGameMode === GAME_MODES.PVP
+      ? store.$state.pvp
+      : currentGameMode === GAME_MODES.PVE
+        ? store.$state.pve
+        : undefined;
+  return modeData ?? createDefaultOwnedProgressData();
 }
 type TeamStoresMap = Record<string, Store<string, UserState>>;
 type CompletionsMap = Record<string, Record<string, boolean>>;

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -62,6 +62,8 @@ import {
   hasDeprecatedTarkovDevProfileData,
   sanitizeOwnedProgressData,
   sanitizeOwnedUserState,
+  sanitizeGameEdition,
+  sanitizeTarkovUid,
 } from '@/utils/progressSanitizers';
 import { STORAGE_KEYS } from '@/utils/storageKeys';
 import { getCompletionFlags, type RawTaskCompletion } from '@/utils/taskStatus';
@@ -1396,8 +1398,8 @@ export async function initializeTarkovSync() {
       const normalizedRemote = data
         ? sanitizeOwnedUserState({
             currentGameMode: coerceGameMode(data.current_game_mode),
-            gameEdition: data.game_edition || defaultState.gameEdition,
-            tarkovUid: data.tarkov_uid ?? null,
+            gameEdition: sanitizeGameEdition(data.game_edition),
+            tarkovUid: sanitizeTarkovUid(data.tarkov_uid),
             pvp: data.pvp_data,
             pve: data.pve_data,
           })
@@ -1592,7 +1594,9 @@ export async function initializeTarkovSync() {
           // SAFETY CHECK: Prevent syncing completely empty state for existing accounts
           // This protects against accidental data overwrites during edge cases
           const stateHasProgress = hasProgress(userState);
-          if (!stateHasProgress && loadResult.hadRemoteData) {
+          const hasIntentionalResetEpoch =
+            toProgressEpoch(userState.pvp) > 0 || toProgressEpoch(userState.pve) > 0;
+          if (!stateHasProgress && loadResult.hadRemoteData && !hasIntentionalResetEpoch) {
             logger.warn(
               '[TarkovStore] Blocking sync of empty state - account had remote data on load'
             );
@@ -1639,6 +1643,7 @@ export async function initializeTarkovSync() {
 // Realtime channel for multi-device sync
 let realtimeChannel: unknown = null;
 let lastLocalSyncTime = 0; // Track when we last synced locally to filter self-origin updates
+let syncResumeTimer: ReturnType<typeof setTimeout> | null = null;
 let deprecatedRemoteCleanupInFlight = false;
 let lastDeprecatedRemoteCleanupAttemptAt = 0;
 let deprecatedRemoteCleanupFailureCount = 0;
@@ -1866,16 +1871,21 @@ function setupRealtimeListener() {
           currentGameMode: remoteData.current_game_mode
             ? coerceGameMode(remoteData.current_game_mode)
             : localState.currentGameMode,
-          gameEdition: remoteData.game_edition || localState.gameEdition,
+          gameEdition:
+            remoteData.game_edition === undefined
+              ? localState.gameEdition
+              : sanitizeGameEdition(remoteData.game_edition),
+          tarkovUid:
+            remoteData.tarkov_uid === undefined
+              ? localState.tarkovUid
+              : sanitizeTarkovUid(remoteData.tarkov_uid),
           pvp: mergeProgressData(localState.pvp, sanitizeOwnedProgressData(remoteData.pvp_data)),
           pve: mergeProgressData(localState.pve, sanitizeOwnedProgressData(remoteData.pve_data)),
         };
         const nextState: UserState = {
           currentGameMode: merged.currentGameMode ?? localState.currentGameMode,
           gameEdition: merged.gameEdition ?? localState.gameEdition,
-          tarkovUid: Object.prototype.hasOwnProperty.call(remoteData, 'tarkov_uid')
-            ? (remoteData.tarkov_uid ?? null)
-            : (localState.tarkovUid ?? null),
+          tarkovUid: merged.tarkovUid ?? null,
           pvp: merged.pvp ?? localState.pvp,
           pve: merged.pve ?? localState.pve,
         };
@@ -1965,7 +1975,11 @@ function setupRealtimeListener() {
           state.pvp = nextState.pvp;
           state.pve = nextState.pve;
         });
-        setTimeout(() => {
+        if (syncResumeTimer) {
+          clearTimeout(syncResumeTimer);
+        }
+        syncResumeTimer = setTimeout(() => {
+          syncResumeTimer = null;
           const currentController = getSyncController();
           if (currentController && currentController === controller) {
             currentController.resume();
@@ -1995,5 +2009,9 @@ function cleanupRealtimeListener() {
     );
     realtimeChannel = null;
     logger.debug('[TarkovStore] Cleaned up realtime listener');
+  }
+  if (syncResumeTimer) {
+    clearTimeout(syncResumeTimer);
+    syncResumeTimer = null;
   }
 }

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -388,13 +388,13 @@ export function useTeamStoreWithSupabase(): TeamStoreInstance {
     },
     (newVal) => {
       if (!taskBroadcastInitialized) {
-        prevTaskCompletions = { ...newVal.taskCompletions };
+        prevTaskCompletions = structuredClone(newVal.taskCompletions);
         taskBroadcastInitialized = true;
         return;
       }
       const currentTeamId = getTeamIdFromSystemStore(systemStore);
       if (!currentTeamId || !teamChannel.value || !$supabase.user?.id) {
-        prevTaskCompletions = { ...newVal.taskCompletions };
+        prevTaskCompletions = structuredClone(newVal.taskCompletions);
         return;
       }
       const scheduleBroadcastFlush = () => {
@@ -427,7 +427,7 @@ export function useTeamStoreWithSupabase(): TeamStoreInstance {
       if (pendingTaskUpdates.size > 0) {
         scheduleBroadcastFlush();
       }
-      prevTaskCompletions = { ...newVal.taskCompletions };
+      prevTaskCompletions = structuredClone(newVal.taskCompletions);
     },
     { deep: true }
   );

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -79,6 +79,20 @@ interface TeamStoreInstance {
   isSubscribed: Ref<boolean>;
   cleanup: () => void;
 }
+type TaskCompletionSnapshot = Record<string, { complete?: boolean; failed?: boolean }>;
+function cloneTaskCompletions(
+  taskCompletions: TaskCompletionSnapshot | undefined
+): TaskCompletionSnapshot {
+  return Object.fromEntries(
+    Object.entries(taskCompletions ?? {}).map(([taskId, completion]) => [
+      taskId,
+      {
+        complete: completion?.complete,
+        failed: completion?.failed,
+      },
+    ])
+  );
+}
 // Singleton instance to prevent multiple listener setups
 let teamStoreInstance: TeamStoreInstance | null = null;
 export function useTeamStoreWithSupabase(): TeamStoreInstance {
@@ -101,7 +115,7 @@ export function useTeamStoreWithSupabase(): TeamStoreInstance {
     level: number | null;
     tasksCompleted: number;
   } | null = null;
-  let prevTaskCompletions: Record<string, { complete?: boolean; failed?: boolean }> = {};
+  let prevTaskCompletions: TaskCompletionSnapshot = {};
   let taskBroadcastInitialized = false;
   const pendingTaskUpdates = new Map<
     string,
@@ -388,13 +402,13 @@ export function useTeamStoreWithSupabase(): TeamStoreInstance {
     },
     (newVal) => {
       if (!taskBroadcastInitialized) {
-        prevTaskCompletions = structuredClone(newVal.taskCompletions);
+        prevTaskCompletions = cloneTaskCompletions(newVal.taskCompletions);
         taskBroadcastInitialized = true;
         return;
       }
       const currentTeamId = getTeamIdFromSystemStore(systemStore);
       if (!currentTeamId || !teamChannel.value || !$supabase.user?.id) {
-        prevTaskCompletions = structuredClone(newVal.taskCompletions);
+        prevTaskCompletions = cloneTaskCompletions(newVal.taskCompletions);
         return;
       }
       const scheduleBroadcastFlush = () => {
@@ -427,7 +441,7 @@ export function useTeamStoreWithSupabase(): TeamStoreInstance {
       if (pendingTaskUpdates.size > 0) {
         scheduleBroadcastFlush();
       }
-      prevTaskCompletions = structuredClone(newVal.taskCompletions);
+      prevTaskCompletions = cloneTaskCompletions(newVal.taskCompletions);
     },
     { deep: true }
   );

--- a/app/utils/progressSanitizers.ts
+++ b/app/utils/progressSanitizers.ts
@@ -175,7 +175,7 @@ export const sanitizeStoryChaptersMap = (value: unknown): UserProgressData['stor
   return sanitized;
 };
 const API_UPDATE_HISTORY_LIMIT = 50;
-const createDefaultOwnedProgressData = (): UserProgressData => ({
+export const createDefaultOwnedProgressData = (): UserProgressData => ({
   level: 1,
   pmcFaction: 'USEC',
   displayName: null,
@@ -241,7 +241,7 @@ export const sanitizeApiUpdateHistory = (value: unknown): ApiUpdateMeta[] => {
 const sanitizeGameMode = (value: unknown): GameMode => {
   return value === GAME_MODES.PVE ? GAME_MODES.PVE : GAME_MODES.PVP;
 };
-const sanitizeGameEdition = (value: unknown): number => {
+export const sanitizeGameEdition = (value: unknown): number => {
   const edition =
     typeof value === 'string' && value.trim() !== ''
       ? toFiniteNumber(Number(value))
@@ -251,7 +251,7 @@ const sanitizeGameEdition = (value: unknown): number => {
   }
   return Math.max(1, Math.min(6, Math.trunc(edition)));
 };
-const sanitizeTarkovUid = (value: unknown): number | null => {
+export const sanitizeTarkovUid = (value: unknown): number | null => {
   const uid = toFiniteNumber(value);
   if (uid === null) {
     return null;

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -68,4 +68,5 @@
    - `TEAM_MEMBERS_RATE_LIMIT_PER_MINUTE`
    - `SHARED_PROFILE_RATE_LIMIT_PER_MINUTE`
    - For `/api/tarkov-dev/profile`, add or tighten a Cloudflare rule; the app route also has a fixed per-IP limiter.
+   - Cache API-backed shared rate limits are best-effort under concurrent bursts; use Cloudflare or Durable Objects for hard enforcement.
 3. If API protection blocks valid traffic, update `API_ALLOWED_HOSTS` and redeploy.

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -115,6 +115,7 @@ export default defineNuxtConfig({
     tarkovJsonBaseUrl:
       process.env.NUXT_TARKOV_JSON_BASE_URL || process.env.TARKOV_JSON_BASE_URL || '',
     logSinkUrl: process.env.NUXT_LOG_SINK_URL || process.env.LOG_SINK_URL || '',
+    publicCacheBypassEnabled: process.env.NUXT_PUBLIC_CACHE_BYPASS_ENABLED === 'true',
     teamMembersCacheTtlMs:
       Number(
         process.env.NUXT_TEAM_MEMBERS_CACHE_TTL_MS ||


### PR DESCRIPTION
## **User description**
## Summary

Addresses the actionable review feedback around progress data safety, sync merge correctness, public API hardening, and async race handling.

## Reasoning and changes

- Progress getters now return a real default `UserProgressData` object when a store is missing, and only read `pvp` or `pve` after explicitly validating `currentGameMode`. This avoids undefined nested progress maps and prevents corrupted mode strings from being cast into the wrong shape.
- Hideout module sync now uses timestamp-aware completion merging, matching task/story merge behavior. This prevents stale remote completion state from overwriting a newer local uncomplete action.
- Progress merge epoch winners are cloned with `structuredClone` so downstream mutation cannot alias the original input object.
- Realtime progress payloads sanitize `game_edition` and `tarkov_uid` before patching local state, so corrupted realtime rows cannot inject bad scalar values.
- Public tarkov cache bypass headers/query params are ignored unless an explicit server config enables bypass. This closes the anonymous upstream DoS vector while preserving an operator escape hatch.
- `/api/tarkov/cache-meta` is always treated as protected even though other `/api/tarkov/*` routes are public, because it reads admin audit metadata with a service key.
- Partial migration detection now correctly handles either missing `pvp` or missing `pve`.
- Team broadcast snapshots use deep clones so in-place task completion mutation is still detected.
- Auth initialization, Tarkov.dev profile import, EFT log import, and realtime sync resume now guard against stale async completions.
- Empty progress sync after an intentional reset is allowed when reset epochs are present, while accidental empty-state syncs remain blocked.
- Team members config errors no longer expose internal environment variable names.
- Env-sourced server fetch targets for overlay and log sink now require HTTPS.
- Auth callback visible strings now use i18n keys, and locale structure was synced with English fallback values for Crowdin.
- Cache API rate-limit best-effort behavior is documented in the runbook.
- The unused `traderLevelsAchieved` getter bug was also fixed to return trader levels instead of player level.

## Validated review items

- Fixed: #1-14, #16-19, and the `traderLevelsAchieved` missing-test bug.
- Valid but deferred cleanup: #15/dead `not-found.vue`, plus the dead-code and duplicated-logic tables. Those are cleanup/refactor concerns rather than the correctness/security fixes in this PR.
- Not valid for this checkout: #20 `logs/client.post.ts`; no matching server route file exists in the current tree.

## Validation

- `npm install`
- `npm run i18n:sync`
- `npm run format`
- `npm run typecheck`
- `npx vitest app/server/utils/__tests__/edgeCache.test.ts app/stores/__tests__/useTarkov.mergeProgressData.test.ts app/stores/__tests__/progressState.test.ts app/server/api/team/__tests__/members.test.ts app/composables/__tests__/useAppInitialization.test.ts app/composables/__tests__/useTarkovDevImport.test.ts app/composables/__tests__/useEftLogsImport.test.ts app/stores/__tests__/useTeamStore.test.ts app/stores/__tests__/useProgress.test.ts app/server/middleware/__tests__/api-protection.test.ts app/server/utils/__tests__/overlay.test.ts`

Focused test result: 11 files, 170 tests passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Localized "Authenticating..." sign-in state added across multiple languages.
  * Import flows now track requests so only the latest import affects the UI.

* **Bug Fixes**
  * Reduced stale/race conditions during authentication, sync and profile import operations.
  * API endpoint protection tightened to prevent unintended public access.

* **Improvements**
  * Optional cache-bypass control added.
  * Stronger URL validation for service/configuration endpoints.
* **Documentation**
  * Runbook clarifies cache-backed rate-limit behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Harden imports, sync, and protected API access**

### What Changed
- Import and sign-in flows now ignore late results from older requests, so a previous file read or profile fetch can no longer overwrite a newer action.
- Progress sync now keeps local and remote state separate, copies merged data before reuse, and preserves hideout module completions instead of overwriting them with stale values.
- Users can reset progress without the app blocking an empty sync when a reset epoch is present, while accidental empty-state uploads are still blocked.
- Team member errors no longer reveal internal missing-config details, and the protected cache metadata route stays locked down even with a trailing slash.
- Cache bypass headers and query params only work when operator bypass is explicitly enabled.
- Overlay and log sink URLs now require HTTPS, and the auth callback loading text uses localized strings.

### Impact
`✅ Fewer lost imports and stale profile previews`
`✅ Fewer progress resets after sync`
`✅ Lower risk of exposing protected API data`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?id=RxP-woyMajqQR9fekkuELnnfiQod19nHKLRP2xMDNb0&org=tarkovtracker-org)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
