### PR TITLE
ci: disable CodeRabbit ESLint tool (enforced in CI and pre-commit)

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -40,4 +40,8 @@ reviews:
     biome:
       enabled: false
     eslint:
-      enabled: true
+      # Disabled: ESLint is enforced in CI (`npm run lint`) and pre-commit (lint-staged).
+      # CodeRabbit's sandbox cannot reliably reproduce the generated `.nuxt/eslint.config.mjs`
+      # (gitignored, produced by `nuxt prepare`), so it intermittently skips with
+      # "missing config or dependency". CI is the source of truth for lint.
+      enabled: false


### PR DESCRIPTION
## **User description**
## Summary

Disables CodeRabbit's sandboxed ESLint tool in \`.coderabbit.yaml\`. This is **de-duplication, not a coverage regression** — ESLint is still authoritatively enforced.

## Why

CodeRabbit lints in a locked-down sandbox and scans the ESLint config for referenced dependencies before installing. Our root \`eslint.config.mjs\` imports \`./.nuxt/eslint.config.mjs\`, which is:

- **gitignored** (\`.nuxt\` in \`.gitignore\`)
- **generated** by \`nuxt prepare\` (our \`postinstall\` script)
- importing directly from relative \`node_modules\` paths

When CodeRabbit's sandbox doesn't reliably run/complete \`nuxt prepare\`, that import resolves to a missing file/dependency and ESLint is skipped with:

> ESLint skipped: missing config or dependency (missing-dependency)

The intermittency comes from whether the generated file + its deps are present in a given sandbox run.

## Why disabling is the right fix

ESLint is already gated deterministically in two places:

- **CI** (\`ci.yml\` → \`npm run lint\`) runs \`nuxt prepare\` then \`eslint app --max-warnings=0\` (blocking).
- **Pre-commit** (lint-staged → \`eslint --fix\`).

CodeRabbit's sandbox copy can only ever be a flakier subset of CI. Committing the generated \`.nuxt\` config or relying on the sandbox's \`postinstall\` both fight the framework's design and stay non-deterministic. CI remains the source of truth for lint.

## Tested

- \`.coderabbit.yaml\` validates as YAML.
- No code changed; CI lint behavior is unchanged.


___

## **CodeAnt-AI Description**
**Stop CodeRabbit from running ESLint checks that are already enforced in CI**

### What Changed
- CodeRabbit no longer runs ESLint on this repository
- The PR keeps lint enforcement in CI and pre-commit, so lint checks still block bad changes
- This avoids intermittent CodeRabbit skips caused by the generated Nuxt ESLint config missing in the sandbox

### Impact
`✅ Fewer false lint skips in code review`
`✅ More consistent review results`
`✅ Lint still enforced before merge`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Disabled automated code style reviews to leverage CI and pre-commit enforcement instead.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->