### PR TITLE
perf(config): optimize supporters and stripe_events RLS policies

### DIFF
--- a/supabase/migrations/20260630130000_optimize_supporters_stripe_events_rls.sql
+++ b/supabase/migrations/20260630130000_optimize_supporters_stripe_events_rls.sql
@@ -1,0 +1,30 @@
+-- Address Supabase performance advisories on supporters and stripe_events RLS:
+-- - 0003 auth_rls_initplan: wrap auth.<fn>() in (select ...) so it is evaluated
+--   once per query (initplan) instead of once per row.
+-- - 0006 multiple_permissive_policies: the "Service role full access" policies
+--   were FOR ALL with no role target, so they applied to anon/authenticated too
+--   and stacked as a second permissive SELECT policy. service_role bypasses RLS
+--   entirely, so scoping these policies TO service_role removes the redundant
+--   overlap without changing access (service_role access is unaffected).
+
+-- supporters
+DROP POLICY IF EXISTS "Users can view own supporter row" ON public.supporters;
+CREATE POLICY "Users can view own supporter row" ON public.supporters
+  FOR SELECT
+  TO authenticated
+  USING ((select auth.uid()) = user_id);
+
+DROP POLICY IF EXISTS "Service role full access" ON public.supporters;
+CREATE POLICY "Service role full access" ON public.supporters
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+-- stripe_events
+DROP POLICY IF EXISTS "Service role full access" ON public.stripe_events;
+CREATE POLICY "Service role full access" ON public.stripe_events
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);


### PR DESCRIPTION
## **User description**
## Summary

Resolves Supabase performance advisories on `public.supporters` and `public.stripe_events`.

### 0003 auth_rls_initplan
`auth.uid()` / `auth.role()` called bare in policy `USING` clauses re-evaluate per row. Wrapped in `(select ...)` so they evaluate once per query (initplan), matching the established pattern in `20251130112639_cleanup_rls_and_indexes.sql`.

### 0006 multiple_permissive_policies (supporters)
The `Service role full access` policies were `FOR ALL` with no role target, so they applied to `anon`/`authenticated` too and stacked as a second permissive SELECT policy alongside `Users can view own supporter row`. Since `service_role` bypasses RLS entirely, scoping these policies `TO service_role` removes the redundant overlap without changing any access.

## Verification
Local stack (`supabase db reset`):
- `supporters`: 1 SELECT policy (`authenticated`) + 1 ALL policy (`service_role`) — no more anon/authenticated overlap.
- `stripe_events`: 1 ALL policy (`service_role`).
- Authenticated user sees only their own supporter row; service_role sees all rows.
- `npm run supabase:check` passes (reset + lint, no schema errors).

## Not addressed (intentional)
The INFO-level `unused_index` findings are left in place. Several back real query paths that show zero scans only because the tables/workers are young or low-traffic:
- `idx_account_deletion_jobs_next_run`/`_status` back the deletion-reconcile worker's `ORDER BY next_run_at` polling.
- `idx_supporters_status` and the stripe lookup indexes back the webhook.
- `idx_api_tokens_active` is a partial index for active-token lookups.

Dropping them now would trade a harmless INFO lint for latency risk under load. Better to re-evaluate after the tables have meaningful traffic.


___

## **CodeAnt-AI Description**
**Reduce RLS policy overhead on supporters and Stripe events**

### What Changed
- Supporter rows now check the signed-in user once per request instead of repeating the check for every row
- Service-role access for supporters and Stripe events is limited to the service role only, removing overlapping policies for regular users
- Existing access stays the same: signed-in users can still view their own supporter row, and service-role access remains unrestricted

### Impact
`✅ Faster supporter lookups`
`✅ Fewer policy conflicts for regular users`
`✅ Lower database overhead on Stripe event access`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved access controls for supporter and payment event records.
  * Users can now only view their own supporter information, while elevated access is limited to the appropriate trusted role.
  * Payment event records are also restricted to trusted system access only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->