### PR TITLE
fix(config): reconcile production schema drift into migrations

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -69,6 +69,67 @@ Set these in Supabase Dashboard → Project Settings → Edge Functions:
 5. If the tarkov.dev profile cleanup migration shipped, note that old manual backups may still
    contain historic imported profile snapshots until users regenerate them.
 
+## Known Benign Database Signals
+
+These show up in Supabase logs / query performance and are expected. Do not treat as incidents.
+
+1. `database "supabase_admin" does not exist` (SQLSTATE `3D000`, FATAL)
+   - Source: Supabase platform-internal process on the DB host. The log event shows
+     `parsed.connection_from: ::1` (loopback), `parsed.user_name: supabase_admin`,
+     `parsed.command_tag: startup`. A local health/liveness probe authenticates as the
+     `supabase_admin` role without specifying a database, so libpq defaults the db name to the
+     role name, which doesn't exist.
+   - Not us: no repo, edge function, CI, or app connection uses the `supabase_admin` Postgres
+     role (app + functions use `@supabase/supabase-js` over HTTPS). Not fixable from our account.
+   - Handling: suppress in log views / drains by excluding `sql_state_code = '3D000'` with
+     `user_name = 'supabase_admin'`. Safe because our app never connects as `supabase_admin`.
+
+2. `realtime.list_changes(...)` as the top query by total time (role `supabase_admin`)
+   - Source: Supabase Realtime's continuous WAL poller. Tops the chart by call volume, not
+     latency (low mean time, ~99.9999% cache hit). Expected for an always-on poller.
+   - Health checks: replication slots are `active`/`streaming` with `0 GB` lag, and the
+     `supabase_realtime` publication is narrowly scoped to `public.user_progress` only (not
+     `FOR ALL TABLES`). This is the desired configuration.
+   - Watch for: occasional high max-time correlates with an inactive/lagging replication slot.
+     Verify with `supabase inspect db replication-slots --linked` (lag should stay ~0).
+
+3. Duplicate realtime-enable migrations (benign)
+   - `20251205120619_enable_realtime_user_progress.sql` plus `_dup_1` (`20251205171031`) and
+     `_dup_2` (`20251205171557`) all run the same idempotent
+     `ALTER PUBLICATION supabase_realtime ADD TABLE public.user_progress` (guarded by a
+     `WHERE pubname...` existence check). Already applied to production; do not delete (would
+     desync migration history). Avoid this duplicate-add pattern in future migrations.
+
+## Database Migrations
+
+- **Migrations are the source of truth. Do not change the production schema directly** via the
+  Supabase dashboard / SQL editor. Direct edits cause drift: a fresh environment built from
+  migrations no longer matches production, and the next `db push` can fail or apply destructive
+  changes. Always write a migration and let CI apply it.
+- Verify migrations reproduce prod: `supabase db reset --local`, then dump both and compare
+  (`supabase db dump --local` vs `--linked`). Catalog-level checks (columns, constraints,
+  indexes, grants, policies, functions, triggers via `information_schema` / `pg_catalog`) are
+  more reliable than dump text, which differs by harmless column/statement ordering.
+- Platform-managed extensions (`pg_graphql`, `pg_net`) differ between the local stack and prod;
+  migrations do not control these and the difference is expected.
+
+### Reconcile migration `20260630075121_reconcile_prod_schema_drift`
+
+- Captures schema changes that were previously made directly in the dashboard (teams
+  `members`/`max_members`/`updated_at`/nullable `join_code`; team_events PK `event_id`→`id`;
+  team_memberships composite PK; user_system `api_tokens`/`created_at` + grants; supporters
+  defaults; `hypopg`/`index_advisor` extensions).
+- **Already applied to production by hand.** This migration is destructive if executed against
+  prod (drops/recreates PKs and columns). It must be marked applied in prod history via
+  `supabase migration repair --status applied 20260630075121`, NOT run via `db push`. It only
+  executes on fresh/local builds so they reproduce prod.
+
+### CLI note
+
+- `supabase db diff` / `db pull` (shadow-DB based) fail in some CLI builds with
+  `unknown flag: --mode`. `db dump`, `db query`, `db reset`, and `migration` work. The bundled
+  Go binary (`supabase-go`) can run `db diff` when the wrapper cannot.
+
 ## Incident Triage
 
 1. Check Cloudflare Pages / Workers deployment logs for failed builds, missing variables, or failed Git sync.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -127,8 +127,8 @@ These show up in Supabase logs / query performance and are expected. Do not trea
 ### CLI note
 
 - `supabase db diff` / `db pull` (shadow-DB based) fail in some CLI builds with
-  `unknown flag: --mode`. `db dump`, `db query`, `db reset`, and `migration` work. The bundled
-  Go binary (`supabase-go`) can run `db diff` when the wrapper cannot.
+  `unknown flag: --mode`. `db dump`, `db query`, `db reset`, and `migration` work. The 2.101
+  Go binary (`supabase-2.101` in `~/.local/bin`) can run `db diff` when the 2.108 wrapper cannot.
 
 ## Incident Triage
 

--- a/supabase/migrations/20260630075121_reconcile_prod_schema_drift.sql
+++ b/supabase/migrations/20260630075121_reconcile_prod_schema_drift.sql
@@ -1,0 +1,99 @@
+-- Reconcile production schema drift: production was modified directly (dashboard/SQL
+-- editor) without matching migrations. This migration brings the migration-defined
+-- schema in line with the live production schema so a fresh build reproduces prod.
+
+create extension if not exists "hypopg" with schema "extensions";
+
+create extension if not exists "index_advisor" with schema "extensions";
+
+alter table "public"."team_memberships" drop constraint "team_memberships_team_id_user_id_key";
+
+alter table "public"."team_events" drop constraint "team_events_initiated_by_fkey";
+
+alter table "public"."user_system" drop constraint "user_system_team_id_fkey";
+
+alter table "public"."team_events" drop constraint "team_events_pkey";
+
+alter table "public"."team_memberships" drop constraint "team_memberships_pkey";
+
+drop index if exists "public"."team_memberships_team_id_user_id_key";
+
+drop index if exists "public"."uniq_supporters_stripe_customer";
+
+drop index if exists "public"."uniq_supporters_stripe_subscription";
+
+drop index if exists "public"."idx_team_events_cooldown";
+
+drop index if exists "public"."team_events_pkey";
+
+drop index if exists "public"."team_memberships_pkey";
+
+alter table "public"."supporters" alter column "has_ever_supported" set default true;
+
+alter table "public"."supporters" alter column "type" drop default;
+
+alter table "public"."team_events" drop column "event_id";
+
+alter table "public"."team_events" add column "id" uuid not null default gen_random_uuid();
+
+alter table "public"."team_events" alter column "event_type" set data type text using "event_type"::text;
+
+alter table "public"."team_events" alter column "initiated_by" drop not null;
+
+alter table "public"."team_events" alter column "team_id" drop not null;
+
+alter table "public"."team_memberships" drop column "id";
+
+alter table "public"."team_memberships" alter column "team_id" set not null;
+
+alter table "public"."team_memberships" alter column "user_id" set not null;
+
+alter table "public"."teams" add column "max_members" integer default 5;
+
+alter table "public"."teams" add column "members" jsonb default '[]'::jsonb;
+
+alter table "public"."teams" add column "updated_at" timestamp with time zone default now();
+
+alter table "public"."teams" alter column "join_code" drop not null;
+
+alter table "public"."user_preferences" alter column "map_pan_speed" drop not null;
+
+alter table "public"."user_system" add column "api_tokens" text[] default '{}'::text[];
+
+alter table "public"."user_system" add column "created_at" timestamp with time zone default now();
+
+CREATE INDEX team_events_target_user_idx ON public.team_events USING btree (target_user);
+
+CREATE UNIQUE INDEX teams_name_unique_idx ON public.teams USING btree (name);
+
+CREATE INDEX idx_team_events_cooldown ON public.team_events USING btree (team_id, event_type, initiated_by, created_at) WHERE (event_type = ANY (ARRAY['member_kicked'::text, 'member_left'::text]));
+
+CREATE UNIQUE INDEX team_events_pkey ON public.team_events USING btree (id);
+
+CREATE UNIQUE INDEX team_memberships_pkey ON public.team_memberships USING btree (team_id, user_id);
+
+alter table "public"."team_events" add constraint "team_events_pkey" PRIMARY KEY using index "team_events_pkey";
+
+alter table "public"."team_memberships" add constraint "team_memberships_pkey" PRIMARY KEY using index "team_memberships_pkey";
+
+alter table "public"."team_memberships" add constraint "team_memberships_role_check" CHECK ((role = ANY (ARRAY['owner'::text, 'member'::text]))) not valid;
+
+alter table "public"."team_memberships" validate constraint "team_memberships_role_check";
+
+alter table "public"."teams" add constraint "teams_max_members_check" CHECK (((max_members >= 2) AND (max_members <= 10))) not valid;
+
+alter table "public"."teams" validate constraint "teams_max_members_check";
+
+alter table "public"."team_events" add constraint "team_events_initiated_by_fkey" FOREIGN KEY (initiated_by) REFERENCES auth.users(id) ON DELETE SET NULL not valid;
+
+alter table "public"."team_events" validate constraint "team_events_initiated_by_fkey";
+
+alter table "public"."user_system" add constraint "user_system_team_id_fkey" FOREIGN KEY (pvp_team_id) REFERENCES public.teams(id) not valid;
+
+alter table "public"."user_system" validate constraint "user_system_team_id_fkey";
+
+grant insert ("api_tokens"), update ("api_tokens") on table "public"."user_system" to "authenticated";
+
+grant insert ("created_at"), update ("created_at") on table "public"."user_system" to "authenticated";
+
+


### PR DESCRIPTION
## **User description**
## Summary

Production was modified directly via the Supabase dashboard, leaving migrations unable to reproduce the live schema. This adds a reconcile migration that captures the real production schema as code, so a fresh build reproduces prod exactly.

## What drifted (now captured as code)

- **teams**: added `members`, `max_members`, `updated_at`; `join_code` made nullable; added `max_members` 2–10 check
- **team_events**: primary key `event_id` → `id`; `team_id`/`initiated_by` relaxed to nullable; FK `initiated_by` → `ON DELETE SET NULL`
- **team_memberships**: removed surrogate `id`, restored composite PK `(team_id, user_id)`
- **user_system**: added `api_tokens`, `created_at` columns + their column-level grants
- **supporters**: `has_ever_supported` default `true`, dropped `type` default
- Extensions: `hypopg`, `index_advisor`

## Verification

Catalog-level comparison between a fresh local build (all migrations + reconcile) and live production — all identical:

| Object | Count |
|---|---|
| Columns | 181 |
| Constraints | 51 |
| Indexes | 39 |
| Table grants | 367 |
| Column grants | 2682 |
| RLS policies | 38 (47 expressions) |
| Functions | 19 |
| Triggers | 17 |

Only differences are platform-managed extensions (`pg_graphql`/`pg_net`) that migrations don't control. `supabase db lint` → no schema errors.

## ⚠️ Important for deploy

This migration is **destructive if executed against prod** (drops/recreates PKs and columns that prod already has). Production history was already reconciled with:

```
supabase migration repair --status applied 20260630075121
```

So prod's `Supabase DB` CI job will **skip** it (already applied). Do **not** `db push` this migration to prod. It only runs on fresh/local builds.

## Going forward

Documented in `docs/runbook.md`: write migrations for all schema changes — never edit the prod schema directly in the dashboard. Normal `db push`/CI flow applies to all future migrations.


___

## **CodeAnt-AI Description**
**Reconcile production schema drift and document safe database handling**

### What Changed
- Added a migration that brings fresh builds in line with the current production database schema, including team fields, team event IDs, team membership keys, user system fields, supporter defaults, and required database extensions.
- Restored the intended database rules for team size, team event ownership, and team membership roles so new environments match production behavior.
- Updated the runbook with guidance on known benign database log noise, the no-direct-production-edits rule, and how to handle the reconcile migration safely.

### Impact
`✅ Fresh environments match production database behavior`
`✅ Fewer false-alarm database incidents`
`✅ Safer future schema changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added/updated team and user system fields (e.g., member limits, timestamps, API tokens) and improved team event identifiers and relationships.
* **Bug Fixes**
  * Reconciled production schema drift by aligning the live database with the migration-defined schema, including updated keys, constraints, indexes, and permissions.
* **Documentation**
  * Expanded the runbook with guidance for known benign database noise and clearer migration/CLI expectations, including notes on a specific schema-drift reconciliation migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->