### PR TITLE
fix(api): prevent tasks-core 524s with bounded retry budget and edge SWR

### DIFF
--- a/app/server/utils/__tests__/edgeCache.test.ts
+++ b/app/server/utils/__tests__/edgeCache.test.ts
@@ -65,7 +65,9 @@ describe('edgeCache', () => {
   });
   it('returns cached payload on cache hit', async () => {
     cacheSpy.match.mockResolvedValueOnce(
-      new Response(JSON.stringify({ data: { items: [{ id: 'cached' }] } }))
+      new Response(JSON.stringify({ data: { items: [{ id: 'cached' }] } }), {
+        headers: { 'X-Cache-Stored-At': String(Date.now()) },
+      })
     );
     const fetcher = vi.fn(async () => ({ data: { items: [{ id: 'fresh' }] } }));
     const event = createEvent();
@@ -79,6 +81,60 @@ describe('edgeCache', () => {
     });
     expect(result).toEqual({ data: { items: [{ id: 'cached' }] } });
     expect(fetcher).not.toHaveBeenCalled();
+    expect(cacheSpy.put).not.toHaveBeenCalled();
+  });
+  it('serves a stale entry and refreshes it in the background', async () => {
+    const staleStoredAt = Date.now() - 61_000;
+    cacheSpy.match.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { items: [{ id: 'stale' }] } }), {
+        headers: { 'X-Cache-Stored-At': String(staleStoredAt) },
+      })
+    );
+    const fetcher = vi.fn(async () => ({ data: { items: [{ id: 'fresh' }] } }));
+    const background: Promise<unknown>[] = [];
+    const event = createEvent();
+    (event.context as { cloudflare?: unknown }).cloudflare = {
+      context: { waitUntil: (p: Promise<unknown>) => background.push(p) },
+    };
+    const { edgeCache } = await import('@/server/utils/edgeCache');
+    const result = await edgeCache(event, 'items-en', fetcher, 60, {
+      cacheKeyPrefix: 'tarkov',
+      deps: {
+        createErrorFn,
+        setResponseHeadersFn: setHeaders,
+      },
+    });
+    expect(result).toEqual({ data: { items: [{ id: 'stale' }] } });
+    await Promise.all(background);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(cacheSpy.put).toHaveBeenCalledTimes(1);
+  });
+  it('keeps serving stale data when background revalidation fails', async () => {
+    const staleStoredAt = Date.now() - 61_000;
+    cacheSpy.match.mockResolvedValueOnce(
+      new Response(JSON.stringify({ data: { items: [{ id: 'stale' }] } }), {
+        headers: { 'X-Cache-Stored-At': String(staleStoredAt) },
+      })
+    );
+    const fetcher = vi.fn(async () => {
+      throw new Error('upstream down');
+    });
+    const background: Promise<unknown>[] = [];
+    const event = createEvent();
+    (event.context as { cloudflare?: unknown }).cloudflare = {
+      context: { waitUntil: (p: Promise<unknown>) => background.push(p) },
+    };
+    const { edgeCache } = await import('@/server/utils/edgeCache');
+    const result = await edgeCache(event, 'items-en', fetcher, 60, {
+      cacheKeyPrefix: 'tarkov',
+      deps: {
+        createErrorFn,
+        setResponseHeadersFn: setHeaders,
+      },
+    });
+    expect(result).toEqual({ data: { items: [{ id: 'stale' }] } });
+    await Promise.all(background);
+    expect(fetcher).toHaveBeenCalledTimes(1);
     expect(cacheSpy.put).not.toHaveBeenCalled();
   });
   it('stores fresh payload on cache miss', async () => {

--- a/app/server/utils/__tests__/edgeCache.test.ts
+++ b/app/server/utils/__tests__/edgeCache.test.ts
@@ -105,9 +105,16 @@ describe('edgeCache', () => {
       },
     });
     expect(result).toEqual({ data: { items: [{ id: 'stale' }] } });
+    expect(setHeaders).toHaveBeenCalledWith(
+      event,
+      expect.objectContaining({ 'X-Cache-Status': 'STALE', 'Cache-Control': 'no-cache' })
+    );
     await Promise.all(background);
     expect(fetcher).toHaveBeenCalledTimes(1);
     expect(cacheSpy.put).toHaveBeenCalledTimes(1);
+    const storedResponse = cacheSpy.put.mock.calls[0]?.[1] as Response;
+    expect(await storedResponse.clone().json()).toEqual({ data: { items: [{ id: 'fresh' }] } });
+    expect(storedResponse.headers.get('X-Cache-Stored-At')).toBeTruthy();
   });
   it('keeps serving stale data when background revalidation fails', async () => {
     const staleStoredAt = Date.now() - 61_000;

--- a/app/server/utils/__tests__/tarkov-json.test.ts
+++ b/app/server/utils/__tests__/tarkov-json.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
+  DEFAULT_MAX_RETRIES,
+  DEFAULT_TIMEOUT_MS,
   adaptBootstrapResponse,
   adaptHideoutResponse,
   adaptItemsResponse,
@@ -21,6 +23,17 @@ const createFetcher = (responses: Record<string, unknown>) =>
     if (response === undefined) throw new Error(`Unexpected URL: ${url}`);
     return response;
   }) as unknown as TestJsonFetcher;
+describe('default fetch budget', () => {
+  it('keeps worst-case server time under Cloudflare 100s origin limit', () => {
+    // A localized endpoint does two sequential legs (base, then lang/en).
+    const backoffPerLeg = Array.from({ length: DEFAULT_MAX_RETRIES - 1 }, (_, i) =>
+      Math.min(1000 * 2 ** i, 5000)
+    ).reduce((sum, ms) => sum + ms, 0);
+    const perLegMs = DEFAULT_MAX_RETRIES * DEFAULT_TIMEOUT_MS + backoffPerLeg;
+    const worstCaseMs = perLegMs * 2;
+    expect(worstCaseMs).toBeLessThan(100_000);
+  });
+});
 describe('fetchTarkovJsonEndpoint', () => {
   it('merges English translations into the base response', async () => {
     const fetcher = createFetcher({

--- a/app/server/utils/edgeCache.ts
+++ b/app/server/utils/edgeCache.ts
@@ -14,7 +14,9 @@ const logger = createLogger('EdgeCache');
 type CacheOptions = {
   cacheKeyPrefix?: string;
   deps?: EdgeCacheDependencies;
+  staleTtl?: number;
 };
+type CfExecutionContext = { waitUntil?: (promise: Promise<unknown>) => void } | undefined;
 type OverlayHeadersMeta = {
   status?: string;
   version?: string;
@@ -50,12 +52,14 @@ function setCacheResponseHeaders(
   event: H3Event,
   setHeaders: typeof setResponseHeaders,
   fullCacheKey: string,
-  status: 'BYPASS' | 'DEV' | 'HIT' | 'MISS',
+  status: 'BYPASS' | 'DEV' | 'HIT' | 'MISS' | 'STALE',
   ttl: number,
   overlayMeta: OverlayHeadersMeta | null
 ) {
   const cacheControl =
-    status === 'HIT' || status === 'MISS' ? `public, max-age=${ttl}, s-maxage=${ttl}` : 'no-cache';
+    status === 'HIT' || status === 'MISS' || status === 'STALE'
+      ? `public, max-age=${ttl}, s-maxage=${ttl}`
+      : 'no-cache';
   setHeaders(event, {
     'X-Cache-Status': status,
     'X-Cache-Key': fullCacheKey,
@@ -83,6 +87,54 @@ function resolveAppUrl(deps?: EdgeCacheDependencies): string | undefined {
     return runtimeAppUrl;
   }
   return undefined;
+}
+const inFlightRevalidations = new Set<string>();
+function buildStoredResponse<T>(
+  payload: T,
+  ttl: number,
+  staleTtl: number,
+  fullCacheKey: string
+): Response {
+  return new Response(JSON.stringify(payload), {
+    headers: {
+      'Content-Type': 'application/json',
+      // s-maxage covers the stale window so Cloudflare keeps the entry past ttl
+      // and we can serve it while a background refresh runs.
+      'Cache-Control': `public, max-age=${ttl}, s-maxage=${ttl + staleTtl}`,
+      'X-Cache-Status': 'MISS',
+      'X-Cache-Key': fullCacheKey,
+      'X-Cache-Stored-At': String(Date.now()),
+    },
+  });
+}
+function reviveCacheEntry<T>(params: {
+  cache: CacheLike;
+  cacheKeyRequest: Request;
+  cfContext: CfExecutionContext;
+  fetcher: () => Promise<T>;
+  fullCacheKey: string;
+  staleTtl: number;
+  ttl: number;
+}): void {
+  const { cache, cacheKeyRequest, cfContext, fetcher, fullCacheKey, staleTtl, ttl } = params;
+  if (inFlightRevalidations.has(fullCacheKey)) return;
+  inFlightRevalidations.add(fullCacheKey);
+  const task = (async () => {
+    try {
+      const fresh = await fetcher();
+      await cache.put(cacheKeyRequest, buildStoredResponse(fresh, ttl, staleTtl, fullCacheKey));
+      logger.info(`Background revalidation refreshed ${fullCacheKey}`);
+    } catch (error) {
+      logger.warn(`Background revalidation failed for ${fullCacheKey}; keeping stale entry`, error);
+    } finally {
+      inFlightRevalidations.delete(fullCacheKey);
+    }
+  })();
+  if (cfContext?.waitUntil) {
+    cfContext.waitUntil(task);
+  } else {
+    void task;
+  }
 }
 export function shouldBypassCache(event: H3Event): boolean {
   const config = useRuntimeConfig(event);
@@ -115,7 +167,7 @@ export async function edgeCache<T>(
   ttl = 43200,
   options: CacheOptions = {}
 ): Promise<T> {
-  const { cacheKeyPrefix = 'tarkovtracker', deps } = options;
+  const { cacheKeyPrefix = 'tarkovtracker', deps, staleTtl = ttl } = options;
   const createErrorFn = deps?.createErrorFn ?? createError;
   const setHeaders = deps?.setResponseHeadersFn ?? setResponseHeaders;
   const cache = deps?.cache ?? getCloudflareCacheFromGlobal();
@@ -130,27 +182,37 @@ export async function edgeCache<T>(
         return response;
       }
       const cacheKeyRequest = buildEdgeCacheRequest(cacheKeyPrefix, key, resolveAppUrl(deps));
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const cfContext = (event.context as any).cloudflare?.context as CfExecutionContext;
       const cachedResponse = await cache.match(cacheKeyRequest);
       if (cachedResponse) {
         const data = await cachedResponse.json();
         const overlayMeta = getOverlayHeadersMeta(data);
+        const storedAtRaw = cachedResponse.headers.get('X-Cache-Stored-At');
+        const storedAt = storedAtRaw ? Number(storedAtRaw) : Number.NaN;
+        const isStale = Number.isFinite(storedAt) && Date.now() - storedAt > ttl * 1000;
+        if (isStale) {
+          // Serve stale immediately, refresh in the background. A slow or failing
+          // upstream never blocks the user once a colo has any cached entry.
+          reviveCacheEntry({
+            cache,
+            cacheKeyRequest,
+            cfContext,
+            fetcher,
+            fullCacheKey,
+            staleTtl,
+            ttl,
+          });
+          setCacheResponseHeaders(event, setHeaders, fullCacheKey, 'STALE', ttl, overlayMeta);
+          return data;
+        }
         setCacheResponseHeaders(event, setHeaders, fullCacheKey, 'HIT', ttl, overlayMeta);
         return data;
       }
       logger.info(`Cache miss for ${fullCacheKey}`);
       const response = await fetcher();
       const overlayMeta = getOverlayHeadersMeta(response);
-      const cacheResponse = new Response(JSON.stringify(response), {
-        headers: {
-          'Content-Type': 'application/json',
-          'Cache-Control': `public, max-age=${ttl}, s-maxage=${ttl}`,
-          'X-Cache-Status': 'MISS',
-          'X-Cache-Key': fullCacheKey,
-        },
-      });
-      // Non-blocking cache write if waitUntil available
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cfContext = (event.context as any).cloudflare?.context;
+      const cacheResponse = buildStoredResponse(response, ttl, staleTtl, fullCacheKey);
       if (cfContext?.waitUntil) {
         cfContext.waitUntil(cache.put(cacheKeyRequest, cacheResponse.clone()));
       } else {

--- a/app/server/utils/edgeCache.ts
+++ b/app/server/utils/edgeCache.ts
@@ -17,6 +17,7 @@ type CacheOptions = {
   staleTtl?: number;
 };
 type CfExecutionContext = { waitUntil?: (promise: Promise<unknown>) => void } | undefined;
+type CfRuntimeContext = { cloudflare?: { context?: CfExecutionContext } };
 type OverlayHeadersMeta = {
   status?: string;
   version?: string;
@@ -57,9 +58,7 @@ function setCacheResponseHeaders(
   overlayMeta: OverlayHeadersMeta | null
 ) {
   const cacheControl =
-    status === 'HIT' || status === 'MISS' || status === 'STALE'
-      ? `public, max-age=${ttl}, s-maxage=${ttl}`
-      : 'no-cache';
+    status === 'HIT' || status === 'MISS' ? `public, max-age=${ttl}, s-maxage=${ttl}` : 'no-cache';
   setHeaders(event, {
     'X-Cache-Status': status,
     'X-Cache-Key': fullCacheKey,
@@ -182,8 +181,7 @@ export async function edgeCache<T>(
         return response;
       }
       const cacheKeyRequest = buildEdgeCacheRequest(cacheKeyPrefix, key, resolveAppUrl(deps));
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const cfContext = (event.context as any).cloudflare?.context as CfExecutionContext;
+      const cfContext = (event.context as CfRuntimeContext).cloudflare?.context;
       const cachedResponse = await cache.match(cacheKeyRequest);
       if (cachedResponse) {
         const data = await cachedResponse.json();

--- a/app/server/utils/tarkov-json.ts
+++ b/app/server/utils/tarkov-json.ts
@@ -24,8 +24,12 @@ import type {
 } from '@/types/tarkov';
 const logger = createLogger('TarkovJson');
 const TARKOV_JSON_BASE_URL = 'https://json.tarkov.dev';
-const DEFAULT_TIMEOUT_MS = 30000;
-const DEFAULT_MAX_RETRIES = 3;
+// ponytail: budget kept under Cloudflare's 100s origin limit so a slow upstream
+// fails fast (502 the client retries) instead of a 524. Worst case per route:
+// 2 legs (base + lang/en) x (MAX_RETRIES x TIMEOUT + backoff) + overlay ~= 55s.
+// Pairs with stale-while-revalidate in edgeCache so warm colos never block.
+export const DEFAULT_TIMEOUT_MS = 12000;
+export const DEFAULT_MAX_RETRIES = 2;
 const ENGLISH_LANGUAGE = 'en';
 const PRESTIGE_SOURCE_GAME_MODE = 'regular';
 const MAX_DETAILED_OBJECTIVE_ITEMS = 24;


### PR DESCRIPTION
## **User description**
## Problem

Users (disproportionately outside the US) intermittently get **524 errors** loading tasks data. A captured console log shows:

```
[GET] "/api/tarkov/tasks-core?lang=en&gameMode=regular": 524
[MetadataStore] Error fetching Task core data: FetchError ... 524
```

A 524 is Cloudflare killing the **origin connection at 100s** (non-Enterprise hard limit). The route couldn't return in time, so it could only 524.

## Root cause

Two compounding causes:

1. **Unbounded retry budget.** `tarkov-json` used `DEFAULT_MAX_RETRIES=3` x `DEFAULT_TIMEOUT_MS=30000`. `tasks-core` fetches `tasks`+`maps`+`traders`, and each localized endpoint runs two sequential legs (base, then `_<lang>`/`_en`). Worst case ≈ **190s** — guaranteed to exceed CF's 100s ceiling when `json.tarkov.dev` is even moderately slow.
2. **Per-colo cold cache.** Cloudflare's cache is per-datacenter. High-traffic US colos stay warm; low-traffic colos (EU/CZ) evict the 12h entry and pay the cold fetch **synchronously**. A worker killed at 100s never runs `cache.put`, so the colo stays cold and the next user hits it too — the "random bursts."

Measured `json.tarkov.dev` latency from a server when healthy: **sub-second** for all four files (TTFB ~0.15s, total 0.14–0.47s incl. the 6.7MB maps file). So slow legs are anomalies, not normal latency — failing fast and retrying a fresh connection is correct.

## Changes

- **Bound the upstream fetch budget** to `12s timeout x 2 retries`. Worst case ≈ **55s** (2 legs + overlay), safely under 100s. A slow upstream now fails fast as a **502 the client already retries** (`metadata.client.ts`) instead of a 524.
- **Add stale-while-revalidate to `edgeCache`:** serve a stale entry instantly and refresh in the background via `waitUntil`, with a per-isolate in-flight guard. Background-refresh failures keep the stale entry (never overwrite good data with an error). Entries are stored with `s-maxage = ttl + staleTtl` so Cloudflare retains them through the stale window.
  - A colo now only pays a synchronous cold fetch after **zero traffic for ttl+staleTtl (24h)**. Any colo with active users never blocks again.
  - **Backward-compatible:** pre-existing cache entries without `X-Cache-Stored-At` are treated as fresh until they age out — no thundering herd on deploy.

## Testing

- `npm run typecheck` — pass
- `npm run lint` (changed files) — pass
- `vitest` — 120 tests across server util suites pass, including new coverage:
  - budget regression guard asserting worst-case < 100s
  - SWR: serve-stale + background refresh
  - SWR: keep stale data when background revalidation fails

## Risk / rollback

Server-only change to the tarkov data proxy + edge cache. No schema, auth, or client API changes. Game data only (not user-specific). Revert is a clean single-commit rollback if needed.

## Follow-ups (not in this PR)

- Per-endpoint `staleTtl` tuning (defaults to `ttl`).
- Optional scheduled cache warming for guaranteed-cold colos.


___

## **CodeAnt-AI Description**
**Prevent task data timeouts by serving stale cache entries during refresh**

### What Changed
- Task data requests now stop waiting on a slow upstream once a cached response exists, and users get the cached result immediately while a refresh runs in the background
- If the background refresh fails, the app keeps serving the stale cached data instead of dropping the response
- Fresh cache entries now stay available through the stale window, so low-traffic regions are less likely to hit cold-cache delays
- The upstream fetch budget for task data is reduced so slow responses fail fast instead of running into Cloudflare’s 100-second timeout
- Added checks for stale-cache serving, refresh success, refresh failure, and the new fetch-time budget

### Impact
`✅ Fewer task loading 524 errors`
`✅ Faster task pages in low-traffic regions`
`✅ Fewer user-facing delays during cache refresh`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Stale cached responses can now be served immediately while a refreshed copy is fetched in the background.
  * Response headers now indicate whether data is fresh, a hit, or stale.
* **Bug Fixes**
  * Cache refreshing is handled more reliably, including when background refresh fails (stale data is still returned).
  * Fetch retry/timeout defaults were reduced to better fit Cloudflare origin limits.
* **Tests**
  * Expanded coverage for stale caching, background revalidation success/failure, and the default fetch “budget.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->