### PR TITLE
chore(config): remove Nuxt SPA dev-server workaround fixed upstream in 4.4.5

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,8 +1,7 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { fileURLToPath, pathToFileURL } from 'node:url';
-import { useNitro, useNuxt } from '@nuxt/kit';
+import { fileURLToPath } from 'node:url';
 import { resolveTrustProxySetting } from './app/utils/apiProtectionConfig';
 import { SUPPORTED_LOCALES } from './app/utils/locales';
 import {
@@ -393,33 +392,6 @@ export default defineNuxtConfig({
             source.includes(sourcePattern) && (names.has(imported.name) || names.has(exposedName))
         );
         if (shouldBlock) imports.splice(index, 1);
-      }
-    },
-    // Workaround for Nuxt 4.4.4 SPA dev server bug (nuxt/nuxt#34957).
-    // With ssr:false the SSR Vite server is never created, so vite-node IPC is
-    // never wired up and `/` returns 500. This stubs the SSR manifest virtuals
-    // and points the client manifest at its built file. Drop after v4.5.0.
-    'vite:extendConfig': (_config, context) => {
-      const nuxt = useNuxt();
-      if (!nuxt.options.dev || nuxt.options.ssr || !context.isClient) return;
-      const nitro = useNitro();
-      const clientManifestPath = pathToFileURL(
-        resolve(nuxt.options.buildDir, 'dist/server/client.manifest.mjs')
-      ).href;
-      const nitroConfig = nitro.options as unknown as {
-        virtual?: Record<string, string>;
-        _config?: { virtual?: Record<string, string> };
-      };
-      nitroConfig.virtual ||= {};
-      const virtualTargets: Record<string, string>[] = [nitroConfig.virtual];
-      if (nitroConfig._config) {
-        nitroConfig._config.virtual ||= {};
-        virtualTargets.push(nitroConfig._config.virtual);
-      }
-      for (const virtual of virtualTargets) {
-        virtual['#build/dist/server/server.mjs'] = 'export default () => {}';
-        virtual['#build/dist/server/client.manifest.mjs'] =
-          `export { default } from ${JSON.stringify(clientManifestPath)}`;
       }
     },
   },


### PR DESCRIPTION
## **User description**
## Summary

Removes the `vite:extendConfig` dev-server workaround in `nuxt.config.ts` that was added for [nuxt/nuxt#34957](https://github.com/nuxt/nuxt/issues/34957) (SPA dev server returning 500 with `ssr: false` because the SSR Vite server / vite-node IPC was never wired up).

The upstream fix [nuxt/nuxt#34959](https://github.com/nuxt/nuxt/pull/34959) shipped in **Nuxt v4.4.5**, and this project is now on **4.4.8**, so the workaround is dead code. This also drops the now-unused `useNitro`, `useNuxt` (from `@nuxt/kit`) and `pathToFileURL` (from `node:url`) imports.

Note: the workaround had evolved from the original `experimental.viteEnvironmentApi` flag described in the issue into this manifest-stubbing hook, but it targeted the same bug.

## Verification

- `npm run dev`: `/` returns HTTP 200 with valid SPA HTML, zero `socketPath`/rollup/500 errors on Nuxt 4.4.8
- `npm run build`: succeeds (only pre-existing benign sourcemap/chunk-size warnings)
- `npm run typecheck`: clean
- `eslint nuxt.config.ts`: clean
- `npm run test`: 1895 tests pass (199 files)

The removed hook was guarded by `nuxt.options.dev`, so production output is unaffected.

Closes #356


___

## **CodeAnt-AI Description**
**Remove an obsolete Nuxt dev-server workaround**

### What Changed
- Removed a SPA dev-server workaround that is no longer needed on the current Nuxt version
- Cleaned up now-unused config imports tied to that workaround

### Impact
`✅ Simpler Nuxt config`
`✅ Fewer maintenance-only code paths`
`✅ No change to production behavior`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified Nuxt configuration by removing unused imports and development workaround logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->