### PR TITLE
feat(settings): add antifandom.com wiki link option

### DIFF
--- a/app/components/ui/AcceptedItemsPopover.vue
+++ b/app/components/ui/AcceptedItemsPopover.vue
@@ -27,7 +27,7 @@
         <ul class="max-h-72 space-y-1 overflow-y-auto pr-1">
           <li v-for="entry in items" :key="entry.id">
             <a
-              :href="getKeyPrimaryUrl(entry)"
+              :href="toWikiUrl(getKeyPrimaryUrl(entry))"
               target="_blank"
               rel="noopener noreferrer"
               class="hover:bg-surface-800 focus-visible:ring-primary-500 group flex items-center gap-2 rounded-md p-1.5 transition-colors focus:outline-none focus-visible:ring-2"
@@ -63,6 +63,7 @@
   </UPopover>
 </template>
 <script setup lang="ts">
+  import { useWikiLink } from '@/composables/useWikiLink';
   import { getKeyPrimaryUrl } from '@/utils/tarkovKeyHelpers';
   import type { TarkovItem } from '@/types/tarkov';
   const props = withDefaults(
@@ -80,6 +81,7 @@
     }
   );
   const { t } = useI18n({ useScope: 'global' });
+  const { toWikiUrl } = useWikiLink();
   const open = defineModel<boolean>('open', { default: false });
   const count = computed(() => props.items.length);
 </script>

--- a/app/components/ui/GameItem.vue
+++ b/app/components/ui/GameItem.vue
@@ -99,7 +99,7 @@
         </AppTooltip>
         <AppTooltip v-if="props.wikiLink" :text="t('page.tasks.questcard.view_on_wiki')">
           <a
-            :href="props.wikiLink"
+            :href="toWikiUrl(props.wikiLink)"
             target="_blank"
             rel="noopener noreferrer"
             class="text-surface-200 inline-flex items-center justify-center rounded p-1.5 transition-colors hover:bg-white/20 hover:text-white"
@@ -204,6 +204,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { useWikiLink } from '@/composables/useWikiLink';
   import { useLocaleNumberFormatter } from '@/utils/formatters';
   import { logger } from '@/utils/logger';
   import type ContextMenu from '@/components/ui/ContextMenu.vue';
@@ -281,6 +282,7 @@
   }>();
   const { t } = useI18n({ useScope: 'global' });
   const { copyToClipboard } = useCopyToClipboard();
+  const { toWikiUrl } = useWikiLink();
   const formatNumber = useLocaleNumberFormatter();
   const BACKGROUND_CLASS_MAP = {
     violet: 'bg-rarity-violet',
@@ -384,8 +386,9 @@
     }
   };
   const openWikiLink = () => {
-    if (props.wikiLink) {
-      window.open(props.wikiLink, '_blank', 'noopener,noreferrer');
+    const url = toWikiUrl(props.wikiLink);
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
     }
   };
   const copyItemName = async () => {
@@ -406,8 +409,9 @@
     }
   };
   const openTaskWiki = () => {
-    if (props.taskWikiLink) {
-      window.open(props.taskWikiLink, '_blank', 'noopener,noreferrer');
+    const url = toWikiUrl(props.taskWikiLink);
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
     }
   };
 </script>

--- a/app/composables/useTaskCardLinks.ts
+++ b/app/composables/useTaskCardLinks.ts
@@ -1,4 +1,5 @@
 import { writeToClipboard } from '@/composables/useCopyToClipboard';
+import { useWikiLink } from '@/composables/useWikiLink';
 import { useTarkovStore } from '@/stores/useTarkov';
 import type { Task, TaskObjective } from '@/types/tarkov';
 export interface UseTaskCardLinksOptions {
@@ -27,6 +28,7 @@ export function useTaskCardLinks(options: UseTaskCardLinksOptions): UseTaskCardL
   const { task, objectives } = options;
   const router = useRouter();
   const tarkovStore = useTarkovStore();
+  const { toWikiUrl } = useWikiLink();
   const selectedItem = ref<SelectedTaskItem | null>(null);
   const tarkovDevTaskUrl = computed(() => `https://tarkov.dev/task/${task().id}`);
   const copyTextToClipboard = async (text: string): Promise<boolean> => {
@@ -37,7 +39,7 @@ export function useTaskCardLinks(options: UseTaskCardLinksOptions): UseTaskCardL
     return copyTextToClipboard(`${window.location.origin}${href}`);
   };
   const openTaskWiki = () => {
-    const wikiLink = task().wikiLink;
+    const wikiLink = toWikiUrl(task().wikiLink);
     if (wikiLink) {
       window.open(wikiLink, '_blank', 'noopener,noreferrer');
     }
@@ -90,15 +92,19 @@ export function useTaskCardLinks(options: UseTaskCardLinksOptions): UseTaskCardL
   const openItemOnWiki = () => {
     if (!selectedItem.value) return;
     if (selectedItem.value.wikiLink) {
-      window.open(selectedItem.value.wikiLink, '_blank', 'noopener,noreferrer');
+      const wikiLink = toWikiUrl(selectedItem.value.wikiLink);
+      if (wikiLink) {
+        window.open(wikiLink, '_blank', 'noopener,noreferrer');
+      }
       return;
     }
     const fallbackQuery = selectedItem.value.name?.trim() || selectedItem.value.id;
-    window.open(
-      `https://escapefromtarkov.fandom.com/wiki/Special:Search?query=${encodeURIComponent(fallbackQuery)}`,
-      '_blank',
-      'noopener,noreferrer'
+    const fallbackUrl = toWikiUrl(
+      `https://escapefromtarkov.fandom.com/wiki/Special:Search?query=${encodeURIComponent(fallbackQuery)}`
     );
+    if (fallbackUrl) {
+      window.open(fallbackUrl, '_blank', 'noopener,noreferrer');
+    }
   };
   return {
     selectedItem,

--- a/app/composables/useWikiLink.ts
+++ b/app/composables/useWikiLink.ts
@@ -1,0 +1,18 @@
+import { usePreferencesStore } from '@/stores/usePreferences';
+import { rewriteWikiUrl } from '@/utils/wikiLink';
+/**
+ * Reactive wiki link helper. Wraps a raw wiki URL and rewrites fandom.com
+ * links to the antifandom.com mirror when the user has enabled the preference.
+ * Reads the preference on every call so templates re-render when it changes.
+ */
+export function useWikiLink() {
+  const preferencesStore = usePreferencesStore();
+  function toWikiUrl(url: string): string;
+  function toWikiUrl(url: string | undefined): string | undefined;
+  function toWikiUrl(url: string | null): string | null;
+  function toWikiUrl(url: string | null | undefined): string | null | undefined;
+  function toWikiUrl(url: string | null | undefined): string | null | undefined {
+    return rewriteWikiUrl(url, preferencesStore.getWikiUseAntifandom);
+  }
+  return { toWikiUrl };
+}

--- a/app/composables/useWikiLink.ts
+++ b/app/composables/useWikiLink.ts
@@ -7,6 +7,10 @@ import { rewriteWikiUrl } from '@/utils/wikiLink';
  */
 export function useWikiLink() {
   const preferencesStore = usePreferencesStore();
+  /**
+   * Rewrite a wiki URL to the antifandom.com mirror when the preference is on,
+   * preserving the nullability of the input for safe `:href` bindings.
+   */
   function toWikiUrl(url: string): string;
   function toWikiUrl(url: string | undefined): string | undefined;
   function toWikiUrl(url: string | null): string | null;

--- a/app/composables/useWikiLink.ts
+++ b/app/composables/useWikiLink.ts
@@ -1,11 +1,17 @@
 import { usePreferencesStore } from '@/stores/usePreferences';
 import { rewriteWikiUrl } from '@/utils/wikiLink';
+interface WikiLinkRewriter {
+  (url: string): string;
+  (url: string | undefined): string | undefined;
+  (url: string | null): string | null;
+  (url: string | null | undefined): string | null | undefined;
+}
 /**
  * Reactive wiki link helper. Wraps a raw wiki URL and rewrites fandom.com
  * links to the antifandom.com mirror when the user has enabled the preference.
  * Reads the preference on every call so templates re-render when it changes.
  */
-export function useWikiLink() {
+export function useWikiLink(): { toWikiUrl: WikiLinkRewriter } {
   const preferencesStore = usePreferencesStore();
   /**
    * Rewrite a wiki URL to the antifandom.com mirror when the preference is on,

--- a/app/features/hideout/HideoutRequirement.vue
+++ b/app/features/hideout/HideoutRequirement.vue
@@ -158,6 +158,7 @@
   import ContextMenu from '@/components/ui/ContextMenu.vue';
   import ContextMenuItem from '@/components/ui/ContextMenuItem.vue';
   import GameItem from '@/components/ui/GameItem.vue';
+  import { useWikiLink } from '@/composables/useWikiLink';
   import { useTarkovStore } from '@/stores/useTarkov';
   import { useLocaleNumberFormatter } from '@/utils/formatters';
   interface Props {
@@ -181,6 +182,7 @@
   }
   const props = defineProps<Props>();
   const tarkovStore = useTarkovStore();
+  const { toWikiUrl } = useWikiLink();
   const formatNumber = useLocaleNumberFormatter();
   const requirementId = computed(() => props.requirement.id);
   const requiredCount = computed(() => props.requirement.count);
@@ -265,8 +267,9 @@
     }
   };
   const openWiki = (): void => {
-    if (props.requirement.item.wikiLink) {
-      window.open(props.requirement.item.wikiLink, '_blank', 'noopener,noreferrer');
+    const url = toWikiUrl(props.requirement.item.wikiLink);
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
     }
   };
 </script>

--- a/app/features/maps/LeafletObjectiveTooltip.vue
+++ b/app/features/maps/LeafletObjectiveTooltip.vue
@@ -93,6 +93,7 @@
 </template>
 <script setup lang="ts">
   import { useI18n, type Composer } from 'vue-i18n';
+  import { useWikiLink } from '@/composables/useWikiLink';
   import { useMetadataStore } from '@/stores/useMetadata';
   import { usePreferencesStore } from '@/stores/usePreferences';
   import { useTarkovStore } from '@/stores/useTarkov';
@@ -141,6 +142,7 @@
   const metadataStore = useMetadataStore();
   const tarkovStore = useTarkovStore();
   const preferencesStore = usePreferencesStore();
+  const { toWikiUrl } = useWikiLink();
   const isCompact = computed(() => preferencesStore.getMapTooltipDensity === 'compact');
   const defaultButtonClass =
     'inline-flex h-7 w-7 items-center justify-center rounded-md border border-white/10 bg-white/5 text-gray-200';
@@ -163,7 +165,7 @@
   const taskTitleProps = computed(() => {
     if (task.value?.wikiLink) {
       return {
-        href: task.value.wikiLink,
+        href: toWikiUrl(task.value.wikiLink),
         target: '_blank',
         rel: 'noopener noreferrer',
       };

--- a/app/features/profile/__tests__/ProfileStorylineTab.test.ts
+++ b/app/features/profile/__tests__/ProfileStorylineTab.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { mount } from '@vue/test-utils';
+import { createPinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import type { StorylineNormalizedChapterView } from '@/composables/useStorylineChapters';
@@ -181,6 +182,7 @@ const createWrapper = async (readOnly: boolean) => {
       readOnly,
     },
     global: {
+      plugins: [createPinia()],
       stubs: {
         UAlert: {
           template: '<div><slot /></div>',

--- a/app/features/settings/ExternalLinksCard.vue
+++ b/app/features/settings/ExternalLinksCard.vue
@@ -1,0 +1,35 @@
+<template>
+  <GenericCard
+    icon="mdi-link-variant"
+    icon-color="info"
+    highlight-color="info"
+    :fill-height="false"
+    :title="$t('settings.interface.links.title')"
+    title-classes="text-lg font-semibold"
+  >
+    <template #content>
+      <div class="px-4 py-4">
+        <div class="flex items-center justify-between gap-3">
+          <div class="space-y-1">
+            <p class="text-surface-200 text-sm font-semibold">
+              {{ $t('settings.interface.links.antifandom') }}
+            </p>
+            <p class="text-surface-400 text-sm">
+              {{ $t('settings.interface.links.antifandom_hint') }}
+            </p>
+          </div>
+          <USwitch v-model="useAntifandom" />
+        </div>
+      </div>
+    </template>
+  </GenericCard>
+</template>
+<script setup lang="ts">
+  import GenericCard from '@/components/ui/GenericCard.vue';
+  import { usePreferencesStore } from '@/stores/usePreferences';
+  const preferencesStore = usePreferencesStore();
+  const useAntifandom = computed({
+    get: () => preferencesStore.getWikiUseAntifandom,
+    set: (val) => preferencesStore.setWikiUseAntifandom(val),
+  });
+</script>

--- a/app/features/settings/PrestigeCard.vue
+++ b/app/features/settings/PrestigeCard.vue
@@ -121,7 +121,7 @@
                       <div class="flex items-center gap-1.5">
                         <a
                           v-if="row.href"
-                          :href="row.href"
+                          :href="toWikiUrl(row.href)"
                           target="_blank"
                           rel="noopener noreferrer"
                           class="text-surface-100 hover:text-warning-300 text-sm font-semibold transition-colors"
@@ -426,6 +426,7 @@
 </template>
 <script setup lang="ts">
   import GenericCard from '@/components/ui/GenericCard.vue';
+  import { useWikiLink } from '@/composables/useWikiLink';
   import {
     buildPrestigeRequirementRows,
     getNextPrestigeLevel,
@@ -450,6 +451,7 @@
   const DAY_MS = 24 * 60 * 60 * 1000;
   const currentPrestigeInputId = 'settings-pvp-prestige-input';
   const { locale, t } = useI18n({ useScope: 'global' });
+  const { toWikiUrl } = useWikiLink();
   const toast = useToast();
   const { $supabase } = useNuxtApp();
   const metadataStore = useMetadataStore();

--- a/app/features/storyline/components/ChapterCard.vue
+++ b/app/features/storyline/components/ChapterCard.vue
@@ -40,7 +40,7 @@
       </div>
       <div class="min-w-0 flex-1">
         <a
-          :href="chapter.wikiLink"
+          :href="toWikiUrl(chapter.wikiLink)"
           target="_blank"
           rel="noopener noreferrer"
           class="text-link hover:text-link-hover flex items-center gap-1 text-sm font-semibold no-underline"
@@ -686,6 +686,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { useWikiLink } from '@/composables/useWikiLink';
   import type {
     StorylineNormalizedChapterView,
     StorylineObjectiveProgress,
@@ -703,6 +704,7 @@
     toggleObjective: [chapterId: string, objectiveId: string];
   }>();
   const { t } = useI18n({ useScope: 'global' });
+  const { toWikiUrl } = useWikiLink();
   const getUnlockBadgeColor = (type: StorylineObjectiveUnlockView['type']) => {
     if (type === 'map') {
       return 'primary';

--- a/app/features/tasks/ObjectiveItemDisplay.vue
+++ b/app/features/tasks/ObjectiveItemDisplay.vue
@@ -71,6 +71,7 @@
 </template>
 <script setup lang="ts">
   import { useCyclingItem } from '@/composables/useCyclingItem';
+  import { useWikiLink } from '@/composables/useWikiLink';
   import { resolveObjectiveItemIcon } from '@/features/tasks/task-objective-item-overrides';
   import { getKeyDevUrl, getKeyPrimaryUrl } from '@/utils/tarkovKeyHelpers';
   import type { TarkovItem } from '@/types/tarkov';
@@ -85,6 +86,7 @@
     paused?: boolean;
   }>();
   const { t } = useI18n({ useScope: 'global' });
+  const { toWikiUrl } = useWikiLink();
   const acceptedItems = computed(() =>
     (props.acceptedItems ?? []).filter((entry): entry is TarkovItem => Boolean(entry?.id))
   );
@@ -131,7 +133,7 @@
   });
   const displayDevUrl = computed(() => (linkItem.value ? getKeyDevUrl(linkItem.value) : undefined));
   const displayPrimaryUrl = computed(() =>
-    linkItem.value ? getKeyPrimaryUrl(linkItem.value) : undefined
+    linkItem.value ? toWikiUrl(getKeyPrimaryUrl(linkItem.value)) : undefined
   );
   const cyclingTooltip = computed(() => {
     if (hasAlternatives.value) {

--- a/app/features/tasks/ObjectiveRequiredItems.vue
+++ b/app/features/tasks/ObjectiveRequiredItems.vue
@@ -30,7 +30,7 @@
       </AppTooltip>
       <AppTooltip :text="getPrimaryTooltip(item)">
         <a
-          :href="getKeyPrimaryUrl(item)"
+          :href="toWikiUrl(getKeyPrimaryUrl(item))"
           target="_blank"
           rel="noopener noreferrer"
           class="text-link hover:text-link-hover focus-visible:ring-primary-500 inline-flex items-center gap-0.5 rounded-sm text-xs font-bold no-underline focus:outline-none focus-visible:ring-2"
@@ -120,6 +120,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { useWikiLink } from '@/composables/useWikiLink';
   import { logger } from '@/utils/logger';
   import {
     getKeyBackgroundClass,
@@ -131,6 +132,7 @@
   import type ContextMenu from '@/components/ui/ContextMenu.vue';
   import type { TarkovItem } from '@/types/tarkov';
   const { t } = useI18n({ useScope: 'global' });
+  const { toWikiUrl } = useWikiLink();
   const props = defineProps<{
     variant: 'keys' | 'equipment';
     requiredKeys?: TarkovItem[][];
@@ -184,7 +186,10 @@
       ? t('page.tasks.questcard.view_on_wiki')
       : t('page.tasks.questcard.view_on_tarkov_dev');
   const openPrimaryLink = (item: TarkovItem) => {
-    window.open(getKeyPrimaryUrl(item), '_blank', 'noopener,noreferrer');
+    const url = toWikiUrl(getKeyPrimaryUrl(item));
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
+    }
   };
   const handleContextMenu = (event: MouseEvent, item: TarkovItem) => {
     activeItem.value = item;
@@ -196,8 +201,9 @@
     }
   };
   const openWikiLink = () => {
-    if (activeItem.value?.wikiLink) {
-      window.open(activeItem.value.wikiLink, '_blank', 'noopener,noreferrer');
+    const url = toWikiUrl(activeItem.value?.wikiLink);
+    if (url) {
+      window.open(url, '_blank', 'noopener,noreferrer');
     }
   };
   const copyItemName = async () => {

--- a/app/features/tasks/TaskCardHeader.vue
+++ b/app/features/tasks/TaskCardHeader.vue
@@ -40,7 +40,7 @@
         :text="t('page.tasks.questcard.view_on_wiki')"
       >
         <a
-          :href="task.wikiLink"
+          :href="toWikiUrl(task.wikiLink)"
           target="_blank"
           rel="noopener noreferrer"
           :class="ICON_BUTTON_CLASS"
@@ -101,6 +101,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { useWikiLink } from '@/composables/useWikiLink';
   import { getFactionIconPath } from '@/utils/factionIcons';
   import type { Task } from '@/types/tarkov';
   const props = defineProps<{
@@ -109,6 +110,7 @@
   }>();
   const route = useRoute();
   const { t } = useI18n({ useScope: 'global' });
+  const { toWikiUrl } = useWikiLink();
   const factionImage = computed(() => getFactionIconPath(props.task.factionName));
   const tarkovDevTaskUrl = computed(() => `https://tarkov.dev/task/${props.task.id}`);
   const isTasksRoute = computed(() => route.path.startsWith('/tasks'));
@@ -121,7 +123,7 @@
   const titleProps = computed(() => {
     if (shouldLinkToWiki.value) {
       return {
-        href: props.task.wikiLink,
+        href: toWikiUrl(props.task.wikiLink),
         target: '_blank',
         rel: 'noopener noreferrer',
       };

--- a/app/features/tasks/TaskLink.vue
+++ b/app/features/tasks/TaskLink.vue
@@ -33,7 +33,7 @@
     </AppTooltip>
     <a
       v-if="props.showWikiLink"
-      :href="props.task.wikiLink"
+      :href="toWikiUrl(props.task.wikiLink)"
       target="_blank"
       class="text-link hover:text-link-hover flex items-center text-xs whitespace-nowrap"
     >
@@ -43,6 +43,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { useWikiLink } from '@/composables/useWikiLink';
   import { getFactionIconPath } from '@/utils/factionIcons';
   const props = defineProps({
     task: {
@@ -61,6 +62,7 @@
     },
   });
   const { t } = useI18n({ useScope: 'global' });
+  const { toWikiUrl } = useWikiLink();
   const factionImage = computed(() => getFactionIconPath(props.task?.factionName) ?? undefined);
   const isFactionTask = computed(() => Boolean(factionImage.value));
   const factionAlt = computed(() => props.task?.factionName || 'Faction image');

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1741,7 +1741,7 @@
       "links": {
         "title": "Wiki Links",
         "antifandom": "Use antifandom.com",
-        "antifandom_hint": "Open wiki links on antifandom.com, an ad-light mirror of Fandom, instead of fandom.com."
+        "antifandom_hint": "Open wiki links on antifandom.com, a community-run, ad-light mirror of Fandom, instead of fandom.com."
       },
       "misc": {
         "title": "Miscellaneous"

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1738,6 +1738,11 @@
           "pmc_spawn": "PMC Spawn"
         }
       },
+      "links": {
+        "title": "Wiki Links",
+        "antifandom": "Use antifandom.com",
+        "antifandom_hint": "Open wiki links on antifandom.com, an ad-light mirror of Fandom, instead of fandom.com."
+      },
       "misc": {
         "title": "Miscellaneous"
       }

--- a/app/pages/__tests__/settings.page.test.ts
+++ b/app/pages/__tests__/settings.page.test.ts
@@ -114,6 +114,7 @@ const defaultGlobalStubs = {
   },
   'i18n-t': { template: '<span><slot /><slot name="word" /></span>' },
   ExperienceCard: { template: '<div data-testid="experience-card" />' },
+  ExternalLinksCard: { template: '<div data-testid="external-links-card" />' },
   KeybindsCard: { template: '<div data-testid="keybinds-card" />' },
   MapSettingsCard: { template: '<div data-testid="map-settings-card" />' },
   PrestigeCard: { template: '<div data-testid="prestige-card" />' },

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -87,6 +87,7 @@
               <PrivacyCard />
               <TaskDisplayCard />
               <MapSettingsCard />
+              <ExternalLinksCard />
               <KeybindsCard />
             </section>
             <section
@@ -163,6 +164,7 @@
   import DebugStateCard from '@/features/settings/DebugStateCard.vue';
   import DisplayNameCard from '@/features/settings/DisplayNameCard.vue';
   import ExperienceCard from '@/features/settings/ExperienceCard.vue';
+  import ExternalLinksCard from '@/features/settings/ExternalLinksCard.vue';
   import KeybindsCard from '@/features/settings/KeybindsCard.vue';
   import MapSettingsCard from '@/features/settings/MapSettingsCard.vue';
   import PrestigeCard from '@/features/settings/PrestigeCard.vue';

--- a/app/stores/usePreferences.ts
+++ b/app/stores/usePreferences.ts
@@ -553,6 +553,7 @@ export const usePreferencesStore = defineStore('preferences', {
     getLocaleOverride: (state) => {
       return state.localeOverride ?? null;
     },
+    /** Whether wiki links should open on the antifandom.com mirror. */
     getWikiUseAntifandom: (state) => {
       return state.wikiUseAntifandom ?? false;
     },
@@ -824,6 +825,7 @@ export const usePreferencesStore = defineStore('preferences', {
     setLocaleOverride(locale: string | null) {
       this.localeOverride = locale;
     },
+    /** Toggle whether wiki links open on the antifandom.com mirror. */
     setWikiUseAntifandom(enabled: boolean) {
       this.wikiUseAntifandom = enabled;
     },

--- a/app/stores/usePreferences.ts
+++ b/app/stores/usePreferences.ts
@@ -121,6 +121,8 @@ export interface PreferencesState {
   hideoutRequireSkillLevels: boolean;
   hideoutRequireTraderLoyalty: boolean;
   localeOverride: string | null;
+  // External links
+  wikiUseAntifandom: boolean;
   // Task filter settings
   showNonSpecialTasks: boolean;
   showLightkeeperTasks: boolean;
@@ -206,6 +208,8 @@ export const preferencesDefaultState: PreferencesState = {
   hideoutRequireSkillLevels: true,
   hideoutRequireTraderLoyalty: true,
   localeOverride: null,
+  // External links
+  wikiUseAntifandom: false,
   // Task filter settings (all shown by default)
   showNonSpecialTasks: true,
   showLightkeeperTasks: true,
@@ -549,6 +553,9 @@ export const usePreferencesStore = defineStore('preferences', {
     getLocaleOverride: (state) => {
       return state.localeOverride ?? null;
     },
+    getWikiUseAntifandom: (state) => {
+      return state.wikiUseAntifandom ?? false;
+    },
     // Task filter getters
     getShowNonSpecialTasks: (state) => {
       return state.showNonSpecialTasks ?? true;
@@ -817,6 +824,9 @@ export const usePreferencesStore = defineStore('preferences', {
     setLocaleOverride(locale: string | null) {
       this.localeOverride = locale;
     },
+    setWikiUseAntifandom(enabled: boolean) {
+      this.wikiUseAntifandom = enabled;
+    },
     // Task filter actions
     setShowNonSpecialTasks(show: boolean) {
       this.showNonSpecialTasks = show;
@@ -986,6 +996,7 @@ export const usePreferencesStore = defineStore('preferences', {
       'neededitemsStyle',
       'hideoutPrimaryView',
       'localeOverride',
+      'wikiUseAntifandom',
       // Task filter settings
       'showNonSpecialTasks',
       'showLightkeeperTasks',

--- a/app/utils/__tests__/wikiLink.test.ts
+++ b/app/utils/__tests__/wikiLink.test.ts
@@ -5,17 +5,17 @@ describe('rewriteWikiUrl', () => {
   it('returns the original url when the preference is disabled', () => {
     expect(rewriteWikiUrl(url, false)).toBe(url);
   });
-  it('swaps the fandom.com host for antifandom.com when enabled', () => {
-    expect(rewriteWikiUrl(url, true)).toBe('https://escapefromtarkov.antifandom.com/wiki/Debut');
+  it('rewrites a fandom wiki url to the antifandom path form when enabled', () => {
+    expect(rewriteWikiUrl(url, true)).toBe('https://antifandom.com/escapefromtarkov/wiki/Debut');
   });
   it('preserves path and query when rewriting', () => {
     expect(
       rewriteWikiUrl('https://escapefromtarkov.fandom.com/wiki/Special:Search?query=Bitcoin', true)
-    ).toBe('https://escapefromtarkov.antifandom.com/wiki/Special:Search?query=Bitcoin');
+    ).toBe('https://antifandom.com/escapefromtarkov/wiki/Special:Search?query=Bitcoin');
   });
-  it('rewrites a bare fandom.com host', () => {
+  it('leaves a bare fandom.com host unchanged', () => {
     expect(rewriteWikiUrl('https://fandom.com/wiki/Test', true)).toBe(
-      'https://antifandom.com/wiki/Test'
+      'https://fandom.com/wiki/Test'
     );
   });
   it('leaves non-fandom hosts untouched', () => {

--- a/app/utils/__tests__/wikiLink.test.ts
+++ b/app/utils/__tests__/wikiLink.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { rewriteWikiUrl } from '@/utils/wikiLink';
+describe('rewriteWikiUrl', () => {
+  const url = 'https://escapefromtarkov.fandom.com/wiki/Debut';
+  it('returns the original url when the preference is disabled', () => {
+    expect(rewriteWikiUrl(url, false)).toBe(url);
+  });
+  it('swaps the fandom.com host for antifandom.com when enabled', () => {
+    expect(rewriteWikiUrl(url, true)).toBe('https://escapefromtarkov.antifandom.com/wiki/Debut');
+  });
+  it('preserves path and query when rewriting', () => {
+    expect(
+      rewriteWikiUrl('https://escapefromtarkov.fandom.com/wiki/Special:Search?query=Bitcoin', true)
+    ).toBe('https://escapefromtarkov.antifandom.com/wiki/Special:Search?query=Bitcoin');
+  });
+  it('rewrites a bare fandom.com host', () => {
+    expect(rewriteWikiUrl('https://fandom.com/wiki/Test', true)).toBe(
+      'https://antifandom.com/wiki/Test'
+    );
+  });
+  it('leaves non-fandom hosts untouched', () => {
+    expect(rewriteWikiUrl('https://tarkov.dev/task/123', true)).toBe('https://tarkov.dev/task/123');
+    expect(rewriteWikiUrl('https://notreallyfandom.com/wiki/X', true)).toBe(
+      'https://notreallyfandom.com/wiki/X'
+    );
+  });
+  it('preserves nullish and unparseable input', () => {
+    expect(rewriteWikiUrl(null, true)).toBeNull();
+    expect(rewriteWikiUrl(undefined, true)).toBeUndefined();
+    expect(rewriteWikiUrl('', true)).toBe('');
+    expect(rewriteWikiUrl('not a url', true)).toBe('not a url');
+  });
+});

--- a/app/utils/wikiLink.ts
+++ b/app/utils/wikiLink.ts
@@ -1,16 +1,20 @@
 /**
- * Wiki link host rewriting - swaps fandom.com wiki URLs to the ad-light
+ * Wiki link rewriting - rewrites fandom.com wiki URLs to the ad-light
  * antifandom.com mirror when the user opts in via preferences.
  */
 const FANDOM_HOST_SUFFIX = '.fandom.com';
-const FANDOM_HOST = 'fandom.com';
+const ANTIFANDOM_HOST = 'antifandom.com';
 /**
  * Rewrite a fandom.com wiki URL to its antifandom.com equivalent.
  *
- * Only the host is swapped (`<sub>.fandom.com` -> `<sub>.antifandom.com`), so
- * the path and query are preserved. Non-fandom URLs (e.g. tarkov.dev) and
- * unparseable values are returned untouched. The rewrite is purely for
- * display/navigation; raw `wikiLink` data used for matching is left alone.
+ * antifandom.com serves each wiki under a path prefix, so
+ * `<wiki>.fandom.com/<path>` becomes `antifandom.com/<wiki>/<path>` with the
+ * query and hash preserved. Building this canonical path form directly avoids
+ * the 302 that the `<wiki>.antifandom.com` host form issues - that redirect
+ * also drops the query string, which would break Special:Search links. Bare
+ * `fandom.com`, non-fandom URLs (e.g. tarkov.dev), and unparseable values are
+ * returned untouched. The rewrite is purely for display/navigation; raw
+ * `wikiLink` data used for matching is left alone.
  *
  * @param url - The original wiki URL (or nullish)
  * @param useAntifandom - Whether the antifandom mirror is enabled
@@ -32,12 +36,17 @@ export function rewriteWikiUrl(
   }
   try {
     const parsed = new URL(url);
-    if (parsed.hostname === FANDOM_HOST || parsed.hostname.endsWith(FANDOM_HOST_SUFFIX)) {
-      parsed.hostname = parsed.hostname.replace(/fandom\.com$/, 'antifandom.com');
-      return parsed.toString();
+    if (!parsed.hostname.endsWith(FANDOM_HOST_SUFFIX)) {
+      return url;
     }
+    const wiki = parsed.hostname.slice(0, -FANDOM_HOST_SUFFIX.length);
+    if (!wiki) {
+      return url;
+    }
+    parsed.hostname = ANTIFANDOM_HOST;
+    parsed.pathname = `/${wiki}${parsed.pathname}`;
+    return parsed.toString();
   } catch {
     return url;
   }
-  return url;
 }

--- a/app/utils/wikiLink.ts
+++ b/app/utils/wikiLink.ts
@@ -1,0 +1,43 @@
+/**
+ * Wiki link host rewriting - swaps fandom.com wiki URLs to the ad-light
+ * antifandom.com mirror when the user opts in via preferences.
+ */
+const FANDOM_HOST_SUFFIX = '.fandom.com';
+const FANDOM_HOST = 'fandom.com';
+/**
+ * Rewrite a fandom.com wiki URL to its antifandom.com equivalent.
+ *
+ * Only the host is swapped (`<sub>.fandom.com` -> `<sub>.antifandom.com`), so
+ * the path and query are preserved. Non-fandom URLs (e.g. tarkov.dev) and
+ * unparseable values are returned untouched. The rewrite is purely for
+ * display/navigation; raw `wikiLink` data used for matching is left alone.
+ *
+ * @param url - The original wiki URL (or nullish)
+ * @param useAntifandom - Whether the antifandom mirror is enabled
+ * @returns The possibly-rewritten URL, preserving nullish input
+ */
+export function rewriteWikiUrl(url: string, useAntifandom: boolean): string;
+export function rewriteWikiUrl(url: string | undefined, useAntifandom: boolean): string | undefined;
+export function rewriteWikiUrl(url: string | null, useAntifandom: boolean): string | null;
+export function rewriteWikiUrl(
+  url: string | null | undefined,
+  useAntifandom: boolean
+): string | null | undefined;
+export function rewriteWikiUrl(
+  url: string | null | undefined,
+  useAntifandom: boolean
+): string | null | undefined {
+  if (!url || !useAntifandom) {
+    return url;
+  }
+  try {
+    const parsed = new URL(url);
+    if (parsed.hostname === FANDOM_HOST || parsed.hostname.endsWith(FANDOM_HOST_SUFFIX)) {
+      parsed.hostname = parsed.hostname.replace(/fandom\.com$/, 'antifandom.com');
+      return parsed.toString();
+    }
+  } catch {
+    return url;
+  }
+  return url;
+}


### PR DESCRIPTION
## **User description**
## Summary

Added option in settings to toggle links used with antifandom.com, more lightweight and cleaner than fandom  (ram usage ~1/2 than official fandom site) 

## Changes

Adds an opt-in setting to open wiki links on **antifandom.com** (Fandom's ad-light mirror) instead of **fandom.com**, applied everywhere the app links to the EFT wiki.

- New **Wiki Links** card in Settings -> Preferences with a **Use antifandom.com** toggle (off by default, persisted).
- A small util + composable rewrite only the host (`<sub>.fandom.com` -> `<sub>.antifandom.com`); path/query are preserved and non-fandom URLs pass through untouched.
- Applied at display/click time across all wiki links: tasks, items, hideout, maps, storyline, and prestige — so links update live when the toggle changes.

Validated locally: typecheck, lint (0 warnings), and tests pass.

## Type of Change

<!-- Mark the relevant option(s) with an 'x' -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing feature)
- [ ] Refactoring (code restructuring without changing functionality)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Area(s) Affected

<!-- Mark all that apply with an 'x' -->

- [x] Frontend (UI/UX)
- [ ] Backend (Supabase/Nitro/Workers)
- [x] Tasks/Quests
- [ ] Team Features
- [x] Hideout
- [x] Maps
- [ ] Traders
- [ ] API
- [x] i18n/Translations
- [x] Other: Settings/Preferences

## Related Issues

None

## Testing

- [x] Tested locally
- [x] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. `npm run test`, `npm run typecheck`, and `npm run lint` all pass (incl. new `wikiLink.test.ts`).
2. Settings -> Preferences -> "Wiki Links" -> enable "Use antifandom.com"; reload and confirm it persists.
3. With it on, wiki links across tasks, hideout, maps, storyline, and prestige open on `antifandom.com`; off, they open on `fandom.com`.


## Screenshots/Videos
antifandom:
<img width="259" height="265" alt="image" src="https://github.com/user-attachments/assets/68642bd2-b799-4348-b581-da1143faf6a5" />
fandom.com:
<img width="253" height="264" alt="image" src="https://github.com/user-attachments/assets/f7a30362-6589-4e2b-a36f-45744e63b34e" />


https://github.com/user-attachments/assets/8dfe1275-e2d4-4494-84fa-b5240f277f40



## Checklist

<!-- Mark completed items with an 'x' -->

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated relevant documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

<!-- Any additional information reviewers should know -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an “Antifandom” option to rewrite wiki links to the Antifandom mirror.
  * Added an “External Links” settings card to control this option.

* **Improvements**
  * Standardized wiki link generation across the app for consistent navigation.
  * “View on wiki” links and wiki-opening actions now only open when a valid URL is available.

* **Tests**
  * Added unit tests for wiki URL rewriting behavior.
  * Updated settings page tests to include the new External Links card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add an antifandom.com option for wiki links and use it across the app**

### What Changed
- Added a new settings toggle to open wiki links on antifandom.com instead of fandom.com, with the choice saved in preferences.
- Wiki links now use the antifandom mirror across tasks, items, hideout, maps, storyline, prestige, and accepted-item links.
- Search and other wiki links keep their full path and query string when opened, and non-wiki links are left unchanged.

### Impact
`✅ Less cluttered wiki pages`
`✅ Fewer broken wiki searches`
`✅ Consistent wiki links across tasks, maps, hideout, and storyline`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
