### PR TITLE
fix(config): harden SECURITY DEFINER functions and capture handle_new_user baseline

### DIFF
--- a/supabase/migrations/20260629115000_baseline_handle_new_user_trigger.sql
+++ b/supabase/migrations/20260629115000_baseline_handle_new_user_trigger.sql
@@ -8,12 +8,15 @@
 --
 -- Definitions dumped from the linked project (ref knptqelvsodccnoehmbj) on
 -- 2026-06-29. Idempotent so it is safe to apply against the existing remote.
+-- search_path is pinned to `pg_catalog, public` (the remote definition used
+-- only `public`) to match the hardened helpers and close the role-mutable
+-- search_path vector on this SECURITY DEFINER function.
 
 CREATE OR REPLACE FUNCTION public.handle_new_user()
 RETURNS trigger
 LANGUAGE plpgsql
 SECURITY DEFINER
-SET search_path = public
+SET search_path = pg_catalog, public
 AS $$
 BEGIN
   INSERT INTO public.user_system (user_id)

--- a/supabase/migrations/20260629115000_baseline_handle_new_user_trigger.sql
+++ b/supabase/migrations/20260629115000_baseline_handle_new_user_trigger.sql
@@ -1,0 +1,35 @@
+-- Capture remote-only objects into migration history (drift fix).
+--
+-- `public.handle_new_user()` and the `on_auth_user_created` trigger on
+-- `auth.users` were created directly on the hosted project (via the dashboard),
+-- so they existed on production but in no migration. A fresh `supabase db reset`
+-- therefore did not reproduce new-user provisioning. This migration captures the
+-- exact remote definitions so every environment matches production.
+--
+-- Definitions dumped from the linked project (ref knptqelvsodccnoehmbj) on
+-- 2026-06-29. Idempotent so it is safe to apply against the existing remote.
+
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  INSERT INTO public.user_system (user_id)
+  VALUES (NEW.id)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  INSERT INTO public.user_progress (user_id)
+  VALUES (NEW.id)
+  ON CONFLICT (user_id) DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+ALTER FUNCTION public.handle_new_user() OWNER TO postgres;
+
+CREATE OR REPLACE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION public.handle_new_user();

--- a/supabase/migrations/20260629120000_fix_function_search_path_and_definer_grants.sql
+++ b/supabase/migrations/20260629120000_fix_function_search_path_and_definer_grants.sql
@@ -1,0 +1,55 @@
+-- Address Supabase advisor lints:
+-- - 0011 function_search_path_mutable: pin search_path on the jsonb sanitizer/
+--   merge helpers so lookups can't be hijacked via a role-mutable search_path.
+-- - 0028/0029 *_security_definer_function_executable: these SECURITY DEFINER
+--   functions are only ever invoked by the service role (api-gateway worker,
+--   account-delete edge function) or fired as triggers. Revoke EXECUTE from
+--   PUBLIC/anon/authenticated so they can't be called directly via PostgREST.
+--
+-- Some functions (e.g. handle_new_user) exist only on the hosted project and
+-- are not created by migrations, so every change is guarded by to_regprocedure
+-- and skipped when the target function is absent. This keeps `supabase db reset`
+-- working locally while still hardening the remote database.
+
+DO $$
+DECLARE
+  fn text;
+  pin_path text[] := ARRAY[
+    'public.merge_api_update_history(jsonb, jsonb, integer)',
+    'public.sanitize_user_progress_api_task_updates(jsonb)',
+    'public.sanitize_user_progress_api_update_meta(jsonb)',
+    'public.sanitize_user_progress_api_update_history(jsonb)',
+    'public.sanitize_user_progress_mode_data(jsonb)'
+  ];
+  -- Functions whose EXECUTE must be locked to the service role only.
+  service_only text[] := ARRAY[
+    'public.increment_token_usage(uuid)',
+    'public.update_task_completion(uuid, text, text, boolean, boolean, bigint)',
+    'public.transfer_team_ownership(uuid, uuid, uuid)'
+  ];
+  -- Trigger / internal functions: revoke direct EXECUTE, no service_role grant.
+  -- Triggers still fire because they run as the table owner, not the caller.
+  revoke_only text[] := ARRAY[
+    'public.handle_new_user()',
+    'public.prevent_user_system_admin_mutation()'
+  ];
+BEGIN
+  FOREACH fn IN ARRAY pin_path LOOP
+    IF to_regprocedure(fn) IS NOT NULL THEN
+      EXECUTE format('ALTER FUNCTION %s SET search_path = pg_catalog, public', fn);
+    END IF;
+  END LOOP;
+
+  FOREACH fn IN ARRAY service_only LOOP
+    IF to_regprocedure(fn) IS NOT NULL THEN
+      EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon, authenticated', fn);
+      EXECUTE format('GRANT EXECUTE ON FUNCTION %s TO service_role', fn);
+    END IF;
+  END LOOP;
+
+  FOREACH fn IN ARRAY revoke_only LOOP
+    IF to_regprocedure(fn) IS NOT NULL THEN
+      EXECUTE format('REVOKE EXECUTE ON FUNCTION %s FROM PUBLIC, anon, authenticated', fn);
+    END IF;
+  END LOOP;
+END $$;


### PR DESCRIPTION
## **User description**
## Summary

Resolves Supabase database advisor lints (0011, 0028, 0029) and fixes migration drift discovered while validating the fix.

### Hardening (`20260629120000`)
- **0011 function_search_path_mutable:** pin `search_path = pg_catalog, public` on the 5 jsonb sanitizer/merge helpers.
- **0028/0029 security_definer_function_executable:** revoke `EXECUTE` from `PUBLIC, anon, authenticated` on the SECURITY DEFINER functions, re-granting only `service_role` for the callable ones (`increment_token_usage`, `update_task_completion`, `transfer_team_ownership`). `handle_new_user` and `prevent_user_system_admin_mutation` are trigger functions — revoking direct EXECUTE does not affect trigger firing.
- All statements guarded by `to_regprocedure(...)` so the migration is a safe no-op when a function is absent in a given environment.

### Drift fix (`20260629115000`)
While testing, a fresh `supabase db reset` revealed `public.handle_new_user()` and the `on_auth_user_created` trigger on `auth.users` existed **only on the hosted project** (created via the dashboard), in no migration. This baseline migration captures the exact remote definitions (dumped from the linked project) so every environment reproduces production. Idempotent (`CREATE OR REPLACE`), safe against the existing remote.

## Verification
Tested on a full local stack (`supabase db reset`):
- All 5 helpers show `search_path=pg_catalog, public`.
- `anon`/`authenticated` removed from all locked functions; `service_role` retained.
- Admin-escalation trigger still blocks a user setting `is_admin=true`.
- `service_role` can still run `update_task_completion`; `anon` is denied on the locked RPCs.
- New-user signup trigger provisions `user_system` + `user_progress`.
- `archive_prestige_run_and_reset_progress` (only frontend RPC) keeps its `authenticated` grant — untouched.
- Repo CI check `npm run supabase:check` passes (reset + lint, no schema errors).

## Notes
- Only callers of the locked RPCs are the api-gateway worker and `account-delete` edge function, both using the service-role key — confirmed in source.
- Migration history was otherwise in sync; no squash performed (append-only ledger).


___

## **CodeAnt-AI Description**
**Reproduce new-user provisioning and lock down sensitive database functions**

### What Changed
- Restores the missing sign-up trigger so new users again get entries created in `user_system` and `user_progress`
- Keeps the trigger definition in migration history, so a fresh database reset matches production
- Removes direct access to sensitive `SECURITY DEFINER` functions for public users and signed-in users, while keeping approved server-side access where needed
- Pins database lookup paths for helper functions so they use the expected tables and cannot be redirected by a changed user search path

### Impact
`✅ New sign-ups create the expected user records`
`✅ Fewer local reset vs. production mismatches`
`✅ Reduced risk of unauthorized direct calls to sensitive database actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - New user accounts are now provisioned automatically, ensuring supporting profile and progress records are created promptly.

- **Bug Fixes**
  - Account setup is now resilient if related records already exist, preventing duplicate-related failures.
  - Improved reliability of backend user provisioning logic.

- **Security / Access Improvements**
  - Hardened database function execution and permissions to reduce accidental or unintended access to sensitive operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->