### PR TITLE
[codex] add admin supporter override

### DIFF
--- a/app/components/PromotedTwitchEmbed.vue
+++ b/app/components/PromotedTwitchEmbed.vue
@@ -56,9 +56,20 @@
         ></iframe>
       </div>
     </aside>
+    <UButton
+      v-else-if="isLive && dismissed"
+      icon="i-mdi-twitch"
+      color="primary"
+      variant="solid"
+      size="sm"
+      class="fixed right-3 bottom-3 z-50 shadow-lg sm:right-5 sm:bottom-5"
+      :aria-label="t('promoted_stream.reopen', 'Reopen stream')"
+      @click="undismiss"
+    />
   </ClientOnly>
 </template>
 <script setup lang="ts">
+  const DISMISS_KEY = 'tt-twitch-dismissed';
   const { t } = useI18n({ useScope: 'global' });
   const runtimeConfig = useRuntimeConfig();
   const config = runtimeConfig.public.promotedTwitch as {
@@ -70,6 +81,7 @@
   const channel = config.channel?.trim().toLowerCase() || 'honeyxxo';
   const displayName = config.displayName?.trim() || channel;
   const isVisible = ref(false);
+  const isLive = ref(false);
   const dismissed = ref(false);
   const isExpanded = ref(true);
   const playerUrl = ref('');
@@ -86,30 +98,44 @@
   const dismiss = (): void => {
     dismissed.value = true;
     isVisible.value = false;
-    if (pollTimer) {
-      clearInterval(pollTimer);
-      pollTimer = null;
+    try {
+      sessionStorage.setItem(DISMISS_KEY, '1');
+    } catch {}
+  };
+  const undismiss = (): void => {
+    dismissed.value = false;
+    try {
+      sessionStorage.removeItem(DISMISS_KEY);
+    } catch {}
+    if (isLive.value) {
+      playerUrl.value = buildPlayerUrl();
+      isVisible.value = true;
     }
   };
   const checkLive = async (): Promise<void> => {
-    if (dismissed.value) return;
     try {
-      const { isLive } = await $fetch<{ isLive: boolean }>('/api/twitch/live', {
+      const data = await $fetch<{ isLive: boolean }>('/api/twitch/live', {
         query: { channel },
       });
-      if (isLive && !isVisible.value) {
+      isLive.value = data.isLive;
+      if (dismissed.value) return;
+      if (data.isLive && !isVisible.value) {
         playerUrl.value = buildPlayerUrl();
         isVisible.value = true;
-      } else if (!isLive) {
+      } else if (!data.isLive) {
         isVisible.value = false;
       }
     } catch {
+      isLive.value = false;
       isVisible.value = false;
     }
   };
   onMounted(() => {
     if (config.enabled === false) return;
     if (config.endsAt && new Date(config.endsAt) < new Date()) return;
+    try {
+      dismissed.value = sessionStorage.getItem(DISMISS_KEY) === '1';
+    } catch {}
     checkLive();
     pollTimer = setInterval(checkLive, 60_000);
   });

--- a/app/features/admin/AdminAuditLog.vue
+++ b/app/features/admin/AdminAuditLog.vue
@@ -107,10 +107,12 @@
     });
   };
   const getActionIcon = (action: string) => {
+    if (action.includes('supporter')) return 'i-mdi-credit-card-check';
     if (action.includes('cache')) return 'i-mdi-cached';
     return 'i-mdi-shield-account';
   };
   const getActionColor = (action: string) => {
+    if (action.includes('supporter')) return 'success';
     if (action.includes('purge')) return 'warning';
     return 'info';
   };

--- a/app/features/admin/AdminSupporterAccessCard.vue
+++ b/app/features/admin/AdminSupporterAccessCard.vue
@@ -1,0 +1,117 @@
+<script setup lang="ts">
+  import { useSupporter } from '@/composables/useSupporter';
+  import { useSystemStoreWithSupabase } from '@/stores/useSystemStore';
+  const { $supabase } = useNuxtApp();
+  const { t } = useI18n({ useScope: 'global' });
+  const toast = useToast();
+  const { fetchStatus } = useSupporter();
+  const { systemStore } = useSystemStoreWithSupabase();
+  type SupporterTier = 'supporter' | 'scav' | 'timmy' | 'chad';
+  const targetUserId = ref($supabase.user?.id ?? '');
+  const tier = ref<SupporterTier>('chad');
+  const enabled = ref(true);
+  const isSaving = ref(false);
+  const tierOptions: Array<{ label: string; value: SupporterTier }> = [
+    { label: t('admin.supporter_tier_supporter'), value: 'supporter' },
+    { label: t('admin.supporter_tier_scav'), value: 'scav' },
+    { label: t('admin.supporter_tier_timmy'), value: 'timmy' },
+    { label: t('admin.supporter_tier_chad'), value: 'chad' },
+  ];
+  const canSave = computed(() => {
+    return systemStore.isAdmin && targetUserId.value.trim().length > 0 && !isSaving.value;
+  });
+  const applySupporterOverride = async () => {
+    if (!canSave.value) return;
+    isSaving.value = true;
+    try {
+      const sessionResp = await $supabase.client.auth.getSession();
+      let token = sessionResp.data.session?.access_token ?? null;
+      if (!token) {
+        const refreshed = await $supabase.client.auth.refreshSession();
+        token = refreshed.data.session?.access_token ?? null;
+      }
+      if (!token) {
+        throw new Error(t('admin.supporter_override_login_required'));
+      }
+      await $fetch('/api/admin/supporter', {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        body: {
+          enabled: enabled.value,
+          targetUserId: targetUserId.value.trim(),
+          tier: tier.value,
+        },
+      });
+      if (targetUserId.value.trim() === $supabase.user?.id) {
+        await fetchStatus(targetUserId.value.trim());
+      }
+      toast.add({
+        title: t('admin.supporter_override_saved_title'),
+        description: enabled.value
+          ? t('admin.supporter_override_enabled_description', { tier: tier.value })
+          : t('admin.supporter_override_disabled_description'),
+        color: 'success',
+        icon: 'i-mdi-check-circle',
+      });
+    } catch (error) {
+      toast.add({
+        title: t('admin.supporter_override_failed_title'),
+        description:
+          error instanceof Error ? error.message : t('admin.supporter_override_failed_description'),
+        color: 'error',
+        icon: 'i-mdi-alert-circle',
+      });
+    } finally {
+      isSaving.value = false;
+    }
+  };
+</script>
+<template>
+  <GenericCard
+    icon="i-mdi-credit-card-check"
+    icon-color="success"
+    highlight-color="primary"
+    :fill-height="false"
+    :title="t('admin.supporter_override_title')"
+    title-classes="text-lg font-semibold"
+  >
+    <template #content>
+      <div class="space-y-4 px-4 py-4">
+        <p class="text-surface-300 text-sm">
+          {{ t('admin.supporter_override_description') }}
+        </p>
+        <UFormField name="targetUserId" :label="t('admin.supporter_target_user_label')">
+          <UInput
+            v-model="targetUserId"
+            class="w-full"
+            :placeholder="t('admin.supporter_target_user_placeholder')"
+          />
+        </UFormField>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <UFormField name="supporterTier" :label="t('admin.supporter_tier_label')">
+            <SelectMenuFixed v-model="tier" :items="tierOptions" value-key="value" />
+          </UFormField>
+          <div class="flex items-end">
+            <USwitch
+              v-model="enabled"
+              :label="
+                enabled ? t('admin.supporter_enabled_label') : t('admin.supporter_disabled_label')
+              "
+            />
+          </div>
+        </div>
+        <div class="flex justify-end">
+          <UButton
+            color="primary"
+            icon="i-mdi-content-save"
+            :disabled="!canSave"
+            :loading="isSaving"
+            @click="applySupporterOverride"
+          >
+            {{ t('admin.supporter_override_save_button') }}
+          </UButton>
+        </div>
+      </div>
+    </template>
+  </GenericCard>
+</template>

--- a/app/features/admin/AdminSupporterAccessCard.vue
+++ b/app/features/admin/AdminSupporterAccessCard.vue
@@ -11,12 +11,12 @@
   const tier = ref<SupporterTier>('chad');
   const enabled = ref(true);
   const isSaving = ref(false);
-  const tierOptions: Array<{ label: string; value: SupporterTier }> = [
+  const tierOptions = computed<Array<{ label: string; value: SupporterTier }>>(() => [
     { label: t('admin.supporter_tier_supporter'), value: 'supporter' },
     { label: t('admin.supporter_tier_scav'), value: 'scav' },
     { label: t('admin.supporter_tier_timmy'), value: 'timmy' },
     { label: t('admin.supporter_tier_chad'), value: 'chad' },
-  ];
+  ]);
   const canSave = computed(() => {
     return systemStore.isAdmin && targetUserId.value.trim().length > 0 && !isSaving.value;
   });

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -82,6 +82,7 @@
     "player_title": "{streamer} Twitch stream",
     "play": "Play stream",
     "region_label": "Promoted Twitch stream for {streamer}",
+    "reopen": "Reopen stream",
     "shrink": "Shrink stream",
     "title": "{streamer} live",
     "unmute": "Unmute stream"

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -40,7 +40,25 @@
     "audit_log_table_not_found_description": "Run the SQL migration to create admin_audit_log.",
     "audit_log_fetch_failed": "Failed to fetch audit logs",
     "no_actions_recorded": "No admin actions recorded yet",
-    "audit_log_by": "by"
+    "audit_log_by": "by",
+    "supporter_override_title": "Supporter Access",
+    "supporter_override_description": "Set a user's supporter state for production testing without creating a Stripe payment.",
+    "supporter_target_user_label": "User ID",
+    "supporter_target_user_placeholder": "Supabase auth user UUID",
+    "supporter_tier_label": "Tier",
+    "supporter_tier_supporter": "Supporter",
+    "supporter_tier_scav": "Scav",
+    "supporter_tier_timmy": "Timmy",
+    "supporter_tier_chad": "Chad",
+    "supporter_enabled_label": "Enabled",
+    "supporter_disabled_label": "Disabled",
+    "supporter_override_save_button": "Apply",
+    "supporter_override_login_required": "You must be signed in to update supporter access.",
+    "supporter_override_saved_title": "Supporter access updated",
+    "supporter_override_enabled_description": "Enabled {tier} supporter access.",
+    "supporter_override_disabled_description": "Disabled active supporter access.",
+    "supporter_override_failed_title": "Update failed",
+    "supporter_override_failed_description": "Could not update supporter access."
   },
   "alerts": {
     "no_map_data": "No map data available for this selection."

--- a/app/pages/__tests__/admin.page.test.ts
+++ b/app/pages/__tests__/admin.page.test.ts
@@ -53,6 +53,7 @@ describe('admin page', () => {
         stubs: {
           AdminAuditLog: { template: '<div data-testid="audit-log" />' },
           AdminCacheCard: { template: '<div data-testid="cache-card" />' },
+          AdminSupporterAccessCard: { template: '<div data-testid="supporter-card" />' },
           UAlert: true,
           UIcon: true,
         },
@@ -60,6 +61,7 @@ describe('admin page', () => {
     });
     expect(wrapper.find('[data-testid="cache-card"]').exists()).toBe(true);
     expect(wrapper.find('[data-testid="audit-log"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="supporter-card"]').exists()).toBe(true);
   });
   it('redirects non-admin users to home', async () => {
     state.isAdmin = false;
@@ -68,6 +70,7 @@ describe('admin page', () => {
         stubs: {
           AdminAuditLog: true,
           AdminCacheCard: true,
+          AdminSupporterAccessCard: true,
           UAlert: true,
           UIcon: true,
         },

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -68,6 +68,7 @@
         </template>
       </UAlert>
       <div class="grid gap-6 lg:grid-cols-2">
+        <AdminSupporterAccessCard />
         <AdminCacheCard />
         <AdminAuditLog />
       </div>

--- a/app/server/api/admin/__tests__/supporter.test.ts
+++ b/app/server/api/admin/__tests__/supporter.test.ts
@@ -74,6 +74,13 @@ describe('POST /api/admin/supporter', () => {
       statusCode: 403,
     });
   });
+  it('normalizes Supabase fetch failures', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('network unavailable'));
+    const { default: handler } = await import('@/server/api/admin/supporter.post');
+    await expect(handler(makeEvent({ id: 'admin-1' }))).rejects.toMatchObject({
+      statusCode: 502,
+    });
+  });
   it('upserts an active supporter tier for admins', async () => {
     mockReadBody.mockResolvedValue({
       enabled: true,
@@ -150,11 +157,23 @@ describe('POST /api/admin/supporter', () => {
     });
     expect(typeof payload.expires_at).toBe('string');
   });
-  it('validates target user id and tier', async () => {
+  it('validates target user id', async () => {
     mockReadBody.mockResolvedValue({
       enabled: true,
       targetUserId: 'not-a-user-id',
       tier: 'chad',
+    });
+    mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }]));
+    const { default: handler } = await import('@/server/api/admin/supporter.post');
+    await expect(handler(makeEvent({ id: 'admin-1' }))).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+  it('validates tier', async () => {
+    mockReadBody.mockResolvedValue({
+      enabled: true,
+      targetUserId: 'c191868d-26e3-40f0-87e0-b2bc07d95d4c',
+      tier: 'invalid-tier',
     });
     mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }]));
     const { default: handler } = await import('@/server/api/admin/supporter.post');

--- a/app/server/api/admin/__tests__/supporter.test.ts
+++ b/app/server/api/admin/__tests__/supporter.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { H3Event, H3EventContext } from 'h3';
+const runtimeConfig = {
+  supabaseServiceKey: 'service-key',
+  supabaseUrl: 'https://test.supabase.co',
+};
+const mockFetch = vi.fn();
+const mockReadBody = vi.fn();
+vi.mock('h3', async () => {
+  const actual = await vi.importActual<typeof import('h3')>('h3');
+  return {
+    ...actual,
+    readBody: (...args: unknown[]) => mockReadBody(...args),
+  };
+});
+vi.mock('@/server/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+mockNuxtImport('useRuntimeConfig', () => () => runtimeConfig);
+function makeEvent(authUser: { id?: string; email?: string } | null): H3Event {
+  return {
+    context: authUser ? { auth: { user: authUser } } : ({} as H3EventContext),
+  } as unknown as H3Event;
+}
+function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+  const text = JSON.stringify(body);
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    text: async () => text,
+  } as Response;
+}
+function emptyResponse(status = 204): Response {
+  return {
+    ok: true,
+    status,
+    text: async () => '',
+  } as Response;
+}
+describe('POST /api/admin/supporter', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+    mockReadBody.mockReset();
+    runtimeConfig.supabaseUrl = 'https://test.supabase.co';
+    runtimeConfig.supabaseServiceKey = 'service-key';
+  });
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+  it('requires service config', async () => {
+    runtimeConfig.supabaseServiceKey = '';
+    const { default: handler } = await import('@/server/api/admin/supporter.post');
+    await expect(handler(makeEvent({ id: 'admin-1' }))).rejects.toMatchObject({
+      statusCode: 500,
+    });
+  });
+  it('requires authentication', async () => {
+    const { default: handler } = await import('@/server/api/admin/supporter.post');
+    await expect(handler(makeEvent(null))).rejects.toMatchObject({ statusCode: 401 });
+  });
+  it('rejects non-admin users', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: false }]));
+    const { default: handler } = await import('@/server/api/admin/supporter.post');
+    await expect(handler(makeEvent({ id: 'user-1' }))).rejects.toMatchObject({
+      statusCode: 403,
+    });
+  });
+  it('upserts an active supporter tier for admins', async () => {
+    mockReadBody.mockResolvedValue({
+      enabled: true,
+      targetUserId: 'c191868d-26e3-40f0-87e0-b2bc07d95d4c',
+      tier: 'chad',
+    });
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse([{ is_admin: true }]))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            expires_at: null,
+            has_ever_supported: true,
+            started_at: '2026-05-28T12:00:00.000Z',
+            status: 'active',
+            tier: 'chad',
+            type: 'subscription',
+          },
+        ])
+      )
+      .mockResolvedValueOnce(emptyResponse());
+    const { default: handler } = await import('@/server/api/admin/supporter.post');
+    const result = await handler(makeEvent({ id: 'admin-1', email: 'admin@example.com' }));
+    expect(result).toEqual({
+      supporter: {
+        expiresAt: null,
+        hasEverSupported: true,
+        startedAt: '2026-05-28T12:00:00.000Z',
+        status: 'active',
+        tier: 'chad',
+        type: 'subscription',
+      },
+    });
+    const [, upsertInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+    expect(JSON.parse(upsertInit.body as string)).toMatchObject({
+      expires_at: null,
+      has_ever_supported: true,
+      status: 'active',
+      tier: 'chad',
+      type: 'subscription',
+      user_id: 'c191868d-26e3-40f0-87e0-b2bc07d95d4c',
+    });
+  });
+  it('disables active supporter access by expiring the row', async () => {
+    mockReadBody.mockResolvedValue({
+      enabled: false,
+      targetUserId: 'c191868d-26e3-40f0-87e0-b2bc07d95d4c',
+      tier: 'chad',
+    });
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse([{ is_admin: true }]))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            expires_at: '2026-05-28T12:00:00.000Z',
+            has_ever_supported: false,
+            started_at: '2026-05-28T12:00:00.000Z',
+            status: 'expired',
+            tier: 'supporter',
+            type: 'subscription',
+          },
+        ])
+      )
+      .mockResolvedValueOnce(emptyResponse());
+    const { default: handler } = await import('@/server/api/admin/supporter.post');
+    await handler(makeEvent({ id: 'admin-1' }));
+    const [, upsertInit] = mockFetch.mock.calls[1] as [string, RequestInit];
+    const payload = JSON.parse(upsertInit.body as string) as Record<string, unknown>;
+    expect(payload).toMatchObject({
+      has_ever_supported: false,
+      status: 'expired',
+      tier: 'supporter',
+      type: 'subscription',
+    });
+    expect(typeof payload.expires_at).toBe('string');
+  });
+  it('validates target user id and tier', async () => {
+    mockReadBody.mockResolvedValue({
+      enabled: true,
+      targetUserId: 'not-a-user-id',
+      tier: 'chad',
+    });
+    mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }]));
+    const { default: handler } = await import('@/server/api/admin/supporter.post');
+    await expect(handler(makeEvent({ id: 'admin-1' }))).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+});

--- a/app/server/api/admin/__tests__/supporter.test.ts
+++ b/app/server/api/admin/__tests__/supporter.test.ts
@@ -129,7 +129,7 @@ describe('POST /api/admin/supporter', () => {
         jsonResponse([
           {
             expires_at: '2026-05-28T12:00:00.000Z',
-            has_ever_supported: false,
+            has_ever_supported: true,
             started_at: '2026-05-28T12:00:00.000Z',
             status: 'expired',
             tier: 'supporter',
@@ -143,10 +143,10 @@ describe('POST /api/admin/supporter', () => {
     const [, upsertInit] = mockFetch.mock.calls[1] as [string, RequestInit];
     const payload = JSON.parse(upsertInit.body as string) as Record<string, unknown>;
     expect(payload).toMatchObject({
-      has_ever_supported: false,
       status: 'expired',
       tier: 'supporter',
       type: 'subscription',
+      has_ever_supported: true,
     });
     expect(typeof payload.expires_at).toBe('string');
   });

--- a/app/server/api/admin/supporter.post.ts
+++ b/app/server/api/admin/supporter.post.ts
@@ -39,7 +39,7 @@ export default defineEventHandler(async (event) => {
     tier: enabled ? tier : 'supporter',
     status: enabled ? 'active' : 'expired',
     type: 'subscription',
-    has_ever_supported: enabled,
+    has_ever_supported: true,
     expires_at: expiresAt,
   };
   const updatedRows = await supabaseFetch<SupabaseRow[]>(

--- a/app/server/api/admin/supporter.post.ts
+++ b/app/server/api/admin/supporter.post.ts
@@ -1,7 +1,7 @@
 import { createError, defineEventHandler, readBody } from 'h3';
 import { createLogger } from '@/server/utils/logger';
+import { VALID_TIERS } from '@/server/utils/stripeCheckoutValidation';
 const logger = createLogger('AdminSupporter');
-const VALID_TIERS = ['supporter', 'scav', 'timmy', 'chad'] as const;
 type SupporterTier = (typeof VALID_TIERS)[number];
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 interface AdminSupporterBody {
@@ -122,16 +122,22 @@ async function supabaseFetch<T>(
   path: string,
   init: RequestInit = {}
 ): Promise<T> {
-  const response = await fetch(`${supabaseUrl}${path}`, {
-    ...init,
-    headers: {
-      apikey: serviceKey,
-      Authorization: `Bearer ${serviceKey}`,
-      Accept: 'application/json',
-      'Content-Type': 'application/json',
-      ...(init.headers || {}),
-    },
-  });
+  let response: Response;
+  try {
+    response = await fetch(`${supabaseUrl}${path}`, {
+      ...init,
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...(init.headers || {}),
+      },
+    });
+  } catch (error) {
+    logger.error('[AdminSupporter] Supabase request failed', { path, error });
+    throw createError({ statusCode: 502, message: 'Supabase request failed' });
+  }
   if (!response.ok) {
     const detail = await response.text().catch(() => '');
     logger.warn('[AdminSupporter] Supabase request failed', {

--- a/app/server/api/admin/supporter.post.ts
+++ b/app/server/api/admin/supporter.post.ts
@@ -1,0 +1,170 @@
+import { createError, defineEventHandler, readBody } from 'h3';
+import { createLogger } from '@/server/utils/logger';
+const logger = createLogger('AdminSupporter');
+const VALID_TIERS = ['supporter', 'scav', 'timmy', 'chad'] as const;
+type SupporterTier = (typeof VALID_TIERS)[number];
+const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+interface AdminSupporterBody {
+  enabled?: unknown;
+  targetUserId?: unknown;
+  tier?: unknown;
+}
+interface SupabaseRow {
+  [key: string]: unknown;
+}
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event);
+  const supabaseUrl = ((config.supabaseUrl as string) || '').replace(/\/$/, '');
+  const serviceKey = (config.supabaseServiceKey as string) || '';
+  if (!supabaseUrl || !serviceKey) {
+    throw createError({ statusCode: 500, message: 'Supabase service config missing' });
+  }
+  const authUser = (event.context as { auth?: { user?: { id?: string; email?: string } } }).auth
+    ?.user;
+  const adminUserId = authUser?.id;
+  if (!adminUserId) {
+    throw createError({ statusCode: 401, message: 'Authentication required' });
+  }
+  const isAdmin = await getIsAdmin(supabaseUrl, serviceKey, adminUserId);
+  if (!isAdmin) {
+    throw createError({ statusCode: 403, message: 'Admin privileges required' });
+  }
+  const body = (await readBody(event)) as AdminSupporterBody;
+  const targetUserId = readUuid(body.targetUserId, 'targetUserId');
+  const tier = readTier(body.tier);
+  const enabled = readEnabled(body.enabled);
+  const expiresAt = enabled ? null : new Date().toISOString();
+  const payload = {
+    user_id: targetUserId,
+    tier: enabled ? tier : 'supporter',
+    status: enabled ? 'active' : 'expired',
+    type: 'subscription',
+    has_ever_supported: enabled,
+    expires_at: expiresAt,
+  };
+  const updatedRows = await supabaseFetch<SupabaseRow[]>(
+    supabaseUrl,
+    serviceKey,
+    `/rest/v1/supporters?on_conflict=user_id`,
+    {
+      method: 'POST',
+      body: JSON.stringify(payload),
+      headers: {
+        Prefer: 'resolution=merge-duplicates,return=representation',
+      },
+    }
+  );
+  const updated = updatedRows[0];
+  if (!updated) {
+    throw createError({ statusCode: 502, message: 'Supporter update returned no row' });
+  }
+  await writeAuditLog(supabaseUrl, serviceKey, {
+    adminUserId,
+    action: 'supporter_override',
+    details: {
+      adminEmail: authUser.email ?? null,
+      enabled,
+      targetUserId,
+      tier: payload.tier,
+    },
+  });
+  return {
+    supporter: {
+      tier: updated.tier,
+      status: updated.status,
+      type: updated.type,
+      hasEverSupported: updated.has_ever_supported,
+      expiresAt: updated.expires_at,
+      startedAt: updated.started_at,
+    },
+  };
+});
+async function getIsAdmin(
+  supabaseUrl: string,
+  serviceKey: string,
+  userId: string
+): Promise<boolean> {
+  const rows = await supabaseFetch<Array<{ is_admin: boolean | null }>>(
+    supabaseUrl,
+    serviceKey,
+    `/rest/v1/user_system?select=is_admin&user_id=eq.${encodeURIComponent(userId)}&limit=1`
+  );
+  return rows[0]?.is_admin === true;
+}
+async function writeAuditLog(
+  supabaseUrl: string,
+  serviceKey: string,
+  payload: {
+    action: string;
+    adminUserId: string;
+    details: Record<string, unknown>;
+  }
+): Promise<void> {
+  try {
+    await supabaseFetch(supabaseUrl, serviceKey, '/rest/v1/admin_audit_log', {
+      method: 'POST',
+      body: JSON.stringify({
+        action: payload.action,
+        admin_user_id: payload.adminUserId,
+        details: payload.details,
+      }),
+      headers: {
+        Prefer: 'return=minimal',
+      },
+    });
+  } catch (error) {
+    logger.warn('[AdminSupporter] Failed to write audit log', { error, action: payload.action });
+  }
+}
+async function supabaseFetch<T>(
+  supabaseUrl: string,
+  serviceKey: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const response = await fetch(`${supabaseUrl}${path}`, {
+    ...init,
+    headers: {
+      apikey: serviceKey,
+      Authorization: `Bearer ${serviceKey}`,
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+      ...(init.headers || {}),
+    },
+  });
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    logger.warn('[AdminSupporter] Supabase request failed', {
+      path,
+      status: response.status,
+      detail,
+    });
+    throw createError({ statusCode: 502, message: 'Supabase request failed' });
+  }
+  if (response.status === 204) {
+    return null as T;
+  }
+  const text = await response.text();
+  if (!text.trim()) {
+    return null as T;
+  }
+  return JSON.parse(text) as T;
+}
+function readUuid(value: unknown, field: string): string {
+  if (typeof value !== 'string' || !UUID_REGEX.test(value)) {
+    throw createError({ statusCode: 400, message: `Invalid ${field}` });
+  }
+  return value;
+}
+function readTier(value: unknown): SupporterTier {
+  if (typeof value !== 'string' || !VALID_TIERS.includes(value as SupporterTier)) {
+    throw createError({ statusCode: 400, message: 'Invalid tier' });
+  }
+  return value as SupporterTier;
+}
+function readEnabled(value: unknown): boolean {
+  if (typeof value !== 'boolean') {
+    throw createError({ statusCode: 400, message: 'Invalid enabled flag' });
+  }
+  return value;
+}


### PR DESCRIPTION
## **User description**
## Summary
- add an admin-only supporter override API route that verifies `is_admin` server-side before writing `supporters`
- add an admin panel card to enable or disable a target user and select Supporter/Scav/Timmy/Chad tiers
- audit supporter override actions and cover the route/admin page with focused tests

## Why
Admins need a production-safe way to test paid/supporter states without creating Stripe payments or manually editing Supabase rows.

## Validation
- `npm run test -- app/server/api/admin/__tests__/supporter.test.ts app/pages/__tests__/admin.page.test.ts`
- `npm run lint`
- `npm run typecheck` (rerun after `nuxt prepare` regenerated `.nuxt`)
- `npm run i18n:check` (non-English fallback notices only)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Admins can override supporter subscription tier and status for any user via a new admin card; card added to the admin page.
  * Promoted stream embed can be reopened after dismissal when a stream is live.
* **UX**
  * Audit logs visually distinguish supporter-related actions with a dedicated icon and success color.
* **Tests**
  * Added server and page tests covering the admin supporter endpoint and card rendering.
* **Localization**
  * Added English strings for the supporter access admin workflow and a “Reopen stream” label.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/tarkovtracker-org/TarkovTracker/pull/407?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add admin supporter access overrides with enable/disable and tier selection**

### What Changed
- Admins can now set or remove supporter access for any user from the admin page
- The form lets admins choose a user ID, pick a tier, and toggle supporter access on or off
- Disabled access now expires the existing supporter row instead of wiping out supporter history
- The admin audit log now highlights supporter-related actions with a distinct icon and success styling

### Impact
`✅ Faster supporter-state testing`
`✅ Fewer manual database edits`
`✅ Preserved supporter history when access is turned off`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
