### PR TITLE
fix(maps): add Icebreaker as unavailable static map data

### DIFF
--- a/app/data/maps.json
+++ b/app/data/maps.json
@@ -44,6 +44,9 @@
       "maxZoom": 6
     }
   },
+  "icebreaker": {
+    "unavailable": true
+  },
   "interchange": {
     "svg": {
       "file": "Interchange.svg",


### PR DESCRIPTION
## **User description**
## Summary

Closes #441.

tarkov.dev now returns the new **Icebreaker** map (May 2026 EFT patch), but our local static map data had no `icebreaker` entry, producing a non-fatal console warning on `/tasks`:

```
[MetadataStore] Static SVG data not found for map: Icebreaker (lookup key: icebreaker)
```

## Why `unavailable` (not a real interactive map)

Verified against tarkov.dev directly:
- The GraphQL API returns Icebreaker (`normalizedName: icebreaker`), which is why it appears in our metadata.
- tarkov.dev's own map config lists Icebreaker as a static `"projection": "2D"` community image with **no** `svgPath`/`tilePath`/`transform`/`bounds` — none of the geometry our Leaflet renderer needs.
- The SVG asset 404s on their CDN (`https://assets.tarkov.dev/maps/svg/Icebreaker*.svg`), while existing maps (e.g. GroundZero) return 200.

So there is genuinely no interactive map available upstream yet. Marking it `{ "unavailable": true }` matches the established pattern for `openworld` and `transits`: it makes `staticData` truthy (warning suppressed) and flows `unavailable: true` through the existing UI path.

## Changes
- `app/data/maps.json`: add `"icebreaker": { "unavailable": true }` (alphabetical position).

## Testing
- JSON re-parses cleanly with the new key.
- `npm run typecheck` passes (no code changes; consumed via existing `unavailable` branch in `useMetadata.ts`).

## Follow-up
If tarkov.dev later promotes Icebreaker to an interactive map (ships SVG/tiles + transform/bounds), replace this entry with a full geometry block.


___

## **CodeAnt-AI Description**
**Add Icebreaker as unavailable map data to avoid missing-map warnings**

### What Changed
- Added Icebreaker to the map list as unavailable, so it is recognized without trying to load a non-existent interactive map
- Stops the console warning seen on pages that include Icebreaker map data

### Impact
`✅ Fewer map-data warnings`
`✅ Cleaner task pages`
`✅ Correct handling of maps without interactive assets`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated map availability configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->