### PR TITLE
fix(config): add deny-all RLS policy on mutation_rate_limits

### DIFF
--- a/supabase/migrations/20260630120000_mutation_rate_limits_deny_all_policy.sql
+++ b/supabase/migrations/20260630120000_mutation_rate_limits_deny_all_policy.sql
@@ -1,0 +1,19 @@
+-- Address Supabase advisor lint 0008 rls_enabled_no_policy.
+--
+-- public.mutation_rate_limits has RLS enabled but no policies, which already
+-- means deny-all for anon/authenticated (and their grants are revoked). Only
+-- service_role touches it, via the SECURITY DEFINER consume_mutation_rate_limit
+-- function, and service_role bypasses RLS. The table is intentionally not
+-- client-accessible.
+--
+-- Add an explicit deny-all policy so the "RLS enabled, no policy" lint clears.
+-- This documents intent and changes no behavior: the policy never grants access,
+-- service_role still bypasses RLS, and anon/authenticated remain locked out.
+
+DROP POLICY IF EXISTS "No direct access" ON public.mutation_rate_limits;
+CREATE POLICY "No direct access"
+  ON public.mutation_rate_limits
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);


### PR DESCRIPTION
## **User description**
## Summary

Resolves Supabase advisor lint 0008 `rls_enabled_no_policy` on `public.mutation_rate_limits`.

The table has RLS enabled but no policies — already deny-all for `anon`/`authenticated` (whose grants are revoked). Only `service_role` touches it via the `SECURITY DEFINER` `consume_mutation_rate_limit` function, and service_role bypasses RLS. Adding an explicit deny-all policy clears the lint and documents intent without changing behavior.

## Verification
Local stack (`supabase db reset`):
- Policy `No direct access` present on the table.
- `anon` denied on the table.
- `service_role` can still run `consume_mutation_rate_limit` (returns allowed/remaining/reset).
- `npm run supabase:check` passes (reset + lint, no schema errors).


___

## **CodeAnt-AI Description**
**Document that mutation rate limits are off-limits to direct access**

### What Changed
- Added an explicit deny-all rule to the mutation rate limits table so direct client access is clearly blocked
- Kept existing behavior the same: anonymous and signed-in users still cannot read or change these limits
- Service-side mutation handling continues to work as before

### Impact
`✅ Clearer access restrictions`
`✅ Fewer accidental direct writes`
`✅ No change to rate-limit enforcement`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Tightened access controls on rate-limit data for signed-out and signed-in users.
  * Added an explicit deny-all rule to prevent direct reads or writes, while preserving existing backend access behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->