### PR TITLE
perf(config): drop unused idx_api_tokens_active index

### DIFF
--- a/supabase/migrations/20260630140000_drop_unused_api_tokens_active_index.sql
+++ b/supabase/migrations/20260630140000_drop_unused_api_tokens_active_index.sql
@@ -3,8 +3,9 @@
 -- idx_api_tokens_active is a partial index on (is_active, expires_at)
 -- WHERE is_active = TRUE, built to optimize "active, non-expired" lookups.
 -- No query issues that shape: the API gateway fetches tokens by token_hash
--- (idx_api_tokens_token_hash) and checks is_active/expires_at in application
--- code, while create/revoke/delete use the primary key, user_id, or token_hash.
+-- (api_tokens_token_hash_key unique constraint) and checks is_active/expires_at
+-- in application code, while create/revoke/delete use the primary key, user_id,
+-- or token_hash.
 -- The index backs no query path, so it only adds write overhead. Safe to drop;
 -- recreate from history if a future feature filters tokens by active/expiry.
 

--- a/supabase/migrations/20260630140000_drop_unused_api_tokens_active_index.sql
+++ b/supabase/migrations/20260630140000_drop_unused_api_tokens_active_index.sql
@@ -1,0 +1,11 @@
+-- Address Supabase advisor lint 0005 unused_index on public.api_tokens.
+--
+-- idx_api_tokens_active is a partial index on (is_active, expires_at)
+-- WHERE is_active = TRUE, built to optimize "active, non-expired" lookups.
+-- No query issues that shape: the API gateway fetches tokens by token_hash
+-- (idx_api_tokens_token_hash) and checks is_active/expires_at in application
+-- code, while create/revoke/delete use the primary key, user_id, or token_hash.
+-- The index backs no query path, so it only adds write overhead. Safe to drop;
+-- recreate from history if a future feature filters tokens by active/expiry.
+
+DROP INDEX IF EXISTS public.idx_api_tokens_active;


### PR DESCRIPTION
## **User description**
## Summary

Resolves Supabase advisor lint 0005 `unused_index` on `public.api_tokens`.

`idx_api_tokens_active` is a partial index on `(is_active, expires_at) WHERE is_active = TRUE`, built to optimize "active, non-expired token" lookups. After tracing every `api_tokens` query in the codebase, nothing issues that query shape:

- API gateway auth fetches by `token_hash` (unique index) and checks `is_active`/`expires_at` in application code.
- Create uses `INSERT`; revoke/delete use `token_id` (PK) / `user_id`.
- Account deletion and the user token list filter by `user_id` (`idx_api_tokens_user_id`).

The index backs no query path, so it only adds write overhead. Dropping is reversible — the original `CREATE INDEX` lives in migration history if a future feature filters tokens by active/expiry.

## Verification
Local stack (`supabase db reset`):
- `idx_api_tokens_active` removed; `api_tokens_pkey`, `api_tokens_token_hash_key`, `idx_api_tokens_user_id` intact (the indexes real queries use).
- `npm run supabase:check` passes (reset + lint, no schema errors).

## Note
This is independent of any future token-expiry UI feature: the gateway already enforces `expires_at` (returns 401 on expired tokens) via a single-row hash lookup, so even with user-set expiry this index would remain unused.


___

## **CodeAnt-AI Description**
Remove an unused token index that was adding write overhead

### What Changed
- Removed the unused `api_tokens` index that was not used by any token lookup or token management flow
- Kept token sign-in checks working the same: tokens are still found by token hash, and active/expiry checks still happen during authentication
- Left the existing token list, revoke, delete, and create behavior unchanged

### Impact
`✅ Fewer writes during token changes`
`✅ Lower database overhead for token updates`
`✅ Cleaner database schema checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed an unused database index to reduce maintenance overhead and keep the system leaner.
  * No changes to token lookup behavior or app functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->