### PR TITLE
feat(ui): needed items UI facelift — rarity borders, compact badges, improved spacing

### DIFF
--- a/app/assets/css/tailwind.css
+++ b/app/assets/css/tailwind.css
@@ -216,9 +216,13 @@ html.no-smooth-scroll {
   --color-rarity-grey: hsl(0 0% 17%);
   --color-rarity-yellow: hsl(44 17% 26%);
   --color-rarity-orange: hsl(28 36% 22%);
+  --color-rarity-orange-400: hsl(28 65% 55%);
   --color-rarity-green: hsl(120 10% 14%);
+  --color-rarity-green-400: hsl(120 35% 50%);
   --color-rarity-red: hsl(0 25% 18%);
+  --color-rarity-red-400: hsl(0 55% 50%);
   --color-rarity-black: hsl(0 0% 7%);
+  --color-rarity-black-400: hsl(0 0% 35%);
   --color-rarity-blue: hsl(195 20% 13%);
   --color-rarity-default: hsl(0 0% 13%);
   /* Extract marker colors */

--- a/app/features/neededitems/ItemIndicators.vue
+++ b/app/features/neededitems/ItemIndicators.vue
@@ -1,23 +1,28 @@
 <template>
-  <AppTooltip v-if="foundInRaid" :text="foundInRaidTitle">
-    <UIcon name="i-mdi-checkbox-marked-circle-outline" :class="firIconClass" />
-  </AppTooltip>
-  <AppTooltip v-if="kappaRequired" :text="kappaTitleText">
-    <UIcon name="i-mdi-trophy" :class="kappaIconClass" />
-  </AppTooltip>
-  <AppTooltip v-if="lightkeeperRequired" :text="lightkeeperTitleText">
-    <UIcon name="i-mdi-lighthouse" :class="lightkeeperIconClass" />
-  </AppTooltip>
-  <AppTooltip v-if="isCraftable" :text="craftableTitleText">
-    <button
-      type="button"
-      class="inline-flex"
-      :aria-label="craftableTitleText"
-      @click.stop="emit('craft')"
-    >
-      <UIcon name="i-mdi-hammer-wrench" :class="[craftableIconBaseClass, craftableIconClass]" />
-    </button>
-  </AppTooltip>
+  <span
+    v-if="foundInRaid || kappaRequired || lightkeeperRequired || isCraftable"
+    class="bg-surface-900/60 ml-1.5 inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 ring-1 ring-white/10"
+  >
+    <AppTooltip v-if="foundInRaid" :text="foundInRaidTitle">
+      <UIcon name="i-mdi-checkbox-marked-circle-outline" :class="firIconClass" />
+    </AppTooltip>
+    <AppTooltip v-if="kappaRequired" :text="kappaTitleText">
+      <UIcon name="i-mdi-trophy" :class="kappaIconClass" />
+    </AppTooltip>
+    <AppTooltip v-if="lightkeeperRequired" :text="lightkeeperTitleText">
+      <UIcon name="i-mdi-lighthouse" :class="lightkeeperIconClass" />
+    </AppTooltip>
+    <AppTooltip v-if="isCraftable" :text="craftableTitleText">
+      <button
+        type="button"
+        class="inline-flex"
+        :aria-label="craftableTitleText"
+        @click.stop="emit('craft')"
+      >
+        <UIcon name="i-mdi-hammer-wrench" :class="[craftableIconBaseClass, craftableIconClass]" />
+      </button>
+    </AppTooltip>
+  </span>
 </template>
 <script setup lang="ts">
   const props = withDefaults(
@@ -37,15 +42,15 @@
       lightkeeperTitle?: string;
     }>(),
     {
-      craftableIconBaseClass: 'ml-1 h-5 w-5',
+      craftableIconBaseClass: 'h-5 w-5',
       craftableIconClass: '',
       craftableTitle: 'Craftable',
-      firIconClass: 'ml-1 h-5 w-5',
+      firIconClass: 'h-5 w-5',
       foundInRaidTitle: 'Found in Raid required',
-      kappaIconClass: 'ml-1 h-5 w-5 text-kappa',
+      kappaIconClass: 'h-5 w-5 text-kappa',
       kappaRequired: false,
       kappaTitle: 'Required for Kappa quest',
-      lightkeeperIconClass: 'ml-1 h-5 w-5 text-lightkeeper',
+      lightkeeperIconClass: 'h-5 w-5 text-lightkeeper',
       lightkeeperRequired: false,
       lightkeeperTitle: 'This quest is required to unlock the Lightkeeper trader',
     }

--- a/app/features/neededitems/NeededItemRow.vue
+++ b/app/features/neededitems/NeededItemRow.vue
@@ -1,7 +1,11 @@
 <template>
   <KeepAlive>
-    <div ref="cardRef" class="mb-1 rounded" :class="itemRowClasses">
-      <div class="px-3 py-2">
+    <div
+      ref="cardRef"
+      class="mb-1.5 rounded-md border-l-2 transition-colors"
+      :class="[itemRowClasses, rarityBorderClass]"
+    >
+      <div class="px-3 py-2.5">
         <div class="mx-0 flex flex-nowrap items-center">
           <div class="flex min-w-0 flex-1 items-center p-0">
             <span class="block h-12 w-12 shrink-0 md:h-16 md:w-16">
@@ -18,7 +22,7 @@
               />
             </span>
             <span class="ml-3 flex min-w-0 flex-1 flex-col overflow-hidden">
-              <span class="flex items-center truncate text-base font-semibold">
+              <span class="flex items-center truncate text-sm font-semibold">
                 <span class="truncate">{{ item?.name ?? '' }}</span>
                 <ItemIndicators
                   :found-in-raid="isFoundInRaid"
@@ -40,7 +44,7 @@
                   </span>
                   <span class="mt-1 flex">
                     <span
-                      class="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                      class="rounded-md px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase"
                       :class="itemStatusClasses"
                     >
                       {{ $t(itemStatusKey) }}
@@ -132,7 +136,7 @@
                           </span>
                           <span class="mt-1 flex">
                             <span
-                              class="rounded px-1.5 py-0.5 text-[10px] font-semibold"
+                              class="rounded-md px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase"
                               :class="itemStatusClasses"
                             >
                               {{ $t(itemStatusKey) }}
@@ -338,6 +342,7 @@
   import RequirementInfo from '@/features/neededitems/RequirementInfo.vue';
   import TeamNeedsDisplay from '@/features/neededitems/TeamNeedsDisplay.vue';
   import { useTarkovStore } from '@/stores/useTarkov';
+  import { GAME_MODES } from '@/utils/constants';
   import { useLocaleNumberFormatter } from '@/utils/formatters';
   import type { NeededItemHideoutModule, NeededItemTaskObjective } from '@/types/tarkov';
   const TaskLink = defineAsyncComponent(() => import('@/features/tasks/TaskLink.vue'));
@@ -386,11 +391,34 @@
     initialVisible: props.initiallyVisible,
   });
   const itemRowClasses = computed(() => {
+    const mode = tarkovStore.getCurrentGameMode();
+    const modeAccent =
+      mode === GAME_MODES.PVE ? 'border-r-2 border-r-pve-400/30' : 'border-r-2 border-r-pvp-400/30';
     return {
       'bg-gradient-to-l from-complete to-surface':
         selfCompletedNeed.value || currentCount.value >= neededCount.value,
       'bg-surface-800': !(selfCompletedNeed.value || currentCount.value >= neededCount.value),
+      [modeAccent]: true,
     };
+  });
+  const RARITY_BORDER_MAP: Record<string, string> = {
+    violet: 'border-l-rarity-violet',
+    grey: 'border-l-rarity-grey',
+    yellow: 'border-l-rarity-yellow',
+    orange: 'border-l-rarity-orange',
+    green: 'border-l-rarity-green',
+    red: 'border-l-rarity-red',
+    black: 'border-l-rarity-black',
+    blue: 'border-l-rarity-blue',
+  };
+  const REQUIREMENT_BORDER_MAP: Record<string, string> = {
+    taskObjective: 'border-l-kappa-400',
+    hideoutModule: 'border-l-lightkeeper-400',
+  };
+  const rarityBorderClass = computed(() => {
+    const bg = imageItem.value?.backgroundColor?.toLowerCase();
+    if (bg && bg in RARITY_BORDER_MAP) return RARITY_BORDER_MAP[bg];
+    return REQUIREMENT_BORDER_MAP[props.need.needType] ?? 'border-l-surface-600';
   });
   const isSingleItem = computed(() => neededCount.value === 1);
   const isCollected = computed(() => currentCount.value >= neededCount.value);
@@ -411,12 +439,12 @@
   });
   const itemStatusClasses = computed(() => {
     if (isHandedOver.value) {
-      return 'bg-success-500/20 text-success-300';
+      return 'bg-success-500/25 text-success-300 ring-1 ring-success-500/20';
     }
     if (isCollected.value) {
-      return 'bg-info-500/20 text-info-300';
+      return 'bg-info-500/25 text-info-300 ring-1 ring-info-500/20';
     }
-    return 'bg-surface-700 text-surface-300';
+    return 'bg-surface-700/80 text-surface-300 ring-1 ring-white/5';
   });
   defineEmits<{
     (event: 'decreaseCount' | 'increaseCount' | 'toggleCount'): void;

--- a/app/features/neededitems/NeededItemRow.vue
+++ b/app/features/neededitems/NeededItemRow.vue
@@ -335,6 +335,10 @@
   import { useSharedBreakpoints } from '@/composables/useSharedBreakpoints';
   import ItemCountControls from '@/features/neededitems/ItemCountControls.vue';
   import {
+    RARITY_BORDER_MAP,
+    REQUIREMENT_BORDER_MAP,
+  } from '@/features/neededitems/itemRarityBorder';
+  import {
     createDefaultNeededItemContext,
     neededItemKey,
     type NeededItemContext,
@@ -342,7 +346,6 @@
   import RequirementInfo from '@/features/neededitems/RequirementInfo.vue';
   import TeamNeedsDisplay from '@/features/neededitems/TeamNeedsDisplay.vue';
   import { useTarkovStore } from '@/stores/useTarkov';
-  import { GAME_MODES } from '@/utils/constants';
   import { useLocaleNumberFormatter } from '@/utils/formatters';
   import type { NeededItemHideoutModule, NeededItemTaskObjective } from '@/types/tarkov';
   const TaskLink = defineAsyncComponent(() => import('@/features/tasks/TaskLink.vue'));
@@ -391,30 +394,12 @@
     initialVisible: props.initiallyVisible,
   });
   const itemRowClasses = computed(() => {
-    const mode = tarkovStore.getCurrentGameMode();
-    const modeAccent =
-      mode === GAME_MODES.PVE ? 'border-r-2 border-r-pve-400/30' : 'border-r-2 border-r-pvp-400/30';
     return {
       'bg-gradient-to-l from-complete to-surface':
         selfCompletedNeed.value || currentCount.value >= neededCount.value,
       'bg-surface-800': !(selfCompletedNeed.value || currentCount.value >= neededCount.value),
-      [modeAccent]: true,
     };
   });
-  const RARITY_BORDER_MAP: Record<string, string> = {
-    violet: 'border-l-rarity-violet',
-    grey: 'border-l-rarity-grey',
-    yellow: 'border-l-rarity-yellow',
-    orange: 'border-l-rarity-orange',
-    green: 'border-l-rarity-green',
-    red: 'border-l-rarity-red',
-    black: 'border-l-rarity-black',
-    blue: 'border-l-rarity-blue',
-  };
-  const REQUIREMENT_BORDER_MAP: Record<string, string> = {
-    taskObjective: 'border-l-kappa-400',
-    hideoutModule: 'border-l-lightkeeper-400',
-  };
   const rarityBorderClass = computed(() => {
     const bg = imageItem.value?.backgroundColor?.toLowerCase();
     if (bg && bg in RARITY_BORDER_MAP) return RARITY_BORDER_MAP[bg];

--- a/app/features/neededitems/NeededItemSmallCard.vue
+++ b/app/features/neededitems/NeededItemSmallCard.vue
@@ -184,6 +184,10 @@
 <script setup lang="ts">
   import ItemCountControls from '@/features/neededitems/ItemCountControls.vue';
   import {
+    RARITY_BORDER_MAP,
+    REQUIREMENT_BORDER_MAP,
+  } from '@/features/neededitems/itemRarityBorder';
+  import {
     createDefaultNeededItemContext,
     neededItemKey,
   } from '@/features/neededitems/neededitem-keys';
@@ -247,20 +251,6 @@
       'bg-surface-800': !(selfCompletedNeed.value || currentCount.value >= neededCount.value),
     };
   });
-  const RARITY_BORDER_MAP: Record<string, string> = {
-    violet: 'border-l-rarity-violet',
-    grey: 'border-l-rarity-grey',
-    yellow: 'border-l-rarity-yellow',
-    orange: 'border-l-rarity-orange',
-    green: 'border-l-rarity-green',
-    red: 'border-l-rarity-red',
-    black: 'border-l-rarity-black',
-    blue: 'border-l-rarity-blue',
-  };
-  const REQUIREMENT_BORDER_MAP: Record<string, string> = {
-    taskObjective: 'border-l-kappa-400',
-    hideoutModule: 'border-l-lightkeeper-400',
-  };
   const rarityBorderClass = computed(() => {
     const bg = imageItem.value?.backgroundColor?.toLowerCase();
     if (bg && bg in RARITY_BORDER_MAP) return RARITY_BORDER_MAP[bg];

--- a/app/features/neededitems/NeededItemSmallCard.vue
+++ b/app/features/neededitems/NeededItemSmallCard.vue
@@ -10,9 +10,10 @@
       "
     >
       <div
-        class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-900 flex h-full flex-col rounded-lg focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+        class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-900 flex h-full flex-col rounded-lg border-l-2 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
         :class="[
           itemCardClasses,
+          rarityBorderClass,
           {
             'cursor-pointer transition-all active:scale-[0.98]':
               hasItem && isSingleItem && !selfCompletedNeed,
@@ -29,7 +30,7 @@
           <div :class="imageContainerClasses">
             <div class="absolute top-0 left-0 z-10">
               <div
-                class="flex items-center gap-1 rounded-br-lg px-2 py-1 text-sm font-bold shadow-lg"
+                class="flex items-center gap-1.5 rounded-br-lg px-2.5 py-1 text-sm font-bold shadow-lg backdrop-blur-sm"
                 :class="itemCountTagClasses"
               >
                 {{ formatNumber(currentCount) }}/{{ formatNumber(neededCount) }}
@@ -74,7 +75,7 @@
               aria-hidden="true"
             >
               <div
-                class="bg-success-600 flex h-6 w-6 items-center justify-center rounded-full shadow-md"
+                class="bg-success-600/90 ring-success-400/30 flex h-7 w-7 items-center justify-center rounded-full shadow-md ring-2"
               >
                 <UIcon name="i-mdi-check" class="h-4 w-4 text-white" />
               </div>
@@ -95,7 +96,7 @@
               />
             </div>
           </div>
-          <div v-if="cardStyle === 'expanded'" class="flex flex-1 flex-col p-2">
+          <div v-if="cardStyle === 'expanded'" class="flex flex-1 flex-col p-2.5">
             <div class="flex min-h-10 items-start justify-center">
               <span
                 class="line-clamp-2 text-center text-[clamp(0.7rem,2.5vw,0.875rem)] leading-snug font-medium"
@@ -103,7 +104,7 @@
                 {{ item?.name ?? '' }}
               </span>
             </div>
-            <div class="flex min-h-7 w-full items-center justify-center overflow-hidden">
+            <div class="mt-0.5 flex min-h-7 w-full items-center justify-center overflow-hidden">
               <template v-if="props.need.needType == 'taskObjective' && relatedTask">
                 <TaskLink
                   :task="relatedTask"
@@ -125,7 +126,7 @@
               </template>
             </div>
             <div
-              class="text-surface-400 flex min-h-10 flex-wrap items-center justify-center gap-x-3 gap-y-0.5 text-[clamp(0.625rem,1.8vw,0.75rem)]"
+              class="text-surface-400 flex min-h-10 flex-wrap items-center justify-center gap-x-3 gap-y-0.5 border-t border-white/5 pt-1.5 text-[clamp(0.625rem,1.8vw,0.75rem)]"
             >
               <span
                 v-if="levelRequired > 0 && levelRequired > playerLevel"
@@ -245,6 +246,25 @@
         selfCompletedNeed.value || currentCount.value >= neededCount.value,
       'bg-surface-800': !(selfCompletedNeed.value || currentCount.value >= neededCount.value),
     };
+  });
+  const RARITY_BORDER_MAP: Record<string, string> = {
+    violet: 'border-l-rarity-violet',
+    grey: 'border-l-rarity-grey',
+    yellow: 'border-l-rarity-yellow',
+    orange: 'border-l-rarity-orange',
+    green: 'border-l-rarity-green',
+    red: 'border-l-rarity-red',
+    black: 'border-l-rarity-black',
+    blue: 'border-l-rarity-blue',
+  };
+  const REQUIREMENT_BORDER_MAP: Record<string, string> = {
+    taskObjective: 'border-l-kappa-400',
+    hideoutModule: 'border-l-lightkeeper-400',
+  };
+  const rarityBorderClass = computed(() => {
+    const bg = imageItem.value?.backgroundColor?.toLowerCase();
+    if (bg && bg in RARITY_BORDER_MAP) return RARITY_BORDER_MAP[bg];
+    return REQUIREMENT_BORDER_MAP[props.need.needType] ?? 'border-l-surface-600';
   });
   const imageContainerClasses = computed(() => {
     const baseLayoutClasses =

--- a/app/features/neededitems/itemRarityBorder.ts
+++ b/app/features/neededitems/itemRarityBorder.ts
@@ -1,0 +1,14 @@
+export const RARITY_BORDER_MAP: Record<string, string> = {
+  violet: 'border-l-rarity-rare-400',
+  grey: 'border-l-rarity-common-400',
+  yellow: 'border-l-rarity-legendary-400',
+  orange: 'border-l-rarity-orange-400',
+  green: 'border-l-rarity-green-400',
+  red: 'border-l-rarity-red-400',
+  black: 'border-l-rarity-black-400',
+  blue: 'border-l-rarity-uncommon-400',
+};
+export const REQUIREMENT_BORDER_MAP: Record<string, string> = {
+  taskObjective: 'border-l-kappa-400',
+  hideoutModule: 'border-l-lightkeeper-400',
+};


### PR DESCRIPTION
## **User description**
## Summary
Visual-only refresh of the needed items UI components.

### Changes
- **Rarity border treatment**: Added colored left border based on item backgroundColor (rarity) with fallback to requirement type (task = kappa color, hideout = lightkeeper color)
- **Compact badge row**: Consolidated FIR, craftable, Kappa, and Lightkeeper indicators into a single pill-shaped badge container with backdrop and subtle ring
- **Improved status badges**: Uppercase, bold tracking-wide labels with ring accents for handed-over/collected/not-collected states
- **Better spacing**: Increased row padding, margin, rounded corners, subtle section separators
- **Enhanced check mark**: Larger with success ring accent on small card overlay

### Files modified
- ItemIndicators.vue — wrapped in badge container, removed ml-1 from icon defaults
- NeededItemRow.vue — rarity border, improved spacing, enhanced status badges
- NeededItemSmallCard.vue — rarity border, enhanced overlay tags, section separators

### Notes
- No logic changes — purely visual/styling
- Tailwind v4 only — no style blocks added
- All changes pass npm run format (prettier + eslint)
- Pre-existing typecheck error is unrelated

Closes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Added new rarity color variants for enhanced visual distinction
  * Introduced rarity-based left borders on item cards for improved visual organization
  * Refined typography sizing and task badge styling for better visual hierarchy
  * Updated item indicator spacing and tooltip presentation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tarkovtracker-org/TarkovTracker/pull/370?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Refresh needed item cards with clearer rarity borders and compact status badges**

### What Changed
- Needed item cards now show a colored left border that reflects item rarity, or task/hideout requirement type when rarity is not available
- Status icons for Found in Raid, craftable, Kappa, and Lightkeeper are grouped into one compact badge area instead of being spread out
- Collected, handed-over, and not-collected labels are now more prominent with bolder uppercase styling and clearer ring accents
- Card spacing, separators, and success check styling were adjusted for a cleaner, more readable layout
- The border colors now use brighter visible shades so the rarity cue is easier to see

### Impact
`✅ Faster item scanning`
`✅ Easier to spot rarity and requirement type`
`✅ Clearer needed-item status at a glance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
