### PR TITLE
fix(app): use normalizedName for locale-independent map key derivation

### DIFF
--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -521,8 +521,7 @@ export const useMetadataStore = defineStore('metadata', {
       });
       const mergedMaps = Object.entries(mapGroups)
         .map(([mapKey, maps]) => {
-          const primaryMap =
-            maps.find((map) => map.name.toLowerCase() === 'ground zero') ?? maps[0];
+          const primaryMap = maps.find((map) => map.normalizedName === 'ground-zero') ?? maps[0];
           if (!primaryMap) return null;
           const staticData = state.staticMapData?.[mapKey];
           const mergedIds = maps.map((map) => map.id);

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -2415,12 +2415,12 @@ export const useMetadataStore = defineStore('metadata', {
           map.normalizedName?.toLowerCase() === lowerCaseName
       );
     },
-    getStaticMapKey(mapNameOrNormalizedName: string): string {
-      if (MAP_NORMALIZED_NAME_MAPPING[mapNameOrNormalizedName]) {
-        return MAP_NORMALIZED_NAME_MAPPING[mapNameOrNormalizedName];
+    getStaticMapKey(mapName: string, normalizedName?: string): string {
+      if (normalizedName) {
+        return MAP_NORMALIZED_NAME_MAPPING[normalizedName] ?? normalizedName.replace(/-/g, '');
       }
-      const lower = mapNameOrNormalizedName.toLowerCase();
-      return MAP_NAME_MAPPING[lower] ?? lower.replace(/[\s+]/g, '').replace(/-/g, '');
+      const lower = mapName.toLowerCase();
+      return MAP_NAME_MAPPING[lower] ?? lower.replace(/[\s+-]/g, '');
     },
     hasMapSvg(mapId: string): boolean {
       const map = this.getMapById(mapId);

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -10,6 +10,7 @@ import {
   GAME_MODES,
   LOCALE_TO_API_MAPPING,
   MAP_NAME_MAPPING,
+  MAP_NORMALIZED_NAME_MAPPING,
   sortMapsByGameOrder,
   sortTradersByGameOrder,
 } from '@/utils/constants';
@@ -508,8 +509,11 @@ export const useMetadataStore = defineStore('metadata', {
       }
       const mapGroups: Record<string, TarkovMap[]> = {};
       state.maps.forEach((map) => {
-        const lowerCaseName = map.name.toLowerCase();
-        const mapKey = MAP_NAME_MAPPING[lowerCaseName] || lowerCaseName.replace(/\s+|\+/g, '');
+        const mapKey = map.normalizedName
+          ? (MAP_NORMALIZED_NAME_MAPPING[map.normalizedName] ??
+            map.normalizedName.replace(/-/g, ''))
+          : (MAP_NAME_MAPPING[map.name.toLowerCase()] ??
+            map.name.toLowerCase().replace(/\s+|\+/g, ''));
         if (!mapGroups[mapKey]) {
           mapGroups[mapKey] = [];
         }
@@ -547,8 +551,13 @@ export const useMetadataStore = defineStore('metadata', {
         .filter((map): map is NonNullable<typeof map> => map !== null);
       // Sort maps by task progression order using the mapKey for lookup
       return sortMapsByGameOrder(mergedMaps, (map) => {
+        if (map.normalizedName) {
+          return (
+            MAP_NORMALIZED_NAME_MAPPING[map.normalizedName] ?? map.normalizedName.replace(/-/g, '')
+          );
+        }
         const lowerCaseName = map.name.toLowerCase();
-        return MAP_NAME_MAPPING[lowerCaseName] || lowerCaseName.replace(/\s+|\+/g, '');
+        return MAP_NAME_MAPPING[lowerCaseName] ?? lowerCaseName.replace(/\s+|\+/g, '');
       });
     },
     // Computed properties for traders (sorted by in-game order)
@@ -2406,9 +2415,12 @@ export const useMetadataStore = defineStore('metadata', {
           map.normalizedName?.toLowerCase() === lowerCaseName
       );
     },
-    getStaticMapKey(mapName: string): string {
-      const lowerCaseName = mapName.toLowerCase();
-      return MAP_NAME_MAPPING[lowerCaseName] || lowerCaseName.replace(/\s+|\+/g, '');
+    getStaticMapKey(mapNameOrNormalizedName: string): string {
+      if (MAP_NORMALIZED_NAME_MAPPING[mapNameOrNormalizedName]) {
+        return MAP_NORMALIZED_NAME_MAPPING[mapNameOrNormalizedName];
+      }
+      const lower = mapNameOrNormalizedName.toLowerCase();
+      return MAP_NAME_MAPPING[lower] ?? lower.replace(/[\s+]/g, '').replace(/-/g, '');
     },
     hasMapSvg(mapId: string): boolean {
       const map = this.getMapById(mapId);

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -393,6 +393,13 @@ const inferNewBeginningPrestigeLevel = (task: Task): number | null => {
   const parsed = Number.parseInt(idMatch[1], 10);
   return Number.isFinite(parsed) && parsed > 0 ? parsed : null;
 };
+const deriveStaticMapKey = (mapName: string, normalizedName?: string): string => {
+  if (normalizedName) {
+    return MAP_NORMALIZED_NAME_MAPPING[normalizedName] ?? normalizedName.replace(/-/g, '');
+  }
+  const lower = mapName.toLowerCase();
+  return MAP_NAME_MAPPING[lower] ?? lower.replace(/[\s+-]/g, '');
+};
 export const useMetadataStore = defineStore('metadata', {
   state: (): MetadataState => ({
     initialized: false,
@@ -509,11 +516,7 @@ export const useMetadataStore = defineStore('metadata', {
       }
       const mapGroups: Record<string, TarkovMap[]> = {};
       state.maps.forEach((map) => {
-        const mapKey = map.normalizedName
-          ? (MAP_NORMALIZED_NAME_MAPPING[map.normalizedName] ??
-            map.normalizedName.replace(/-/g, ''))
-          : (MAP_NAME_MAPPING[map.name.toLowerCase()] ??
-            map.name.toLowerCase().replace(/\s+|\+/g, ''));
+        const mapKey = deriveStaticMapKey(map.name, map.normalizedName);
         if (!mapGroups[mapKey]) {
           mapGroups[mapKey] = [];
         }
@@ -549,15 +552,9 @@ export const useMetadataStore = defineStore('metadata', {
         })
         .filter((map): map is NonNullable<typeof map> => map !== null);
       // Sort maps by task progression order using the mapKey for lookup
-      return sortMapsByGameOrder(mergedMaps, (map) => {
-        if (map.normalizedName) {
-          return (
-            MAP_NORMALIZED_NAME_MAPPING[map.normalizedName] ?? map.normalizedName.replace(/-/g, '')
-          );
-        }
-        const lowerCaseName = map.name.toLowerCase();
-        return MAP_NAME_MAPPING[lowerCaseName] ?? lowerCaseName.replace(/\s+|\+/g, '');
-      });
+      return sortMapsByGameOrder(mergedMaps, (map) =>
+        deriveStaticMapKey(map.name, map.normalizedName)
+      );
     },
     // Computed properties for traders (sorted by in-game order)
     sortedTraders: (state): Trader[] => sortTradersByGameOrder(state.traders),
@@ -2415,11 +2412,7 @@ export const useMetadataStore = defineStore('metadata', {
       );
     },
     getStaticMapKey(mapName: string, normalizedName?: string): string {
-      if (normalizedName) {
-        return MAP_NORMALIZED_NAME_MAPPING[normalizedName] ?? normalizedName.replace(/-/g, '');
-      }
-      const lower = mapName.toLowerCase();
-      return MAP_NAME_MAPPING[lower] ?? lower.replace(/[\s+-]/g, '');
+      return deriveStaticMapKey(mapName, normalizedName);
     },
     hasMapSvg(mapId: string): boolean {
       const map = this.getMapById(mapId);

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -96,14 +96,24 @@ export const API_SUPPORTED_LANGUAGES = [
 export const LOCALE_TO_API_MAPPING: Record<string, string> = {
   uk: 'en', // Ukrainian -> English (Not supported by API)
 };
-// Mapping from tarkov.dev map names to static data keys (kept for backward compatibility)
+// Mapping from tarkov.dev map names to static data keys (fallback when normalizedName is absent)
 export const MAP_NAME_MAPPING: Record<string, string> = {
   'night factory': 'factory',
   'the lab': 'lab',
   'ground zero 21+': 'groundzero',
-  'ground zero tutorial': 'groundzero', // Tutorial uses same map as Ground Zero
+  'ground zero tutorial': 'groundzero',
   'the labyrinth': 'labyrinth',
   terminal: 'terminal',
+};
+// Mapping from tarkov.dev normalizedName to static data keys (locale-independent, preferred)
+export const MAP_NORMALIZED_NAME_MAPPING: Record<string, string> = {
+  'night-factory': 'factory',
+  'the-lab': 'lab',
+  'ground-zero': 'groundzero',
+  'ground-zero-21': 'groundzero',
+  'ground-zero-tutorial': 'groundzero',
+  'the-labyrinth': 'labyrinth',
+  'streets-of-tarkov': 'streetsoftarkov',
 };
 // API Permissions
 export const API_PERMISSIONS: Record<string, { title: string; description: string }> = {


### PR DESCRIPTION
## **User description**
## Summary

- Map names from tarkov.dev are localized when a non-English locale is active, causing the static SVG/tile lookup to produce Cyrillic/German/etc. keys that never match the English-keyed `staticMapData`
- Introduces `MAP_NORMALIZED_NAME_MAPPING` in `constants.ts` — a locale-independent mapping from tarkov.dev `normalizedName` slugs to static data keys
- Updates `mapsWithSvg` computed and the sort callback in `useMetadata.ts` to prefer `normalizedName` when available, with the existing name-based logic kept as a fallback

## Test plan

- [ ] Switch app locale to Russian — verify no `[MetadataStore] Static SVG data not found` warnings in console
- [ ] Switch app locale to German — same check (originally triggered "Factory bei Nacht" warning)
- [ ] Switch back to English — maps display correctly with SVGs/tiles
- [ ] Maps page and task map filter work correctly across all locales


___

## **CodeAnt-AI Description**
**Use locale-independent map names so maps load correctly in all languages**

### What Changed
- Maps now match static map data using the language-neutral map name when available, instead of relying on translated display names
- Added support for several renamed maps so they still point to the correct static map data
- Map lookup now recognizes both the translated name and the normalized name when searching for a map

### Impact
`✅ Fewer missing map images in non-English locales`
`✅ Reliable map pages in Russian, German, and other languages`
`✅ Fewer incorrect map lookup results`


[🔄 Retrigger CodeAnt AI Review](https://api.codeant.ai/pr/retrigger_review?token=bdbRSOP6o2YBiXjzKhCCdkSz6uG_XYBFKligq5tG5Bk&org=tarkovtracker-org)<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved map identification and grouping with more consistent organization and ordering.

* **Bug Fixes**
  * Enhanced stability in map references and sorting logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->