### PR TITLE
fix(api): rate-limit client log sink and drop logged client IP

### DIFF
--- a/app/server/api/logs/__tests__/client.post.test.ts
+++ b/app/server/api/logs/__tests__/client.post.test.ts
@@ -135,4 +135,20 @@ describe('client logs endpoint', () => {
     expect(mockLogger.warn).not.toHaveBeenCalled();
     expect(mockLogger.error).not.toHaveBeenCalled();
   });
+  it('reports cache errors without forwarding to the log sink', async () => {
+    const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    mockConsumeSharedRateLimit.mockImplementationOnce(
+      async (_handle, _prefix, _key, _limit, _windowMs, onError) => {
+        onError?.({ action: 'read', error: new Error('cache down'), key: 'k', prefix: 'p' });
+        return false;
+      }
+    );
+    const { default: handler } = await import('@/server/api/logs/client.post');
+    await handler(event);
+    expect(consoleWarnSpy).toHaveBeenCalledTimes(1);
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
+    expect(mockSetResponseStatus).toHaveBeenCalledWith(event, 204);
+    consoleWarnSpy.mockRestore();
+  });
 });

--- a/app/server/api/logs/__tests__/client.post.test.ts
+++ b/app/server/api/logs/__tests__/client.post.test.ts
@@ -6,6 +6,9 @@ const {
   mockSetResponseHeader,
   mockSetResponseStatus,
   mockLogger,
+  mockConsumeSharedRateLimit,
+  mockCreateSharedCacheHandle,
+  mockGetProxyAwareClientIdentifier,
 } = vi.hoisted(() => ({
   mockGetRequestHeader: vi.fn(),
   mockReadBody: vi.fn(),
@@ -17,6 +20,9 @@ const {
     info: vi.fn(),
     warn: vi.fn(),
   },
+  mockConsumeSharedRateLimit: vi.fn(),
+  mockCreateSharedCacheHandle: vi.fn(),
+  mockGetProxyAwareClientIdentifier: vi.fn(),
 }));
 vi.mock('h3', async () => {
   const actual = await vi.importActual<typeof import('h3')>('h3');
@@ -29,8 +35,21 @@ vi.mock('h3', async () => {
     setResponseStatus: mockSetResponseStatus,
   };
 });
+vi.mock('#imports', () => ({
+  useRuntimeConfig: () => ({
+    apiProtection: { trustProxy: true },
+    public: { appUrl: 'https://tarkovtracker.org' },
+  }),
+}));
 vi.mock('@/server/utils/logger', () => ({
   createLogger: () => mockLogger,
+}));
+vi.mock('@/server/utils/requestIdentity', () => ({
+  getProxyAwareClientIdentifier: mockGetProxyAwareClientIdentifier,
+}));
+vi.mock('@/server/utils/sharedEdgeStore', () => ({
+  consumeSharedRateLimit: mockConsumeSharedRateLimit,
+  createSharedCacheHandle: mockCreateSharedCacheHandle,
 }));
 describe('client logs endpoint', () => {
   const event = {
@@ -45,6 +64,9 @@ describe('client logs endpoint', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetRequestHeader.mockReturnValue(undefined);
+    mockGetProxyAwareClientIdentifier.mockReturnValue('203.0.113.9');
+    mockCreateSharedCacheHandle.mockReturnValue({ cache: null, origin: {} });
+    mockConsumeSharedRateLimit.mockResolvedValue(true);
   });
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -64,10 +86,7 @@ describe('client logs endpoint', () => {
     expect(mockLogger.warn).not.toHaveBeenCalled();
     expect(mockLogger.error).not.toHaveBeenCalled();
   });
-  it('logs sanitized payloads at the requested level', async () => {
-    mockGetRequestHeader.mockImplementation((_event, name: string) =>
-      name === 'cf-connecting-ip' ? '203.0.113.9' : undefined
-    );
+  it('logs sanitized payloads at the requested level without client ip', async () => {
     mockReadBody.mockResolvedValueOnce({
       args: Array.from({ length: 25 }, (_value, index) => `arg-${index}`),
       href: ' https://tarkovtracker.org/tasks ',
@@ -76,15 +95,12 @@ describe('client logs endpoint', () => {
     });
     const { default: handler } = await import('@/server/api/logs/client.post');
     await handler(event);
-    expect(mockLogger.warn).toHaveBeenCalledWith(
-      'Client log',
-      expect.objectContaining({
-        args: Array.from({ length: 20 }, (_value, index) => `arg-${index}`),
-        clientIp: '203.0.113.9',
-        href: 'https://tarkovtracker.org/tasks',
-        timestamp: '2026-02-24T10:11:12.000Z',
-      })
-    );
+    expect(mockLogger.warn).toHaveBeenCalledWith('Client log', {
+      args: Array.from({ length: 20 }, (_value, index) => `arg-${index}`),
+      href: 'https://tarkovtracker.org/tasks',
+      timestamp: '2026-02-24T10:11:12.000Z',
+    });
+    expect(mockLogger.warn.mock.calls[0]?.[1]).not.toHaveProperty('clientIp');
     expect(mockSetResponseStatus).toHaveBeenCalledWith(event, 204);
   });
   it('falls back to info level and generated timestamp for invalid values', async () => {
@@ -101,11 +117,22 @@ describe('client logs endpoint', () => {
       'Client log',
       expect.objectContaining({
         args: ['a'],
-        clientIp: '198.51.100.8',
         href: null,
         timestamp: expect.any(String),
       })
     );
+    expect(mockLogger.info.mock.calls[0]?.[1]).not.toHaveProperty('clientIp');
     expect(mockSetResponseStatus).toHaveBeenCalledWith(event, 204);
+  });
+  it('drops the request without reading the body when rate limited', async () => {
+    mockConsumeSharedRateLimit.mockResolvedValueOnce(false);
+    const { default: handler } = await import('@/server/api/logs/client.post');
+    const response = await handler(event);
+    expect(response).toBeNull();
+    expect(mockReadBody).not.toHaveBeenCalled();
+    expect(mockSetResponseStatus).toHaveBeenCalledWith(event, 204);
+    expect(mockLogger.info).not.toHaveBeenCalled();
+    expect(mockLogger.warn).not.toHaveBeenCalled();
+    expect(mockLogger.error).not.toHaveBeenCalled();
   });
 });

--- a/app/server/api/logs/client.post.ts
+++ b/app/server/api/logs/client.post.ts
@@ -1,11 +1,13 @@
-import {
-  defineEventHandler,
-  getRequestHeader,
-  readBody,
-  setResponseHeader,
-  setResponseStatus,
-} from 'h3';
+import { defineEventHandler, readBody, setResponseHeader, setResponseStatus } from 'h3';
+import { useRuntimeConfig } from '#imports';
 import { createLogger } from '@/server/utils/logger';
+import { getProxyAwareClientIdentifier } from '@/server/utils/requestIdentity';
+import {
+  consumeSharedRateLimit,
+  createSharedCacheHandle,
+  type SharedCacheHandle,
+} from '@/server/utils/sharedEdgeStore';
+import type { ApiProtectionConfig } from '@/server/middleware/api-protection';
 type ClientLogLevel = 'debug' | 'info' | 'warn' | 'error';
 type ClientLogBody = {
   args?: unknown[];
@@ -15,6 +17,9 @@ type ClientLogBody = {
 };
 const clientLogLevels: ClientLogLevel[] = ['debug', 'info', 'warn', 'error'];
 const logger = createLogger('ClientLogsApi');
+const CLIENT_LOG_RATE_LIMIT_PREFIX = 'client-logs-rate';
+const CLIENT_LOG_RATE_LIMIT_PER_MINUTE = 60;
+const RATE_LIMIT_WINDOW_MS = 60_000;
 const toClientLogLevel = (value: unknown): ClientLogLevel => {
   if (typeof value === 'string' && clientLogLevels.includes(value as ClientLogLevel)) {
     return value as ClientLogLevel;
@@ -37,8 +42,33 @@ const sanitizeArgs = (value: unknown): unknown[] => {
   }
   return value.slice(0, 20);
 };
+const consumeRateLimit = async (handle: SharedCacheHandle, key: string): Promise<boolean> => {
+  return consumeSharedRateLimit(
+    handle,
+    CLIENT_LOG_RATE_LIMIT_PREFIX,
+    key,
+    CLIENT_LOG_RATE_LIMIT_PER_MINUTE,
+    RATE_LIMIT_WINDOW_MS,
+    ({ action, error, key: failedKey }) => {
+      logger.warn('Client log rate-limit cache operation failed', {
+        action,
+        error: error instanceof Error ? error.message : String(error),
+        key: failedKey,
+      });
+    }
+  );
+};
 export default defineEventHandler(async (event) => {
   setResponseHeader(event, 'Cache-Control', 'no-store, max-age=0');
+  const typedConfig = useRuntimeConfig(event) as ReturnType<typeof useRuntimeConfig> &
+    ApiProtectionConfig;
+  const trustProxy = Boolean(typedConfig.apiProtection?.trustProxy);
+  const sharedCacheHandle = createSharedCacheHandle(typedConfig.public?.appUrl);
+  const rateLimitKey = `client-logs:ip:${getProxyAwareClientIdentifier(event, trustProxy)}`;
+  if (!(await consumeRateLimit(sharedCacheHandle, rateLimitKey))) {
+    setResponseStatus(event, 204);
+    return null;
+  }
   const body = (await readBody(event).catch(() => null)) as ClientLogBody | null;
   if (!body || typeof body !== 'object') {
     setResponseStatus(event, 204);
@@ -48,13 +78,8 @@ export default defineEventHandler(async (event) => {
   const args = sanitizeArgs(body.args);
   const href = toSafeString(body.href, 1024);
   const timestamp = toSafeString(body.timestamp, 64) ?? new Date().toISOString();
-  const clientIp =
-    toSafeString(getRequestHeader(event, 'cf-connecting-ip')) ||
-    toSafeString(getRequestHeader(event, 'x-forwarded-for')) ||
-    toSafeString(event.node?.req?.socket?.remoteAddress);
   const payload = {
     args,
-    clientIp,
     href,
     timestamp,
   };

--- a/app/server/api/logs/client.post.ts
+++ b/app/server/api/logs/client.post.ts
@@ -50,7 +50,7 @@ const consumeRateLimit = async (handle: SharedCacheHandle, key: string): Promise
     CLIENT_LOG_RATE_LIMIT_PER_MINUTE,
     RATE_LIMIT_WINDOW_MS,
     ({ action, error, key: failedKey }) => {
-      logger.warn('Client log rate-limit cache operation failed', {
+      console.warn('[ClientLogsApi] Client log rate-limit cache operation failed', {
         action,
         error: error instanceof Error ? error.message : String(error),
         key: failedKey,


### PR DESCRIPTION
## **User description**
## Summary

Hardens the unauthenticated client log sink (`/api/logs/client`). Follow-up to #462, which recovered this endpoint into version control.

### Why
The server logger forwards every accepted log to an external sink (`LOG_SINK_URL`) via outbound HTTPS `fetch`, and `error`-level logs always forward. Because `/api/logs/client` is a public (no-auth) route with no rate limit, one inbound POST produces one outbound request to that sink. That makes the endpoint a request amplifier: anyone reaching it through Cloudflare could drive unbounded outbound traffic and log volume against a sink that may be billed or rate-limited.

### Changes
- **Rate limit.** Add an IP-based limit (60/min/IP) using `consumeSharedRateLimit` from the shared edge store, keyed on `getProxyAwareClientIdentifier(event, trustProxy)`. This mirrors the established pattern in `app/server/api/tarkov-dev/profile.get.ts`. The check runs before `readBody`, so over-limit requests are dropped without parsing or logging work.
- **Drop on exceed with 204, not 429.** The client sender (`app/utils/logger.ts`) uses `navigator.sendBeacon` / `fetch().catch()` and never inspects the response status, so a 429 gives no client benefit and would add noise to error dashboards. Returning 204 keeps the endpoint's uniform contract. (429 is a trivial alternative if preferred.)
- **Remove `clientIp` from logged payload.** It is spoofable PII (mitigated here since the origin is only reachable via Cloudflare, but still unnecessary), Cloudflare already records the client IP at the edge, and it added nothing beyond log attribution. The proxy-aware identifier is now used only as the rate-limit key, which is its intended use.
- Existing input safeguards (level allowlist, 20-arg cap, length truncation, 204 on bad body) are unchanged.

## What was tested
- `npm run test` on `client.post.test.ts` — 4 tests pass, including a new rate-limit-exceeded case (asserts body is never read, 204 returned, nothing logged) and a regression assertion that the payload no longer contains `clientIp`.
- `npm run typecheck` passes.
- `eslint --max-warnings=0` on both changed files passes.


___

## **CodeAnt-AI Description**
Limit unauthenticated client log submissions and stop recording the client IP in logs

### What Changed
- The client log endpoint now rejects excess requests from the same IP after 60 per minute, returning 204 without reading or logging the body
- Logged client messages no longer include the user’s IP address
- Existing log cleanup stays in place: invalid bodies are ignored, long argument lists are trimmed, and timestamps and URLs are still normalized

### Impact
`✅ Fewer log sink overloads`
`✅ Lower risk of client log spam`
`✅ Less personal data in server logs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added rate limiting for client log submissions using a shared edge cache to help prevent excessive requests.
* **Behavior Changes**
  * Rate-limited requests are rejected with no response body and no event logging.
  * Logged event payloads are sanitized/normalized, and the payload no longer includes client IP information.
* **Tests**
  * Updated and expanded automated coverage to validate sanitized payloads, invalid input handling, and shared rate-limit denial scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->