### PR TITLE
perf(config): drop unused supporters and game_mode indexes

### DIFF
--- a/supabase/migrations/20260630150000_drop_unused_indexes.sql
+++ b/supabase/migrations/20260630150000_drop_unused_indexes.sql
@@ -1,0 +1,21 @@
+-- Address Supabase advisor lint 0005 unused_index on several public tables.
+--
+-- idx_supporters_stripe_subscription duplicates uniq_supporters_stripe_subscription
+-- (UNIQUE partial index on the same column from 20260522210000); every
+-- stripe_subscription_id lookup uses the unique index, so the plain b-tree is
+-- redundant write overhead.
+--
+-- idx_supporters_status, idx_teams_game_mode, and idx_team_memberships_game_mode
+-- index low-cardinality CHECK-constrained columns ('active'/'past_due'/... and
+-- 'pvp'/'pve'). Queries always pair game_mode/status with a selective column, so
+-- the planner never chooses these 2-4 value indexes.
+--
+-- The account_deletion_jobs indexes are intentionally left in place: the reconcile
+-- job filters by status and orders by next_run_at, so they back a real query path.
+--
+-- All safe to drop; recreate from history if access patterns change.
+
+DROP INDEX IF EXISTS public.idx_supporters_stripe_subscription;
+DROP INDEX IF EXISTS public.idx_supporters_status;
+DROP INDEX IF EXISTS public.idx_teams_game_mode;
+DROP INDEX IF EXISTS public.idx_team_memberships_game_mode;


### PR DESCRIPTION
## **User description**
## Summary

Drops four indexes flagged by Supabase advisor lint 0005 (unused_index) that no query path uses:

- \`idx_supporters_stripe_subscription\` — duplicate of \`uniq_supporters_stripe_subscription\` (UNIQUE partial index on the same column); every \`stripe_subscription_id\` lookup uses the unique index.
- \`idx_supporters_status\` — low-cardinality CHECK column (active/past_due/expired/cancelled); planner never picks it.
- \`idx_teams_game_mode\` / \`idx_team_memberships_game_mode\` — 2-value CHECK column (pvp/pve); queries always pair it with a selective column.

Kept the \`account_deletion_jobs\` indexes: the reconcile job filters by \`status\` and orders by \`next_run_at\`, so they back a real query path.

## Tested

- \`npm run supabase:check\` — migration applies cleanly, no schema lint errors.

All drops use \`IF EXISTS\` and are recreatable from history if access patterns change.


___

## **CodeAnt-AI Description**
**Remove unused database indexes**

### What Changed
- Removed four indexes that were not used by queries: one duplicate on supporter subscription IDs, one on supporter status, and two on game mode fields
- Left the account deletion job indexes in place because they still support an active query path
- Reduces unnecessary index maintenance when records are created or updated

### Impact
`✅ Lower write overhead for supporter and team updates`
`✅ Fewer unused indexes to maintain`
`✅ Safer database cleanup without affecting active queries`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed several unused database indexes to reduce overhead and keep the system lean.
  * Kept the remaining indexes that still support active query patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->