### PR TITLE
feat(ui): add Kappa and Lightkeeper quest overview tracker (#89)

### DIFF
--- a/app/features/drawer/DrawerLinks.vue
+++ b/app/features/drawer/DrawerLinks.vue
@@ -49,6 +49,12 @@
         to="/settings"
         :is-collapsed="props.isCollapsed"
       ></DrawerItem>
+      <DrawerItem
+        icon="i-mdi-trophy"
+        locale-key="kappa"
+        to="/kappa"
+        :is-collapsed="props.isCollapsed"
+      ></DrawerItem>
     </ul>
   </div>
 </template>

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -605,6 +605,22 @@
       "route_unlock_trader": "Trader: {name}",
       "route_unlock_reward": "Reward: {name}"
     },
+    "kappa": {
+      "title": "Kappa & Lightkeeper Tracker",
+      "subtitle": "Track your progress toward the Kappa container and Lightkeeper quests.",
+      "tabs": {
+        "kappa": "Kappa",
+        "lightkeeper": "Lightkeeper"
+      },
+      "stats": {
+        "total": "Kappa Tasks",
+        "completed": "Kappa Done",
+        "lightkeeper_total": "Lightkeeper Tasks",
+        "lightkeeper_completed": "Lightkeeper Done"
+      },
+      "progress_label": "complete",
+      "all_complete": "All tasks complete! Well done, PMC."
+    },
     "tasks": {
       "title": "Tasks",
       "primary_views": {
@@ -1298,6 +1314,7 @@
     "credits": "Credits",
     "settings": "Settings",
     "profile": "Profile",
+    "kappa": "Kappa & Lightkeeper",
     "section_navigation": "Navigation",
     "section_game_settings": "Game Settings",
     "section_external": "External Tools",

--- a/app/pages/kappa.vue
+++ b/app/pages/kappa.vue
@@ -1,0 +1,141 @@
+<template>
+  <div class="flex min-h-full flex-col px-3 py-6 sm:px-6">
+    <div class="mx-auto w-full max-w-[1400px]">
+      <!-- Header -->
+      <div class="mb-6">
+        <div class="flex items-center gap-3">
+          <span
+            class="bg-kappa/15 border-kappa/25 inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border"
+          >
+            <UIcon name="i-mdi-trophy" class="text-kappa h-5 w-5" />
+          </span>
+          <div>
+            <h1 class="text-2xl font-bold text-white">
+              {{ t('page.kappa.title') }}
+            </h1>
+            <p class="text-surface-400 text-sm">
+              {{ t('page.kappa.subtitle') }}
+            </p>
+          </div>
+        </div>
+      </div>
+      <!-- Stats -->
+      <div class="mb-6 grid grid-cols-2 gap-3 sm:grid-cols-4">
+        <div class="bg-surface-800/50 rounded-lg border border-white/5 p-3">
+          <div class="text-surface-400 text-xs font-medium tracking-wide uppercase">
+            {{ t('page.kappa.stats.total') }}
+          </div>
+          <div class="mt-1 text-2xl font-bold text-white">
+            {{ kappaTasks.length }}
+          </div>
+        </div>
+        <div class="bg-surface-800/50 rounded-lg border border-white/5 p-3">
+          <div class="text-surface-400 text-xs font-medium tracking-wide uppercase">
+            {{ t('page.kappa.stats.completed') }}
+          </div>
+          <div class="text-success-400 mt-1 text-2xl font-bold">
+            {{ kappaCompleted }}
+          </div>
+        </div>
+        <div class="bg-surface-800/50 rounded-lg border border-white/5 p-3">
+          <div class="text-surface-400 text-xs font-medium tracking-wide uppercase">
+            {{ t('page.kappa.stats.lightkeeper_total') }}
+          </div>
+          <div class="mt-1 text-2xl font-bold text-white">
+            {{ lightkeeperTasks.length }}
+          </div>
+        </div>
+        <div class="bg-surface-800/50 rounded-lg border border-white/5 p-3">
+          <div class="text-surface-400 text-xs font-medium tracking-wide uppercase">
+            {{ t('page.kappa.stats.lightkeeper_completed') }}
+          </div>
+          <div class="text-lightkeeper mt-1 text-2xl font-bold">
+            {{ lightkeeperCompleted }}
+          </div>
+        </div>
+      </div>
+      <!-- Tab toggle -->
+      <div class="mb-4 flex gap-2">
+        <UButton
+          :variant="activeTab === 'kappa' ? 'solid' : 'outline'"
+          color="primary"
+          size="sm"
+          @click="activeTab = 'kappa'"
+        >
+          <UIcon name="i-mdi-trophy" class="mr-1.5 h-4 w-4" />
+          {{ t('page.kappa.tabs.kappa') }} ({{ kappaTasks.length }})
+        </UButton>
+        <UButton
+          :variant="activeTab === 'lightkeeper' ? 'solid' : 'outline'"
+          color="info"
+          size="sm"
+          @click="activeTab = 'lightkeeper'"
+        >
+          <UIcon name="i-mdi-lighthouse" class="mr-1.5 h-4 w-4" />
+          {{ t('page.kappa.tabs.lightkeeper') }} ({{ lightkeeperTasks.length }})
+        </UButton>
+      </div>
+      <!-- Progress bar -->
+      <div class="mb-6">
+        <div class="bg-surface-800 h-2 overflow-hidden rounded-full">
+          <div
+            class="h-full rounded-full transition-all duration-300"
+            :class="activeTab === 'kappa' ? 'bg-kappa' : 'bg-lightkeeper'"
+            :style="{ width: `${progressPercent}%` }"
+          />
+        </div>
+        <div class="text-surface-400 mt-1 text-right text-xs">
+          {{ progressPercent }}% {{ t('page.kappa.progress_label') }}
+        </div>
+      </div>
+      <!-- Task list -->
+      <div class="space-y-3">
+        <TaskCard
+          v-for="task in displayedTasks"
+          :key="task.id"
+          :task="task"
+          @on-task-action="handleTaskAction"
+        />
+      </div>
+      <div v-if="displayedTasks.length === 0" class="py-12 text-center">
+        <UIcon name="i-mdi-check-circle-outline" class="text-success-400 mx-auto mb-3 h-12 w-12" />
+        <p class="text-surface-300 text-lg font-medium">
+          {{ t('page.kappa.all_complete') }}
+        </p>
+      </div>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+  import TaskCard from '@/features/tasks/TaskCard.vue';
+  const { t } = useI18n({ useScope: 'global' });
+  const metadataStore = useMetadataStore();
+  const tarkovStore = useTarkovStore();
+  const activeTab = ref<'kappa' | 'lightkeeper'>('kappa');
+  const kappaTasks = computed(() => metadataStore.tasks.filter((task) => task.kappaRequired));
+  const lightkeeperTasks = computed(() =>
+    metadataStore.tasks.filter((task) => task.lightkeeperRequired)
+  );
+  const displayedTasks = computed(() =>
+    activeTab.value === 'kappa' ? kappaTasks.value : lightkeeperTasks.value
+  );
+  const kappaCompleted = computed(
+    () => kappaTasks.value.filter((task) => tarkovStore.isTaskComplete(task.id)).length
+  );
+  const lightkeeperCompleted = computed(
+    () => lightkeeperTasks.value.filter((task) => tarkovStore.isTaskComplete(task.id)).length
+  );
+  const progressPercent = computed(() => {
+    const tasks = activeTab.value === 'kappa' ? kappaTasks.value : lightkeeperTasks.value;
+    const completed =
+      activeTab.value === 'kappa' ? kappaCompleted.value : lightkeeperCompleted.value;
+    return tasks.length > 0 ? Math.round((completed / tasks.length) * 100) : 0;
+  });
+  function handleTaskAction(_action: unknown) {
+    // Task actions handled by TaskCard internally
+  }
+  useSeoMeta({
+    title: () => t('page.kappa.title'),
+    description: () => t('page.kappa.subtitle'),
+  });
+</script>


### PR DESCRIPTION
## **User description**
## Summary

New page at /kappa showing all kappaRequired and lightkeeperRequired tasks with completion stats, progress bar, and tab switching.

Closes #89

## Changes

- **app/pages/kappa.vue**: New overview page with:
  - Stats cards showing total/completed for both Kappa and Lightkeeper
  - Progress bar with completion percentage
  - Tab toggle between Kappa and Lightkeeper task lists
  - Uses existing TaskCard component for consistent rendering
- **DrawerLinks.vue**: Added nav link for Kappa page
- **en.json**: Added i18n keys for kappa page and nav item

## Testing
- `npm run lint` — clean
- `npm run typecheck` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added new Kappa & Lightkeeper tracker accessible from the drawer navigation menu
  * Tracker provides tabbed interface to view Kappa and Lightkeeper tasks separately
  * Displays completion statistics, progress tracking, and task lists for each category
  * Includes empty-state messaging when no tasks are available

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tarkovtracker-org/TarkovTracker/pull/375?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Track Kappa and Lightkeeper quests from one page**

### What Changed
- Added a new Kappa page that shows Kappa-required and Lightkeeper-required quests with completion counts and a progress bar
- Users can switch between the Kappa and Lightkeeper quest lists on the same screen
- When every quest in the selected list is done, the page shows a clear completion message
- Added a navigation link so the page is easier to open from the main menu

### Impact
`✅ Faster quest tracking`
`✅ Quicker access to Kappa and Lightkeeper progress`
`✅ Clearer completion status`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
