### PR TITLE
chore(config): make AI reviews manual-only

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,7 +1,8 @@
 language: en-US
 reviews:
   auto_review:
-    enabled: true
+    enabled: false
+    auto_incremental_review: false
   path_filters:
     - '!app/locales/de.json'
     - '!app/locales/es.json'

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -7,7 +7,7 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 ### CI (`ci.yml`)
 
 **Trigger:** Push to main/develop/wip branches, PRs
-**Jobs:** `Validate` (lint, typecheck, format, coverage, CodeAnt upload, build), `Supabase DB` (reset + lint local migrations), `Workers` (validate api-gateway)
+**Jobs:** `Validate` (lint, typecheck, format, coverage, build), `Supabase DB` (reset + lint local migrations), `Workers` (validate api-gateway)
 
 ### Security (`security.yml`)
 
@@ -51,7 +51,11 @@ the current floors as long-term targets.
 
 ## Secrets
 
-Workflow-specific secrets are not required for the Gitleaks step anymore. The workflow downloads a pinned Gitleaks release and verifies its published checksum before scanning. App build jobs still use the existing Nuxt/Supabase secrets configured for CI and release. CodeAnt coverage upload requires `ACCESS_TOKEN_GITHUB` with the repository access documented by CodeAnt.
+Workflow-specific secrets are not required for the Gitleaks step anymore. The workflow downloads a pinned Gitleaks release and verifies its published checksum before scanning. App build jobs still use the existing Nuxt/Supabase secrets configured for CI and release.
+
+## AI Review Bots
+
+CodeRabbit automatic reviews are disabled in `.coderabbit.yaml`; invoke it on demand with `@coderabbitai review`. CodeAnt and Kilo Code PR reviews are controlled by their GitHub App dashboards, not GitHub Actions in this repo. Keep those apps disabled or remove this repository from their automatic review selections, then invoke them manually from their PR comments or dashboards when needed.
 
 ## Commands
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,38 +37,6 @@ jobs:
       - name: Test with coverage
         run: npm run test:coverage
 
-      - name: Check CodeAnt token
-        id: codeant-token
-        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-        run: |
-          if [ -n "$CODEANT_ACCESS_TOKEN" ]; then
-            echo "available=true" >> "$GITHUB_OUTPUT"
-          fi
-        env:
-          CODEANT_ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_GITHUB }}
-
-      - name: Upload coverage to CodeAnt AI
-        if: steps.codeant-token.outputs.available == 'true'
-        env:
-          ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN_GITHUB }}
-          COVERAGE_FILE: coverage/cobertura-coverage.xml
-          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: |
-          curl -sS -X GET "https://api.codeant.ai/pr/analysis/coverage/script/get" \
-            --output upload_coverage.sh.b64
-          base64 -d upload_coverage.sh.b64 > upload_coverage.sh
-          chmod +x upload_coverage.sh
-          commit_id="${PR_HEAD_SHA:-$GITHUB_SHA}"
-          branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
-          bash upload_coverage.sh \
-            -t "$ACCESS_TOKEN" \
-            -r "$GITHUB_REPOSITORY" \
-            -c "$commit_id" \
-            -f "$COVERAGE_FILE" \
-            -p github \
-            -b "$branch" \
-            -u "https://github.com"
-
       - name: Build
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
         run: npm run build

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -13,6 +13,7 @@ Complete workflow automation setup for TarkovTracker with CI/CD pipelines, quali
 - Pre-commit hooks for code quality
 - Dependency update automation via Dependabot
 - Conservative auto-merge for low-risk Dependabot updates
+- AI review bots are manual-only; CodeRabbit is disabled in repo config, while CodeAnt and Kilo Code must stay disabled in their GitHub App dashboards unless explicitly requested.
 
 ## GitHub Actions Workflows
 


### PR DESCRIPTION
## Summary
- disable automatic CodeRabbit reviews and incremental re-reviews
- remove proactive CodeAnt coverage upload from CI
- document that CodeAnt and Kilo Code automatic reviews are controlled in their GitHub App dashboards

## Verification
- npm run format
- parsed .codeant/configuration.json
- confirmed PR #338 is draft

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automatic AI-powered code reviews; manual reviews available upon request.
  * Removed automated coverage upload from CI pipeline.

* **Documentation**
  * Updated workflow documentation to clarify AI review bot policies and manual-only operation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->