### PR TITLE
fix(hideout): match skill requirements by canonical skill id (#420)

### DIFF
--- a/app/composables/__tests__/useHideoutStationStatus.test.ts
+++ b/app/composables/__tests__/useHideoutStationStatus.test.ts
@@ -133,6 +133,23 @@ describe('useHideoutStationStatus', () => {
     expect(isSkillReqMet(skillRequirement)).toBe(false);
     expect(getStationStatus(station)).toBe('locked');
   });
+  it('matches a skill requirement by skill.id when the display name differs (issue #420)', () => {
+    // Hideout requirement uses the spaced display name, but the level is stored
+    // under the canonical id key (as produced by task rewards / SkillsCard).
+    mockState.hideoutLevels = { 'station-main': { self: 0 } };
+    mockState.skills = { HideoutManagement: 11 };
+    const requirement: SkillRequirement = {
+      id: 'req-hideout-mgmt',
+      name: 'Hideout Management',
+      level: 5,
+      skill: { id: 'HideoutManagement', name: 'Hideout Management' },
+    };
+    const level = createLevel(1, { skillRequirements: [requirement] });
+    const station = createStation([level]);
+    const { getStationStatus, isSkillReqMet } = useHideoutStationStatus();
+    expect(isSkillReqMet(requirement)).toBe(true);
+    expect(getStationStatus(station)).toBe('available');
+  });
   it('returns locked when a trader requirement is unmet', () => {
     const { stationRequirement, skillRequirement, traderRequirement } = createRequirements();
     mockState.hideoutLevels = {

--- a/app/composables/useHideoutStationStatus.ts
+++ b/app/composables/useHideoutStationStatus.ts
@@ -3,6 +3,7 @@ import { usePreferencesStore } from '@/stores/usePreferences';
 import { useProgressStore } from '@/stores/useProgress';
 import { useTarkovStore } from '@/stores/useTarkov';
 import { logger } from '@/utils/logger';
+import { getCanonicalSkillKey } from '@/utils/skillHelpers';
 import type {
   HideoutLevel,
   HideoutStation,
@@ -46,7 +47,9 @@ export const useHideoutStationStatus = (): UseHideoutStationStatusReturn => {
       });
       return true;
     }
-    const currentLevel = skillCalculation.getSkillLevel(requirement.name);
+    const skillKey =
+      getCanonicalSkillKey(requirement.name, requirement.skill?.id) ?? requirement.name;
+    const currentLevel = skillCalculation.getSkillLevel(skillKey);
     return currentLevel >= requirement.level;
   };
   const isTraderReqMet = (requirement: TraderRequirement): boolean => {

--- a/app/stores/tarkov/hideoutPrereqs.ts
+++ b/app/stores/tarkov/hideoutPrereqs.ts
@@ -80,7 +80,8 @@ export const checkSkillReqsMet = (
   return (
     module.skillRequirements?.every((req) => {
       if (!req?.name || typeof req?.level !== 'number') return true;
-      const skillKey = resolveSkillKey(req.name, options.skillKeyAliases);
+      const canonicalKey = getCanonicalSkillKey(req.name, req.skill?.id) ?? req.name;
+      const skillKey = resolveSkillKey(canonicalKey, options.skillKeyAliases);
       const playerSkillLevel = options.skills?.[skillKey] ?? 0;
       return playerSkillLevel >= req.level;
     }) ?? true


### PR DESCRIPTION
## **User description**
## Summary

Fixes #420 — Hideout Management skill set in Settings did not register as fulfilled for the Library hideout requirement (stayed red even at level 11).

## Root cause

A naming asymmetry between two tarkov.dev proxy endpoints:

- Hideout requirement (proxy, `lang=en`): `name: "Hideout Management"` (spaced display name) + `skill.id: "HideoutManagement"`
- Task skill reward (proxy): `name: "HideoutManagement"` (unspaced canonical form) + `skill.id: "HideoutManagement"`

The skill-key alias map is built only from task data, so it only ever learned `HideoutManagement → HideoutManagement` and never the spaced form. `isSkillReqMet` looked up the player's level by `requirement.name` (`"Hideout Management"`), which failed to resolve to the canonical key the level is actually stored under, so it read `0` instead of the real value and the requirement rendered red.

## Fix

Resolve the skill by its canonical key (preferring `skill.id`) before reading the level, in both:

- `app/composables/useHideoutStationStatus.ts` — `isSkillReqMet` (display / build-readiness path)
- `app/stores/tarkov/hideoutPrereqs.ts` — `checkSkillReqsMet` (module auto-uncomplete enforcement path), so enforcement and display stay consistent

## Tests

- Added a regression test in `useHideoutStationStatus.test.ts` that matches a skill requirement by `skill.id` when the display name differs. It fails on the old code (`expected false to be true`) and passes with the fix.

## Validation

- `npm run typecheck` — clean
- `eslint` on changed files — zero warnings
- 27 related tests pass (`useHideoutStationStatus`, `useHideoutFiltering`, `useTarkov.hideoutPrereqs`, `useSkillCalculation`, `prestigeRequirements`)
- Real-browser check (headless Chrome via CDP): seeded Hideout Management to 11, opened `/hideout`. Before the fix the "Hideout Management level 5" prerequisite rendered red (`text-error-400`); after the fix it renders green (`text-success-400`).

### Note

In the post-fix screenshot the Library card still reads "Not ready to build" — that is correct, because it also requires Rest Space level 3, which the test profile did not have. The skill prerequisite itself is now correctly satisfied, which is exactly what the issue reported.


___

## **CodeAnt-AI Description**
**Match hideout skill requirements using the skill’s canonical ID**

### What Changed
- Hideout requirements now recognize a skill even when the displayed name differs from the stored skill ID
- The hideout screen now shows the correct availability state for stations that depend on skills like Hideout Management
- Module requirement checks use the same skill matching rule, so auto-uncomplete behavior stays in sync with what players see
- Added a regression test for the Hideout Management requirement with a spaced display name and canonical ID

### Impact
`✅ Correct hideout requirement status`
`✅ Fewer false red requirements`
`✅ Consistent hideout unlock behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill requirement validation for hideout stations. The system now correctly matches skills against requirements, even when a skill's display name differs from its canonical identifier. This resolves issues where hideout stations were incorrectly marked as unavailable despite your character meeting all required skill levels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->