### PR TITLE
ci: retry on UNKNOWN merge state in dependabot auto-merge

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -181,12 +181,32 @@ jobs:
         run: |
           set -euo pipefail
 
-          merge_state="$(
-            gh pr view "$PR_NUMBER" \
-              --repo "$GITHUB_REPOSITORY" \
-              --json mergeStateStatus \
-              --jq '.mergeStateStatus'
-          )"
+          # GitHub recomputes mergeability asynchronously, so the status can be
+          # UNKNOWN for a short window right after checks settle. Poll until it
+          # resolves instead of failing on the transient state.
+          merge_state="UNKNOWN"
+          deadline=$((SECONDS + 120))
+
+          while true; do
+            merge_state="$(
+              gh pr view "$PR_NUMBER" \
+                --repo "$GITHUB_REPOSITORY" \
+                --json mergeStateStatus \
+                --jq '.mergeStateStatus'
+            )"
+
+            if [ "$merge_state" != "UNKNOWN" ]; then
+              break
+            fi
+
+            if [ "$SECONDS" -ge "$deadline" ]; then
+              echo "::error::Timed out waiting for merge state to resolve (still UNKNOWN)."
+              exit 1
+            fi
+
+            echo "Merge state is UNKNOWN; waiting for GitHub to recompute mergeability."
+            sleep 10
+          done
 
           case "$merge_state" in
             CLEAN | UNSTABLE)


### PR DESCRIPTION
## **User description**
## Summary

The "Auto-merge safe Dependabot PR" job was failing on otherwise-green Dependabot PRs (e.g. #478) at the **Merge Dependabot PR** step with:

```
##[error]PR merge state is UNKNOWN, not mergeable.
```

GitHub recomputes `mergeStateStatus` asynchronously, so it can briefly return `UNKNOWN` right after the "Wait for checks" loop settles. The merge step read the status once and bailed because `UNKNOWN` is not in the `CLEAN | UNSTABLE` allowlist.

## Change

Poll `mergeStateStatus` for up to 120s (every 10s) until it resolves out of `UNKNOWN` before evaluating mergeability. Real non-mergeable states still fail fast.

## Testing

- YAML validated locally.
- Logic is exercised by the next Dependabot PR that hits the auto-merge path.


___

## **CodeAnt-AI Description**
Wait for Dependabot merge status to settle before auto-merging

### What Changed
- Dependabot auto-merge now waits for GitHub to finish updating mergeability instead of failing when the status is briefly `UNKNOWN`
- If the status stays unresolved for too long, the merge stops with a clear timeout error
- Once resolved, only mergeable states are allowed to continue

### Impact
`✅ Fewer Dependabot auto-merge failures`
`✅ Less manual retrying after green checks`
`✅ Clearer merge failure messages`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Dependabot auto-merge reliability by waiting for merge status to update before deciding whether a pull request can be merged.
  * Reduced cases where eligible updates could be skipped or delayed because status checks were still in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->