### PR TITLE
[codex] Fix metadata hydration in dev

### DIFF
--- a/app/stores/__tests__/useMetadata.promiseTracking.test.ts
+++ b/app/stores/__tests__/useMetadata.promiseTracking.test.ts
@@ -1,0 +1,137 @@
+// @vitest-environment happy-dom
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMetadataStore } from '@/stores/useMetadata';
+import * as cacheUtils from '@/utils/tarkovCache';
+import type { TarkovHideoutQueryResult, TarkovTasksCoreQueryResult } from '@/types/tarkov';
+vi.mock('@/utils/logger', () => ({
+  logger: {
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+vi.mock('@/stores/useProgress', () => ({
+  useProgressStore: () => ({
+    migrateDuplicateObjectiveProgress: vi.fn(),
+  }),
+}));
+vi.mock('@/stores/useTarkov', () => ({
+  useTarkovStore: () => ({
+    getCurrentGameMode: () => 'pvp',
+    repairCompletedTaskObjectives: vi.fn(),
+    repairFailedTaskStates: vi.fn(),
+  }),
+}));
+const tasksCorePayload = (): TarkovTasksCoreQueryResult => ({
+  maps: [{ id: 'map-1', name: 'Map 1', normalizedName: 'map-1' }],
+  tasks: [
+    {
+      id: 'task-1',
+      name: 'Task 1',
+      objectives: [],
+      failConditions: [],
+      taskRequirements: [],
+    },
+  ] as TarkovTasksCoreQueryResult['tasks'],
+  traders: [{ id: 'trader-1', name: 'Trader 1', normalizedName: 'trader-1' }],
+});
+const hideoutPayload = (): TarkovHideoutQueryResult => ({
+  hideoutStations: [
+    {
+      id: 'station-1',
+      name: 'Station 1',
+      normalizedName: 'station-1',
+      levels: [
+        {
+          id: 'station-1-l1',
+          level: 1,
+          constructionTime: 0,
+          itemRequirements: [],
+          stationLevelRequirements: [],
+          skillRequirements: [],
+          traderRequirements: [],
+          crafts: [],
+        },
+      ],
+    },
+  ] as TarkovHideoutQueryResult['hideoutStations'],
+});
+describe('useMetadataStore promise tracking', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue(null);
+    vi.spyOn(cacheUtils, 'setCachedData').mockResolvedValue(undefined);
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+  it('populates tasks and hideout when JSON API responses return valid { data } envelopes', async () => {
+    const store = useMetadataStore();
+    const fetchMock = vi.fn(async (endpoint: string) => {
+      if (endpoint === '/api/tarkov/tasks-core') {
+        return { data: tasksCorePayload() };
+      }
+      if (endpoint === '/api/tarkov/hideout') {
+        return { data: hideoutPayload() };
+      }
+      throw new Error(`unexpected endpoint: ${endpoint}`);
+    });
+    vi.stubGlobal('$fetch', fetchMock);
+    await store.fetchTasksCoreData();
+    await store.fetchHideoutData();
+    expect(store.tasks.map((task) => task.id)).toEqual(['task-1']);
+    expect(store.hideoutStations.map((station) => station.id)).toEqual(['station-1']);
+    expect(store.error).toBeNull();
+    expect(store.hideoutError).toBeNull();
+    expect(store.loading).toBe(false);
+    expect(store.hideoutLoading).toBe(false);
+  });
+  it('keeps tasks-core hydration working when each action call sees a fresh `this` proxy (Pinia devtools wrapping)', async () => {
+    const store = useMetadataStore();
+    type StoreRecord = Record<string, (...args: unknown[]) => unknown>;
+    const record = store as unknown as StoreRecord;
+    const wrappableNames = [
+      '_doFetchWithCache',
+      'fetchTasksCoreData',
+      'fetchWithCache',
+      'getApiGameMode',
+      'processTasksCoreData',
+      'resetTasksData',
+    ];
+    for (const name of wrappableNames) {
+      const original = record[name];
+      if (!original) continue;
+      record[name] = function patched(this: unknown, ...args: unknown[]) {
+        const trackedThis = new Proxy(store, {});
+        return original.apply(trackedThis as typeof store, args);
+      };
+    }
+    const fetchMock = vi.fn().mockResolvedValue({ data: tasksCorePayload() });
+    vi.stubGlobal('$fetch', fetchMock);
+    await store.fetchTasksCoreData();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(store.tasks.map((task) => task.id)).toEqual(['task-1']);
+    expect(store.error).toBeNull();
+    expect(store.loading).toBe(false);
+  });
+  it('dedupes concurrent in-flight fetches for the same request key', async () => {
+    const store = useMetadataStore();
+    let resolveFetch!: (value: { data: TarkovTasksCoreQueryResult }) => void;
+    const fetchMock = vi.fn().mockReturnValue(
+      new Promise<{ data: TarkovTasksCoreQueryResult }>((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+    vi.stubGlobal('$fetch', fetchMock);
+    const first = store.fetchTasksCoreData();
+    const second = store.fetchTasksCoreData();
+    resolveFetch({ data: tasksCorePayload() });
+    await Promise.all([first, second]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(store.tasks.map((task) => task.id)).toEqual(['task-1']);
+  });
+});

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -199,13 +199,28 @@ type PromiseKey = {
 type MutablePromiseStore = {
   -readonly [K in keyof PromiseStore]: PromiseStore[K];
 };
-const storePromises = new WeakMap<object, MutablePromiseStore>();
-const storePromiseRequestKeys = new WeakMap<object, Partial<Record<PromiseKey, string>>>();
-const storePromiseRequestIds = new WeakMap<object, Partial<Record<PromiseKey, symbol>>>();
+const PROMISE_STORE_KEY = Symbol('metadataPromiseStore');
+const PROMISE_REQUEST_KEYS_KEY = Symbol('metadataPromiseRequestKeys');
+const PROMISE_REQUEST_IDS_KEY = Symbol('metadataPromiseRequestIds');
+type PromiseStoreHost = object & {
+  [PROMISE_REQUEST_IDS_KEY]?: Partial<Record<PromiseKey, symbol>>;
+  [PROMISE_REQUEST_KEYS_KEY]?: Partial<Record<PromiseKey, string>>;
+  [PROMISE_STORE_KEY]?: MutablePromiseStore;
+};
+function setHiddenStoreValue<T>(storeInstance: PromiseStoreHost, key: symbol, value: T): T {
+  Object.defineProperty(storeInstance, key, {
+    configurable: true,
+    enumerable: false,
+    value,
+    writable: true,
+  });
+  return value;
+}
 function getPromiseStore(storeInstance: object): MutablePromiseStore {
-  let promises = storePromises.get(storeInstance);
+  const host = storeInstance as PromiseStoreHost;
+  let promises = host[PROMISE_STORE_KEY];
   if (!promises) {
-    promises = {
+    promises = setHiddenStoreValue(host, PROMISE_STORE_KEY, {
       bootstrapPromise: null,
       tasksCorePromise: null,
       hideoutPromise: null,
@@ -219,24 +234,23 @@ function getPromiseStore(storeInstance: object): MutablePromiseStore {
       editionsPromise: null,
       initPromise: null,
       isInitializing: false,
-    };
-    storePromises.set(storeInstance, promises);
+    });
   }
   return promises;
 }
 function getPromiseRequestKeyStore(storeInstance: object): Partial<Record<PromiseKey, string>> {
-  let keys = storePromiseRequestKeys.get(storeInstance);
+  const host = storeInstance as PromiseStoreHost;
+  let keys = host[PROMISE_REQUEST_KEYS_KEY];
   if (!keys) {
-    keys = {};
-    storePromiseRequestKeys.set(storeInstance, keys);
+    keys = setHiddenStoreValue(host, PROMISE_REQUEST_KEYS_KEY, {});
   }
   return keys;
 }
 function getPromiseRequestIdStore(storeInstance: object): Partial<Record<PromiseKey, symbol>> {
-  let ids = storePromiseRequestIds.get(storeInstance);
+  const host = storeInstance as PromiseStoreHost;
+  let ids = host[PROMISE_REQUEST_IDS_KEY];
   if (!ids) {
-    ids = {};
-    storePromiseRequestIds.set(storeInstance, ids);
+    ids = setHiddenStoreValue(host, PROMISE_REQUEST_IDS_KEY, {});
   }
   return ids;
 }


### PR DESCRIPTION
## Summary
- keep metadata promise/request tracking on hidden store-instance symbols so Pinia dev proxy wrappers share request context
- add regression coverage for JSON API envelopes, fresh proxy-wrapped action calls, and concurrent fetch dedupe
- preserve the existing metadata fetch flow without broad useMetadata decomposition

## Root Cause
In local dev, Pinia/devtools can invoke actions through fresh proxy identities. The old WeakMap-backed request bookkeeping could be written under one proxy and read under another, making valid tasks-core and hideout responses look stale. That skipped processing and left critical metadata empty, so the loading overlay never cleared.

## Validation
- npm run test -- app/stores/__tests__/useMetadata.promiseTracking.test.ts app/stores/__tests__/useMetadata.initialize.test.ts
- npm run format
- npm run typecheck
- npm run test
- manual Chromium dev load confirmed metadata initialized with 503 tasks and 26 hideout stations, with the loading overlay gone

## Notes
- Claude delegated review confirmed the fix and did not find broader JSON API payload-shape issues in the metadata routes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive test suite for data store verification, including concurrent request handling and deduplication scenarios.

* **Refactor**
  * Internal optimization and refinement of state management architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->