### PR TITLE
test: silence Vue Suspense experimental warning in test output

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -481,10 +481,6 @@ export default defineNuxtConfig({
         'pinia-plugin-persistedstate',
       ],
     },
-    define: {
-      // Suppress Suspense experimental feature warning
-      __VUE_PROD_SUSPENSE__: 'false',
-    },
     vue: {
       // Forwarded to @vitejs/plugin-vue
       template: {

--- a/tests/test-setup.ts
+++ b/tests/test-setup.ts
@@ -2,6 +2,19 @@ import { enableAutoUnmount } from '@vue/test-utils';
 import 'fake-indexeddb/auto';
 import { afterAll, afterEach, vi } from 'vitest';
 
+// ponytail: Vue hardcodes this experimental-Suspense notice (console.info, gated only on
+// non-prod) and Vitest's isolated forked workers reload Vue per file, so it spams every run.
+// Drop just that one line; pass everything else through.
+for (const method of ['info', 'log'] as const) {
+  const original = console[method].bind(console);
+  console[method] = (...args: unknown[]) => {
+    if (typeof args[0] === 'string' && args[0].includes('<Suspense> is an experimental feature')) {
+      return;
+    }
+    original(...args);
+  };
+}
+
 type FetchInput = string | Request | URL;
 type MockFetchResponse =
   | { data: { playerLevels: unknown[] } }


### PR DESCRIPTION
## **User description**
## Summary

The `<Suspense> is an experimental feature and its API will likely change.` message was logging repeatedly across the test suite (and showing up in other runs), which was noisy.

### Root cause
The message is hardcoded in `@vue/runtime-core`'s `createSuspenseBoundary`, gated only on `NODE_ENV !== "production"` and printed via `console.info`/`console.log`. It fires once per Vue module instance. Vitest runs isolated forked workers and reloads Vue per test file, so the one-shot guard resets and it printed for every file that mounts a Suspense boundary.

The pre-existing `__VUE_PROD_SUSPENSE__: 'false'` define in `nuxt.config.ts` never affected this — that flag only tree-shakes Suspense from production builds, and setting it to `false` is actually risky since Nuxt wraps pages in `<Suspense>`.

### Changes
- `tests/test-setup.ts`: wrap `console.info`/`console.log` to drop only that one line; everything else passes through.
- `nuxt.config.ts`: remove the ineffective/risky `__VUE_PROD_SUSPENSE__: 'false'` define block.

### Testing
- Full suite: 200 files / 1911 tests pass, zero Suspense warnings.
- `npm run typecheck`: clean.
- `npm run lint`: clean (0 warnings).


___

## **CodeAnt-AI Description**
Silence the Vue Suspense warning in test runs

### What Changed
- Test runs no longer print the repeated `<Suspense> is an experimental feature` warning
- Only that specific Suspense message is hidden; other console output still shows normally
- Removed the unused Nuxt setting that was meant to suppress the warning but did not affect test output

### Impact
`✅ Cleaner test output`
`✅ Fewer noisy logs during local and CI runs`
`✅ Easier to spot real warnings in test output`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary warning output related to experimental Vue Suspense messages in non-production environments.
  * Kept normal logging behavior unchanged for other console messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->