### PR TITLE
feat: add debug state export for bug reports

### DIFF
--- a/app/composables/useDebugStateExport.ts
+++ b/app/composables/useDebugStateExport.ts
@@ -1,0 +1,122 @@
+import { useMetadataStore } from '@/stores/useMetadata';
+import { useTarkovStore } from '@/stores/useTarkov';
+import { GAME_MODES } from '@/utils/constants';
+import { logger } from '@/utils/logger';
+import type { TaskCompletion, UserProgressData } from '@/types/progress';
+import type { Task } from '@/types/tarkov';
+export interface DebugTaskEntry {
+  id: string;
+  name: string;
+  complete: boolean;
+  failed: boolean;
+  manual: boolean | undefined;
+  hasPrerequisites: boolean;
+  prerequisiteIds: string[];
+  prerequisiteStates: Record<string, { complete: boolean; failed: boolean }>;
+}
+export interface DebugStateSnapshot {
+  exportedAt: string;
+  appVersion: string;
+  gameMode: string;
+  playerLevel: number;
+  gameEdition: number;
+  pmcFaction: string;
+  taskCount: number;
+  completedTaskCount: number;
+  failedTaskCount: number;
+  manualTaskCount: number;
+  importedTaskCount: number;
+  tasks: DebugTaskEntry[];
+}
+type SourceBreakdown = {
+  manual: number;
+  imported: number;
+  normal: number;
+};
+const classifyTaskSource = (
+  completion: TaskCompletion | undefined
+): 'manual' | 'imported' | 'normal' => {
+  if (!completion) return 'normal';
+  if (completion.manual === true) return 'manual';
+  if (completion.manual === false) return 'imported';
+  return 'normal';
+};
+const buildTaskEntries = (
+  modeData: UserProgressData,
+  tasksById: Map<string, Task>
+): { entries: DebugTaskEntry[]; sources: SourceBreakdown } => {
+  const entries: DebugTaskEntry[] = [];
+  const sources: SourceBreakdown = { manual: 0, imported: 0, normal: 0 };
+  const completions: Record<string, TaskCompletion> = modeData.taskCompletions ?? {};
+  for (const [taskId, completion] of Object.entries(completions)) {
+    const task = tasksById.get(taskId);
+    const prereqIds = (task?.taskRequirements ?? [])
+      .map((req) => req?.task?.id)
+      .filter((id): id is string => typeof id === 'string' && id.trim().length > 0);
+    const prereqStates: Record<string, { complete: boolean; failed: boolean }> = {};
+    for (const prereqId of prereqIds) {
+      const prereqCompletion = completions[prereqId];
+      prereqStates[prereqId] = {
+        complete: Boolean(prereqCompletion?.complete && !prereqCompletion?.failed),
+        failed: Boolean(prereqCompletion?.failed),
+      };
+    }
+    const isComplete = Boolean(completion?.complete && !completion?.failed);
+    const isFailed = Boolean(completion?.failed);
+    const source = classifyTaskSource(completion);
+    if (isComplete || isFailed) {
+      sources[source] += 1;
+    }
+    entries.push({
+      id: taskId,
+      name: task?.name ?? taskId,
+      complete: isComplete,
+      failed: isFailed,
+      manual: completion?.manual,
+      hasPrerequisites: prereqIds.length > 0,
+      prerequisiteIds: prereqIds,
+      prerequisiteStates: prereqStates,
+    });
+  }
+  return { entries, sources };
+};
+export function useDebugStateExport() {
+  const tarkovStore = useTarkovStore();
+  const metadataStore = useMetadataStore();
+  const buildSnapshot = (): DebugStateSnapshot => {
+    const currentMode = tarkovStore.getCurrentGameMode();
+    const modeData: UserProgressData =
+      currentMode === GAME_MODES.PVE ? tarkovStore.$state.pve : tarkovStore.$state.pvp;
+    const tasks = metadataStore.tasks as Task[];
+    const tasksById = new Map(tasks.map((t) => [t.id, t]));
+    const { entries, sources } = buildTaskEntries(modeData, tasksById);
+    const runtimeConfig = useRuntimeConfig();
+    return {
+      exportedAt: new Date().toISOString(),
+      appVersion: runtimeConfig.public.appVersion || 'dev',
+      gameMode: currentMode,
+      playerLevel: modeData.level ?? 1,
+      gameEdition: tarkovStore.$state.gameEdition ?? 1,
+      pmcFaction: modeData.pmcFaction ?? 'USEC',
+      taskCount: entries.length,
+      completedTaskCount: entries.filter((e) => e.complete).length,
+      failedTaskCount: entries.filter((e) => e.failed).length,
+      manualTaskCount: sources.manual,
+      importedTaskCount: sources.imported,
+      tasks: entries,
+    };
+  };
+  const exportDebugState = (): string => {
+    try {
+      const snapshot = buildSnapshot();
+      return JSON.stringify(snapshot, null, 2);
+    } catch (error) {
+      logger.error('[DebugStateExport] Failed to build snapshot:', error);
+      return JSON.stringify({
+        exportedAt: new Date().toISOString(),
+        error: 'Failed to build debug snapshot',
+      });
+    }
+  };
+  return { exportDebugState };
+}

--- a/app/features/settings/DebugStateCard.vue
+++ b/app/features/settings/DebugStateCard.vue
@@ -1,0 +1,51 @@
+<template>
+  <GenericCard
+    icon="mdi-bug-outline"
+    icon-color="warning"
+    highlight-color="warning"
+    :fill-height="false"
+    :title="t('settings.debug_state.title', 'Debug State')"
+    title-classes="text-lg font-semibold"
+  >
+    <template #content>
+      <div class="space-y-3 px-4 py-4">
+        <p class="text-surface-400 text-sm">
+          {{
+            t(
+              'settings.debug_state.description',
+              'Capture a JSON snapshot of your current tracker state for bug reports. Includes game mode, level, task completion states, and prerequisite chains.'
+            )
+          }}
+        </p>
+        <UButton
+          icon="i-mdi-content-copy"
+          color="neutral"
+          variant="soft"
+          size="sm"
+          :loading="isCopying"
+          @click="handleCopyDebugState"
+        >
+          {{ t('settings.debug_state.copy_button', 'Copy Debug State') }}
+        </UButton>
+      </div>
+    </template>
+  </GenericCard>
+</template>
+<script setup lang="ts">
+  import GenericCard from '@/components/ui/GenericCard.vue';
+  import { useCopyToClipboard } from '@/composables/useCopyToClipboard';
+  import { useDebugStateExport } from '@/composables/useDebugStateExport';
+  const { t } = useI18n({ useScope: 'global' });
+  const { exportDebugState } = useDebugStateExport();
+  const { copyToClipboard } = useCopyToClipboard();
+  const isCopying = ref(false);
+  const handleCopyDebugState = async () => {
+    isCopying.value = true;
+    try {
+      const json = exportDebugState();
+      await copyToClipboard(json);
+    } finally {
+      isCopying.value = false;
+    }
+  };
+</script>

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1503,6 +1503,11 @@
     "account": {
       "begin_deletion": "Begin Account Deletion"
     },
+    "debug_state": {
+      "title": "Debug State",
+      "description": "Capture a JSON snapshot of your current tracker state for bug reports. Includes game mode, level, task completion states, and prerequisite chains.",
+      "copy_button": "Copy Debug State"
+    },
     "general": {
       "privacy_mode": "Streamer Mode",
       "privacy_mode_hint": "Hides sensitive information while you're streaming.",

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -97,6 +97,7 @@
               :aria-label="$t('settings.tabs.account')"
             >
               <ProfileSharingCard />
+              <DebugStateCard />
               <AccountDeletionCard />
               <div v-if="isAdmin" class="flex justify-center pt-4">
                 <NuxtLink
@@ -158,6 +159,7 @@
   import AccountDeletionCard from '@/features/settings/AccountDeletionCard.vue';
   import ApiTokensCard from '@/features/settings/ApiTokensCard.vue';
   import DataManagementCard from '@/features/settings/DataManagementCard.vue';
+  import DebugStateCard from '@/features/settings/DebugStateCard.vue';
   import DisplayNameCard from '@/features/settings/DisplayNameCard.vue';
   import ExperienceCard from '@/features/settings/ExperienceCard.vue';
   import MapSettingsCard from '@/features/settings/MapSettingsCard.vue';


### PR DESCRIPTION
## **User description**
## Summary

Adds a 'Copy Debug State' button to the Account section of Settings that captures a JSON snapshot of relevant tracker state for bug reports.

Closes #243

## What's included

- **Composable** `useDebugStateExport` — serializes the current game mode's progress state into a structured JSON snapshot
- **Component** `DebugStateCard` — settings card with a single copy button
- **i18n keys** in `en.json` under `settings.debug_state`

## Debug state snapshot captures

- App version, export timestamp
- Current game mode (pvp/pve), player level, game edition, PMC faction
- All task completions with their completion/failed status
- Whether each task was set manually, via import, or through normal progression
- Prerequisite task chains with their completion states
- Aggregate counts (total, completed, failed, manual, imported)

## Testing

- `npm run lint` — passes (no new warnings)
- `npm run typecheck` — passes


___

## **CodeAnt-AI Description**
**Add a debug state copy option in Settings**

### What Changed
- Added a new card in Account settings that lets users copy a JSON snapshot of their current tracker state for bug reports
- The snapshot includes app version, game mode, player level, faction, task completion status, prerequisite chains, and whether tasks were set manually or imported
- If the snapshot cannot be built, the copied output falls back to a simple error message instead of failing

### Impact
`✅ Easier bug reports`
`✅ Clearer support cases`
`✅ Fewer missing task-state details`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Copy Debug State" feature in Settings (Account tab) that allows players to export and copy a snapshot of their current game progress.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tarkovtracker-org/TarkovTracker/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->