### PR TITLE
docs: correct migration deploy step (manual db push, not CI)

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -60,13 +60,20 @@ Set these in Supabase Dashboard → Project Settings → Edge Functions:
 ## Deployment
 
 1. Merge to `main` and verify CI workflow `Validate`, `Supabase DB`, and `Workers` jobs are green.
-2. Confirm Cloudflare Pages and Cloudflare Workers Git deployments completed for `main`.
-3. Confirm workers are serving the expected revision:
+2. **Apply DB migrations manually** (CI does not deploy them; Supabase branch/preview deploy is
+   intentionally disabled to avoid per-preview billing):
+   ```bash
+   supabase migration list --linked   # any row with a blank REMOTE column is pending
+   supabase db push --linked          # apply pending migrations to production
+   ```
+   Skip only if `migration list` shows nothing pending. Verify the change landed afterward.
+3. Confirm Cloudflare Pages and Cloudflare Workers Git deployments completed for `main`.
+4. Confirm workers are serving the expected revision:
    - `workers/api-gateway`
-4. Smoke test:
+5. Smoke test:
    - `https://tarkovtracker.org`
    - `https://api.tarkovtracker.org/health`
-5. If the tarkov.dev profile cleanup migration shipped, note that old manual backups may still
+6. If the tarkov.dev profile cleanup migration shipped, note that old manual backups may still
    contain historic imported profile snapshots until users regenerate them.
 
 ## Known Benign Database Signals
@@ -107,8 +114,9 @@ These show up in Supabase logs / query performance and are expected. Do not trea
   migrations no longer matches production, and the next `db push` can fail or apply destructive
   changes. Always write a migration.
 - **CI does NOT apply migrations to production.** The `Supabase DB` job only validates
-  (`supabase:check` = local reset + lint); no workflow runs `db push`. Applying to prod is a
-  **manual step** after merge to `main`:
+  (`supabase:check` = local reset + lint); no workflow runs `db push`. Supabase branch/preview
+  auto-deploy is intentionally **disabled** (it bills per ephemeral preview DB). Applying to prod
+  is a **manual step** after merge to `main` (see Deployment checklist):
   ```bash
   supabase migration list --linked   # confirm the new migration is pending (blank REMOTE column)
   supabase db push --linked          # applies pending migrations to production

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -105,7 +105,15 @@ These show up in Supabase logs / query performance and are expected. Do not trea
 - **Migrations are the source of truth. Do not change the production schema directly** via the
   Supabase dashboard / SQL editor. Direct edits cause drift: a fresh environment built from
   migrations no longer matches production, and the next `db push` can fail or apply destructive
-  changes. Always write a migration and let CI apply it.
+  changes. Always write a migration.
+- **CI does NOT apply migrations to production.** The `Supabase DB` job only validates
+  (`supabase:check` = local reset + lint); no workflow runs `db push`. Applying to prod is a
+  **manual step** after merge to `main`:
+  ```bash
+  supabase migration list --linked   # confirm the new migration is pending (blank REMOTE column)
+  supabase db push --linked          # applies pending migrations to production
+  ```
+  Then verify the change landed (e.g. catalog query / `has_column_privilege`).
 - Verify migrations reproduce prod: `supabase db reset --local`, then dump both and compare
   (`supabase db dump --local` vs `--linked`). Catalog-level checks (columns, constraints,
   indexes, grants, policies, functions, triggers via `information_schema` / `pg_catalog`) are


### PR DESCRIPTION
## **User description**
Corrects an inaccurate note in the runbook's Database Migrations section.

CI (`Supabase DB` job) only **validates** migrations via `supabase:check` (local reset + lint) — no workflow runs `supabase db push`. Applying migrations to production is a **manual** step after merge:

```bash
supabase migration list --linked   # confirm pending
supabase db push --linked          # apply to prod
```

Discovered while applying #489: the prior note said "let CI apply it," which is wrong and could leave a merged migration unapplied in prod.

Docs-only change.


___

## **CodeAnt-AI Description**
**Clarify that production migrations must be applied manually after merge**

### What Changed
- Corrects the runbook to say CI only checks migrations and does not apply them to production
- Adds the manual production step to run after merge, including checking for pending migrations and then pushing them to Supabase
- Recommends verifying that the schema change landed before considering the migration complete

### Impact
`✅ Fewer missed production migrations`
`✅ Clearer database release steps`
`✅ Lower risk of assuming CI deployed schema changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
