### PR TITLE
fix(deps): eliminate deprecated vue-i18n v10 nested dependency

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -3,23 +3,23 @@ version: alpha
 name: TarkovTracker
 description: Agent-facing design contract for the TarkovTracker Nuxt 4 SPA.
 colors:
-  canvas: '#0a0a0a'
-  shell: '#171717'
-  panel: '#1f1f1f'
+  canvas: '#090909'
+  shell: '#161616'
+  panel: '#1d1d1d'
   raised: '#262626'
-  text: '#e5e5e5'
-  text-secondary: '#d4d4d4'
-  text-muted: '#a3a3a3'
-  primary: '#ad7a3d'
-  primary-strong: '#c08b48'
-  secondary: '#339299'
-  accent: '#3f6870'
-  success: '#22b981'
-  warning: '#cea617'
-  error: '#b83333'
-  info: '#3f98d0'
-  pvp: '#b8aa96'
-  pve: '#5c9ab7'
+  text: '#e6e6e6'
+  text-secondary: '#b7bcc2'
+  text-muted: '#9da2aa'
+  primary: '#9a8866'
+  primary-strong: '#a99366'
+  secondary: '#1e7777'
+  accent: '#3b6268'
+  success: '#009365'
+  warning: '#bc9200'
+  error: '#b13346'
+  info: '#197cb3'
+  pvp: '#c9bfaa'
+  pve: '#5a99b0'
 typography:
   body:
     fontFamily: 'ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, Liberation Mono, Courier New, monospace'
@@ -80,7 +80,7 @@ components:
     typography: '{typography.body}'
   badge-secondary:
     backgroundColor: '{colors.secondary}'
-    textColor: '{colors.canvas}'
+    textColor: '#ffffff'
     rounded: '{rounded.sm}'
     padding: '{spacing.xs}'
   badge-accent:
@@ -102,7 +102,7 @@ components:
     rounded: '{rounded.sm}'
   status-info:
     backgroundColor: '{colors.info}'
-    textColor: '{colors.canvas}'
+    textColor: '#ffffff'
     rounded: '{rounded.sm}'
   mode-pvp:
     backgroundColor: '{colors.pvp}'
@@ -131,11 +131,13 @@ slot defaults in `app/app.config.ts`.
 Use the Tailwind v4 theme tokens already defined in `app/assets/css/tailwind.css`. Do not put hex
 colors in Vue templates.
 
-The front matter uses sRGB hex values because the `DESIGN.md` token schema validates colors as hex.
-Treat those values as agent-readable representatives of the runtime Tailwind tokens, not a separate
-CSS source of truth.
+The color system uses a two-layer architecture: HSL values in `@theme static` provide browser
+fallbacks, while OKLCH overrides in an `@supports (color: oklch(...))` block provide the
+perceptually tuned production colors. Modern browsers use the OKLCH values, which produce better
+uniformity across hues (equal chroma steps look equal) and more natural desaturation at low
+lightness. The front matter hex values represent the rendered OKLCH output, not the HSL fallbacks.
 
-Primary actions use the tan `primary` palette. Secondary accents use `secondary` or `accent`.
+Primary actions use the golden-tan `primary` palette. Secondary accents use `secondary` or `accent`.
 Surfaces follow the `surface` ladder: page canvas at `surface-950`, shell chrome at `surface-900`,
 content panels at `surface-850` or `surface-900`, raised controls at `surface-800`, hover states at
 `surface-700`, and dividers at `surface-600`.
@@ -150,8 +152,12 @@ Surface token mapping:
 - hover states -> `surface-700`
 - dividers -> `surface-600`
 
-State colors are semantic: `success`, `warning`, `error`, and `info`. Game-mode color should use
+State colors are semantic: `success`, `warning`, `error`, and `info`. Game-mode colors should use
 `pvp` and `pve`, not ad hoc tan or blue classes.
+
+Note: Nuxt UI maps its semantic `info` color to the `accent` (teal) palette in `app.config.ts`, so
+`<UButton color="info">` renders teal, while the CSS `text-info-500` class renders blue. This is
+intentional — the teal accent is the primary informational tone in the UI.
 
 ## Typography
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3551,38 +3551,6 @@
         }
       }
     },
-    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/core-base": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@intlify/core-base/-/core-base-10.0.8.tgz",
-      "integrity": "sha512-FoHslNWSoHjdUBLy35bpm9PV/0LVI/DSv9L6Km6J2ad8r/mm0VaGg06C40FqlE8u2ADcGUM60lyoU7Myo4WNZQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/message-compiler": "10.0.8",
-        "@intlify/shared": "10.0.8"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/message-compiler": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/@intlify/message-compiler/-/message-compiler-10.0.8.tgz",
-      "integrity": "sha512-DV+sYXIkHVd5yVb2mL7br/NEUwzUoLBsMkV3H0InefWgmYa34NLZUvMCGi5oWX+Hqr2Y2qUxnVrnOWF4aBlgWg==",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/shared": "10.0.8",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      }
-    },
     "node_modules/@intlify/vue-i18n-extensions/node_modules/@intlify/shared": {
       "version": "10.0.8",
       "resolved": "https://registry.npmjs.org/@intlify/shared/-/shared-10.0.8.tgz",
@@ -3593,33 +3561,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/kazupon"
-      }
-    },
-    "node_modules/@intlify/vue-i18n-extensions/node_modules/@vue/devtools-api": {
-      "version": "6.6.4",
-      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-6.6.4.tgz",
-      "integrity": "sha512-sGhTPMuXqZ1rVOk32RylztWkfXTRhuS7vgAKv0zjqk8gbsHkJ7xfFf+jbySxt7tWObEJwyKaHMikV/WGDiQm8g==",
-      "license": "MIT"
-    },
-    "node_modules/@intlify/vue-i18n-extensions/node_modules/vue-i18n": {
-      "version": "10.0.8",
-      "resolved": "https://registry.npmjs.org/vue-i18n/-/vue-i18n-10.0.8.tgz",
-      "integrity": "sha512-mIjy4utxMz9lMMo6G9vYePv7gUFt4ztOMhY9/4czDJxZ26xPeJ49MAGa9wBAE3XuXbYCrtVPmPxNjej7JJJkZQ==",
-      "deprecated": "v9 and v10 no longer supported. please migrate to v11. about maintenance status, see https://vue-i18n.intlify.dev/guide/maintenance.html",
-      "license": "MIT",
-      "dependencies": {
-        "@intlify/core-base": "10.0.8",
-        "@intlify/shared": "10.0.8",
-        "@vue/devtools-api": "^6.5.0"
-      },
-      "engines": {
-        "node": ">= 16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/kazupon"
-      },
-      "peerDependencies": {
-        "vue": "^3.0.0"
       }
     },
     "node_modules/@ioredis/commands": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5580,9 +5580,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5598,9 +5595,6 @@
       "integrity": "sha512-F6RkJ90S1Xt25Mk7/wPUmddsE4RZ7Nei+HlEa2FAjfhpoaTciOwV6E/Gtp7wPIYbwft7UfhMYwuEuZiZQytVWw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -5618,9 +5612,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5636,9 +5627,6 @@
       "integrity": "sha512-2j6Bd340IZqZbu4KUI28z87Ao9aHhq56HH1Qz5/+EdE732ajFYIoDF3z+QcxHXY0CFOG/Ur1ZOKTBEIWQ6BYIw==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5656,9 +5644,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5674,9 +5659,6 @@
       "integrity": "sha512-9rxYqH7P8NiYqRlLxlnNjJSF8BYADOmihM5ZHVkmlE4tqjHkoLNevdAyAP2ZBkL8QJflm1WGOXFWmFnWA54EvA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -5694,9 +5676,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5712,9 +5691,6 @@
       "integrity": "sha512-59Cxvjppy09TsaB15gr6rA9Bf87rm9t0bD1EW9dCZsdxWElnAC+TvWZ7v9dFUIeYeZUkhAAMPtpdqa3Y9CI2zA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8754,9 +8730,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8772,9 +8745,6 @@
       "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -8792,9 +8762,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -8810,9 +8777,6 @@
       "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -21024,9 +20988,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21039,9 +21000,6 @@
       "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -21056,9 +21014,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21071,9 +21026,6 @@
       "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -21088,9 +21040,6 @@
       "cpu": [
         "loong64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21103,9 +21052,6 @@
       "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
       "cpu": [
         "loong64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -21120,9 +21066,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21135,9 +21078,6 @@
       "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -21152,9 +21092,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21167,9 +21104,6 @@
       "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -21184,9 +21118,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21200,9 +21131,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -21215,9 +21143,6 @@
       "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -23880,9 +23805,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23898,9 +23820,6 @@
       "integrity": "sha512-M7iwBGmYJTx+pKOYFjI0buop4gJvlmcVzFGaXPt21DKpQkbQZG1f63Yg7LloIYT/t9yLxCw0Lhfx/RFlAlMSjA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -23918,9 +23837,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23936,9 +23852,6 @@
       "integrity": "sha512-gyHjOTFpg9bTTYjxPmQirvufb89+VdZwVfcMtAUyPr6F5H8ZswvCQshK4qOW+Q+2Xyb33hduRgY/eFHJQjU/vQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -23956,9 +23869,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -23974,9 +23884,6 @@
       "integrity": "sha512-BdzTmqxfxoYkpgokoLaSnOX6T+R3/goL42klre2tnG+kHbG2TXS0VN+P5BPofH1axdKOHy5ei4ENZrjmCOt2lA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -23994,9 +23901,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24012,9 +23916,6 @@
       "integrity": "sha512-4NehAe404MRdoZVS9DW8C5XbJwbXIc/KfVlYdpi5vE4081zc9Y0YzKVqyOYj/Puye7/Do+ohaONBFWlEHYl9hw==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -24235,9 +24136,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24253,9 +24151,6 @@
       "integrity": "sha512-dPSjyd0gQ9dE3mpdJi0BHNJaqQz4V7mVW6Fbs6jRSiGnrxwGfXdMJFInXoJ49B3k5Zhfa9Is9Ixp6St7c6ouCA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -24273,9 +24168,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24291,9 +24183,6 @@
       "integrity": "sha512-jjSiG9H8ya/U3igW5DdIBFIDwhffF7Vbc7th2tcHV73eg0DQz75n36a9RmQ1/0aS9vknUuNtY6SODr8/gmuzsQ==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -24311,9 +24200,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24329,9 +24215,6 @@
       "integrity": "sha512-caJnVw5PG8v339zAyHgA7p34xXa3A4Kc9VyrDgsT1znr51qacaUv4BRlgRi0qkqxRWXYNVFfsbU2g0t1qS7E9w==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -24349,9 +24232,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -24367,9 +24247,6 @@
       "integrity": "sha512-NjYtwl9ijp34iisHxYBvE7nii1Ac0QPP3doHv8MQHhDA3zjUcDCROuBNybfaEYCxnJ1aF+cAPqsyeopnAGsyuQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -79,6 +79,9 @@
       ".": "^11.13.0",
       "picomatch": "^4.0.4"
     },
+    "@intlify/vue-i18n-extensions": {
+      "vue-i18n": "$vue-i18n"
+    },
     "@tiptap/core": "3.14.0",
     "@tiptap/pm": "3.14.0",
     "fast-xml-parser": "^5.7.1",

--- a/package.json
+++ b/package.json
@@ -79,9 +79,6 @@
       ".": "^11.13.0",
       "picomatch": "^4.0.4"
     },
-    "@intlify/vue-i18n-extensions": {
-      "vue-i18n": "$vue-i18n"
-    },
     "@tiptap/core": "3.14.0",
     "@tiptap/pm": "3.14.0",
     "fast-xml-parser": "^5.7.1",
@@ -96,7 +93,8 @@
     "node-forge": "^1.4.0",
     "serialize-javascript": "^7.0.5",
     "tar": "^7.5.13",
-    "yaml": "^2.8.3"
+    "yaml": "^2.8.3",
+    "vue-i18n": "$vue-i18n"
   },
   "packageManager": "npm@11.13.0",
   "private": true,


### PR DESCRIPTION
## **User description**
## Summary

Adds an npm override to force `@intlify/vue-i18n-extensions` to resolve `vue-i18n` from the root version (^11.4.2) instead of pulling in its own dependency on the deprecated v10 line.

## Problem

The deprecation warning was triggered by a **nested** copy of `vue-i18n@10.0.8` installed under:

```
@nuxtjs/i18n@10.3.0
└── @intlify/unplugin-vue-i18n@11.1.2
    └── @intlify/vue-i18n-extensions@8.0.0
        └── vue-i18n@10.0.8   ← deprecated
```

The project's direct `vue-i18n` dependency was already at v11, but this transitive dependency brought in its own v10 copy.

## Fix

Override `@intlify/vue-i18n-extensions` to use `-i18n` (the root-resolved version) so the entire tree deduplicates to v11.

## Safety

- `@intlify/vue-i18n-extensions@8.0.0` already declares `vue-i18n: ^9.0.0 || ^10.0.0 || ^11.0.0` in `peerDependencies`, so v11 is explicitly supported.
- After the override, `npm ls vue-i18n` shows only `11.4.2` across the entire dependency tree.
- `npm audit` reports 0 vulnerabilities after regeneration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed design tokens and palettes (canvas/shell/panel, text, primary/secondary/accent, status, pvp/pve); badge and status examples now use white text.
  * Expanded color-system guidance (two-layer fallbacks, OKLCH override) and clarified how front-matter colors map to runtime tokens and semantic state-color mapping differences.

* **Chores**
  * Updated dependency resolution configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tarkovtracker-org/TarkovTracker/pull/383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Remove the deprecated nested Vue I18n package and align design color guidance**

### What Changed
- The app now forces the shared Vue I18n version from the root install, so the deprecated v10 copy is no longer pulled in through a nested dependency
- The lock file no longer includes the old nested Vue I18n v10 packages and their related subpackages
- DESIGN.md now lists the updated rendered color values, uses white text on badge/status examples, and explains how the app’s color system maps to runtime colors

### Impact
`✅ No more deprecated Vue I18n v10 warning`
`✅ Cleaner dependency installs`
`✅ More accurate design color references`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
