### PR TITLE
feat(ui): show task alternatives badge for quest choices (#189, #188)

### DIFF
--- a/app/features/tasks/TaskCardBadges.vue
+++ b/app/features/tasks/TaskCardBadges.vue
@@ -124,6 +124,15 @@
       />
     </AppTooltip>
     <AppTooltip
+      v-if="task.alternatives && task.alternatives.length > 0"
+      :text="t('page.tasks.questcard.alternatives_tooltip', { count: task.alternatives.length })"
+    >
+      <UBadge size="xs" color="warning" variant="soft" class="shrink-0 cursor-help text-[11px]">
+        <UIcon name="i-mdi-swap-horizontal" class="mr-0.5 h-3 w-3" aria-hidden="true" />
+        {{ t('page.tasks.questcard.alternatives_badge', { count: task.alternatives.length }) }}
+      </UBadge>
+    </AppTooltip>
+    <AppTooltip
       v-if="showRequiredLabels && exclusiveEditionBadge"
       :text="
         t(

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -867,6 +867,8 @@
         "kappa_required": "KAPPA REQUIRED",
         "level_badge_tooltip": "Minimum player level {level} required to unlock this quest",
         "lightkeeper_tooltip": "This quest is required to unlock the Lightkeeper trader",
+        "alternatives_tooltip": "This quest has {count} alternative choice(s) — you only need to complete one",
+        "alternatives_badge": "{count} alt",
         "lightkeeper_required": "LIGHTKEEPER REQUIRED",
         "location_tooltip": "Quest objectives are on {map}",
         "next_tasks": "Next Task(s):",


### PR DESCRIPTION
## **User description**
## Summary

Adds an "alternatives" badge to task cards that have alternative quest choices, making it visible when players only need to complete one of several options.

Closes #189
Closes #188

## Changes

- **TaskCardBadges.vue**: Added alternatives badge with swap icon showing count
- **en.json**: Added i18n keys for alternatives tooltip and badge text

## Design

- Shows a warning-colored badge with "X alt" text
- Tooltip explains: "This quest has X alternative choice(s) — you only need to complete one"
- Uses existing `task.alternatives` field from the Task type

## Testing
- `npm run lint` — clean
- `npm run typecheck` — clean

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Task cards now display an alternatives badge and accompanying tooltip when alternative choices are available, with the tooltip indicating the number of alternatives to help users quickly identify tasks with multiple options.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tarkovtracker-org/TarkovTracker/pull/376?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
Show an alternatives badge on quest cards

### What Changed
- Quest cards now show a small badge when a task has alternative choices
- The badge shows how many alternatives exist and uses a swap icon to make it easy to spot
- Hovering the badge explains that only one of the alternative choices needs to be completed

### Impact
`✅ Clearer quest choices`
`✅ Less confusion about optional task paths`
`✅ Faster quest selection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
