### PR TITLE
feat(api): add tiered daily rate limits and burst smoothing

### DIFF
--- a/app/server/api/admin/__tests__/api-usage.test.ts
+++ b/app/server/api/admin/__tests__/api-usage.test.ts
@@ -57,31 +57,20 @@ describe('GET /api/admin/api-usage', () => {
     const { default: handler } = await import('@/server/api/admin/api-usage.get');
     await expect(handler(makeEvent({ id: 'user-1' }))).rejects.toMatchObject({ statusCode: 403 });
   });
-  it('aggregates and ranks the top consumers over the last 24h', async () => {
+  it('returns the top consumers from the SQL aggregation RPC', async () => {
     mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }])).mockResolvedValueOnce(
       jsonResponse([
         {
           user_id: 'u1',
           token_id: 't1',
-          day: '2026-07-05',
           tier: 'free',
-          reads: 900,
-          writes: 50,
+          reads: 1000,
+          writes: 60,
           throttled: 12,
-        },
-        {
-          user_id: 'u1',
-          token_id: 't1',
-          day: '2026-07-04',
-          tier: 'free',
-          reads: 100,
-          writes: 10,
-          throttled: 0,
         },
         {
           user_id: 'u2',
           token_id: 't2',
-          day: '2026-07-05',
           tier: 'chad',
           reads: 200,
           writes: 20,
@@ -91,8 +80,16 @@ describe('GET /api/admin/api-usage', () => {
     );
     const { default: handler } = await import('@/server/api/admin/api-usage.get');
     const result = (await handler(makeEvent({ id: 'admin-1' }))) as unknown as {
+      since: string;
       consumers: Array<Record<string, unknown>>;
     };
+    const rpcCall = mockFetch.mock.calls[1] as [string, RequestInit];
+    expect(rpcCall[0]).toContain('/rest/v1/rpc/get_api_usage_summary');
+    expect(rpcCall[1].method).toBe('POST');
+    expect(JSON.parse(String(rpcCall[1].body))).toMatchObject({
+      p_since: result.since,
+      p_limit: 20,
+    });
     expect(result.consumers).toHaveLength(2);
     expect(result.consumers[0]).toMatchObject({
       userId: 'u1',

--- a/app/server/api/admin/__tests__/api-usage.test.ts
+++ b/app/server/api/admin/__tests__/api-usage.test.ts
@@ -1,0 +1,107 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { H3Event, H3EventContext } from 'h3';
+const runtimeConfig = {
+  supabaseServiceKey: 'service-key',
+  supabaseUrl: 'https://test.supabase.co',
+};
+const mockFetch = vi.fn();
+vi.mock('h3', async () => {
+  const actual = await vi.importActual<typeof import('h3')>('h3');
+  return {
+    ...actual,
+    getQuery: () => ({}),
+  };
+});
+vi.mock('@/server/utils/logger', () => ({
+  createLogger: () => ({
+    debug: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  }),
+}));
+mockNuxtImport('useRuntimeConfig', () => () => runtimeConfig);
+function makeEvent(authUser: { id?: string } | null): H3Event {
+  return {
+    context: authUser ? { auth: { user: authUser } } : ({} as H3EventContext),
+  } as unknown as H3Event;
+}
+function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+  const text = JSON.stringify(body);
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    text: async () => text,
+    json: async () => JSON.parse(text),
+  } as Response;
+}
+describe('GET /api/admin/api-usage', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', mockFetch);
+    mockFetch.mockReset();
+    runtimeConfig.supabaseUrl = 'https://test.supabase.co';
+    runtimeConfig.supabaseServiceKey = 'service-key';
+  });
+  afterEach(() => {
+    vi.resetModules();
+    vi.unstubAllGlobals();
+  });
+  it('requires authentication', async () => {
+    const { default: handler } = await import('@/server/api/admin/api-usage.get');
+    await expect(handler(makeEvent(null))).rejects.toMatchObject({ statusCode: 401 });
+  });
+  it('rejects non-admin users', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: false }]));
+    const { default: handler } = await import('@/server/api/admin/api-usage.get');
+    await expect(handler(makeEvent({ id: 'user-1' }))).rejects.toMatchObject({ statusCode: 403 });
+  });
+  it('aggregates and ranks the top consumers over the last 24h', async () => {
+    mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }])).mockResolvedValueOnce(
+      jsonResponse([
+        {
+          user_id: 'u1',
+          token_id: 't1',
+          day: '2026-07-05',
+          tier: 'free',
+          reads: 900,
+          writes: 50,
+          throttled: 12,
+        },
+        {
+          user_id: 'u1',
+          token_id: 't1',
+          day: '2026-07-04',
+          tier: 'free',
+          reads: 100,
+          writes: 10,
+          throttled: 0,
+        },
+        {
+          user_id: 'u2',
+          token_id: 't2',
+          day: '2026-07-05',
+          tier: 'chad',
+          reads: 200,
+          writes: 20,
+          throttled: 0,
+        },
+      ])
+    );
+    const { default: handler } = await import('@/server/api/admin/api-usage.get');
+    const result = (await handler(makeEvent({ id: 'admin-1' }))) as unknown as {
+      consumers: Array<Record<string, unknown>>;
+    };
+    expect(result.consumers).toHaveLength(2);
+    expect(result.consumers[0]).toMatchObject({
+      userId: 'u1',
+      tokenId: 't1',
+      tier: 'free',
+      reads: 1000,
+      writes: 60,
+      throttled: 12,
+    });
+    expect(result.consumers[1]).toMatchObject({ userId: 'u2', tier: 'chad' });
+  });
+});

--- a/app/server/api/admin/api-usage.get.ts
+++ b/app/server/api/admin/api-usage.get.ts
@@ -1,6 +1,5 @@
 import { createError, defineEventHandler, getQuery } from 'h3';
-import { createLogger } from '@/server/utils/logger';
-const logger = createLogger('AdminApiUsage');
+import { adminSupabaseFetch, getIsAdmin } from '@/server/utils/adminSupabase';
 interface UsageSummaryRow {
   user_id: string;
   token_id: string;
@@ -43,7 +42,7 @@ export default defineEventHandler(async (event): Promise<ApiUsageResponse> => {
   const sinceDay = since.toISOString().slice(0, 10);
   // Aggregation, ranking, and limiting happen in SQL so no raw rows are
   // truncated before the top consumers are computed.
-  const rows = await supabaseFetch<UsageSummaryRow[]>(
+  const rows = await adminSupabaseFetch<UsageSummaryRow[]>(
     supabaseUrl,
     serviceKey,
     '/rest/v1/rpc/get_api_usage_summary',
@@ -64,51 +63,6 @@ export default defineEventHandler(async (event): Promise<ApiUsageResponse> => {
 });
 function readLimit(raw: unknown): number {
   const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed <= 0) return 20;
+  if (!Number.isFinite(parsed) || parsed < 1) return 20;
   return Math.min(Math.floor(parsed), 100);
-}
-async function getIsAdmin(
-  supabaseUrl: string,
-  serviceKey: string,
-  userId: string
-): Promise<boolean> {
-  const rows = await supabaseFetch<Array<{ is_admin: boolean | null }>>(
-    supabaseUrl,
-    serviceKey,
-    `/rest/v1/user_system?select=is_admin&user_id=eq.${encodeURIComponent(userId)}&limit=1`
-  );
-  return rows[0]?.is_admin === true;
-}
-async function supabaseFetch<T>(
-  supabaseUrl: string,
-  serviceKey: string,
-  path: string,
-  init: RequestInit = {}
-): Promise<T> {
-  let response: Response;
-  try {
-    response = await fetch(`${supabaseUrl}${path}`, {
-      ...init,
-      headers: {
-        apikey: serviceKey,
-        Authorization: `Bearer ${serviceKey}`,
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        ...(init.headers || {}),
-      },
-    });
-  } catch (error) {
-    logger.error('[AdminApiUsage] Supabase request failed', { path, error });
-    throw createError({ statusCode: 502, message: 'Supabase request failed' });
-  }
-  if (!response.ok) {
-    const body = await response.text().catch(() => '');
-    logger.error('[AdminApiUsage] Supabase request error', {
-      path,
-      status: response.status,
-      body: body.slice(0, 300),
-    });
-    throw createError({ statusCode: 502, message: 'Supabase request error' });
-  }
-  return (await response.json()) as T;
 }

--- a/app/server/api/admin/api-usage.get.ts
+++ b/app/server/api/admin/api-usage.get.ts
@@ -51,7 +51,7 @@ export default defineEventHandler(async (event): Promise<ApiUsageResponse> => {
       body: JSON.stringify({ p_since: sinceDay, p_limit: limit }),
     }
   );
-  const consumers: ConsumerSummary[] = rows.map((row) => ({
+  const consumers: ConsumerSummary[] = (rows ?? []).map((row) => ({
     userId: row.user_id,
     tokenId: row.token_id,
     tier: row.tier,

--- a/app/server/api/admin/api-usage.get.ts
+++ b/app/server/api/admin/api-usage.get.ts
@@ -1,10 +1,9 @@
 import { createError, defineEventHandler, getQuery } from 'h3';
 import { createLogger } from '@/server/utils/logger';
 const logger = createLogger('AdminApiUsage');
-interface UsageRow {
+interface UsageSummaryRow {
   user_id: string;
   token_id: string;
-  day: string;
   tier: string;
   reads: number;
   writes: number;
@@ -18,7 +17,11 @@ interface ConsumerSummary {
   writes: number;
   throttled: number;
 }
-export default defineEventHandler(async (event) => {
+interface ApiUsageResponse {
+  since: string;
+  consumers: ConsumerSummary[];
+}
+export default defineEventHandler(async (event): Promise<ApiUsageResponse> => {
   const config = useRuntimeConfig(event);
   const supabaseUrl = ((config.supabaseUrl as string) || '').replace(/\/$/, '');
   const serviceKey = (config.supabaseServiceKey as string) || '';
@@ -35,33 +38,28 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 403, message: 'Admin privileges required' });
   }
   const limit = readLimit(getQuery(event).limit);
+  // UTC-day buckets: covers today and yesterday (UTC), not a rolling 24 hours.
   const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
   const sinceDay = since.toISOString().slice(0, 10);
-  const rows = await supabaseFetch<UsageRow[]>(
+  // Aggregation, ranking, and limiting happen in SQL so no raw rows are
+  // truncated before the top consumers are computed.
+  const rows = await supabaseFetch<UsageSummaryRow[]>(
     supabaseUrl,
     serviceKey,
-    `/rest/v1/api_usage_daily?day=gte.${sinceDay}&select=user_id,token_id,day,tier,reads,writes,throttled&order=day.desc&limit=2000`
+    '/rest/v1/rpc/get_api_usage_summary',
+    {
+      method: 'POST',
+      body: JSON.stringify({ p_since: sinceDay, p_limit: limit }),
+    }
   );
-  const byToken = new Map<string, ConsumerSummary>();
-  for (const row of rows) {
-    const key = `${row.user_id}:${row.token_id}`;
-    const entry = byToken.get(key) ?? {
-      userId: row.user_id,
-      tokenId: row.token_id,
-      tier: row.tier,
-      reads: 0,
-      writes: 0,
-      throttled: 0,
-    };
-    entry.tier = row.tier;
-    entry.reads += row.reads;
-    entry.writes += row.writes;
-    entry.throttled += row.throttled;
-    byToken.set(key, entry);
-  }
-  const consumers = [...byToken.values()]
-    .sort((a, b) => b.reads + b.writes - (a.reads + a.writes))
-    .slice(0, limit);
+  const consumers: ConsumerSummary[] = rows.map((row) => ({
+    userId: row.user_id,
+    tokenId: row.token_id,
+    tier: row.tier,
+    reads: Number(row.reads) || 0,
+    writes: Number(row.writes) || 0,
+    throttled: Number(row.throttled) || 0,
+  }));
   return { since: sinceDay, consumers };
 });
 function readLimit(raw: unknown): number {

--- a/app/server/api/admin/api-usage.get.ts
+++ b/app/server/api/admin/api-usage.get.ts
@@ -1,0 +1,116 @@
+import { createError, defineEventHandler, getQuery } from 'h3';
+import { createLogger } from '@/server/utils/logger';
+const logger = createLogger('AdminApiUsage');
+interface UsageRow {
+  user_id: string;
+  token_id: string;
+  day: string;
+  tier: string;
+  reads: number;
+  writes: number;
+  throttled: number;
+}
+interface ConsumerSummary {
+  userId: string;
+  tokenId: string;
+  tier: string;
+  reads: number;
+  writes: number;
+  throttled: number;
+}
+export default defineEventHandler(async (event) => {
+  const config = useRuntimeConfig(event);
+  const supabaseUrl = ((config.supabaseUrl as string) || '').replace(/\/$/, '');
+  const serviceKey = (config.supabaseServiceKey as string) || '';
+  if (!supabaseUrl || !serviceKey) {
+    throw createError({ statusCode: 500, message: 'Supabase service config missing' });
+  }
+  const authUser = (event.context as { auth?: { user?: { id?: string } } }).auth?.user;
+  const adminUserId = authUser?.id;
+  if (!adminUserId) {
+    throw createError({ statusCode: 401, message: 'Authentication required' });
+  }
+  const isAdmin = await getIsAdmin(supabaseUrl, serviceKey, adminUserId);
+  if (!isAdmin) {
+    throw createError({ statusCode: 403, message: 'Admin privileges required' });
+  }
+  const limit = readLimit(getQuery(event).limit);
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000);
+  const sinceDay = since.toISOString().slice(0, 10);
+  const rows = await supabaseFetch<UsageRow[]>(
+    supabaseUrl,
+    serviceKey,
+    `/rest/v1/api_usage_daily?day=gte.${sinceDay}&select=user_id,token_id,day,tier,reads,writes,throttled&order=day.desc&limit=2000`
+  );
+  const byToken = new Map<string, ConsumerSummary>();
+  for (const row of rows) {
+    const key = `${row.user_id}:${row.token_id}`;
+    const entry = byToken.get(key) ?? {
+      userId: row.user_id,
+      tokenId: row.token_id,
+      tier: row.tier,
+      reads: 0,
+      writes: 0,
+      throttled: 0,
+    };
+    entry.tier = row.tier;
+    entry.reads += row.reads;
+    entry.writes += row.writes;
+    entry.throttled += row.throttled;
+    byToken.set(key, entry);
+  }
+  const consumers = [...byToken.values()]
+    .sort((a, b) => b.reads + b.writes - (a.reads + a.writes))
+    .slice(0, limit);
+  return { since: sinceDay, consumers };
+});
+function readLimit(raw: unknown): number {
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return 20;
+  return Math.min(Math.floor(parsed), 100);
+}
+async function getIsAdmin(
+  supabaseUrl: string,
+  serviceKey: string,
+  userId: string
+): Promise<boolean> {
+  const rows = await supabaseFetch<Array<{ is_admin: boolean | null }>>(
+    supabaseUrl,
+    serviceKey,
+    `/rest/v1/user_system?select=is_admin&user_id=eq.${encodeURIComponent(userId)}&limit=1`
+  );
+  return rows[0]?.is_admin === true;
+}
+async function supabaseFetch<T>(
+  supabaseUrl: string,
+  serviceKey: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
+  let response: Response;
+  try {
+    response = await fetch(`${supabaseUrl}${path}`, {
+      ...init,
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...(init.headers || {}),
+      },
+    });
+  } catch (error) {
+    logger.error('[AdminApiUsage] Supabase request failed', { path, error });
+    throw createError({ statusCode: 502, message: 'Supabase request failed' });
+  }
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    logger.error('[AdminApiUsage] Supabase request error', {
+      path,
+      status: response.status,
+      body: body.slice(0, 300),
+    });
+    throw createError({ statusCode: 502, message: 'Supabase request error' });
+  }
+  return (await response.json()) as T;
+}

--- a/app/server/api/admin/supporter.post.ts
+++ b/app/server/api/admin/supporter.post.ts
@@ -1,4 +1,5 @@
 import { createError, defineEventHandler, readBody } from 'h3';
+import { adminSupabaseFetch, getIsAdmin } from '@/server/utils/adminSupabase';
 import { createLogger } from '@/server/utils/logger';
 import { VALID_TIERS } from '@/server/utils/stripeCheckoutValidation';
 const logger = createLogger('AdminSupporter');
@@ -42,7 +43,7 @@ export default defineEventHandler(async (event) => {
     has_ever_supported: true,
     expires_at: expiresAt,
   };
-  const updatedRows = await supabaseFetch<SupabaseRow[]>(
+  const updatedRows = await adminSupabaseFetch<SupabaseRow[]>(
     supabaseUrl,
     serviceKey,
     `/rest/v1/supporters?on_conflict=user_id`,
@@ -79,18 +80,6 @@ export default defineEventHandler(async (event) => {
     },
   };
 });
-async function getIsAdmin(
-  supabaseUrl: string,
-  serviceKey: string,
-  userId: string
-): Promise<boolean> {
-  const rows = await supabaseFetch<Array<{ is_admin: boolean | null }>>(
-    supabaseUrl,
-    serviceKey,
-    `/rest/v1/user_system?select=is_admin&user_id=eq.${encodeURIComponent(userId)}&limit=1`
-  );
-  return rows[0]?.is_admin === true;
-}
 async function writeAuditLog(
   supabaseUrl: string,
   serviceKey: string,
@@ -101,7 +90,7 @@ async function writeAuditLog(
   }
 ): Promise<void> {
   try {
-    await supabaseFetch(supabaseUrl, serviceKey, '/rest/v1/admin_audit_log', {
+    await adminSupabaseFetch(supabaseUrl, serviceKey, '/rest/v1/admin_audit_log', {
       method: 'POST',
       body: JSON.stringify({
         action: payload.action,
@@ -115,46 +104,6 @@ async function writeAuditLog(
   } catch (error) {
     logger.warn('[AdminSupporter] Failed to write audit log', { error, action: payload.action });
   }
-}
-async function supabaseFetch<T>(
-  supabaseUrl: string,
-  serviceKey: string,
-  path: string,
-  init: RequestInit = {}
-): Promise<T> {
-  let response: Response;
-  try {
-    response = await fetch(`${supabaseUrl}${path}`, {
-      ...init,
-      headers: {
-        apikey: serviceKey,
-        Authorization: `Bearer ${serviceKey}`,
-        Accept: 'application/json',
-        'Content-Type': 'application/json',
-        ...(init.headers || {}),
-      },
-    });
-  } catch (error) {
-    logger.error('[AdminSupporter] Supabase request failed', { path, error });
-    throw createError({ statusCode: 502, message: 'Supabase request failed' });
-  }
-  if (!response.ok) {
-    const detail = await response.text().catch(() => '');
-    logger.warn('[AdminSupporter] Supabase request failed', {
-      path,
-      status: response.status,
-      detail,
-    });
-    throw createError({ statusCode: 502, message: 'Supabase request failed' });
-  }
-  if (response.status === 204) {
-    return null as T;
-  }
-  const text = await response.text();
-  if (!text.trim()) {
-    return null as T;
-  }
-  return JSON.parse(text) as T;
 }
 function readUuid(value: unknown, field: string): string {
   if (typeof value !== 'string' || !UUID_REGEX.test(value)) {

--- a/app/server/api/admin/supporter.post.ts
+++ b/app/server/api/admin/supporter.post.ts
@@ -55,7 +55,7 @@ export default defineEventHandler(async (event) => {
       },
     }
   );
-  const updated = updatedRows[0];
+  const updated = updatedRows?.[0];
   if (!updated) {
     throw createError({ statusCode: 502, message: 'Supporter update returned no row' });
   }

--- a/app/server/utils/adminSupabase.ts
+++ b/app/server/utils/adminSupabase.ts
@@ -1,0 +1,80 @@
+import { createError } from 'h3';
+import { createLogger } from '@/server/utils/logger';
+const logger = createLogger('AdminSupabase');
+const SUPABASE_ADMIN_FETCH_TIMEOUT_MS = 5000;
+function isHttpError(error: unknown): error is { statusCode: number } {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    typeof (error as { statusCode?: unknown }).statusCode === 'number'
+  );
+}
+/**
+ * Shared Supabase REST helper for admin server routes. Uses the service-role
+ * key, bounds the request with an AbortController timeout so a stalled upstream
+ * cannot hang the handler, and normalizes failures to a 502. Returns `null` for
+ * empty/`204` bodies so callers using `Prefer: return=minimal` behave.
+ */
+export async function adminSupabaseFetch<T>(
+  supabaseUrl: string,
+  serviceKey: string,
+  path: string,
+  init: RequestInit = {}
+): Promise<T> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), SUPABASE_ADMIN_FETCH_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${supabaseUrl}${path}`, {
+      ...init,
+      signal: controller.signal,
+      headers: {
+        apikey: serviceKey,
+        Authorization: `Bearer ${serviceKey}`,
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...(init.headers || {}),
+      },
+    });
+    if (!response.ok) {
+      const body = await response.text().catch(() => '');
+      logger.error('Supabase request error', {
+        path,
+        status: response.status,
+        body: body.slice(0, 300),
+      });
+      throw createError({ statusCode: 502, message: 'Supabase request failed' });
+    }
+    if (response.status === 204) {
+      return null as T;
+    }
+    const text = await response.text();
+    if (!text.trim()) {
+      return null as T;
+    }
+    return JSON.parse(text) as T;
+  } catch (error) {
+    if (isHttpError(error)) {
+      throw error;
+    }
+    logger.error('Supabase request failed', { path, error });
+    throw createError({ statusCode: 502, message: 'Supabase request failed' });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+/**
+ * Resolve whether the given user is a TarkovTracker admin via `public.user_system`.
+ * Shared by the admin server routes so the gate lives in exactly one place.
+ */
+export async function getIsAdmin(
+  supabaseUrl: string,
+  serviceKey: string,
+  userId: string
+): Promise<boolean> {
+  const rows = await adminSupabaseFetch<Array<{ is_admin: boolean | null }>>(
+    supabaseUrl,
+    serviceKey,
+    `/rest/v1/user_system?select=is_admin&user_id=eq.${encodeURIComponent(userId)}&limit=1`
+  );
+  return rows?.[0]?.is_admin === true;
+}

--- a/app/server/utils/adminSupabase.ts
+++ b/app/server/utils/adminSupabase.ts
@@ -20,7 +20,7 @@ export async function adminSupabaseFetch<T>(
   serviceKey: string,
   path: string,
   init: RequestInit = {}
-): Promise<T> {
+): Promise<T | null> {
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), SUPABASE_ADMIN_FETCH_TIMEOUT_MS);
   try {
@@ -45,11 +45,11 @@ export async function adminSupabaseFetch<T>(
       throw createError({ statusCode: 502, message: 'Supabase request failed' });
     }
     if (response.status === 204) {
-      return null as T;
+      return null;
     }
     const text = await response.text();
     if (!text.trim()) {
-      return null as T;
+      return null;
     }
     return JSON.parse(text) as T;
   } catch (error) {

--- a/docs/API.md
+++ b/docs/API.md
@@ -345,7 +345,7 @@ Progress API requests (`api.tarkovtracker.org`, `/api/v2/*`) are subject to tier
 | Timmy | 3,000     | 400        | 90        |
 | Chad  | 5,000     | 600        | 120       |
 
-Every gateway response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix seconds) for the daily quota, plus `Retry-After` on `429` responses. When a free-tier user exhausts a daily quota, the `429` body includes an upgrade link. Admins can inspect the top consumers of the last 24 hours via `GET /api/admin/api-usage`.
+Every gateway response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix seconds) for the daily quota, plus `Retry-After` on `429` responses. On burst `429`s the `X-RateLimit-*` headers still describe the daily quota (burst-throttled requests do not consume it) while `Retry-After` indicates when burst capacity frees. When a free-tier user exhausts a daily quota, the `429` body includes an upgrade link. Admins can inspect the top consumers via `GET /api/admin/api-usage`; usage is bucketed by UTC day, so the report covers the current and previous UTC day (the `since` field gives the exact starting day).
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -334,6 +334,21 @@ The `returnUrl` host must match the configured app URL host. Mismatched hosts fa
 
 ---
 
+## Rate Limits (API Gateway)
+
+Progress API requests (`api.tarkovtracker.org`, `/api/v2/*`) are subject to tiered quotas keyed by user account (not per token). Daily quotas reset at 00:00 UTC; burst limits use a 60-second sliding window so batch updates near a minute boundary are not spuriously throttled.
+
+| Tier  | Reads/day | Writes/day | Burst/min |
+| ----- | --------- | ---------- | --------- |
+| Free  | 1,000     | 100        | 30        |
+| Scav  | 2,000     | 250        | 60        |
+| Timmy | 3,000     | 400        | 90        |
+| Chad  | 5,000     | 600        | 120       |
+
+Every gateway response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix seconds) for the daily quota, plus `Retry-After` on `429` responses. When a free-tier user exhausts a daily quota, the `429` body includes an upgrade link. Admins can inspect the top consumers of the last 24 hours via `GET /api/admin/api-usage`.
+
+---
+
 ## Error Responses
 
 All endpoints return errors in this format:

--- a/supabase/migrations/20260705120000_add_api_usage_daily.sql
+++ b/supabase/migrations/20260705120000_add_api_usage_daily.sql
@@ -61,3 +61,42 @@ REVOKE ALL ON FUNCTION public.record_api_usage(UUID, TEXT, TEXT, INTEGER, INTEGE
   FROM PUBLIC, anon, authenticated;
 GRANT EXECUTE ON FUNCTION public.record_api_usage(UUID, TEXT, TEXT, INTEGER, INTEGER, INTEGER)
   TO service_role;
+
+-- Aggregate usage per user/token in SQL so the admin endpoint never truncates
+-- raw rows before ranking. Tier is taken from the newest day per token. The
+-- window is UTC-day bucketed (day >= p_since), not a rolling 24 hours.
+CREATE OR REPLACE FUNCTION public.get_api_usage_summary(
+  p_since DATE,
+  p_limit INTEGER DEFAULT 20
+)
+RETURNS TABLE (
+  user_id UUID,
+  token_id TEXT,
+  tier TEXT,
+  reads BIGINT,
+  writes BIGINT,
+  throttled BIGINT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  SELECT
+    u.user_id,
+    u.token_id,
+    (ARRAY_AGG(u.tier ORDER BY u.day DESC))[1] AS tier,
+    COALESCE(SUM(u.reads), 0)::BIGINT AS reads,
+    COALESCE(SUM(u.writes), 0)::BIGINT AS writes,
+    COALESCE(SUM(u.throttled), 0)::BIGINT AS throttled
+  FROM public.api_usage_daily u
+  WHERE u.day >= p_since
+  GROUP BY u.user_id, u.token_id
+  ORDER BY COALESCE(SUM(u.reads), 0) + COALESCE(SUM(u.writes), 0) DESC
+  LIMIT LEAST(GREATEST(COALESCE(p_limit, 20), 1), 100)
+$$;
+
+REVOKE ALL ON FUNCTION public.get_api_usage_summary(DATE, INTEGER)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.get_api_usage_summary(DATE, INTEGER)
+  TO service_role;

--- a/supabase/migrations/20260705120000_add_api_usage_daily.sql
+++ b/supabase/migrations/20260705120000_add_api_usage_daily.sql
@@ -1,0 +1,63 @@
+CREATE TABLE IF NOT EXISTS public.api_usage_daily (
+  user_id UUID NOT NULL,
+  token_id TEXT NOT NULL,
+  day DATE NOT NULL,
+  tier TEXT NOT NULL DEFAULT 'free',
+  reads INTEGER NOT NULL DEFAULT 0,
+  writes INTEGER NOT NULL DEFAULT 0,
+  throttled INTEGER NOT NULL DEFAULT 0,
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, token_id, day)
+);
+
+CREATE INDEX IF NOT EXISTS idx_api_usage_daily_day ON public.api_usage_daily(day);
+
+ALTER TABLE public.api_usage_daily ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON public.api_usage_daily FROM anon, authenticated;
+GRANT SELECT, INSERT, UPDATE ON public.api_usage_daily TO service_role;
+
+COMMENT ON TABLE public.api_usage_daily IS
+  'Per user/token daily API gateway usage counters for quota observability.';
+
+CREATE OR REPLACE FUNCTION public.record_api_usage(
+  p_user_id UUID,
+  p_token_id TEXT,
+  p_tier TEXT,
+  p_reads INTEGER,
+  p_writes INTEGER,
+  p_throttled INTEGER
+)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF p_user_id IS NULL OR p_token_id IS NULL OR btrim(p_token_id) = '' THEN
+    RAISE EXCEPTION 'p_user_id and p_token_id are required';
+  END IF;
+
+  INSERT INTO public.api_usage_daily (user_id, token_id, day, tier, reads, writes, throttled)
+  VALUES (
+    p_user_id,
+    p_token_id,
+    (NOW() AT TIME ZONE 'utc')::date,
+    COALESCE(NULLIF(btrim(p_tier), ''), 'free'),
+    GREATEST(COALESCE(p_reads, 0), 0),
+    GREATEST(COALESCE(p_writes, 0), 0),
+    GREATEST(COALESCE(p_throttled, 0), 0)
+  )
+  ON CONFLICT (user_id, token_id, day) DO UPDATE SET
+    tier = EXCLUDED.tier,
+    reads = public.api_usage_daily.reads + EXCLUDED.reads,
+    writes = public.api_usage_daily.writes + EXCLUDED.writes,
+    throttled = public.api_usage_daily.throttled + EXCLUDED.throttled,
+    updated_at = NOW();
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.record_api_usage(UUID, TEXT, TEXT, INTEGER, INTEGER, INTEGER)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.record_api_usage(UUID, TEXT, TEXT, INTEGER, INTEGER, INTEGER)
+  TO service_role;

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -176,7 +176,7 @@ describe('api-gateway', () => {
       BASE_ENV
     );
     expect(res.status).toBe(200);
-    expect(res.headers.get('X-RateLimit-Limit')).toBe('60');
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('1000');
     expect(res.headers.get('X-RateLimit-Remaining')).toBe('10');
     expect(res.headers.get('X-RateLimit-Reset')).toMatch(/^\d+$/);
     expect(res.headers.get('Retry-After')).toBeNull();
@@ -197,7 +197,7 @@ describe('api-gateway', () => {
       env
     );
     expect(res.status).toBe(429);
-    expect(res.headers.get('X-RateLimit-Limit')).toBe('60');
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('1000');
     expect(res.headers.get('X-RateLimit-Remaining')).toBe('0');
     expect(res.headers.get('X-RateLimit-Reset')).toBe(String(Math.ceil(resetAt / 1000)));
     const retryAfter = Number(res.headers.get('Retry-After'));

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -201,6 +201,51 @@ describe('ApiGatewayRateLimiter durable object', () => {
     expect(afterRefund.remaining).toBe(0);
   });
 
+  it('does not refund across a UTC-day rollover when resetAt no longer matches', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-05T23:59:58Z'));
+    const limiter = new ApiGatewayRateLimiter(makeState());
+    const payload = { limit: 1, windowSec: 86400, anchor: 'utc-day' };
+    const consumed = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+      resetAt: number;
+    };
+    expect(consumed.allowed).toBe(true);
+    expect(consumed.resetAt).toBe(Date.parse('2026-07-06T00:00:00Z'));
+    // Roll into the next UTC day and consume the new window's only slot.
+    vi.setSystemTime(new Date('2026-07-06T00:00:02Z'));
+    const newDay = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+      resetAt: number;
+    };
+    expect(newDay.allowed).toBe(true);
+    expect(newDay.resetAt).toBe(Date.parse('2026-07-07T00:00:00Z'));
+    // A delayed refund for the previous day must not steal the new day's slot.
+    await limiter.fetch(limiterRequest({ refund: true, resetAt: consumed.resetAt }));
+    const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+    };
+    expect(blocked.allowed).toBe(false);
+    vi.useRealTimers();
+  });
+
+  it('still refunds when resetAt matches the current window', async () => {
+    const limiter = new ApiGatewayRateLimiter(makeState());
+    const payload = { limit: 1, windowSec: 86400, anchor: 'utc-day' };
+    const consumed = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+      resetAt: number;
+    };
+    expect(consumed.allowed).toBe(true);
+    await limiter.fetch(limiterRequest({ refund: true, resetAt: consumed.resetAt }));
+    const afterRefund = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+      remaining: number;
+    };
+    expect(afterRefund.allowed).toBe(true);
+    expect(afterRefund.remaining).toBe(0);
+  });
+
   it('keeps legacy fixed-window behavior for payloads without mode or anchor', async () => {
     const limiter = new ApiGatewayRateLimiter(makeState());
     const payload = { limit: 2, windowSec: 60 };

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import worker, { ApiGatewayRateLimiter } from '../index';
-import { TIER_LIMITS, UPGRADE_URL } from '../limits';
+import { isKnownTier, TIER_LIMITS, UPGRADE_URL } from '../limits';
 import { deleteMemoryCache } from '../utils/memory-cache';
 import type { Env } from '../types';
 
@@ -183,6 +183,24 @@ describe('ApiGatewayRateLimiter durable object', () => {
     expect(allowedAgain.allowed).toBe(true);
   });
 
+  it('refunds a consumed fixed-window slot on demand', async () => {
+    const limiter = new ApiGatewayRateLimiter(makeState());
+    const payload = { limit: 2, windowSec: 86400, anchor: 'utc-day' };
+    await limiter.fetch(limiterRequest(payload));
+    await limiter.fetch(limiterRequest(payload));
+    const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+    };
+    expect(blocked.allowed).toBe(false);
+    await limiter.fetch(limiterRequest({ refund: true }));
+    const afterRefund = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+      remaining: number;
+    };
+    expect(afterRefund.allowed).toBe(true);
+    expect(afterRefund.remaining).toBe(0);
+  });
+
   it('keeps legacy fixed-window behavior for payloads without mode or anchor', async () => {
     const limiter = new ApiGatewayRateLimiter(makeState());
     const payload = { limit: 2, windowSec: 60 };
@@ -302,6 +320,48 @@ describe('tiered quotas in the worker', () => {
     await flushAsync();
     expect(rpcCalls).toHaveLength(1);
     expect(rpcCalls[0]).toMatchObject({ p_user_id: 'user-free', p_throttled: 1, p_reads: 0 });
+  });
+
+  it('rejects inherited object keys as tiers', () => {
+    expect(isKnownTier('__proto__')).toBe(false);
+    expect(isKnownTier('constructor')).toBe(false);
+    expect(isKnownTier('chad')).toBe(true);
+  });
+
+  it('refunds the daily slot and returns daily headers when burst throttles', async () => {
+    const calls: LimiterCall[] = [];
+    const burstResetAt = Date.now() + 30_000;
+    const env: Env = {
+      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, (call) => {
+        if (call.body.refund === true) {
+          return { allowed: true, remaining: 0, resetAt: burstResetAt };
+        }
+        if (String(call.key).startsWith('burst-')) {
+          return { allowed: false, remaining: 0, resetAt: burstResetAt };
+        }
+        return { allowed: true, remaining: 5, resetAt: Date.now() + 1000 };
+      }),
+      SUPABASE_URL: 'https://supabase.example',
+      SUPABASE_ANON_KEY: 'anon',
+      SUPABASE_SERVICE_ROLE_KEY: 'service',
+      ALLOWED_ORIGIN: '*',
+    };
+    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
+    const res = await worker.fetch(
+      buildRequest('/token', { method: 'GET', headers: { Authorization: 'Bearer PVP_abc123' } }),
+      env
+    );
+    expect(res.status).toBe(429);
+    // X-RateLimit-* reflects the daily quota; remaining includes the refunded slot.
+    expect(res.headers.get('X-RateLimit-Limit')).toBe(String(TIER_LIMITS.free.readsPerDay));
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('6');
+    const retryAfter = Number(res.headers.get('Retry-After'));
+    expect(retryAfter).toBeGreaterThan(0);
+    expect(retryAfter).toBeLessThanOrEqual(31);
+    await flushAsync();
+    const refunds = calls.filter((call) => call.body.refund === true);
+    expect(refunds).toHaveLength(1);
+    expect(refunds[0].key).toBe('daily-read:user-free');
   });
 
   it('records successful usage through the record_api_usage rpc', async () => {

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -1,0 +1,338 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import worker, { ApiGatewayRateLimiter } from '../index';
+import { TIER_LIMITS, UPGRADE_URL } from '../limits';
+import { deleteMemoryCache } from '../utils/memory-cache';
+import type { Env } from '../types';
+
+const DAY_MS = 86400000;
+
+const makeState = () => {
+  const store = new Map<string, unknown>();
+  let alarm: number | null = null;
+  return {
+    storage: {
+      get: async <T>(key: string) => store.get(key) as T | undefined,
+      put: async (key: string, value: unknown) => {
+        store.set(key, value);
+      },
+      getAlarm: async () => alarm,
+      setAlarm: async (at: number) => {
+        alarm = at;
+      },
+      deleteAll: async () => {
+        store.clear();
+        alarm = null;
+      },
+    },
+  } as unknown as DurableObjectState;
+};
+
+const limiterRequest = (body: Record<string, unknown>) =>
+  new Request('https://rate-limit', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+
+type LimiterCall = { key: string; body: Record<string, unknown> };
+
+const makeCapturingLimiter = (
+  calls: LimiterCall[],
+  respond: (call: LimiterCall) => { allowed: boolean; remaining: number; resetAt: number }
+) =>
+  ({
+    idFromName: (name: string) => name,
+    get: (id: unknown) => ({
+      fetch: async (_url: string, init?: RequestInit) => {
+        const call: LimiterCall = { key: String(id), body: JSON.parse(String(init?.body || '{}')) };
+        calls.push(call);
+        return new Response(JSON.stringify(respond(call)), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      },
+    }),
+  }) as unknown as Env['API_GATEWAY_LIMITER'];
+
+const jsonResponse = (payload: unknown, status = 200) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'content-type': 'application/json' },
+  });
+
+const makeFetchMock = ({
+  userId,
+  supporter,
+  rpcCalls,
+}: {
+  userId: string;
+  supporter?: { tier: string; status: string; expires_at?: string | null };
+  rpcCalls?: Array<Record<string, unknown>>;
+}) =>
+  vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    if (url.includes('/rest/v1/api_tokens')) {
+      return jsonResponse([
+        {
+          token_id: 'token-1',
+          user_id: userId,
+          token_hash: 'hash',
+          permissions: ['GP', 'WP'],
+          game_mode: 'pvp',
+          note: 'test',
+          is_active: true,
+          usage_count: 0,
+          expires_at: null,
+        },
+      ]);
+    }
+    if (url.includes('/rest/v1/supporters')) {
+      return jsonResponse(supporter ? [supporter] : []);
+    }
+    if (url.includes('/rest/v1/rpc/record_api_usage')) {
+      rpcCalls?.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>);
+      return jsonResponse({ ok: true });
+    }
+    if (url.includes('/rest/v1/rpc/increment_token_usage')) {
+      return jsonResponse({ ok: true });
+    }
+    if (url.includes('/rest/v1/user_progress')) {
+      return jsonResponse([
+        { user_id: userId, game_edition: 1, pvp_data: { taskCompletions: {} }, pve_data: null },
+      ]);
+    }
+    return new Response('Not Found', { status: 404 });
+  });
+
+const buildRequest = (path: string, init?: RequestInit) =>
+  new Request(`https://api.tarkovtracker.org${path}`, init);
+
+const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+describe('ApiGatewayRateLimiter durable object', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('anchors utc-day windows to the next UTC midnight', async () => {
+    const limiter = new ApiGatewayRateLimiter(makeState());
+    const expectedReset = Math.floor(Date.now() / DAY_MS) * DAY_MS + DAY_MS;
+    const first = await limiter.fetch(
+      limiterRequest({ limit: 2, windowSec: 86400, anchor: 'utc-day' })
+    );
+    const firstBody = (await first.json()) as { allowed: boolean; resetAt: number };
+    expect(firstBody.allowed).toBe(true);
+    expect(firstBody.resetAt).toBe(expectedReset);
+    await limiter.fetch(limiterRequest({ limit: 2, windowSec: 86400, anchor: 'utc-day' }));
+    const third = await limiter.fetch(
+      limiterRequest({ limit: 2, windowSec: 86400, anchor: 'utc-day' })
+    );
+    const thirdBody = (await third.json()) as { allowed: boolean; resetAt: number };
+    expect(thirdBody.allowed).toBe(false);
+    expect(thirdBody.resetAt).toBe(expectedReset);
+  });
+
+  it('resets utc-day counters after midnight', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-05T23:59:30Z'));
+    const limiter = new ApiGatewayRateLimiter(makeState());
+    const payload = { limit: 1, windowSec: 86400, anchor: 'utc-day' };
+    const first = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+    };
+    expect(first.allowed).toBe(true);
+    const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+    };
+    expect(blocked.allowed).toBe(false);
+    vi.setSystemTime(new Date('2026-07-06T00:00:01Z'));
+    const afterMidnight = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+      resetAt: number;
+    };
+    expect(afterMidnight.allowed).toBe(true);
+    expect(afterMidnight.resetAt).toBe(Date.parse('2026-07-07T00:00:00Z'));
+  });
+
+  it('sliding mode frees capacity as old requests age out', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-05T12:00:00Z'));
+    const limiter = new ApiGatewayRateLimiter(makeState());
+    const payload = { limit: 3, windowSec: 60, mode: 'sliding' };
+    for (let i = 0; i < 3; i++) {
+      const res = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+        allowed: boolean;
+      };
+      expect(res.allowed).toBe(true);
+    }
+    const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+    };
+    expect(blocked.allowed).toBe(false);
+    vi.setSystemTime(new Date('2026-07-05T12:00:30Z'));
+    const stillBlocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+    };
+    expect(stillBlocked.allowed).toBe(false);
+    vi.setSystemTime(new Date('2026-07-05T12:01:01Z'));
+    const allowedAgain = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+      remaining: number;
+    };
+    expect(allowedAgain.allowed).toBe(true);
+  });
+
+  it('keeps legacy fixed-window behavior for payloads without mode or anchor', async () => {
+    const limiter = new ApiGatewayRateLimiter(makeState());
+    const payload = { limit: 2, windowSec: 60 };
+    const first = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+      remaining: number;
+    };
+    expect(first.allowed).toBe(true);
+    expect(first.remaining).toBe(1);
+    await limiter.fetch(limiterRequest(payload));
+    const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
+      allowed: boolean;
+    };
+    expect(blocked.allowed).toBe(false);
+  });
+});
+
+describe('tiered quotas in the worker', () => {
+  beforeEach(() => {
+    deleteMemoryCache('tier:user-free');
+    deleteMemoryCache('tier:user-scav');
+    deleteMemoryCache('tier:user-chad');
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('applies free-tier daily and burst limits keyed by user id', async () => {
+    const calls: LimiterCall[] = [];
+    const env: Env = {
+      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
+        allowed: true,
+        remaining: 5,
+        resetAt: Date.now() + 1000,
+      })),
+      SUPABASE_URL: 'https://supabase.example',
+      SUPABASE_ANON_KEY: 'anon',
+      SUPABASE_SERVICE_ROLE_KEY: 'service',
+      ALLOWED_ORIGIN: '*',
+    };
+    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
+    const res = await worker.fetch(
+      buildRequest('/token', { method: 'GET', headers: { Authorization: 'Bearer PVP_abc123' } }),
+      env
+    );
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(2);
+    expect(calls[0].key).toBe('daily-read:user-free');
+    expect(calls[0].body).toMatchObject({
+      limit: TIER_LIMITS.free.readsPerDay,
+      windowSec: 86400,
+      anchor: 'utc-day',
+    });
+    expect(calls[1].key).toBe('burst-read:user-free');
+    expect(calls[1].body).toMatchObject({
+      limit: TIER_LIMITS.free.burstPerMinute,
+      windowSec: 60,
+      mode: 'sliding',
+    });
+  });
+
+  it('applies paid-tier limits from the supporters table', async () => {
+    const calls: LimiterCall[] = [];
+    const env: Env = {
+      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
+        allowed: true,
+        remaining: 5,
+        resetAt: Date.now() + 1000,
+      })),
+      SUPABASE_URL: 'https://supabase.example',
+      SUPABASE_ANON_KEY: 'anon',
+      SUPABASE_SERVICE_ROLE_KEY: 'service',
+      ALLOWED_ORIGIN: '*',
+    };
+    vi.stubGlobal(
+      'fetch',
+      makeFetchMock({
+        userId: 'user-chad',
+        supporter: { tier: 'chad', status: 'active', expires_at: null },
+      })
+    );
+    const res = await worker.fetch(
+      buildRequest('/token', { method: 'GET', headers: { Authorization: 'Bearer PVP_abc123' } }),
+      env
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('X-RateLimit-Limit')).toBe(String(TIER_LIMITS.chad.readsPerDay));
+    expect(calls[0].body).toMatchObject({ limit: TIER_LIMITS.chad.readsPerDay });
+    expect(calls[1].body).toMatchObject({ limit: TIER_LIMITS.chad.burstPerMinute });
+  });
+
+  it('returns an upgrade message when a free user exhausts the daily quota', async () => {
+    const calls: LimiterCall[] = [];
+    const rpcCalls: Array<Record<string, unknown>> = [];
+    const env: Env = {
+      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, (call) => ({
+        allowed: !String(call.key).startsWith('daily-'),
+        remaining: 0,
+        resetAt: Date.now() + 1000,
+      })),
+      SUPABASE_URL: 'https://supabase.example',
+      SUPABASE_ANON_KEY: 'anon',
+      SUPABASE_SERVICE_ROLE_KEY: 'service',
+      ALLOWED_ORIGIN: '*',
+    };
+    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free', rpcCalls }));
+    const res = await worker.fetch(
+      buildRequest('/token', { method: 'GET', headers: { Authorization: 'Bearer PVP_abc123' } }),
+      env
+    );
+    expect(res.status).toBe(429);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain(UPGRADE_URL);
+    expect(body.error).toContain('Daily read quota');
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('0');
+    await flushAsync();
+    expect(rpcCalls).toHaveLength(1);
+    expect(rpcCalls[0]).toMatchObject({ p_user_id: 'user-free', p_throttled: 1, p_reads: 0 });
+  });
+
+  it('records successful usage through the record_api_usage rpc', async () => {
+    const calls: LimiterCall[] = [];
+    const rpcCalls: Array<Record<string, unknown>> = [];
+    const env: Env = {
+      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
+        allowed: true,
+        remaining: 5,
+        resetAt: Date.now() + 1000,
+      })),
+      SUPABASE_URL: 'https://supabase.example',
+      SUPABASE_ANON_KEY: 'anon',
+      SUPABASE_SERVICE_ROLE_KEY: 'service',
+      ALLOWED_ORIGIN: '*',
+    };
+    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free', rpcCalls }));
+    const res = await worker.fetch(
+      buildRequest('/token', { method: 'GET', headers: { Authorization: 'Bearer PVP_abc123' } }),
+      env
+    );
+    expect(res.status).toBe(200);
+    await flushAsync();
+    expect(rpcCalls).toHaveLength(1);
+    expect(rpcCalls[0]).toMatchObject({
+      p_user_id: 'user-free',
+      p_token_id: 'token-1',
+      p_tier: 'free',
+      p_reads: 1,
+      p_writes: 0,
+      p_throttled: 0,
+    });
+  });
+});

--- a/workers/api-gateway/src/__tests__/supporter.test.ts
+++ b/workers/api-gateway/src/__tests__/supporter.test.ts
@@ -1,0 +1,70 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { resolveTier } from '../services/supporter';
+import { deleteMemoryCache } from '../utils/memory-cache';
+import type { Env } from '../types';
+
+const baseEnv: Env = {
+  API_GATEWAY_LIMITER: {} as unknown as Env['API_GATEWAY_LIMITER'],
+  SUPABASE_URL: 'https://supabase.example',
+  SUPABASE_ANON_KEY: 'anon',
+  SUPABASE_SERVICE_ROLE_KEY: 'service',
+  ALLOWED_ORIGIN: '*',
+};
+
+const supporterResponse = (rows: unknown[]) =>
+  new Response(JSON.stringify(rows), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
+describe('resolveTier', () => {
+  beforeEach(() => {
+    deleteMemoryCache('tier:user-1');
+  });
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('caches the tier after a successful lookup', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/rest/v1/supporters')) {
+        return supporterResponse([{ tier: 'chad', status: 'active', expires_at: null }]);
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await resolveTier(baseEnv, 'user-1')).toBe('chad');
+    expect(await resolveTier(baseEnv, 'user-1')).toBe('chad');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not cache the fallback when Supabase errors, so the next call retries', async () => {
+    let calls = 0;
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      calls += 1;
+      if (url.includes('/rest/v1/supporters')) {
+        if (calls === 1) return new Response('boom', { status: 500 });
+        return supporterResponse([{ tier: 'timmy', status: 'active', expires_at: null }]);
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await resolveTier(baseEnv, 'user-1')).toBe('free');
+    expect(await resolveTier(baseEnv, 'user-1')).toBe('timmy');
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('treats an unparseable expires_at as expired (fail closed)', async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      if (url.includes('/rest/v1/supporters')) {
+        return supporterResponse([{ tier: 'chad', status: 'active', expires_at: 'not-a-date' }]);
+      }
+      return new Response('Not Found', { status: 404 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    expect(await resolveTier(baseEnv, 'user-1')).toBe('free');
+  });
+});

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -107,7 +107,8 @@ export class ApiGatewayRateLimiter {
       anchor?: string;
       mode?: string;
       refund?: boolean;
-    } = {};
+      resetAt?: number;
+    };
     try {
       payload = (await request.json()) as {
         limit?: number;
@@ -115,6 +116,7 @@ export class ApiGatewayRateLimiter {
         anchor?: string;
         mode?: string;
         refund?: boolean;
+        resetAt?: number;
       };
     } catch {
       return new Response('Bad Request', { status: 400 });
@@ -122,9 +124,18 @@ export class ApiGatewayRateLimiter {
     if (payload.refund === true) {
       // Return one previously consumed fixed-window slot (e.g. when a request
       // that passed the daily check is then rejected by the burst limiter).
+      // The caller passes the resetAt of the window it consumed from so a
+      // refund delayed past a UTC-day rollover cannot decrement the new day.
       await this.load();
       const now = Date.now();
-      if (this.data && !this.data.mode && now < this.data.resetAt && this.data.count > 0) {
+      const expectedResetAt = payload.resetAt;
+      if (
+        this.data &&
+        !this.data.mode &&
+        now < this.data.resetAt &&
+        this.data.count > 0 &&
+        (typeof expectedResetAt !== 'number' || this.data.resetAt === expectedResetAt)
+      ) {
         this.data.count -= 1;
         await this.state.storage.put('state', this.data);
       }
@@ -284,8 +295,16 @@ async function rateLimit(
 /**
  * Best-effort refund of one fixed-window slot (used when the daily counter was
  * consumed but the request was subsequently rejected by the burst limiter).
+ * `consumedResetAt` is the resetAt of the window the slot was taken from; the
+ * Durable Object only decrements when its current window still matches, so a
+ * refund delayed past a UTC-day rollover cannot steal a slot from the new day.
  */
-async function refundRateLimit(env: Env, key: string, action: string): Promise<void> {
+async function refundRateLimit(
+  env: Env,
+  key: string,
+  action: string,
+  consumedResetAt?: number
+): Promise<void> {
   const id = env.API_GATEWAY_LIMITER.idFromName(key);
   const stub = env.API_GATEWAY_LIMITER.get(id);
   const controller = new AbortController();
@@ -294,7 +313,7 @@ async function refundRateLimit(env: Env, key: string, action: string): Promise<v
     await stub.fetch('https://rate-limit', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ refund: true }),
+      body: JSON.stringify({ refund: true, resetAt: consumedResetAt }),
       signal: controller.signal,
     });
   } catch (error) {
@@ -511,7 +530,12 @@ async function authenticateAndRateLimit(
   if (!burst.allowed) {
     // Give back the daily slot consumed above so burst-throttled attempts do
     // not drain the daily quota.
-    const refund = refundRateLimit(env, dailyKey, `daily-${kind}`);
+    const refund = refundRateLimit(
+      env,
+      dailyKey,
+      `daily-${kind}`,
+      typeof daily.resetAt === 'number' ? daily.resetAt : undefined
+    );
     if (ctx) ctx.waitUntil(refund);
     track(true);
     // X-RateLimit-* always describes the daily quota (see docs/API.md); adjust

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -101,16 +101,34 @@ export class ApiGatewayRateLimiter {
     if (request.method !== 'POST') {
       return new Response('Method Not Allowed', { status: 405 });
     }
-    let payload: { limit?: number; windowSec?: number; anchor?: string; mode?: string } = {};
+    let payload: {
+      limit?: number;
+      windowSec?: number;
+      anchor?: string;
+      mode?: string;
+      refund?: boolean;
+    } = {};
     try {
       payload = (await request.json()) as {
         limit?: number;
         windowSec?: number;
         anchor?: string;
         mode?: string;
+        refund?: boolean;
       };
     } catch {
       return new Response('Bad Request', { status: 400 });
+    }
+    if (payload.refund === true) {
+      // Return one previously consumed fixed-window slot (e.g. when a request
+      // that passed the daily check is then rejected by the burst limiter).
+      await this.load();
+      const now = Date.now();
+      if (this.data && !this.data.mode && now < this.data.resetAt && this.data.count > 0) {
+        this.data.count -= 1;
+        await this.state.storage.put('state', this.data);
+      }
+      return this.json({ allowed: true, remaining: 0, resetAt: this.data?.resetAt ?? now });
     }
     const limit = Number(payload.limit);
     const windowSec = Number(payload.windowSec);
@@ -256,6 +274,28 @@ async function rateLimit(
       status: 503,
       message: 'Rate limiter unavailable',
     };
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+/**
+ * Best-effort refund of one fixed-window slot (used when the daily counter was
+ * consumed but the request was subsequently rejected by the burst limiter).
+ */
+async function refundRateLimit(env: Env, key: string): Promise<void> {
+  const id = env.API_GATEWAY_LIMITER.idFromName(key);
+  const stub = env.API_GATEWAY_LIMITER.get(id);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), RATE_LIMIT_TIMEOUT_MS);
+  try {
+    await stub.fetch('https://rate-limit', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ refund: true }),
+      signal: controller.signal,
+    });
+  } catch (error) {
+    console.warn('rateLimit refund failed', { key, error });
   } finally {
     clearTimeout(timeout);
   }
@@ -445,7 +485,8 @@ async function authenticateAndRateLimit(
   // Daily quota first, so a request rejected by the daily quota does not
   // consume a burst slot. Both counters key on user_id so extra tokens do not
   // multiply a user's quota.
-  const daily = await rateLimit(env, `daily-${kind}:${token.user_id}`, dailyLimit, DAILY_WINDOW_SEC, {
+  const dailyKey = `daily-${kind}:${token.user_id}`;
+  const daily = await rateLimit(env, dailyKey, dailyLimit, DAILY_WINDOW_SEC, {
     anchor: 'utc-day',
   });
   const dailyHeaders = rateLimitHeaders(daily);
@@ -465,13 +506,26 @@ async function authenticateAndRateLimit(
     { mode: 'sliding' }
   );
   if (!burst.allowed) {
+    // Give back the daily slot consumed above so burst-throttled attempts do
+    // not drain the daily quota.
+    const refund = refundRateLimit(env, dailyKey);
+    if (ctx) ctx.waitUntil(refund);
     track(true);
+    // X-RateLimit-* always describes the daily quota (see docs/API.md); adjust
+    // remaining for the refund. Retry-After reflects when burst capacity frees.
+    const headers = rateLimitHeaders({
+      ...daily,
+      remaining: typeof daily.remaining === 'number' ? daily.remaining + 1 : undefined,
+    });
+    if (typeof burst.resetAt === 'number') {
+      headers['Retry-After'] = String(Math.max(1, Math.ceil((burst.resetAt - Date.now()) / 1000)));
+    }
     return errorResponse(
       burst.message || 'Rate limit exceeded',
       burst.status || 429,
       envOrigin,
       requestOrigin,
-      rateLimitHeaders(burst)
+      headers
     );
   }
   track(false);

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -147,8 +147,11 @@ export class ApiGatewayRateLimiter {
       const timestamps = (this.data?.timestamps ?? []).filter((ts) => ts > cutoff);
       const resetAt = timestamps.length ? timestamps[0] + windowMs : now + windowMs;
       if (timestamps.length >= limit) {
+        // Deny path: refresh in-memory state but skip the storage write. The
+        // pruned timestamps/resetAt are recomputed from storage on the next
+        // load, so persisting on every throttled hit would only add Durable
+        // Object write amplification under sustained bursts.
         this.data = { count: timestamps.length, resetAt, windowSec, mode, timestamps };
-        await this.state.storage.put('state', this.data);
         await this.scheduleCleanup(resetAt);
         return this.json({ allowed: false, remaining: 0, resetAt });
       }

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -8,7 +8,10 @@ import {
 } from './handlers/progress';
 import { handleGetTeamProgress } from './handlers/team';
 import { handleGetToken } from './handlers/token';
+import { BURST_WINDOW_SEC, DAILY_WINDOW_SEC, TIER_LIMITS, upgradeMessage } from './limits';
 import { OPENAPI_JSON } from './openapi';
+import { resolveTier } from './services/supporter';
+import { recordUsage } from './services/usage';
 import type {
   ApiToken,
   Env,
@@ -46,15 +49,20 @@ function normalizeTaskUpdates(body: unknown): BatchTaskUpdate[] | null {
   return null;
 }
 type Action = 'progress-read' | 'progress-write' | 'token-info';
-const RATE_LIMITS: Record<Action, { limit: number; windowSec: number }> = {
-  'progress-read': { limit: 60, windowSec: 60 },
-  'progress-write': { limit: 30, windowSec: 60 },
-  'token-info': { limit: 60, windowSec: 60 },
+type UsageKind = 'read' | 'write';
+type RateLimitAnchor = 'utc-day';
+type RateLimitMode = 'sliding';
+type RateLimitOptions = {
+  anchor?: RateLimitAnchor;
+  mode?: RateLimitMode;
 };
 type RateLimitState = {
   count: number;
   resetAt: number;
   windowSec: number;
+  anchor?: RateLimitAnchor;
+  mode?: RateLimitMode;
+  timestamps?: number[];
 };
 type RateLimitResponse = {
   allowed: boolean;
@@ -71,6 +79,10 @@ type RateLimitResult = {
 };
 const RATE_LIMIT_TIMEOUT_MS = 3000;
 const RATE_LIMIT_SLOW_MS = 200;
+const DAY_MS = 86400000;
+function nextUtcMidnight(now: number): number {
+  return Math.floor(now / DAY_MS) * DAY_MS + DAY_MS;
+}
 export class ApiGatewayRateLimiter {
   private data?: RateLimitState;
   constructor(private state: DurableObjectState) {}
@@ -89,9 +101,14 @@ export class ApiGatewayRateLimiter {
     if (request.method !== 'POST') {
       return new Response('Method Not Allowed', { status: 405 });
     }
-    let payload: { limit?: number; windowSec?: number } = {};
+    let payload: { limit?: number; windowSec?: number; anchor?: string; mode?: string } = {};
     try {
-      payload = (await request.json()) as { limit?: number; windowSec?: number };
+      payload = (await request.json()) as {
+        limit?: number;
+        windowSec?: number;
+        anchor?: string;
+        mode?: string;
+      };
     } catch {
       return new Response('Bad Request', { status: 400 });
     }
@@ -100,34 +117,67 @@ export class ApiGatewayRateLimiter {
     if (!Number.isFinite(limit) || !Number.isFinite(windowSec) || limit <= 0 || windowSec <= 0) {
       return new Response('Bad Request', { status: 400 });
     }
+    const anchor: RateLimitAnchor | undefined = payload.anchor === 'utc-day' ? 'utc-day' : undefined;
+    const mode: RateLimitMode | undefined = payload.mode === 'sliding' ? 'sliding' : undefined;
     await this.load();
     const now = Date.now();
     const windowMs = windowSec * 1000;
-    if (!this.data || this.data.windowSec !== windowSec || now >= this.data.resetAt) {
-      this.data = { count: 0, resetAt: now + windowMs, windowSec };
+    if (mode === 'sliding') {
+      // Sliding-window log: bounded by `limit` entries, so short bursts across
+      // a fixed-window boundary are not spuriously throttled.
+      const cutoff = now - windowMs;
+      const timestamps = (this.data?.timestamps ?? []).filter((ts) => ts > cutoff);
+      const resetAt = timestamps.length ? timestamps[0] + windowMs : now + windowMs;
+      if (timestamps.length >= limit) {
+        this.data = { count: timestamps.length, resetAt, windowSec, mode, timestamps };
+        await this.state.storage.put('state', this.data);
+        await this.scheduleCleanup(resetAt);
+        return this.json({ allowed: false, remaining: 0, resetAt });
+      }
+      timestamps.push(now);
+      this.data = { count: timestamps.length, resetAt: timestamps[0] + windowMs, windowSec, mode, timestamps };
+      await this.state.storage.put('state', this.data);
+      await this.scheduleCleanup(this.data.resetAt);
+      return this.json({
+        allowed: true,
+        remaining: Math.max(limit - timestamps.length, 0),
+        resetAt: this.data.resetAt,
+      });
     }
-    // Schedule self-cleanup so abandoned keys (e.g. rotated teamId/userId in
-    // pre-auth rate-limit keys) do not retain billable storage forever. The
-    // alarm fires shortly after the window resets and wipes all storage.
-    const cleanupAt = this.data.resetAt + 1000;
+    const configChanged =
+      !this.data ||
+      this.data.windowSec !== windowSec ||
+      this.data.anchor !== anchor ||
+      this.data.mode !== undefined;
+    if (configChanged || now >= this.data!.resetAt) {
+      const resetAt = anchor === 'utc-day' ? nextUtcMidnight(now) : now + windowMs;
+      this.data = { count: 0, resetAt, windowSec, anchor };
+    }
+    await this.scheduleCleanup(this.data!.resetAt);
+    if (this.data!.count >= limit) {
+      return this.json({
+        allowed: false,
+        remaining: 0,
+        resetAt: this.data!.resetAt,
+      });
+    }
+    this.data!.count += 1;
+    await this.state.storage.put('state', this.data);
+    return this.json({
+      allowed: true,
+      remaining: Math.max(limit - this.data!.count, 0),
+      resetAt: this.data!.resetAt,
+    });
+  }
+  // Schedule self-cleanup so abandoned keys (e.g. rotated teamId/userId in
+  // pre-auth rate-limit keys) do not retain billable storage forever. The
+  // alarm fires shortly after the window resets and wipes all storage.
+  private async scheduleCleanup(resetAt: number): Promise<void> {
+    const cleanupAt = resetAt + 1000;
     const existingAlarm = await this.state.storage.getAlarm();
     if (existingAlarm !== cleanupAt) {
       await this.state.storage.setAlarm(cleanupAt);
     }
-    if (this.data.count >= limit) {
-      return this.json({
-        allowed: false,
-        remaining: 0,
-        resetAt: this.data.resetAt,
-      });
-    }
-    this.data.count += 1;
-    await this.state.storage.put('state', this.data);
-    return this.json({
-      allowed: true,
-      remaining: Math.max(limit - this.data.count, 0),
-      resetAt: this.data.resetAt,
-    });
   }
   async alarm(): Promise<void> {
     const stored = await this.state.storage.get<RateLimitState>('state');
@@ -144,7 +194,8 @@ async function rateLimit(
   env: Env,
   key: string,
   limit: number,
-  windowSec: number
+  windowSec: number,
+  options?: RateLimitOptions
 ): Promise<RateLimitResult> {
   const action = key.split(':', 1)[0] || 'unknown';
   const id = env.API_GATEWAY_LIMITER.idFromName(key);
@@ -156,7 +207,7 @@ async function rateLimit(
     const res = await stub.fetch('https://rate-limit', {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ limit, windowSec }),
+      body: JSON.stringify({ limit, windowSec, anchor: options?.anchor, mode: options?.mode }),
       signal: controller.signal,
     });
     const durationMs = Date.now() - startedAt;
@@ -367,26 +418,64 @@ async function authenticateAndRateLimit(
   permission: Permission,
   action: Action,
   envOrigin?: string,
-  requestOrigin?: string
+  requestOrigin?: string,
+  ctx?: ExecutionContext
 ): Promise<AuthSuccess | Response> {
   const validation = await validateToken(env, rawToken, permission);
   if (!validation.valid) {
     return errorResponse(validation.error, validation.status, envOrigin, requestOrigin);
   }
-  const clientIp = request.headers.get('CF-Connecting-IP') || 'unknown';
-  const rlKey = `${action}:${clientIp}:${rawToken.slice(-16)}`;
-  const rl = await rateLimit(env, rlKey, RATE_LIMITS[action].limit, RATE_LIMITS[action].windowSec);
-  const rlHeaders = rateLimitHeaders(rl);
-  if (!rl.allowed) {
+  const token = validation.token;
+  const kind: UsageKind = action === 'progress-write' ? 'write' : 'read';
+  const tier = await resolveTier(env, token.user_id);
+  const limits = TIER_LIMITS[tier];
+  const dailyLimit = kind === 'write' ? limits.writesPerDay : limits.readsPerDay;
+  const track = (throttled: boolean) => {
+    const promise = recordUsage(env, {
+      userId: token.user_id,
+      tokenId: token.token_id,
+      tier,
+      kind,
+      throttled,
+    });
+    if (ctx) {
+      ctx.waitUntil(promise);
+    }
+  };
+  // Daily quota first, so a request rejected by the daily quota does not
+  // consume a burst slot. Both counters key on user_id so extra tokens do not
+  // multiply a user's quota.
+  const daily = await rateLimit(env, `daily-${kind}:${token.user_id}`, dailyLimit, DAILY_WINDOW_SEC, {
+    anchor: 'utc-day',
+  });
+  const dailyHeaders = rateLimitHeaders(daily);
+  if (!daily.allowed) {
+    track(true);
+    const message =
+      daily.status === 429 && tier === 'free'
+        ? upgradeMessage(kind)
+        : daily.message || 'Rate limit exceeded';
+    return errorResponse(message, daily.status || 429, envOrigin, requestOrigin, dailyHeaders);
+  }
+  const burst = await rateLimit(
+    env,
+    `burst-${kind}:${token.user_id}`,
+    limits.burstPerMinute,
+    BURST_WINDOW_SEC,
+    { mode: 'sliding' }
+  );
+  if (!burst.allowed) {
+    track(true);
     return errorResponse(
-      rl.message || 'Rate limit exceeded',
-      rl.status || 429,
+      burst.message || 'Rate limit exceeded',
+      burst.status || 429,
       envOrigin,
       requestOrigin,
-      rlHeaders
+      rateLimitHeaders(burst)
     );
   }
-  return { validation, rlHeaders };
+  track(false);
+  return { validation, rlHeaders: dailyHeaders };
 }
 function decodeUrlParam(
   raw: string,
@@ -429,7 +518,7 @@ async function parseJsonObjectBody(
   return parsedBody as Record<string, unknown>;
 }
 export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
+  async fetch(request: Request, env: Env, ctx?: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
     const host = url.hostname.toLowerCase();
     const path = '/' + url.pathname.split('/').filter(Boolean).join('/');
@@ -503,7 +592,8 @@ export default {
           'GP',
           'token-info',
           origin,
-          reqOrigin
+          reqOrigin,
+          ctx
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -519,7 +609,8 @@ export default {
           'GP',
           'progress-read',
           origin,
-          reqOrigin
+          reqOrigin,
+          ctx
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -536,7 +627,8 @@ export default {
           'TP',
           'progress-read',
           origin,
-          reqOrigin
+          reqOrigin,
+          ctx
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -554,7 +646,8 @@ export default {
           'WP',
           'progress-write',
           origin,
-          reqOrigin
+          reqOrigin,
+          ctx
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -584,7 +677,8 @@ export default {
           'WP',
           'progress-write',
           origin,
-          reqOrigin
+          reqOrigin,
+          ctx
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -643,7 +737,8 @@ export default {
           'WP',
           'progress-write',
           origin,
-          reqOrigin
+          reqOrigin,
+          ctx
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -682,7 +777,8 @@ export default {
           'WP',
           'progress-write',
           origin,
-          reqOrigin
+          reqOrigin,
+          ctx
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -282,8 +282,7 @@ async function rateLimit(
  * Best-effort refund of one fixed-window slot (used when the daily counter was
  * consumed but the request was subsequently rejected by the burst limiter).
  */
-async function refundRateLimit(env: Env, key: string): Promise<void> {
-  const action = key.split(':', 1)[0] || 'unknown';
+async function refundRateLimit(env: Env, key: string, action: string): Promise<void> {
   const id = env.API_GATEWAY_LIMITER.idFromName(key);
   const stub = env.API_GATEWAY_LIMITER.get(id);
   const controller = new AbortController();
@@ -509,7 +508,7 @@ async function authenticateAndRateLimit(
   if (!burst.allowed) {
     // Give back the daily slot consumed above so burst-throttled attempts do
     // not drain the daily quota.
-    const refund = refundRateLimit(env, dailyKey);
+    const refund = refundRateLimit(env, dailyKey, `daily-${kind}`);
     if (ctx) ctx.waitUntil(refund);
     track(true);
     // X-RateLimit-* always describes the daily quota (see docs/API.md); adjust

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -283,6 +283,7 @@ async function rateLimit(
  * consumed but the request was subsequently rejected by the burst limiter).
  */
 async function refundRateLimit(env: Env, key: string): Promise<void> {
+  const action = key.split(':', 1)[0] || 'unknown';
   const id = env.API_GATEWAY_LIMITER.idFromName(key);
   const stub = env.API_GATEWAY_LIMITER.get(id);
   const controller = new AbortController();
@@ -295,7 +296,7 @@ async function refundRateLimit(env: Env, key: string): Promise<void> {
       signal: controller.signal,
     });
   } catch (error) {
-    console.warn('rateLimit refund failed', { key, error });
+    console.warn('rateLimit refund failed', { action, error });
   } finally {
     clearTimeout(timeout);
   }

--- a/workers/api-gateway/src/limits.ts
+++ b/workers/api-gateway/src/limits.ts
@@ -37,5 +37,5 @@ export function upgradeMessage(kind: 'read' | 'write'): string {
 }
 
 export function isKnownTier(value: string): value is ApiTier {
-  return value in TIER_LIMITS;
+  return Object.hasOwn(TIER_LIMITS, value);
 }

--- a/workers/api-gateway/src/limits.ts
+++ b/workers/api-gateway/src/limits.ts
@@ -1,0 +1,41 @@
+export type ApiTier = 'free' | 'supporter' | 'scav' | 'timmy' | 'chad';
+
+export interface TierLimits {
+  readsPerDay: number;
+  writesPerDay: number;
+  burstPerMinute: number;
+}
+
+/**
+ * Tiered API quotas (decision log):
+ * Observed free-tier consumers reached ~1.4k requests/day, far above what a
+ * single TarkovMonitor + dashboard session needs. Free daily reads are capped
+ * at 1,000 (roughly one poll per 90s all day) and writes at 100 (a full quest
+ * wipe-to-Kappa run is ~400 task writes spread over weeks, so 100/day covers
+ * normal play with batch updates counting as one write). Paid tiers scale
+ * roughly 2x/3x/5x so upgrades map to the existing supporter tiers
+ * (scav/timmy/chad in public.supporters). Burst limits keep the previous
+ * per-minute ceilings but scale by tier and use a sliding window so a
+ * TarkovMonitor batch right at a minute boundary is not spuriously throttled.
+ * The legacy generic 'supporter' tier maps to scav-level limits.
+ */
+export const TIER_LIMITS: Record<ApiTier, TierLimits> = {
+  free: { readsPerDay: 1000, writesPerDay: 100, burstPerMinute: 30 },
+  supporter: { readsPerDay: 2000, writesPerDay: 250, burstPerMinute: 60 },
+  scav: { readsPerDay: 2000, writesPerDay: 250, burstPerMinute: 60 },
+  timmy: { readsPerDay: 3000, writesPerDay: 400, burstPerMinute: 90 },
+  chad: { readsPerDay: 5000, writesPerDay: 600, burstPerMinute: 120 },
+};
+
+export const UPGRADE_URL = 'https://tarkovtracker.org/supporter';
+
+export const DAILY_WINDOW_SEC = 86400;
+export const BURST_WINDOW_SEC = 60;
+
+export function upgradeMessage(kind: 'read' | 'write'): string {
+  return `Daily ${kind} quota exceeded for the free tier. Quotas reset at 00:00 UTC. Upgrade your account for higher limits: ${UPGRADE_URL}`;
+}
+
+export function isKnownTier(value: string): value is ApiTier {
+  return value in TIER_LIMITS;
+}

--- a/workers/api-gateway/src/openapi.ts
+++ b/workers/api-gateway/src/openapi.ts
@@ -113,6 +113,15 @@ export const OPENAPI_SPEC = {
             schema: { $ref: '#/components/schemas/ErrorResponse' },
             examples: {
               rateLimited: { value: { success: false, error: 'Rate limit exceeded' } },
+              dailyQuotaUpgrade: {
+                summary: 'Free-tier daily quota exhausted',
+                value: {
+                  success: false,
+                  error:
+                    'Daily read quota exceeded for the free tier. Quotas reset at 00:00 UTC. ' +
+                    'Upgrade your account for higher limits: https://tarkovtracker.org/supporter',
+                },
+              },
             },
           },
         },

--- a/workers/api-gateway/src/openapi.ts
+++ b/workers/api-gateway/src/openapi.ts
@@ -7,10 +7,13 @@ export const OPENAPI_SPEC = {
       'Public API gateway for TarkovTracker progress, team progress, and token info.\n\n' +
       'Authentication: Send API tokens in the Authorization header as `Bearer <token>`.\n' +
       'Tokens use prefixes `PVP_` or `PVE_`.\n\n' +
-      'Rate limits: enforced per IP + token. Read endpoints are ~60/min, write endpoints are ~30/min. ' +
+      'Rate limits: tiered daily quotas keyed by user account (free: 1,000 reads/day and ' +
+      '100 writes/day; supporter tiers scale up), resetting at 00:00 UTC, plus a per-minute ' +
+      'burst limit using a 60-second sliding window. ' +
       'Every response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` ' +
-      '(unix seconds). On `429` responses a `Retry-After` header (seconds) is also returned, so clients ' +
-      'should queue and retry after that delay rather than busy-looping.\n\n' +
+      '(unix seconds) describing the daily quota. On `429` responses a `Retry-After` header (seconds) ' +
+      'is also returned, so clients should queue and retry after that delay rather than busy-looping. ' +
+      'Burst-throttled requests do not consume the daily quota.\n\n' +
       'Docs: https://api.tarkovtracker.org/docs (or / on the api subdomain).',
     contact: {
       name: 'TarkovTracker',
@@ -85,22 +88,23 @@ export const OPENAPI_SPEC = {
         },
       },
       RateLimited: {
-        description: 'Rate limit exceeded',
+        description: 'Rate limit exceeded (daily quota or per-minute burst limit)',
         headers: {
           'Retry-After': {
-            description: 'Seconds the client should wait before retrying.',
+            description:
+              'Seconds the client should wait before retrying (daily reset, or when burst capacity frees).',
             schema: { type: 'integer', minimum: 1 },
           },
           'X-RateLimit-Limit': {
-            description: 'Maximum requests permitted in the current window.',
+            description: 'Maximum requests permitted per UTC day for the account tier.',
             schema: { type: 'integer', minimum: 1 },
           },
           'X-RateLimit-Remaining': {
-            description: 'Requests remaining in the current window (0 on a 429).',
+            description: 'Requests remaining in the daily quota.',
             schema: { type: 'integer', minimum: 0 },
           },
           'X-RateLimit-Reset': {
-            description: 'Unix timestamp (seconds) when the current window resets.',
+            description: 'Unix timestamp (seconds) when the daily quota resets (00:00 UTC).',
             schema: { type: 'integer', minimum: 0 },
           },
         },
@@ -280,9 +284,7 @@ export const OPENAPI_SPEC = {
             success: true,
             data: {
               tasksProgress: [{ id: 'task-1', complete: true, failed: false, invalid: false }],
-              taskObjectivesProgress: [
-                { id: 'obj-1', complete: true, count: 2, invalid: false },
-              ],
+              taskObjectivesProgress: [{ id: 'obj-1', complete: true, count: 2, invalid: false }],
               hideoutModulesProgress: [],
               hideoutPartsProgress: [],
               displayName: 'Tracker',
@@ -348,7 +350,12 @@ export const OPENAPI_SPEC = {
       TaskUpdateArray: {
         type: 'array',
         items: { $ref: '#/components/schemas/BatchTaskUpdateItem' },
-        examples: [[{ id: 'task-1', state: 'completed' }, { id: 'task-2', state: 'failed' }]],
+        examples: [
+          [
+            { id: 'task-1', state: 'completed' },
+            { id: 'task-2', state: 'failed' },
+          ],
+        ],
       },
       ObjectiveUpdateRequest: {
         type: 'object',
@@ -526,7 +533,8 @@ export const OPENAPI_SPEC = {
       get: {
         tags: ['tokens'],
         summary: 'Get token info',
-        description: 'Requires GP permission. Rate limit: ~60/min per IP + token.',
+        description:
+          'Requires GP permission. Counts against the tiered daily read quota (keyed by user) and the per-minute burst limit.',
         operationId: 'getTokenInfo',
         security: [{ bearerAuth: [] }],
         responses: {
@@ -549,7 +557,8 @@ export const OPENAPI_SPEC = {
       get: {
         tags: ['progress'],
         summary: 'Get user progress',
-        description: 'Requires GP permission. Rate limit: ~60/min per IP + token.',
+        description:
+          'Requires GP permission. Counts against the tiered daily read quota (keyed by user) and the per-minute burst limit.',
         operationId: 'getProgress',
         security: [{ bearerAuth: [] }],
         responses: {
@@ -572,7 +581,8 @@ export const OPENAPI_SPEC = {
       get: {
         tags: ['team'],
         summary: 'Get team progress',
-        description: 'Requires TP permission. Rate limit: ~60/min per IP + token.',
+        description:
+          'Requires TP permission. Counts against the tiered daily read quota (keyed by user) and the per-minute burst limit.',
         operationId: 'getTeamProgress',
         security: [{ bearerAuth: [] }],
         responses: {
@@ -595,7 +605,8 @@ export const OPENAPI_SPEC = {
       post: {
         tags: ['progress'],
         summary: 'Update player level',
-        description: 'Requires WP permission. Rate limit: ~30/min per IP + token.',
+        description:
+          'Requires WP permission. Counts against the tiered daily write quota (keyed by user) and the per-minute burst limit.',
         operationId: 'updatePlayerLevel',
         security: [{ bearerAuth: [] }],
         parameters: [
@@ -629,7 +640,8 @@ export const OPENAPI_SPEC = {
       post: {
         tags: ['progress'],
         summary: 'Update single task state',
-        description: 'Requires WP permission. Rate limit: ~30/min per IP + token.',
+        description:
+          'Requires WP permission. Counts against the tiered daily write quota (keyed by user) and the per-minute burst limit.',
         operationId: 'updateTask',
         security: [{ bearerAuth: [] }],
         parameters: [
@@ -675,7 +687,8 @@ export const OPENAPI_SPEC = {
       post: {
         tags: ['progress'],
         summary: 'Update a task objective',
-        description: 'Requires WP permission. Rate limit: ~30/min per IP + token.',
+        description:
+          'Requires WP permission. Counts against the tiered daily write quota (keyed by user) and the per-minute burst limit.',
         operationId: 'updateTaskObjective',
         security: [{ bearerAuth: [] }],
         parameters: [
@@ -721,7 +734,8 @@ export const OPENAPI_SPEC = {
       post: {
         tags: ['progress'],
         summary: 'Batch update tasks',
-        description: 'Requires WP permission. Rate limit: ~30/min per IP + token.',
+        description:
+          'Requires WP permission. Counts against the tiered daily write quota (keyed by user) and the per-minute burst limit.',
         operationId: 'updateTasksBatch',
         security: [{ bearerAuth: [] }],
         requestBody: {

--- a/workers/api-gateway/src/services/supporter.ts
+++ b/workers/api-gateway/src/services/supporter.ts
@@ -3,6 +3,7 @@ import { getMemoryCache, setMemoryCache } from '../utils/memory-cache';
 import type { Env } from '../types';
 
 const TIER_CACHE_TTL_SECONDS = 60;
+const TIER_FETCH_TIMEOUT_MS = 3000;
 
 interface SupporterRow {
   tier?: string | null;
@@ -19,13 +20,16 @@ export async function resolveTier(env: Env, userId: string): Promise<ApiTier> {
   const cached = getMemoryCache<ApiTier>(cacheKey);
   if (cached) return cached;
   let tier: ApiTier = 'free';
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), TIER_FETCH_TIMEOUT_MS);
   try {
-    const url = `${env.SUPABASE_URL}/rest/v1/supporters?user_id=eq.${userId}&select=tier,status,expires_at&limit=1`;
+    const url = `${env.SUPABASE_URL}/rest/v1/supporters?user_id=eq.${encodeURIComponent(userId)}&select=tier,status,expires_at&limit=1`;
     const response = await fetch(url, {
       headers: {
         Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
         apikey: env.SUPABASE_SERVICE_ROLE_KEY,
       },
+      signal: controller.signal,
     });
     if (response.ok) {
       const rows = (await response.json()) as SupporterRow[];
@@ -39,6 +43,8 @@ export async function resolveTier(env: Env, userId: string): Promise<ApiTier> {
     }
   } catch (error) {
     console.warn('resolveTier failed, defaulting to free', { error });
+  } finally {
+    clearTimeout(timeout);
   }
   setMemoryCache(cacheKey, tier, TIER_CACHE_TTL_SECONDS);
   return tier;

--- a/workers/api-gateway/src/services/supporter.ts
+++ b/workers/api-gateway/src/services/supporter.ts
@@ -1,0 +1,51 @@
+import { isKnownTier, type ApiTier } from '../limits';
+import { getMemoryCache, setMemoryCache } from '../utils/memory-cache';
+import type { Env } from '../types';
+
+const TIER_CACHE_TTL_SECONDS = 60;
+
+interface SupporterRow {
+  tier?: string | null;
+  status?: string | null;
+  expires_at?: string | null;
+}
+
+/**
+ * Resolve the API tier for a user from public.supporters.
+ * Fails open to 'free' so a Supabase hiccup never blocks authenticated traffic.
+ */
+export async function resolveTier(env: Env, userId: string): Promise<ApiTier> {
+  const cacheKey = `tier:${userId}`;
+  const cached = getMemoryCache<ApiTier>(cacheKey);
+  if (cached) return cached;
+  let tier: ApiTier = 'free';
+  try {
+    const url = `${env.SUPABASE_URL}/rest/v1/supporters?user_id=eq.${userId}&select=tier,status,expires_at&limit=1`;
+    const response = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+        apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+      },
+    });
+    if (response.ok) {
+      const rows = (await response.json()) as SupporterRow[];
+      const row = rows[0];
+      if (row && row.status === 'active' && !isExpired(row.expires_at)) {
+        const value = (row.tier || '').toLowerCase();
+        if (isKnownTier(value)) tier = value;
+      }
+    } else {
+      console.warn('resolveTier supabase error', { status: response.status });
+    }
+  } catch (error) {
+    console.warn('resolveTier failed, defaulting to free', { error });
+  }
+  setMemoryCache(cacheKey, tier, TIER_CACHE_TTL_SECONDS);
+  return tier;
+}
+
+function isExpired(expiresAt: string | null | undefined): boolean {
+  if (!expiresAt) return false;
+  const ts = Date.parse(expiresAt);
+  return Number.isFinite(ts) && ts <= Date.now();
+}

--- a/workers/api-gateway/src/services/supporter.ts
+++ b/workers/api-gateway/src/services/supporter.ts
@@ -14,12 +14,15 @@ interface SupporterRow {
 /**
  * Resolve the API tier for a user from public.supporters.
  * Fails open to 'free' so a Supabase hiccup never blocks authenticated traffic.
+ * Only the result of a successful lookup is cached, so a transient outage does
+ * not pin a paid user to free limits for the cache TTL.
  */
 export async function resolveTier(env: Env, userId: string): Promise<ApiTier> {
   const cacheKey = `tier:${userId}`;
   const cached = getMemoryCache<ApiTier>(cacheKey);
   if (cached) return cached;
   let tier: ApiTier = 'free';
+  let cacheable = false;
   const controller = new AbortController();
   const timeout = setTimeout(() => controller.abort(), TIER_FETCH_TIMEOUT_MS);
   try {
@@ -38,6 +41,7 @@ export async function resolveTier(env: Env, userId: string): Promise<ApiTier> {
         const value = (row.tier || '').toLowerCase();
         if (isKnownTier(value)) tier = value;
       }
+      cacheable = true;
     } else {
       console.warn('resolveTier supabase error', { status: response.status });
     }
@@ -46,12 +50,16 @@ export async function resolveTier(env: Env, userId: string): Promise<ApiTier> {
   } finally {
     clearTimeout(timeout);
   }
-  setMemoryCache(cacheKey, tier, TIER_CACHE_TTL_SECONDS);
+  if (cacheable) {
+    setMemoryCache(cacheKey, tier, TIER_CACHE_TTL_SECONDS);
+  }
   return tier;
 }
 
 function isExpired(expiresAt: string | null | undefined): boolean {
   if (!expiresAt) return false;
   const ts = Date.parse(expiresAt);
-  return Number.isFinite(ts) && ts <= Date.now();
+  // Fail closed: an unparseable expiry is treated as expired so a malformed
+  // supporter row cannot grant elevated limits indefinitely.
+  return !Number.isFinite(ts) || ts <= Date.now();
 }

--- a/workers/api-gateway/src/services/usage.ts
+++ b/workers/api-gateway/src/services/usage.ts
@@ -1,6 +1,8 @@
 import type { ApiTier } from '../limits';
 import type { Env } from '../types';
 
+const USAGE_RPC_TIMEOUT_MS = 3000;
+
 export interface UsageRecord {
   userId: string;
   tokenId: string;
@@ -14,6 +16,8 @@ export interface UsageRecord {
  * record_api_usage RPC. Best-effort: failures are logged, never surfaced.
  */
 export async function recordUsage(env: Env, record: UsageRecord): Promise<void> {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), USAGE_RPC_TIMEOUT_MS);
   try {
     const response = await fetch(`${env.SUPABASE_URL}/rest/v1/rpc/record_api_usage`, {
       method: 'POST',
@@ -22,6 +26,7 @@ export async function recordUsage(env: Env, record: UsageRecord): Promise<void> 
         apikey: env.SUPABASE_SERVICE_ROLE_KEY,
         'content-type': 'application/json',
       },
+      signal: controller.signal,
       body: JSON.stringify({
         p_user_id: record.userId,
         p_token_id: record.tokenId,
@@ -36,5 +41,7 @@ export async function recordUsage(env: Env, record: UsageRecord): Promise<void> 
     }
   } catch (error) {
     console.warn('recordUsage error', { error });
+  } finally {
+    clearTimeout(timeout);
   }
 }

--- a/workers/api-gateway/src/services/usage.ts
+++ b/workers/api-gateway/src/services/usage.ts
@@ -1,0 +1,40 @@
+import type { ApiTier } from '../limits';
+import type { Env } from '../types';
+
+export interface UsageRecord {
+  userId: string;
+  tokenId: string;
+  tier: ApiTier;
+  kind: 'read' | 'write';
+  throttled: boolean;
+}
+
+/**
+ * Record one API request into public.api_usage_daily via the atomic
+ * record_api_usage RPC. Best-effort: failures are logged, never surfaced.
+ */
+export async function recordUsage(env: Env, record: UsageRecord): Promise<void> {
+  try {
+    const response = await fetch(`${env.SUPABASE_URL}/rest/v1/rpc/record_api_usage`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
+        apikey: env.SUPABASE_SERVICE_ROLE_KEY,
+        'content-type': 'application/json',
+      },
+      body: JSON.stringify({
+        p_user_id: record.userId,
+        p_token_id: record.tokenId,
+        p_tier: record.tier,
+        p_reads: record.kind === 'read' && !record.throttled ? 1 : 0,
+        p_writes: record.kind === 'write' && !record.throttled ? 1 : 0,
+        p_throttled: record.throttled ? 1 : 0,
+      }),
+    });
+    if (!response.ok) {
+      console.warn('recordUsage failed', { status: response.status });
+    }
+  } catch (error) {
+    console.warn('recordUsage error', { error });
+  }
+}


### PR DESCRIPTION
## **User description**
## Why

Free-tier consumers reached ~1.4k API requests/day. The gateway only enforced fixed per-minute windows, with no daily quotas, no tier awareness, and no consumer observability.

## What

- **Tiered quotas** (`workers/api-gateway/src/limits.ts`, keyed by user id so extra tokens do not multiply quota):
  | Tier | Reads/day | Writes/day | Burst/min |
  |---|---|---|---|
  | Free | 1,000 | 100 | 30 |
  | Scav | 2,000 | 250 | 60 |
  | Timmy | 3,000 | 400 | 90 |
  | Chad | 5,000 | 600 | 120 |
  Tier resolved from `public.supporters` (active + unexpired), 60s memory cache, fails open to free. Legacy generic `supporter` tier maps to scav limits. Decision log in `limits.ts`.
- **Daily counters**: the existing `ApiGatewayRateLimiter` Durable Object gains a `utc-day` anchor (atomic, resets at 00:00 UTC). Daily check runs before burst so daily 429s don't consume burst slots.
- **Burst smoothing**: burst limits move from fixed-window to a **sliding-window log** in the DO, so TarkovMonitor batches near a minute boundary aren't spuriously throttled. Legacy fixed-window payloads keep old behavior.
- **Headers**: `X-RateLimit-Limit/Remaining/Reset` now reflect the daily quota on every gateway response; `Retry-After` on 429.
- **Upgrade message**: free-tier daily-quota 429s return a clear message with the supporter upgrade link.
- **Admin observability**: new `public.api_usage_daily` table + atomic `record_api_usage` RPC (SECURITY DEFINER, service-role only, RLS deny-all) recorded via `ctx.waitUntil`; new `GET /api/admin/api-usage` returns top consumers (tier/reads/writes/429s) for the last 24h, admin-gated like `admin/supporter`.
- Docs: rate-limit section added to `docs/API.md`.

## Validation

- `npm run test:api-gateway` — 40 tests pass (new: DO utc-day anchoring + midnight reset, sliding-window aging, legacy fixed-window compat, tier mapping from supporters, free-tier upgrade message, usage RPC recording).
- `npx vitest run app/server/api/admin/__tests__/api-usage.test.ts` — 3 pass.
- `npm run typecheck` clean, `npm run lint` zero warnings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added admin-only `GET /api/admin/api-usage` to list top API consumers over the last 24 hours.
  * Introduced tiered gateway rate limiting with UTC daily quotas and sliding-window burst throttling, including usage tracking and upgrade messaging.
* **Bug Fixes**
  * Refunded daily quota when burst throttling denies a request.
* **Documentation**
  * Updated API docs and OpenAPI rate-limit guidance and examples for `X-RateLimit-*` and `Retry-After`.
* **Tests**
  * Added/updated gateway and admin test coverage for daily/burst headers and usage/authorization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


___

## **CodeAnt-AI Description**
**Add tiered daily API limits, burst smoothing, and usage reporting**

### What Changed
- API requests are now limited by user tier with daily read/write quotas, and free-tier 429s show a clear upgrade link
- Per-minute throttling now uses a sliding window, which reduces false blocks near minute boundaries and keeps burst failures from using up the daily quota
- Rate-limit headers now describe the daily quota, and the admin API now returns top consumers for the last 24 hours
- Admin routes share the same authentication and Supabase request handling, with stalled upstream requests timing out instead of hanging the request

### Impact
`✅ Fewer false rate-limit blocks during batch updates`
`✅ Clearer free-tier upgrade prompts`
`✅ Faster admin usage lookups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
