### PR TITLE
fix(maps): align Labs tile map and add tile-map floor switching

### DIFF
--- a/app/composables/__tests__/useLeafletMap.test.ts
+++ b/app/composables/__tests__/useLeafletMap.test.ts
@@ -621,6 +621,41 @@ describe('useLeafletMap', () => {
       expect(result.floors.value).toEqual(['ground', 'upper']);
       wrapper.unmount();
     });
+    it('rebuilds the tile layer with the new floor path when switching floors', async () => {
+      const leafletModule = await import('leaflet');
+      const tileLayerSpy = vi.spyOn(leafletModule.default, 'tileLayer');
+      const mapData = {
+        id: 'lab',
+        name: 'The Lab',
+        normalizedName: 'lab',
+        tile: {
+          tilePath: 'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png',
+          floorTilePaths: {
+            First_Level: 'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png',
+            Second_Level: 'https://tiles.example.com/lab/2nd/{z}/{x}/{y}.png',
+          },
+          floors: ['First_Level', 'Second_Level'],
+          defaultFloor: 'First_Level',
+          coordinateRotation: 0,
+          bounds: [
+            [0, 0],
+            [100, 100],
+          ],
+        },
+      } as unknown as TarkovMap;
+      const { result, wrapper } = await mountUseLeafletMap(mapData);
+      tileLayerSpy.mockClear();
+      result.setFloor('Second_Level');
+      await nextTick();
+      await vi.advanceTimersByTimeAsync(1000);
+      await nextTick();
+      expect(result.selectedFloor.value).toBe('Second_Level');
+      expect(tileLayerSpy).toHaveBeenCalledWith(
+        'https://tiles.example.com/lab/2nd/{z}/{x}/{y}.png',
+        expect.any(Object)
+      );
+      wrapper.unmount();
+    });
   });
   describe('marker management', () => {
     it('clearMarkers removes all layers', async () => {

--- a/app/composables/__tests__/useLeafletMap.test.ts
+++ b/app/composables/__tests__/useLeafletMap.test.ts
@@ -122,6 +122,9 @@ vi.mock('@/utils/mapCoordinates', () => ({
   isValidMapSvgConfig: vi.fn((config) => !!config?.file),
   isValidMapTileConfig: vi.fn((config) => !!config?.tilePath),
   normalizeTileConfig: vi.fn((config) => config),
+  resolveFloorTilePath: vi.fn(
+    (config, floor) => (floor && config?.floorTilePaths?.[floor]) || config?.tilePath
+  ),
 }));
 const waitFor = async (predicate: () => boolean, maxIterations = 10) => {
   for (let index = 0; index < maxIterations; index++) {
@@ -619,6 +622,70 @@ describe('useLeafletMap', () => {
       } as TarkovMap;
       await nextTick();
       expect(result.floors.value).toEqual(['ground', 'upper']);
+      wrapper.unmount();
+    });
+    it('initializes tile maps with the configured default floor and tileSize', async () => {
+      const leafletModule = await import('leaflet');
+      const tileLayerSpy = vi.spyOn(leafletModule.default, 'tileLayer');
+      const mapData = {
+        id: 'lab',
+        name: 'The Lab',
+        normalizedName: 'lab',
+        tile: {
+          tilePath: 'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png',
+          floorTilePaths: {
+            Technical: 'https://tiles.example.com/lab/technical/{z}/{x}/{y}.png',
+            First_Level: 'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png',
+            Second_Level: 'https://tiles.example.com/lab/2nd/{z}/{x}/{y}.png',
+          },
+          floors: ['Technical', 'First_Level', 'Second_Level'],
+          defaultFloor: 'First_Level',
+          coordinateRotation: 0,
+          tileSize: 175,
+          bounds: [
+            [0, 0],
+            [100, 100],
+          ],
+        },
+      } as unknown as TarkovMap;
+      const { result, wrapper } = await mountUseLeafletMap(mapData);
+      expect(result.selectedFloor.value).toBe('First_Level');
+      expect(result.floors.value).toEqual(['Technical', 'First_Level', 'Second_Level']);
+      expect(result.hasMultipleFloors.value).toBe(true);
+      expect(tileLayerSpy).toHaveBeenCalledWith(
+        'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png',
+        expect.objectContaining({ tileSize: 175 })
+      );
+      wrapper.unmount();
+    });
+    it('respects an explicit initial floor for tile maps', async () => {
+      const leafletModule = await import('leaflet');
+      const tileLayerSpy = vi.spyOn(leafletModule.default, 'tileLayer');
+      const mapData = {
+        id: 'lab',
+        name: 'The Lab',
+        normalizedName: 'lab',
+        tile: {
+          tilePath: 'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png',
+          floorTilePaths: {
+            First_Level: 'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png',
+            Second_Level: 'https://tiles.example.com/lab/2nd/{z}/{x}/{y}.png',
+          },
+          floors: ['First_Level', 'Second_Level'],
+          defaultFloor: 'First_Level',
+          coordinateRotation: 0,
+          bounds: [
+            [0, 0],
+            [100, 100],
+          ],
+        },
+      } as unknown as TarkovMap;
+      const { result, wrapper } = await mountUseLeafletMap(mapData, 'Second_Level');
+      expect(result.selectedFloor.value).toBe('Second_Level');
+      expect(tileLayerSpy).toHaveBeenCalledWith(
+        'https://tiles.example.com/lab/2nd/{z}/{x}/{y}.png',
+        expect.any(Object)
+      );
       wrapper.unmount();
     });
     it('rebuilds the tile layer with the new floor path when switching floors', async () => {

--- a/app/composables/useLeafletMap.ts
+++ b/app/composables/useLeafletMap.ts
@@ -930,13 +930,14 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
       }
     }
   );
-  // Watch selected floor to update tile layer url if needed
-  watch(selectedFloor, (newFloor) => {
+  // Rebuild the tile layer on a user-initiated floor change so the tile-error fallback chain
+  // is recreated for the new floor instead of reusing stale fallback state from the initial
+  // floor. Skip while a load is already in flight (initial load already builds the right floor).
+  watch(selectedFloor, () => {
+    if (isLoading.value) return;
     const tileConfig = getTileConfig();
-    if (tileConfig && tileLayer.value) {
-      const floorPath = tileConfig.floorTilePaths?.[newFloor] ?? tileConfig.tilePath;
-      tileLayer.value.setUrl(floorPath);
-    }
+    if (!tileConfig || !tileLayer.value || !leaflet.value || !mapInstance.value) return;
+    void loadTileMap(leaflet.value, tileConfig, undefined, createMapLayerLoadToken());
   });
   // Lifecycle
   onMounted(() => {

--- a/app/composables/useLeafletMap.ts
+++ b/app/composables/useLeafletMap.ts
@@ -261,7 +261,7 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
   });
   const getRenderKey = (): string | undefined => renderKeyRef.value;
   const rawFloors = computed<string[]>(() => {
-    return getSvgConfig()?.floors ?? [];
+    return getSvgConfig()?.floors ?? getTileConfig()?.floors ?? [];
   });
   const floors = computed<string[]>(() => {
     if (rawFloors.value.length <= 1) return rawFloors.value;
@@ -371,13 +371,17 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
     }
     try {
       const bounds = getLeafletBounds(tileConfig);
-      const tilePaths = [tileConfig.tilePath, ...(tileConfig.tileFallbacks ?? [])];
-      tileLayer.value = L.tileLayer(tileConfig.tilePath, {
+      const initialPath =
+        (selectedFloor.value && tileConfig.floorTilePaths?.[selectedFloor.value]) ||
+        tileConfig.tilePath;
+      const tilePaths = [initialPath, ...(tileConfig.tileFallbacks ?? [])];
+      tileLayer.value = L.tileLayer(initialPath, {
         minZoom: tileConfig.minZoom ?? 1,
         maxZoom: tileConfig.maxZoom ?? 6,
         noWrap: true,
         bounds,
         pane: 'mapBackground',
+        tileSize: tileConfig.tileSize ?? 256,
       });
       const layer = tileLayer.value;
       const attachTileErrorHandler = (currentIndex: number) => {
@@ -580,7 +584,7 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
     }
     return floorToId;
   }
-  const FLOOR_GROUP_ID_PATTERN = /(ground|underground|basement|bunker|tunnel|garage|floor)/i;
+  const FLOOR_GROUP_ID_PATTERN = /(ground|underground|basement|bunker|tunnel|garage|floor|level)/i;
   function getTopLevelFloorGroups(svgElement: SVGElement): SVGGElement[] {
     return Array.from(svgElement.children).filter(
       (child): child is SVGGElement =>
@@ -756,6 +760,12 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
           svgConfig.defaultFloor ||
           svgConfig.floors[svgConfig.floors.length - 1] ||
           '';
+      } else if (tileConfig) {
+        selectedFloor.value =
+          initialFloor ||
+          tileConfig.defaultFloor ||
+          tileConfig.floors?.[tileConfig.floors.length - 1] ||
+          '';
       } else {
         selectedFloor.value = '';
       }
@@ -920,6 +930,14 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
       }
     }
   );
+  // Watch selected floor to update tile layer url if needed
+  watch(selectedFloor, (newFloor) => {
+    const tileConfig = getTileConfig();
+    if (tileConfig && tileLayer.value) {
+      const floorPath = tileConfig.floorTilePaths?.[newFloor] ?? tileConfig.tilePath;
+      tileLayer.value.setUrl(floorPath);
+    }
+  });
   // Lifecycle
   onMounted(() => {
     initializeMap();

--- a/app/composables/useLeafletMap.ts
+++ b/app/composables/useLeafletMap.ts
@@ -9,6 +9,7 @@ import {
   isValidMapSvgConfig,
   isValidMapTileConfig,
   normalizeTileConfig,
+  resolveFloorTilePath,
   type MapRenderConfig,
   type MapSvgConfig,
   type MapTileConfig,
@@ -65,6 +66,29 @@ interface MapLayerLoadToken {
   signal: AbortSignal;
 }
 const svgCache = new Map<string, string>();
+function resolveInitialFloor(
+  svgConfig?: MapSvgConfig,
+  tileConfig?: MapTileConfig,
+  preferredFloor?: string
+): string {
+  if (svgConfig) {
+    return (
+      preferredFloor ||
+      svgConfig.defaultFloor ||
+      svgConfig.floors[svgConfig.floors.length - 1] ||
+      ''
+    );
+  }
+  if (tileConfig) {
+    return (
+      preferredFloor ||
+      tileConfig.defaultFloor ||
+      tileConfig.floors?.[tileConfig.floors.length - 1] ||
+      ''
+    );
+  }
+  return '';
+}
 function isAbortError(error: unknown): boolean {
   return (
     (error instanceof DOMException && error.name === 'AbortError') ||
@@ -371,9 +395,7 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
     }
     try {
       const bounds = getLeafletBounds(tileConfig);
-      const initialPath =
-        (selectedFloor.value && tileConfig.floorTilePaths?.[selectedFloor.value]) ||
-        tileConfig.tilePath;
+      const initialPath = resolveFloorTilePath(tileConfig, selectedFloor.value);
       const tilePaths = [initialPath, ...(tileConfig.tileFallbacks ?? [])];
       tileLayer.value = L.tileLayer(initialPath, {
         minZoom: tileConfig.minZoom ?? 1,
@@ -754,21 +776,7 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
       const bounds = getLeafletBounds(renderConfig);
       mapInstance.value.fitBounds(bounds);
       // Set initial floor
-      if (svgConfig) {
-        selectedFloor.value =
-          initialFloor ||
-          svgConfig.defaultFloor ||
-          svgConfig.floors[svgConfig.floors.length - 1] ||
-          '';
-      } else if (tileConfig) {
-        selectedFloor.value =
-          initialFloor ||
-          tileConfig.defaultFloor ||
-          tileConfig.floors?.[tileConfig.floors.length - 1] ||
-          '';
-      } else {
-        selectedFloor.value = '';
-      }
+      selectedFloor.value = resolveInitialFloor(svgConfig, tileConfig, initialFloor);
       renderKey.value = getRenderKey() ?? '';
       loadToken = createMapLayerLoadToken();
       await loadMapLayer(initToken, loadToken);
@@ -906,13 +914,7 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
         return;
       }
       // Update floor selection
-      const svgConfig = newMap.svg;
-      if (isValidMapSvgConfig(svgConfig)) {
-        selectedFloor.value =
-          svgConfig.defaultFloor || svgConfig.floors[svgConfig.floors.length - 1] || '';
-      } else {
-        selectedFloor.value = '';
-      }
+      selectedFloor.value = resolveInitialFloor(newSvgConfig, newTileConfig);
       const nextRenderKey = getRenderKey() ?? '';
       if (nextRenderKey !== renderKey.value) {
         const loadToken = createMapLayerLoadToken();
@@ -933,6 +935,8 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
   // Rebuild the tile layer on a user-initiated floor change so the tile-error fallback chain
   // is recreated for the new floor instead of reusing stale fallback state from the initial
   // floor. Skip while a load is already in flight (initial load already builds the right floor).
+  // The rebuild re-reads bounds/tileSize from the shared tile config: per-floor geometry is not
+  // supported because all current tile maps (Labs) share bounds and tileSize across floors.
   watch(selectedFloor, () => {
     if (isLoading.value) return;
     const tileConfig = getTileConfig();

--- a/app/data/maps.json
+++ b/app/data/maps.json
@@ -65,6 +65,13 @@
   "lab": {
     "tile": {
       "tilePath": "https://assets.tarkov.dev/maps/labs_v4/1st/{z}/{x}/{y}.png",
+      "floorTilePaths": {
+        "Technical": "https://assets.tarkov.dev/maps/labs_v4/technical/{z}/{x}/{y}.png",
+        "First_Level": "https://assets.tarkov.dev/maps/labs_v4/1st/{z}/{x}/{y}.png",
+        "Second_Level": "https://assets.tarkov.dev/maps/labs_v4/2nd/{z}/{x}/{y}.png"
+      },
+      "floors": ["Technical", "First_Level", "Second_Level"],
+      "defaultFloor": "First_Level",
       "coordinateRotation": 270,
       "transform": [0.575, 281.2, 0.575, 193.7],
       "bounds": [
@@ -72,7 +79,8 @@
         [-287, -193]
       ],
       "minZoom": 2,
-      "maxZoom": 6
+      "maxZoom": 6,
+      "tileSize": 175
     }
   },
   "labyrinth": {

--- a/app/utils/__tests__/mapCoordinates.test.ts
+++ b/app/utils/__tests__/mapCoordinates.test.ts
@@ -6,7 +6,9 @@ import {
   getMapSvgCdnUrl,
   getMapSvgFallbackUrl,
   isValidMapSvgConfig,
+  resolveFloorTilePath,
   rotateGameCoordinates,
+  type MapTileConfig,
 } from '@/utils/mapCoordinates';
 describe('mapCoordinates', () => {
   describe('rotateGameCoordinates', () => {
@@ -243,6 +245,54 @@ describe('mapCoordinates', () => {
       const preEncoded = 'customs%20east.svg';
       expect(getMapSvgFallbackUrl(preEncoded)).toBe(
         'https://tarkovtracker.github.io/tarkovdata/maps/customs%2520east.svg'
+      );
+    });
+  });
+  describe('resolveFloorTilePath', () => {
+    const tileConfig: MapTileConfig = {
+      tilePath: 'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png',
+      floorTilePaths: {
+        Technical: 'https://tiles.example.com/lab/technical/{z}/{x}/{y}.png',
+        First_Level: 'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png',
+        Second_Level: 'https://tiles.example.com/lab/2nd/{z}/{x}/{y}.png',
+      },
+      floors: ['Technical', 'First_Level', 'Second_Level'],
+      defaultFloor: 'First_Level',
+      coordinateRotation: 0,
+      bounds: [
+        [0, 0],
+        [100, 100],
+      ],
+    };
+    it('returns the floor-specific path for each configured floor', () => {
+      expect(resolveFloorTilePath(tileConfig, 'Technical')).toBe(
+        'https://tiles.example.com/lab/technical/{z}/{x}/{y}.png'
+      );
+      expect(resolveFloorTilePath(tileConfig, 'First_Level')).toBe(
+        'https://tiles.example.com/lab/1st/{z}/{x}/{y}.png'
+      );
+      expect(resolveFloorTilePath(tileConfig, 'Second_Level')).toBe(
+        'https://tiles.example.com/lab/2nd/{z}/{x}/{y}.png'
+      );
+    });
+    it('falls back to tilePath when the floor has no dedicated tile set', () => {
+      expect(resolveFloorTilePath(tileConfig, 'Unknown_Floor')).toBe(tileConfig.tilePath);
+    });
+    it('falls back to tilePath when no floor is selected', () => {
+      expect(resolveFloorTilePath(tileConfig)).toBe(tileConfig.tilePath);
+      expect(resolveFloorTilePath(tileConfig, '')).toBe(tileConfig.tilePath);
+    });
+    it('falls back to tilePath when the map has no floorTilePaths', () => {
+      const singleFloorConfig: MapTileConfig = {
+        tilePath: 'https://tiles.example.com/interchange/{z}/{x}/{y}.png',
+        coordinateRotation: 0,
+        bounds: [
+          [0, 0],
+          [100, 100],
+        ],
+      };
+      expect(resolveFloorTilePath(singleFloorConfig, 'First_Level')).toBe(
+        singleFloorConfig.tilePath
       );
     });
   });

--- a/app/utils/mapCoordinates.ts
+++ b/app/utils/mapCoordinates.ts
@@ -31,6 +31,10 @@ export interface MapTileConfig {
   bounds: number[][];
   minZoom?: number;
   maxZoom?: number;
+  tileSize?: number;
+  floors?: string[];
+  defaultFloor?: string;
+  floorTilePaths?: Record<string, string>;
 }
 export type MapRenderConfig = MapSvgConfig | MapTileConfig;
 export function rotateGameCoordinates(

--- a/app/utils/mapCoordinates.ts
+++ b/app/utils/mapCoordinates.ts
@@ -275,6 +275,18 @@ export function isValidMapTileConfig(tile: unknown): tile is MapTileConfig {
     hasValidFallbacks
   );
 }
+/**
+ * Resolves the tile URL template for a floor of a tile-based map.
+ * Falls back to the base tilePath when no floor is selected or the floor
+ * has no dedicated tile set.
+ * @param tileConfig Map tile configuration
+ * @param floor Currently selected floor name
+ * @returns Tile URL template for the floor
+ */
+export function resolveFloorTilePath(tileConfig: MapTileConfig, floor?: string): string {
+  const floorPath = floor ? tileConfig.floorTilePaths?.[floor] : undefined;
+  return floorPath || tileConfig.tilePath;
+}
 export function normalizeTileConfig(tileConfig: MapTileConfig): MapTileConfig {
   if (!Array.isArray(tileConfig.transform) || tileConfig.transform.length < 4) return tileConfig;
   const [scaleX, marginX, scaleYRaw, marginY] = tileConfig.transform;


### PR DESCRIPTION
## **User description**
## Summary

Work-in-progress fix for #276 (Labs map misaligned, breaks/blacks out on zoom).

- Set `tileSize: 175` for Labs to match tarkov.dev's own map config. tarkov.dev serves 256px tiles but renders Labs at 175px; without this the tiles don't align with the coordinate `transform`/`bounds`, which is the root cause of the misalignment in #276.
- Add multi-floor support for **tile-based** maps (previously only SVG maps had floor switching): `floorTilePaths` for `technical` / `1st` / `2nd`, `floors`, and `defaultFloor` in `maps.json`.
- `useLeafletMap`: fall back to `tileConfig.floors`, pick initial tile URL from selected floor, and add a `selectedFloor` watcher that swaps the tile URL via `setUrl`.
- Extend `MapTileConfig` type with `tileSize`, `floors`, `defaultFloor`, `floorTilePaths`.

## Status — ready for review

All previously flagged WIP items are now addressed:

- The `selectedFloor` watcher rebuilds the tile layer via `loadTileMap`, which recreates the tile-error fallback chain and re-reads `bounds`/`tileSize` from the shared tile config. Per-floor geometry is intentionally unsupported (all current tile maps, i.e. Labs, share geometry across floors) and this is documented in a code comment.
- Floor-path lookup is extracted into a shared exported helper `resolveFloorTilePath(tileConfig, floor)` in `app/utils/mapCoordinates.ts`; default-floor resolution is shared via `resolveInitialFloor` and now also applies when switching maps (tile maps previously reset to an empty floor).
- Zoom blackout from #276 verified in-browser (see verification below).
- Tests added for tile-map floor defaults, explicit initial floor, floor-switch tile rebuild, and the floor-path helper.

## Verification

- `npm run typecheck`, `npm run lint`, and the full `npm run test` suite (203 files / 1949 tests) pass.
- All three floor tile URLs return HTTP 200; `tileSize: 175` confirmed against tarkov.dev's upstream maps config.
- In-browser (headless Chrome via CDP against `npm run dev`, Labs selected on `/tasks`):
  - Tiles load at every zoom step from 2 to max (6, zoom-in control disables), 0 broken tiles at each step.
  - Map-area dark-pixel fraction stayed <= 0.01 across all zoom levels — no blackout (#276).
  - Floor switching (First → Technical → Second) swaps to `labs_v4/technical` / `labs_v4/2nd` tile URLs, including while fully zoomed in, with all tiles loading.

Closes #276

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for floor-specific tile URL templates, allowing different imagery per floor when viewing tile-based maps.

* **Improvements**
  * Improved floor selection to better handle missing SVG data and more reliably pick the initial/selected floor.
  * Floor changes now rebuild the tile layer to fetch the correct tiles for the newly selected floor.
  * Expanded compatibility for matching floor identifiers in SVG-based maps.

* **Tests**
  * Added coverage to verify tile-layer rebuilds with the correct per-floor tile URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Fix Labs map alignment and floor switching on tile maps**

### What Changed
- The Labs map now lines up correctly on the map view, and uses the correct tile size for the default floor.
- Tile-based maps can now switch between floors using floor-specific imagery, instead of reusing the same tiles for every floor.
- Changing floors now reloads the map tiles for the selected floor, so the view shows the right level after a switch.
- Labs is set up with separate tile paths for Technical, 1st, and 2nd floors, plus a default floor.

### Impact
`✅ Correct Labs map positioning`
`✅ Floor-specific tile views`
`✅ Reliable Labs floor switching`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

