### PR TITLE
perf(api): skip kappa overlay polling while hidden

### DIFF
--- a/app/server/routes/overlay/kappa/[userId]/[mode].get.ts
+++ b/app/server/routes/overlay/kappa/[userId]/[mode].get.ts
@@ -1379,6 +1379,14 @@ export default defineEventHandler((event) => {
           return;
         }
 
+        if (document.hidden) {
+          if (timerId) {
+            window.clearTimeout(timerId);
+          }
+          timerId = window.setTimeout(fetchMetrics, CONFIG.intervalMs);
+          return;
+        }
+
         if (abortController) {
           abortController.abort();
         }


### PR DESCRIPTION
## **User description**
## Summary

The kappa OBS overlay (`/overlay/kappa/:userId/:mode`) polls `/api/streamer/:userId/:mode/kappa` every 60s, 24/7. Each poll invokes a Pages Function plus a 3-way server-side fan-out (`/api/profile`, `/api/tarkov/tasks-core`, `/api/tarkov/tasks-objectives`), counting against the Cloudflare 100k/day request budget — even when the OBS browser source is hidden off-scene.

This skips the network fetch while `document.hidden` is true, keeping a lightweight timer alive so the loop never dies. `lastFetchTime` is intentionally left untouched on the skipped tick, so the existing `refreshOnWake` (visibilitychange) handler triggers an immediate fetch the moment the source becomes visible again.

## Why this is lossless

- A hidden overlay is not on screen, so skipping its refresh changes nothing a viewer sees.
- Visible overlays behave exactly as before (same 60s cadence).
- On becoming visible, `refreshOnWake` fetches immediately rather than waiting for the next interval.

## Scope of impact

Savings materialize only for overlays OBS actually marks hidden (off-scene sources, or "shut down source when not visible"). Overlays kept visible 24/7 still poll every 60s — that structural cost is tied to live updates and is out of scope here.

## Testing

- `npm run typecheck` clean on the changed file (LSP diagnostics: no problems).
- Overlay route tests pass: `app/server/routes/overlay/kappa/__tests__/route.test.ts` (3/3).
- Pre-commit hook (prettier + eslint --fix) ran clean.


___

## **CodeAnt-AI Description**
**Skip kappa overlay polling while the source is hidden**

### What Changed
- The kappa OBS overlay no longer sends its periodic refresh request when the browser source is hidden.
- Hidden overlays keep a lightweight timer running, so they resume normal updates immediately when shown again.
- Visible overlays continue to refresh on the same 60-second schedule as before.

### Impact
`✅ Lower API usage for off-scene overlays`
`✅ Fewer wasted background requests`
`✅ Faster refresh after showing the overlay again`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved background behavior by pausing metric updates when the tab is not visible, reducing unnecessary network activity and avoiding interrupted requests.
  * Resumes the normal update cycle automatically when the page becomes visible again.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->