### PR TITLE
fix(config): revoke unused client write grants on user_system

### DIFF
--- a/supabase/migrations/20260630160000_revoke_user_system_client_writes.sql
+++ b/supabase/migrations/20260630160000_revoke_user_system_client_writes.sql
@@ -1,0 +1,15 @@
+-- Least-privilege hardening for public.user_system.
+--
+-- Background: 20260213090000 granted authenticated INSERT/UPDATE on every column
+-- except is_admin, on the assumption clients might write user_system directly.
+-- They do not: every user_system write goes through edge functions using the
+-- service_role client (team-create, team-join, team-leave, account-delete*),
+-- and service_role bypasses column grants entirely. The app only ever reads
+-- user_system (realtime subscription in useSystemStore + admin SELECT).
+--
+-- The leftover authenticated write grants are therefore unused attack surface:
+-- they let a user rewrite server-owned columns on their own row (created_at,
+-- updated_at), scoped to self by RLS but still undesirable. Revoke all
+-- authenticated/anon INSERT/UPDATE on user_system; SELECT is unaffected.
+
+REVOKE INSERT, UPDATE ON public.user_system FROM anon, authenticated;


### PR DESCRIPTION
## **User description**
## Summary

Hardens `public.user_system` by removing unused client write grants. Addresses the CodeRabbit finding from #488 (server-owned `created_at` was client-writable), fixed at root cause rather than per-column.

## Root cause

Migration `20260213090000` granted `authenticated` INSERT/UPDATE on every `user_system` column except `is_admin`, on the assumption clients write the table directly. They don't:

- Every `user_system` write goes through edge functions (`team-create`, `team-join`, `team-leave`, `account-delete*`) using the **service_role** client, which **bypasses column grants** entirely.
- The app only **reads** `user_system` (realtime subscription in `useSystemStore`, admin SELECT in `supporter.post.ts`). Zero client-side writes (grep-verified).

So the `authenticated` INSERT/UPDATE grants are unused surface that let a user rewrite server-owned columns (`created_at`, `updated_at`) on their own row (scoped to self by RLS, but undesirable).

## Change

```sql
REVOKE INSERT, UPDATE ON public.user_system FROM anon, authenticated;
```

SELECT/REFERENCES unaffected. `is_admin` protections (trigger + RLS) unchanged.

## Verification (local)

- `db reset` applies cleanly.
- `authenticated`/`anon` INSERT/UPDATE grants on `user_system`: **0** (was present on `api_tokens`, `created_at`, `updated_at`, `pvp_team_id`, `pve_team_id`, `user_id`).
- SELECT retained (7 columns), `user_system_protect_is_admin` trigger intact.
- `db lint` → no schema errors.

## Deploy

This is a normal forward migration — applied to prod via the standard `db push`/CI flow (unlike #488's reconcile, which was marked already-applied).


___

## **CodeAnt-AI Description**
**Remove unused write access to user system data**

### What Changed
- Removed client write access to `user_system` for signed-in and anonymous users
- Kept read access intact, so the app can still show and subscribe to user system data
- Prevented users from changing server-owned fields on their own row, such as creation and update timestamps

### Impact
`✅ Fewer unauthorized profile changes`
`✅ Safer account metadata`
`✅ Clearer access control for user data`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Tightened write access to a sensitive user-related area, removing direct create and update permissions for regular client sessions.
  * Read access remains unchanged, helping preserve existing app behavior while reducing exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->