### PR TITLE
fix(api): atomic durable-object rate limiting with graceful fallback

### DIFF
--- a/app/server/api/profile/[userId]/[mode].get.ts
+++ b/app/server/api/profile/[userId]/[mode].get.ts
@@ -616,7 +616,7 @@ export default defineEventHandler(async (event) => {
   );
   const clientIdentifier = getProxyAwareClientIdentifier(event, trustProxy);
   if (!isTestEnvironment) {
-    const preAuthRateLimitKey = `shared-profile:ip:${clientIdentifier}:${userId}:${mode}`;
+    const preAuthRateLimitKey = `shared-profile:ip:${clientIdentifier}`;
     if (
       !(await consumeRateLimit(
         sharedCacheHandle,

--- a/app/server/api/profile/[userId]/[mode].get.ts
+++ b/app/server/api/profile/[userId]/[mode].get.ts
@@ -10,6 +10,7 @@ import { getProxyAwareClientIdentifier } from '@/server/utils/requestIdentity';
 import {
   consumeSharedRateLimit,
   createSharedCacheHandle,
+  getRateLimiterBinding,
   readSharedCache,
   writeSharedCache,
   type SharedCacheHandle,
@@ -609,7 +610,10 @@ export default defineEventHandler(async (event) => {
     DEFAULT_SHARED_PROFILE_CACHE_TTL_MS
   );
   const trustProxy = Boolean(typedConfig.apiProtection?.trustProxy);
-  const sharedCacheHandle = createSharedCacheHandle(typedConfig.public?.appUrl);
+  const sharedCacheHandle = createSharedCacheHandle(
+    typedConfig.public?.appUrl,
+    getRateLimiterBinding(event)
+  );
   const clientIdentifier = getProxyAwareClientIdentifier(event, trustProxy);
   if (!isTestEnvironment) {
     const preAuthRateLimitKey = `shared-profile:ip:${clientIdentifier}:${userId}:${mode}`;

--- a/app/server/api/team/members.ts
+++ b/app/server/api/team/members.ts
@@ -212,7 +212,7 @@ export default defineEventHandler(async (event) => {
     getRateLimiterBinding(event)
   );
   if (!isTestEnvironment) {
-    const preAuthRateLimitKey = `team-members:ip:${teamId}:${getProxyAwareClientIdentifier(
+    const preAuthRateLimitKey = `team-members:ip:${getProxyAwareClientIdentifier(
       event,
       trustProxy
     )}`;

--- a/app/server/api/team/members.ts
+++ b/app/server/api/team/members.ts
@@ -4,6 +4,7 @@ import { getProxyAwareClientIdentifier } from '@/server/utils/requestIdentity';
 import {
   consumeSharedRateLimit,
   createSharedCacheHandle,
+  getRateLimiterBinding,
   readSharedCache,
   writeSharedCache,
   type SharedCacheHandle,
@@ -206,7 +207,10 @@ export default defineEventHandler(async (event) => {
   );
   const typedConfig = config as ApiProtectionConfig;
   const trustProxy = Boolean(typedConfig.apiProtection?.trustProxy);
-  const sharedCacheHandle = createSharedCacheHandle(typedConfig.public?.appUrl);
+  const sharedCacheHandle = createSharedCacheHandle(
+    typedConfig.public?.appUrl,
+    getRateLimiterBinding(event)
+  );
   if (!isTestEnvironment) {
     const preAuthRateLimitKey = `team-members:ip:${teamId}:${getProxyAwareClientIdentifier(
       event,

--- a/app/server/utils/__tests__/sharedEdgeStore.test.ts
+++ b/app/server/utils/__tests__/sharedEdgeStore.test.ts
@@ -161,4 +161,114 @@ describe('consumeSharedRateLimit', () => {
       false
     );
   });
+  it('serializes concurrent same-isolate calls so the cap is enforced exactly', async () => {
+    const { consumeSharedRateLimit } = await import('@/server/utils/sharedEdgeStore');
+    let releaseReads: () => void = () => {};
+    const allReadsStarted = (() => {
+      let started = 0;
+      let resolveGate: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        resolveGate = resolve;
+      });
+      return {
+        gate,
+        mark: () => {
+          started += 1;
+          if (started === 5) {
+            resolveGate();
+          }
+        },
+      };
+    })();
+    const barrier = new Promise<void>((resolve) => {
+      releaseReads = resolve;
+    });
+    const handle = {
+      cache: {
+        match: vi.fn(async () => {
+          allReadsStarted.mark();
+          await barrier;
+          return undefined;
+        }),
+        put: vi.fn(async () => undefined),
+      } as unknown as Cache,
+      origin: {
+        host: 'example.com',
+        protocol: 'https:',
+      },
+    };
+    const calls = Array.from({ length: 5 }, () =>
+      consumeSharedRateLimit(handle, 'rate-limit', 'burst-user', 3, 60_000)
+    );
+    await allReadsStarted.gate;
+    releaseReads();
+    const results = await Promise.all(calls);
+    expect(results.filter((allowed) => allowed === true)).toHaveLength(3);
+    expect(results.filter((allowed) => allowed === false)).toHaveLength(2);
+  });
+  it('delegates to the durable object limiter when the binding is present', async () => {
+    const { consumeSharedRateLimit } = await import('@/server/utils/sharedEdgeStore');
+    const stubFetch = vi.fn(
+      async (_input: RequestInfo | URL, _init?: RequestInit) =>
+        new Response(JSON.stringify({ allowed: true }))
+    );
+    const cacheMatch = vi.fn(async () => undefined);
+    const handle = {
+      cache: { match: cacheMatch, put: vi.fn(async () => undefined) } as unknown as Cache,
+      origin: { host: 'example.com', protocol: 'https:' },
+      limiter: {
+        idFromName: vi.fn(() => 'id-1'),
+        get: vi.fn(() => ({ fetch: stubFetch })),
+      },
+    };
+    await expect(consumeSharedRateLimit(handle, 'rate-limit', 'user-1', 5, 60_000)).resolves.toBe(
+      true
+    );
+    expect(stubFetch).toHaveBeenCalledTimes(1);
+    expect(cacheMatch).not.toHaveBeenCalled();
+    const requestInit = stubFetch.mock.calls[0]?.[1] as RequestInit | undefined;
+    const sentBody = JSON.parse(String(requestInit?.body));
+    expect(sentBody).toEqual({ limit: 5, windowSec: 60 });
+  });
+  it('blocks when the durable object limiter denies the request', async () => {
+    const { consumeSharedRateLimit } = await import('@/server/utils/sharedEdgeStore');
+    const handle = {
+      cache: {
+        match: vi.fn(async () => undefined),
+        put: vi.fn(async () => undefined),
+      } as unknown as Cache,
+      origin: { host: 'example.com', protocol: 'https:' },
+      limiter: {
+        idFromName: vi.fn(() => 'id-1'),
+        get: vi.fn(() => ({
+          fetch: vi.fn(async () => new Response(JSON.stringify({ allowed: false }))),
+        })),
+      },
+    };
+    await expect(consumeSharedRateLimit(handle, 'rate-limit', 'user-1', 5, 60_000)).resolves.toBe(
+      false
+    );
+  });
+  it('fails open to the cache path when the durable object limiter errors', async () => {
+    const { consumeSharedRateLimit } = await import('@/server/utils/sharedEdgeStore');
+    const cacheMatch = vi.fn(async () => undefined);
+    const onError = vi.fn();
+    const handle = {
+      cache: { match: cacheMatch, put: vi.fn(async () => undefined) } as unknown as Cache,
+      origin: { host: 'example.com', protocol: 'https:' },
+      limiter: {
+        idFromName: vi.fn(() => 'id-1'),
+        get: vi.fn(() => ({
+          fetch: vi.fn(async () => {
+            throw new Error('durable object unavailable');
+          }),
+        })),
+      },
+    };
+    await expect(
+      consumeSharedRateLimit(handle, 'rate-limit', 'user-1', 2, 60_000, onError)
+    ).resolves.toBe(true);
+    expect(cacheMatch).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
 });

--- a/app/server/utils/__tests__/sharedEdgeStore.test.ts
+++ b/app/server/utils/__tests__/sharedEdgeStore.test.ts
@@ -271,4 +271,30 @@ describe('consumeSharedRateLimit', () => {
     expect(cacheMatch).toHaveBeenCalledTimes(1);
     expect(onError).toHaveBeenCalledTimes(1);
   });
+  it('aborts a hung durable object request and falls back to the cache path', async () => {
+    const { consumeSharedRateLimit } = await import('@/server/utils/sharedEdgeStore');
+    const cacheMatch = vi.fn(async () => undefined);
+    const onError = vi.fn();
+    const stubFetch = vi.fn(
+      (_input: RequestInfo | URL, init?: RequestInit) =>
+        new Promise<Response>((_resolve, reject) => {
+          init?.signal?.addEventListener('abort', () => {
+            reject(new DOMException('aborted', 'AbortError'));
+          });
+        })
+    );
+    const handle = {
+      cache: { match: cacheMatch, put: vi.fn(async () => undefined) } as unknown as Cache,
+      origin: { host: 'example.com', protocol: 'https:' },
+      limiter: {
+        idFromName: vi.fn(() => 'id-1'),
+        get: vi.fn(() => ({ fetch: stubFetch })),
+      },
+    };
+    const pending = consumeSharedRateLimit(handle, 'rate-limit', 'user-1', 2, 60_000, onError);
+    await vi.advanceTimersByTimeAsync(3000);
+    await expect(pending).resolves.toBe(true);
+    expect(cacheMatch).toHaveBeenCalledTimes(1);
+    expect(onError).toHaveBeenCalledTimes(1);
+  });
 });

--- a/app/server/utils/sharedEdgeStore.ts
+++ b/app/server/utils/sharedEdgeStore.ts
@@ -274,6 +274,7 @@ export const writeSharedCache = async <T>(
     onError?.({ action: 'write', error, key, prefix });
   }
 };
+const DURABLE_RATE_LIMIT_TIMEOUT_MS = 3000;
 const consumeDurableRateLimit = async (
   limiter: SharedRateLimitNamespace,
   prefix: string,
@@ -283,6 +284,8 @@ const consumeDurableRateLimit = async (
   onError?: SharedCacheErrorHandler
 ): Promise<boolean | null> => {
   const windowSec = Math.max(1, Math.round(windowMs / 1000));
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), DURABLE_RATE_LIMIT_TIMEOUT_MS);
   try {
     const id = limiter.idFromName(`${prefix}:${key}`);
     const stub = limiter.get(id);
@@ -290,6 +293,7 @@ const consumeDurableRateLimit = async (
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify({ limit, windowSec }),
+      signal: controller.signal,
     });
     if (!response.ok) {
       onError?.({
@@ -314,6 +318,8 @@ const consumeDurableRateLimit = async (
   } catch (error) {
     onError?.({ action: 'read', error, key, prefix });
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 };
 /**

--- a/app/server/utils/sharedEdgeStore.ts
+++ b/app/server/utils/sharedEdgeStore.ts
@@ -283,7 +283,7 @@ const consumeDurableRateLimit = async (
   windowMs: number,
   onError?: SharedCacheErrorHandler
 ): Promise<boolean | null> => {
-  const windowSec = Math.max(1, Math.round(windowMs / 1000));
+  const windowSec = Math.max(1, Math.ceil(windowMs / 1000));
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), DURABLE_RATE_LIMIT_TIMEOUT_MS);
   try {

--- a/app/server/utils/sharedEdgeStore.ts
+++ b/app/server/utils/sharedEdgeStore.ts
@@ -2,9 +2,17 @@ export type SharedCacheOrigin = {
   host: string;
   protocol: string;
 };
+export type SharedRateLimitStub = {
+  fetch: (input: RequestInfo | URL, init?: RequestInit) => Promise<Response>;
+};
+export type SharedRateLimitNamespace = {
+  idFromName: (name: string) => unknown;
+  get: (id: unknown) => SharedRateLimitStub;
+};
 export type SharedCacheHandle = {
   cache: Cache | null;
   origin: SharedCacheOrigin;
+  limiter?: SharedRateLimitNamespace | null;
 };
 type SharedCacheEnvelope<T> = {
   expiresAt: number;
@@ -181,9 +189,35 @@ const consumeInMemoryRateLimit = (
   setInMemoryRateLimitEntry(key, nextEntry);
   return nextEntry;
 };
-export const createSharedCacheHandle = (appUrl: unknown): SharedCacheHandle => ({
+const isRateLimitNamespace = (value: unknown): value is SharedRateLimitNamespace => {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+  const candidate = value as Partial<SharedRateLimitNamespace>;
+  return typeof candidate.idFromName === 'function' && typeof candidate.get === 'function';
+};
+export const resolveSharedRateLimitNamespace = (
+  binding: unknown
+): SharedRateLimitNamespace | null => {
+  return isRateLimitNamespace(binding) ? binding : null;
+};
+const RATE_LIMITER_BINDING_NAME = 'API_GATEWAY_LIMITER';
+export const getRateLimiterBinding = (event: unknown): SharedRateLimitNamespace | null => {
+  if (!event || typeof event !== 'object') {
+    return null;
+  }
+  const context = (event as { context?: { cloudflare?: { env?: Record<string, unknown> } } })
+    .context;
+  const env = context?.cloudflare?.env;
+  if (!env || typeof env !== 'object') {
+    return null;
+  }
+  return resolveSharedRateLimitNamespace(env[RATE_LIMITER_BINDING_NAME]);
+};
+export const createSharedCacheHandle = (appUrl: unknown, limiter?: unknown): SharedCacheHandle => ({
   cache: getSharedCache(),
   origin: resolveSharedCacheOrigin(appUrl),
+  limiter: resolveSharedRateLimitNamespace(limiter),
 });
 export const readSharedCache = async <T>(
   handle: SharedCacheHandle,
@@ -240,6 +274,64 @@ export const writeSharedCache = async <T>(
     onError?.({ action: 'write', error, key, prefix });
   }
 };
+const consumeDurableRateLimit = async (
+  limiter: SharedRateLimitNamespace,
+  prefix: string,
+  key: string,
+  limit: number,
+  windowMs: number,
+  onError?: SharedCacheErrorHandler
+): Promise<boolean | null> => {
+  const windowSec = Math.max(1, Math.round(windowMs / 1000));
+  try {
+    const id = limiter.idFromName(`${prefix}:${key}`);
+    const stub = limiter.get(id);
+    const response = await stub.fetch('https://rate-limit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ limit, windowSec }),
+    });
+    if (!response.ok) {
+      onError?.({
+        action: 'read',
+        error: new Error(`rate limiter responded ${response.status}`),
+        key,
+        prefix,
+      });
+      return null;
+    }
+    const data = (await response.json()) as { allowed?: unknown };
+    if (typeof data.allowed !== 'boolean') {
+      onError?.({
+        action: 'read',
+        error: new Error('rate limiter returned malformed payload'),
+        key,
+        prefix,
+      });
+      return null;
+    }
+    return data.allowed;
+  } catch (error) {
+    onError?.({ action: 'read', error, key, prefix });
+    return null;
+  }
+};
+/**
+ * Best-effort distributed rate limiter.
+ *
+ * Enforcement tiers, strongest to weakest:
+ * 1. When a Durable Object limiter binding is present (`handle.limiter`), counting is
+ *    globally atomic and exact across isolates and data centers.
+ * 2. Otherwise the limiter falls back to the Cloudflare Cache API plus a per-isolate
+ *    in-memory map. Concurrent calls for a retained key within one live isolate serialize
+ *    the local counter update (the critical section between the cache read and write is
+ *    synchronous), but enforcement across isolates, data centers, in-memory eviction
+ *    (MAX_IN_MEMORY_RATE_LIMIT_ENTRIES), and isolate restarts remains best-effort. Worst-case
+ *    overshoot is roughly `limit x active isolates x active data centers`.
+ *
+ * The Durable Object path fails open to the cache/in-memory path on any binding error so a
+ * limiter outage degrades gracefully instead of breaking request handling.
+ */
 export const consumeSharedRateLimit = async (
   handle: SharedCacheHandle,
   prefix: string,
@@ -250,6 +342,19 @@ export const consumeSharedRateLimit = async (
 ): Promise<boolean> => {
   if (!Number.isFinite(limit) || limit <= 0 || !Number.isFinite(windowMs) || windowMs <= 0) {
     return true;
+  }
+  if (handle.limiter) {
+    const durableResult = await consumeDurableRateLimit(
+      handle.limiter,
+      prefix,
+      key,
+      limit,
+      windowMs,
+      onError
+    );
+    if (durableResult !== null) {
+      return durableResult;
+    }
   }
   const inMemoryKey = `${prefix}:${key}`;
   if (!handle.cache) {

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -710,6 +710,7 @@ describe('ApiGatewayRateLimiter storage cleanup', () => {
     await limiter.alarm();
     expect(mock.storage.deleteAll).not.toHaveBeenCalled();
     expect(mock.store.has('state')).toBe(true);
+    expect(mock.storage.setAlarm).toHaveBeenLastCalledWith(stored.resetAt + 1000);
     vi.restoreAllMocks();
   });
 });

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import worker from '../index';
+import worker, { ApiGatewayRateLimiter } from '../index';
 import { deleteMemoryCache } from '../utils/memory-cache';
 import type { Env } from '../types';
 const makeLimiter = (
@@ -640,5 +640,76 @@ describe('api-gateway', () => {
       | Record<string, { complete?: boolean }>
       | undefined;
     expect(taskObjectives?.['obj-1']?.complete).toBe(true);
+  });
+});
+describe('ApiGatewayRateLimiter storage cleanup', () => {
+  const createStorageMock = () => {
+    const store = new Map<string, unknown>();
+    let alarm: number | null = null;
+    return {
+      store,
+      getAlarmCalls: () => alarm,
+      deleteAllCount: 0,
+      storage: {
+        get: vi.fn(async (key: string) => store.get(key)),
+        put: vi.fn(async (key: string, value: unknown) => {
+          store.set(key, value);
+        }),
+        getAlarm: vi.fn(async () => alarm),
+        setAlarm: vi.fn(async (time: number) => {
+          alarm = time;
+        }),
+        deleteAll: vi.fn(async () => {
+          store.clear();
+          alarm = null;
+        }),
+      },
+    };
+  };
+  const callLimit = (limiter: ApiGatewayRateLimiter, limit = 5, windowSec = 60) =>
+    limiter.fetch(
+      new Request('https://rate-limit', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ limit, windowSec }),
+      })
+    );
+  it('schedules a cleanup alarm after the window when a request is counted', async () => {
+    const mock = createStorageMock();
+    const limiter = new ApiGatewayRateLimiter({
+      storage: mock.storage,
+    } as unknown as DurableObjectState);
+    const before = Date.now();
+    await callLimit(limiter);
+    expect(mock.storage.setAlarm).toHaveBeenCalledTimes(1);
+    const scheduled = mock.storage.setAlarm.mock.calls[0]?.[0] as number;
+    expect(scheduled).toBeGreaterThan(before + 60_000);
+  });
+  it('wipes all storage when the cleanup alarm fires after the window', async () => {
+    const mock = createStorageMock();
+    const limiter = new ApiGatewayRateLimiter({
+      storage: mock.storage,
+    } as unknown as DurableObjectState);
+    await callLimit(limiter, 5, 60);
+    expect(mock.store.has('state')).toBe(true);
+    const stored = mock.store.get('state') as { resetAt: number };
+    vi.spyOn(Date, 'now').mockReturnValue(stored.resetAt + 5000);
+    await limiter.alarm();
+    expect(mock.storage.deleteAll).toHaveBeenCalledTimes(1);
+    expect(mock.store.has('state')).toBe(false);
+    vi.restoreAllMocks();
+  });
+  it('reschedules cleanup instead of wiping when a newer window is still active', async () => {
+    const mock = createStorageMock();
+    const limiter = new ApiGatewayRateLimiter({
+      storage: mock.storage,
+    } as unknown as DurableObjectState);
+    await callLimit(limiter, 5, 60);
+    const stored = mock.store.get('state') as { resetAt: number };
+    vi.spyOn(Date, 'now').mockReturnValue(stored.resetAt - 1000);
+    await limiter.alarm();
+    expect(mock.storage.deleteAll).not.toHaveBeenCalled();
+    expect(mock.store.has('state')).toBe(true);
+    vi.restoreAllMocks();
   });
 });

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -106,6 +106,14 @@ export class ApiGatewayRateLimiter {
     if (!this.data || this.data.windowSec !== windowSec || now >= this.data.resetAt) {
       this.data = { count: 0, resetAt: now + windowMs, windowSec };
     }
+    // Schedule self-cleanup so abandoned keys (e.g. rotated teamId/userId in
+    // pre-auth rate-limit keys) do not retain billable storage forever. The
+    // alarm fires shortly after the window resets and wipes all storage.
+    const cleanupAt = this.data.resetAt + 1000;
+    const existingAlarm = await this.state.storage.getAlarm();
+    if (existingAlarm === null || existingAlarm < cleanupAt) {
+      await this.state.storage.setAlarm(cleanupAt);
+    }
     if (this.data.count >= limit) {
       return this.json({
         allowed: false,
@@ -120,6 +128,16 @@ export class ApiGatewayRateLimiter {
       remaining: Math.max(limit - this.data.count, 0),
       resetAt: this.data.resetAt,
     });
+  }
+  async alarm(): Promise<void> {
+    const stored = await this.state.storage.get<RateLimitState>('state');
+    // If a newer window is still active, reschedule cleanup instead of wiping it.
+    if (stored && Date.now() < stored.resetAt) {
+      await this.state.storage.setAlarm(stored.resetAt + 1000);
+      return;
+    }
+    this.data = undefined;
+    await this.state.storage.deleteAll();
   }
 }
 async function rateLimit(

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -111,7 +111,7 @@ export class ApiGatewayRateLimiter {
     // alarm fires shortly after the window resets and wipes all storage.
     const cleanupAt = this.data.resetAt + 1000;
     const existingAlarm = await this.state.storage.getAlarm();
-    if (existingAlarm === null || existingAlarm < cleanupAt) {
+    if (existingAlarm !== cleanupAt) {
       await this.state.storage.setAlarm(cleanupAt);
     }
     if (this.data.count >= limit) {

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,17 @@ compatibility_date = "2026-01-09"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "dist"
 
+# Atomic, globally-consistent rate limiter shared with the api-gateway Worker.
+# The ApiGatewayRateLimiter Durable Object class is owned and deployed by
+# workers/api-gateway; Pages binds to it by script_name (Pages cannot define a
+# DO class itself). When this binding is absent the rate limiter degrades to a
+# best-effort Cache API + in-memory path. durable_objects is a non-inheritable
+# key, so it must also be repeated under [env.preview].
+[[durable_objects.bindings]]
+name = "API_GATEWAY_LIMITER"
+class_name = "ApiGatewayRateLimiter"
+script_name = "api-gateway"
+
 [vars]
 NODE_ENV = "production"
 APP_URL = "https://tarkovtracker.org"
@@ -42,3 +53,9 @@ STRIPE_PRICE_TIMMY_YEARLY = "price_1TaNKwLaRBke56G2ySrDQVcC"
 STRIPE_PRICE_CHAD_MONTHLY = "price_1TaNKwLaRBke56G2NzMWPZUT"
 STRIPE_PRICE_CHAD_6MONTH = "price_1TaNKwLaRBke56G2v0oqXYeA"
 STRIPE_PRICE_CHAD_YEARLY = "price_1TaNKwLaRBke56G2IXA28xmv"
+
+# durable_objects is non-inheritable, so the binding is repeated for preview.
+[[env.preview.durable_objects.bindings]]
+name = "API_GATEWAY_LIMITER"
+class_name = "ApiGatewayRateLimiter"
+script_name = "api-gateway"


### PR DESCRIPTION
## Summary

Closes #464 for the auth/rate-sensitive routes by giving `consumeSharedRateLimit` a globally-atomic enforcement path, while preserving today's behavior everywhere the binding is absent.

The root cause in #464 is that the Cache API has no atomic increment, so the read-then-write counter can be raced across isolates and data centers (worst case ≈ `limit × isolates × colos`). The repo already ships a correct atomic limiter — the SQLite-backed `ApiGatewayRateLimiter` Durable Object in `workers/api-gateway`. This PR reuses it from the Pages deployment instead of standing up new infrastructure.

## What changed

### Pages-side (atomic limiter wiring)

- **`app/server/utils/sharedEdgeStore.ts`**
  - `consumeSharedRateLimit` now prefers the Durable Object limiter when an `API_GATEWAY_LIMITER` binding is present on the handle. The DO serializes count+increment per key, so enforcement is exact across isolates and locations.
  - On a missing binding **or any DO error/malformed response**, it **fails open** to the existing Cache API + in-memory path — a limiter outage degrades to best-effort rather than breaking requests.
  - DO request is bounded by an `AbortController`-backed 3s timeout so a hung stub falls back to the cache path instead of stalling on Cloudflare's platform timeout.
  - `windowSec` conversion uses `Math.ceil(windowMs / 1000)` so sub-second remainders never produce a shorter-than-configured DO window.
  - Added `getRateLimiterBinding(event)` to read the binding from `event.context.cloudflare.env`, and `resolveSharedRateLimitNamespace` for validation.
  - Documented the enforcement tiers and the precise best-effort limits of the fallback (cross-isolate, cross-colo, in-memory eviction, isolate restarts).
- **Call sites:** wired the binding into the two routes #464 calls out as sensitive — `team/members` and `profile/[userId]/[mode]`. The fire-and-forget client log sink intentionally stays on the best-effort path (a per-request DO hop isn't worth it for telemetry).
- **Pre-auth keying:** team-members and shared-profile pre-auth gates now key on IP only. Embedding attacker-controlled `teamId`/`userId`/`mode` let callers bypass the gate by rotating IDs and spawn unbounded DO instances.
- **`wrangler.toml`:** bind the external DO by `script_name = "api-gateway"` at the top level, mirrored under `[env.preview]` because `durable_objects` is a non-inheritable key (the file already overrides `vars` for preview).

### Worker-side (`ApiGatewayRateLimiter` hardening)

- **Storage cleanup alarm.** Each request schedules a self-cleanup alarm at `resetAt + 1s`. `alarm()` calls `state.storage.deleteAll()` once the window has elapsed, or reschedules to the current window's deadline if a newer window is still active. Alarm comparison uses `existingAlarm !== cleanupAt` so both earlier and later existing alarms are normalized to the current window. Without this, every unique key retained billable SQLite storage forever.

## Why this approach

- Native Rate Limiting binding: not confirmed on Pages Functions, eventually-consistent by design, and config-static (can't express the runtime-configurable team/profile limits). Rejected.
- KV/D1 CAS: KV has no CAS and is limited to one write/key/sec; D1 adds a DB dependency. Rejected.
- Durable Object: the issue's recommended option, already implemented and deployed in this account, accepts `{limit, windowSec}` per call. Chosen.

## Tests

- **`app/server/utils/__tests__/sharedEdgeStore.test.ts`** — DO allowed/denied paths, fail-open on DO error, hung-stub abort + fallback (advances fake timers), and a barrier-based concurrency regression that forces all `cache.match()` calls to observe the same stale value before any write resolves, then asserts a burst of 5 concurrent same-isolate calls yields exactly 3 allowed / 2 denied at `limit=3`. Verified the regression test fails if the in-memory serialization is removed.
- **`workers/api-gateway/src/__tests__/gateway.test.ts`** — alarm scheduling, post-window `deleteAll`, active-window reschedule (asserts `setAlarm` is called with `stored.resetAt + 1000`). 32 tests pass.

Validation: `npm run typecheck`, `npx eslint app --max-warnings=0`, `npm run test:api-gateway`, and the 4 affected endpoint suites all pass.

## Deployment notes / risk

- Cloudflare auto-deploys both Pages and the `api-gateway` Worker on push to `main` / preview branches, so the standard merge flow rolls out the storage-cleanup alarm alongside the Pages binding.
- Because the code fails open, the deploy is safe even if the binding doesn't resolve immediately — endpoints fall back to current behavior.
- `client.post.ts` behavior is unchanged.

Relates to #464.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Infrastructure**
  * Enhanced rate limiting system with improved reliability and enforcement across distributed environments.
  * Updated API endpoints to utilize a more robust rate limiter backed by persistent storage.
  * Improved automatic cleanup of expired rate limit data to prevent stale entries.

* **Tests**
  * Added comprehensive test coverage for rate limiting behavior under concurrent conditions and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->