### PR TITLE
feat(ui): remember map panel collapsed state

### DIFF
--- a/app/features/tasks/composables/__tests__/useTasksPageEffects.test.ts
+++ b/app/features/tasks/composables/__tests__/useTasksPageEffects.test.ts
@@ -25,7 +25,6 @@ describe('useTasksPageEffects', () => {
     };
     const showMapDisplay = computed(() => true);
     const selectedMapData = computed(() => ({ id: 'woods' }));
-    const isMapPanelExpanded = ref(true);
     const stopResize = vi.fn();
     const filteredTasksState = ref([createTask('1')]);
     const filteredTasks = computed(() => filteredTasksState.value);
@@ -39,7 +38,6 @@ describe('useTasksPageEffects', () => {
       checkAndLoadMore,
       filteredTasks,
       handleTaskQueryParam,
-      isMapPanelExpanded,
       metadataStore,
       route,
       selectedMapData,
@@ -59,7 +57,6 @@ describe('useTasksPageEffects', () => {
     };
     const showMapDisplay = computed(() => true);
     const selectedMapData = computed(() => ({ id: 'woods' }));
-    const isMapPanelExpanded = ref(true);
     const stopResize = vi.fn();
     const filteredTasksState = ref([createTask('1')]);
     const filteredTasks = computed(() => filteredTasksState.value);
@@ -75,7 +72,6 @@ describe('useTasksPageEffects', () => {
       checkAndLoadMore,
       filteredTasks,
       handleTaskQueryParam,
-      isMapPanelExpanded,
       metadataStore,
       route,
       selectedMapData,
@@ -99,7 +95,6 @@ describe('useTasksPageEffects', () => {
     };
     const showMapDisplay = computed(() => false);
     const selectedMapData = computed(() => null);
-    const isMapPanelExpanded = ref(true);
     const stopResize = vi.fn();
     const filteredTasksState = ref<Task[]>([]);
     const filteredTasks = computed(() => filteredTasksState.value);
@@ -113,7 +108,6 @@ describe('useTasksPageEffects', () => {
       checkAndLoadMore,
       filteredTasks,
       handleTaskQueryParam,
-      isMapPanelExpanded,
       metadataStore,
       route,
       selectedMapData,
@@ -131,7 +125,6 @@ describe('useTasksPageEffects', () => {
     };
     const showMapDisplay = computed(() => false);
     const selectedMapData = computed(() => null);
-    const isMapPanelExpanded = ref(true);
     const stopResize = vi.fn();
     const filteredTasksState = ref<Task[]>([createTask('task-hidden')]);
     const filteredTasks = computed(() => filteredTasksState.value);
@@ -145,7 +138,6 @@ describe('useTasksPageEffects', () => {
       checkAndLoadMore,
       filteredTasks,
       handleTaskQueryParam,
-      isMapPanelExpanded,
       metadataStore,
       route,
       selectedMapData,

--- a/app/features/tasks/composables/useTasksPageEffects.ts
+++ b/app/features/tasks/composables/useTasksPageEffects.ts
@@ -7,7 +7,6 @@ type TasksPageEffectsInputs = {
   checkAndLoadMore: () => Promise<void> | void;
   filteredTasks: ComputedRefLike<Task[]>;
   handleTaskQueryParam: () => Promise<void> | void;
-  isMapPanelExpanded: RefLike<boolean>;
   metadataStore: {
     fetchMapSpawnsData: () => Promise<unknown>;
   };
@@ -25,7 +24,6 @@ export function useTasksPageEffects({
   checkAndLoadMore,
   filteredTasks,
   handleTaskQueryParam,
-  isMapPanelExpanded,
   metadataStore,
   route,
   selectedMapData,
@@ -47,7 +45,6 @@ export function useTasksPageEffects({
   );
   watch(showMapDisplay, (isVisible) => {
     if (!isVisible) {
-      isMapPanelExpanded.value = true;
       stopResize();
     }
   });

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -2,6 +2,7 @@ import { mountSuspended } from '@nuxt/test-utils/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, inject, isRef, nextTick, ref } from 'vue';
 import { jumpToMapObjectiveKey } from '@/features/tasks/task-context';
+import { STORAGE_KEYS } from '@/utils/storageKeys';
 import type { Task, TaskObjective } from '@/types/tarkov';
 /**
  * Factory to create a default Task with all required properties.
@@ -296,6 +297,7 @@ describe('tasks page', () => {
     metadataStoreMock.fetchMapSpawnsData.mockClear();
     mapTaskCountsMock.withHide = 0;
     mapTaskCountsMock.withoutHide = 1;
+    localStorage.removeItem(STORAGE_KEYS.tasksMapPanelExpanded);
     const module = await import('@/pages/tasks.vue');
     TasksPage = module.default;
     await mountPage();
@@ -350,12 +352,21 @@ describe('tasks page', () => {
     await mountPage();
     const toggleButton = wrapper.find('[data-testid="map-panel-toggle"]');
     expect(toggleButton.exists()).toBe(true);
+    expect(toggleButton.attributes('aria-expanded')).toBe('false');
+    await toggleButton.trigger('click');
+    await nextTick();
     expect(toggleButton.attributes('aria-expanded')).toBe('true');
     await toggleButton.trigger('click');
     await nextTick();
     expect(toggleButton.attributes('aria-expanded')).toBe('false');
-    await toggleButton.trigger('click');
-    await nextTick();
+  });
+  it('restores the saved map panel expanded state', async () => {
+    localStorage.setItem(STORAGE_KEYS.tasksMapPanelExpanded, 'true');
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    await mountPage();
+    const toggleButton = wrapper.find('[data-testid="map-panel-toggle"]');
     expect(toggleButton.attributes('aria-expanded')).toBe('true');
   });
   it('expands the map panel when jumping to a map objective from a collapsed state', async () => {
@@ -381,9 +392,6 @@ describe('tasks page', () => {
       },
     });
     const toggleButton = wrapper.find('[data-testid="map-panel-toggle"]');
-    expect(toggleButton.attributes('aria-expanded')).toBe('true');
-    await toggleButton.trigger('click');
-    await nextTick();
     expect(toggleButton.attributes('aria-expanded')).toBe('false');
     const jumpButton = wrapper.find('[data-testid="jump-to-map-objective"]');
     expect(jumpButton.exists()).toBe(true);

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -329,6 +329,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { useStorage } from '@vueuse/core';
   import { storeToRefs } from 'pinia';
   import {
     type DashboardFocusProgressInteraction,
@@ -364,6 +365,7 @@
   import { useTarkovStore } from '@/stores/useTarkov';
   import { debounce, isDebounceRejection } from '@/utils/debounce';
   import { logger } from '@/utils/logger';
+  import { STORAGE_KEYS } from '@/utils/storageKeys';
   import { getTaskSecondaryViewForPrimaryView } from '@/utils/taskFilterNormalization';
   import { buildTaskTypeFilterOptions, filterTasksByTypeSettings } from '@/utils/taskTypeFilters';
   import type { TaskActionPayload } from '@/composables/useTaskActions';
@@ -458,7 +460,7 @@
     stopResize,
     onResizeKeydown,
   } = useMapResize();
-  const isMapPanelExpanded = ref(true);
+  const isMapPanelExpanded = useStorage<boolean>(STORAGE_KEYS.tasksMapPanelExpanded, false);
   const toggleMapPanelVisibility = () => {
     if (isMapPanelExpanded.value) {
       stopResize();
@@ -710,7 +712,6 @@
     checkAndLoadMore,
     filteredTasks,
     handleTaskQueryParam,
-    isMapPanelExpanded,
     metadataStore,
     route,
     selectedMapData,

--- a/app/utils/storageKeys.ts
+++ b/app/utils/storageKeys.ts
@@ -13,6 +13,7 @@ export const STORAGE_KEYS = {
   sessionDataMigrated: `${STORAGE_PREFIX}tarkovDataMigrated`,
   activityLogManual: `${STORAGE_PREFIX}activity_log_manual`,
   activityLogLastRead: `${STORAGE_PREFIX}activity_log_last_read`,
+  tasksMapPanelExpanded: `${STORAGE_PREFIX}tasks_map_panel_expanded`,
 } as const;
 export const LEGACY_STORAGE_KEYS = {
   progress: 'progress',


### PR DESCRIPTION
## **User description**
## **User description**
## Summary

Prevent the Tasks Maps view from automatically reopening the map panel every time users enter the view. The panel now remembers the user’s expanded/collapsed preference.

## Changes

- Persist the Tasks map panel expanded state in local storage.
- Stop resetting the map panel to expanded when leaving/re-entering Maps view.
- Preserve intentional auto-expand behavior when jumping directly to a map objective.
- Update related page/effects tests for the new collapsed-by-default behavior.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing feature)
- [ ] Refactoring (code restructuring without changing functionality)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Area(s) Affected

- [x] Frontend (UI/UX)
- [ ] Backend (Supabase/Nitro/Workers)
- [ ] Tasks/Quests
- [ ] Team Features
- [ ] Hideout
- [ ] Maps
- [ ] Traders
- [ ] API
- [ ] i18n/Translations
- [ ] Other:

## Related Issues

N/A

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. Open Tasks Maps view and verify the map panel does not auto-open by default.
2. Toggle the map panel open/closed and verify the state is remembered after leaving and returning to Maps view.
3. Verify jumping to a map objective still expands the panel intentionally.

## Screenshots/Videos

<img width="1447" height="1138" alt="image" src="https://github.com/user-attachments/assets/ce4042e2-85a6-480e-a4a1-ef688383c377" />

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated relevant documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes


___

## **CodeAnt-AI Description**
**Tasks map panel now remembers whether you left it open or closed**

### What Changed
- The Tasks map panel starts collapsed instead of reopening every time you return to the Maps view
- Your last open or closed state is saved and restored on later visits
- Jumping directly to a map objective still opens the panel when needed
- Leaving the map view no longer forces the panel back open

### Impact
`✅ Fewer unexpected map popups`
`✅ Saved map panel preference`
`✅ Clearer map objective jumps`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The tasks map panel now remembers whether it was open or closed between visits.

* **Bug Fixes**
  * Updated map panel behavior so it starts collapsed by default and opens correctly when needed.
  * Improved task page interactions to keep the map panel state in sync with user actions.

* **Tests**
  * Added coverage for map panel persistence and expanded/collapsed toggle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->