### PR TITLE
refactor(ui): migrate remaining useHead SEO calls to useSeoMeta

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -36,6 +36,10 @@ reviews:
 
         In this project, `useI18n` may be auto-imported in .vue files via Nuxt i18n integration.
         Do not require explicit `import { useI18n } from 'vue-i18n'` unless typecheck fails.
+
+        SEO meta convention: this project uses `useSeoMeta` for all SEO properties (title, description, og:*, twitter:*).
+        Do not suggest replacing `useSeoMeta` with `useHead`. `useHead` is reserved for non-meta head elements
+        (htmlAttrs, link, script, style) only.
   tools:
     biome:
       enabled: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -94,7 +94,9 @@ Naming:
 - Vue SFCs use `<script setup lang="ts">`.
 - Auto-imported Vue/Nuxt utilities (`ref`, `computed`, `watch`, `useRoute`, `useFetch`, hooks) must not be explicitly imported.
 - Explicitly import Pinia stores and utilities.
-- Use `definePageMeta` and `useHead` for page metadata.
+- Use `definePageMeta` for route metadata (layout, middleware).
+- Use `useSeoMeta` for SEO properties (`title`, `description`, `og:*`, `twitter:*`). This is the established convention across all pages — do not suggest `useHead` as a replacement.
+- Reserve `useHead` for non-meta head elements only (`htmlAttrs`, `link`, `script`, `style`).
 - Prefer `useFetch`/`useAsyncData` for data fetching.
 - Use `*.client.ts` suffix for client-only plugins.
 - Keep page files lean; move logic into features/composables.

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1329,7 +1329,9 @@
       "error_description": "Authentication was canceled or failed. Please try again.",
       "success_title": "Signed in",
       "success_description": "Signed in with {provider}.",
-      "login_options": "Login options"
+      "login_options": "Login options",
+      "meta_title": "Login",
+      "meta_description": "Sign in to TarkovTracker to sync your progress across devices and collaborate with your team."
     },
     "profile": {
       "title": "User Profile",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -2256,6 +2256,7 @@
   },
   "oauth": {
     "consent": {
+      "meta_title": "OAuth Consent - TarkovTracker",
       "authorize": "Authorize Application",
       "loading": "Loading...",
       "error": "{error}",

--- a/app/pages/login.vue
+++ b/app/pages/login.vue
@@ -192,11 +192,6 @@
   import { toProviderLabel, useOAuthLogin } from '@/composables/useOAuthLogin';
   import { logger } from '@/utils/logger';
   import { sanitizeInternalRedirect } from '@/utils/redirect';
-  useSeoMeta({
-    title: 'Login',
-    description:
-      'Sign in to TarkovTracker to sync your progress across devices and collaborate with your team.',
-  });
   const { $supabase } = useNuxtApp();
   const isOfflineMode = computed(() => $supabase.isOfflineMode === true);
   const loading = ref({
@@ -209,6 +204,14 @@
   let loginPageUnmounted = false;
   const route = useRoute();
   const { t } = useI18n({ useScope: 'global' });
+  useSeoMeta({
+    title: () => t('page.login.meta_title', 'Login'),
+    description: () =>
+      t(
+        'page.login.meta_description',
+        'Sign in to TarkovTracker to sync your progress across devices and collaborate with your team.'
+      ),
+  });
   const { showErrorToast, showSuccessToast } = useDiagnosticToast();
   const buildCallbackUrl = () => {
     const config = useRuntimeConfig();

--- a/app/pages/oauth/consent.vue
+++ b/app/pages/oauth/consent.vue
@@ -98,6 +98,7 @@
   }
   useSeoMeta({
     title: () => t('oauth.consent.meta_title', 'OAuth Consent - TarkovTracker'),
+    robots: 'noindex, nofollow',
   });
 </script>
 <template>

--- a/app/pages/oauth/consent.vue
+++ b/app/pages/oauth/consent.vue
@@ -97,7 +97,7 @@
     }
   }
   useSeoMeta({
-    title: 'OAuth Consent - TarkovTracker',
+    title: () => t('oauth.consent.meta_title', 'OAuth Consent - TarkovTracker'),
   });
 </script>
 <template>

--- a/app/pages/oauth/consent.vue
+++ b/app/pages/oauth/consent.vue
@@ -96,7 +96,7 @@
       loading.value = false;
     }
   }
-  useHead({
+  useSeoMeta({
     title: 'OAuth Consent - TarkovTracker',
   });
 </script>

--- a/app/pages/supporter.vue
+++ b/app/pages/supporter.vue
@@ -44,13 +44,11 @@
   const { $supabase } = useNuxtApp();
   const { fetchStatus } = useSupporter();
   definePageMeta({ layout: 'default' });
-  useHead({
+  useSeoMeta({
     title: () => t('page.supporter.title'),
-    meta: [
-      { name: 'description', content: () => t('page.supporter.subtitle') },
-      { property: 'og:title', content: () => t('page.supporter.title') },
-      { property: 'og:description', content: () => t('page.supporter.subtitle') },
-    ],
+    description: () => t('page.supporter.subtitle'),
+    ogTitle: () => t('page.supporter.title'),
+    ogDescription: () => t('page.supporter.subtitle'),
   });
   const interval = ref<BillingInterval>('monthly');
   onMounted(() => {

--- a/docs/agent-context/style-and-validation.md
+++ b/docs/agent-context/style-and-validation.md
@@ -34,3 +34,8 @@ Deeper conventions for agents. Root `AGENTS.md` links here for reference; these 
 - Keep types close to usage; reuse existing types where possible.
 - Match existing patterns for enums (often union types in this codebase).
 - Prefer explicit types for exported functions, stores, and composables.
+
+## SEO / Head Meta
+
+- Use `useSeoMeta` for all SEO properties (`title`, `description`, `og:*`, `twitter:*`). This is the established convention across all pages.
+- Do not replace `useSeoMeta` with `useHead` — they serve different purposes.


### PR DESCRIPTION
## **User description**
Closes #446

## Summary

Standardizes SEO metadata on `useSeoMeta` and documents the convention. Salvaged from the stale `docs/seo-composable-conventions` branch, rebuilt cleanly off current `main` so it no longer carries that branch's unrelated reverts (re-enabling CodeRabbit ESLint, npm version downgrade, doc-section deletions).

## Changes

- `app/pages/oauth/consent.vue` — `useHead({ title })` → `useSeoMeta`
- `app/pages/supporter.vue` — `useHead` with `meta[]` → `useSeoMeta` (`description`, `ogTitle`, `ogDescription`)
- `AGENTS.md`, `docs/agent-context/style-and-validation.md`, `.coderabbit.yaml` — document the `useSeoMeta` convention; `useHead` reserved for non-meta head elements (`htmlAttrs`, `link`, `script`, `style`)

`app/layouts/default.vue` intentionally keeps `useHead` (used for `htmlAttrs`).

## Validation

- `npm run typecheck` — pass
- `eslint` on changed files — pass


___

## **CodeAnt-AI Description**
**Use the SEO metadata format consistently on pages and document the convention**

### What Changed
- Page titles and social sharing text now use the site’s standard SEO metadata format on the OAuth consent and supporter pages
- The supporter page now sets its description, Open Graph title, and Open Graph description in the same place as its title
- The project guidance now clearly says to use the SEO metadata format for page metadata and reserve page head changes for non-SEO elements

### Impact
`✅ Consistent page titles and sharing previews`
`✅ Clearer support page metadata`
`✅ Fewer SEO convention mismatches`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized SEO/head metadata handling across pages to use the unified SEO meta approach for titles, descriptions, and social previews; page metadata now uses localized strings.
* **Documentation**
  * Updated contributor and agent guidance and project config to prefer the SEO meta approach and reserve the general head API for non-metadata elements.
* **Chores**
  * Added locale strings for login and OAuth consent page metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->