### PR TITLE
fix(api): make 1970 timestamp backfill timeout-safe

### DIFF
--- a/supabase/migrations/20260605120000_fix_api_update_at_timestamp_clamp.sql
+++ b/supabase/migrations/20260605120000_fix_api_update_at_timestamp_clamp.sql
@@ -399,38 +399,31 @@ $$;
 
 -- Repair already-clamped rows in place. Functions above are already fixed, so
 -- the BEFORE triggers preserve the recovered millisecond values.
-DO $$
-DECLARE
-  rows_updated integer := 0;
-BEGIN
-  LOOP
-    WITH batch AS (
-      SELECT user_id
-      FROM public.user_progress
-      WHERE
-        public.fix_api_update_history_needs_recovery(COALESCE(pvp_data, '{}'::jsonb))
-        OR public.fix_api_update_history_needs_recovery(COALESCE(pve_data, '{}'::jsonb))
-      LIMIT 500
-    )
-    UPDATE public.user_progress AS up
-    SET
-      pvp_data = public.fix_recover_api_update_history_timestamps(
-        COALESCE(up.pvp_data, '{}'::jsonb),
-        (extract(epoch FROM COALESCE(up.updated_at, now())) * 1000)::bigint
-      ),
-      pve_data = public.fix_recover_api_update_history_timestamps(
-        COALESCE(up.pve_data, '{}'::jsonb),
-        (extract(epoch FROM COALESCE(up.updated_at, now())) * 1000)::bigint
-      )
-    FROM batch
-    WHERE up.user_id = batch.user_id;
+--
+-- Run as a single set-based UPDATE that only rewrites rows still carrying the
+-- int32 sentinel. The per-statement timeout is lifted for this maintenance step
+-- because hosted Postgres caps statements at 2 minutes and a DO-block loop
+-- counts as one statement -- its internal batching and pg_sleep cannot dodge
+-- statement_timeout. Plain SET (not SET LOCAL) so it applies whether or not the
+-- migration runner wraps this file in a transaction; RESET restores the default
+-- once the backfill completes.
+SET statement_timeout = 0;
 
-    GET DIAGNOSTICS rows_updated = ROW_COUNT;
-    EXIT WHEN rows_updated = 0;
-    PERFORM pg_sleep(0.05);
-  END LOOP;
-END;
-$$;
+UPDATE public.user_progress AS up
+SET
+  pvp_data = public.fix_recover_api_update_history_timestamps(
+    COALESCE(up.pvp_data, '{}'::jsonb),
+    (extract(epoch FROM COALESCE(up.updated_at, now())) * 1000)::bigint
+  ),
+  pve_data = public.fix_recover_api_update_history_timestamps(
+    COALESCE(up.pve_data, '{}'::jsonb),
+    (extract(epoch FROM COALESCE(up.updated_at, now())) * 1000)::bigint
+  )
+WHERE
+  public.fix_api_update_history_needs_recovery(COALESCE(up.pvp_data, '{}'::jsonb))
+  OR public.fix_api_update_history_needs_recovery(COALESCE(up.pve_data, '{}'::jsonb));
+
+RESET statement_timeout;
 
 DROP FUNCTION IF EXISTS public.fix_api_update_history_needs_recovery(jsonb);
 DROP FUNCTION IF EXISTS public.fix_recover_api_update_history_timestamps(jsonb, bigint);


### PR DESCRIPTION
## **User description**
## Summary
Follow-up to #426. The clamp-fix migration `20260605120000` failed to apply to production with `ERROR: canceling statement due to statement timeout (SQLSTATE 57014)`. The push rolled back cleanly (transactional) — no partial state — but the migration never reached remote.

## Root cause
The one-time data-repair step was written as a `DO $$ ... $$` loop. A DO block is a **single statement** under Postgres `statement_timeout`, so its internal batching + `pg_sleep` cannot dodge the limit. On hosted Supabase (120s cap, ~12k `user_progress` rows with large jsonb) the loop re-scanned the whole table via the expensive `fix_api_update_history_needs_recovery` predicate every iteration and was cancelled at 120s, aborting the whole migration. Local CI passed only because the local DB is tiny and has no timeout.

## Fix
- Replace the self-rescanning DO loop with a single set-based `UPDATE` that touches only rows still carrying the int32 sentinel (one table scan).
- Lift `statement_timeout` for the backfill (`SET statement_timeout = 0` / `RESET` after). Plain `SET` (not `SET LOCAL`) so it works whether or not the runner wraps the file in a transaction.

## Validation
- `npm run supabase:check` (full local db reset + lint): migration applies with no warnings, "No schema errors found".
- Sanitizer unit tests: 7/7 pass.
- Editing the merged migration in place is safe: it was never recorded on remote (clean rollback verified via `supabase migration list` and a PostgREST RPC probe), so there is no remote history row to conflict with.

## Deploy note
After merge, the migration still needs to be applied to production (`supabase db push --linked`). A data-only snapshot of `public.user_progress` was taken before the first attempt.


___

## **CodeAnt-AI Description**
Make the timestamp backfill complete reliably on large databases

### What Changed
- Replaced the retrying repair loop with a single pass that updates only rows still needing timestamp recovery
- Removed the 2-minute statement timeout during this maintenance step, then restored the default afterward so the migration can finish on hosted databases
- Kept the same timestamp recovery behavior for existing progress data

### Impact
`✅ Fewer failed production migrations`
`✅ Reliable backfills on large user_progress tables`
`✅ Lower risk of timeout during data repair`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed incorrect timestamp values displayed in Recent Sync History that were being clamped to an invalid number. Accurate timestamps have been recovered from backup data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->