### PR TITLE
feat(test): add zero-dep page-load measurement scripts

### DIFF
--- a/scripts/build-measure.sh
+++ b/scripts/build-measure.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# Build a static SPA into dist-measure/ for repeatable page-load measurement.
+# Uses the `static` nitro preset so we get a real index.html shell (the default
+# cloudflare-pages build serves the shell from _worker.js with no html file).
+set -e
+cd "$(dirname "$0")/.."
+export NITRO_PRESET=static
+export NODE_ENV=production
+npx nuxt generate >/tmp/generate.log 2>&1
+echo "GENERATE_EXIT=$?"
+tail -5 /tmp/generate.log
+echo "=== output html ==="
+find .output/public -maxdepth 1 -name '*.html' 2>/dev/null

--- a/scripts/build-measure.sh
+++ b/scripts/build-measure.sh
@@ -1,13 +1,15 @@
 #!/bin/bash
-# Build a static SPA into dist-measure/ for repeatable page-load measurement.
+# Build a static SPA into .output/public/ for repeatable page-load measurement.
 # Uses the `static` nitro preset so we get a real index.html shell (the default
 # cloudflare-pages build serves the shell from _worker.js with no html file).
-set -e
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || exit 1
 export NITRO_PRESET=static
 export NODE_ENV=production
+set +e
 npx nuxt generate >/tmp/generate.log 2>&1
-echo "GENERATE_EXIT=$?"
+GENERATE_EXIT=$?
+set -e
+echo "GENERATE_EXIT=$GENERATE_EXIT"
 tail -5 /tmp/generate.log
 echo "=== output html ==="
 find .output/public -maxdepth 1 -name '*.html' 2>/dev/null

--- a/scripts/build-measure.sh
+++ b/scripts/build-measure.sh
@@ -11,5 +11,8 @@ GENERATE_EXIT=$?
 set -e
 echo "GENERATE_EXIT=$GENERATE_EXIT"
 tail -5 /tmp/generate.log
+if [ "$GENERATE_EXIT" != "0" ]; then
+  exit "$GENERATE_EXIT"
+fi
 echo "=== output html ==="
 find .output/public -maxdepth 1 -name '*.html' 2>/dev/null

--- a/scripts/build-measure.sh
+++ b/scripts/build-measure.sh
@@ -5,12 +5,14 @@
 cd "$(dirname "$0")/.." || exit 1
 export NITRO_PRESET=static
 export NODE_ENV=production
+GENERATE_LOG="$(mktemp)"
+trap 'rm -f "$GENERATE_LOG"' EXIT
 set +e
-npx nuxt generate >/tmp/generate.log 2>&1
+npx nuxt generate >"$GENERATE_LOG" 2>&1
 GENERATE_EXIT=$?
 set -e
 echo "GENERATE_EXIT=$GENERATE_EXIT"
-tail -5 /tmp/generate.log
+tail -5 "$GENERATE_LOG"
 if [ "$GENERATE_EXIT" != "0" ]; then
   exit "$GENERATE_EXIT"
 fi

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -6,11 +6,9 @@
 import { spawn } from 'node:child_process';
 import { createReadStream, existsSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { extname, join, normalize } from 'node:path';
+import { extname, join, normalize, sep } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
-
 const log = (...a) => process.stderr.write(`[measure] ${a.join(' ')}\n`);
-
 const DIST = join(process.cwd(), process.env.MEASURE_DIST || '.output/public');
 const PORT = Number(process.env.MEASURE_PORT || 4178);
 const RUNS = Number(process.env.MEASURE_RUNS || 5);
@@ -19,7 +17,6 @@ const CHROME = process.env.CHROME_BIN || '/usr/bin/google-chrome';
 const PAGES = (process.env.MEASURE_PAGES || '/,/tasks,/hideout,/needed-items,/settings,/team').split(
   ','
 );
-
 const MIME = {
   '.js': 'text/javascript',
   '.css': 'text/css',
@@ -32,12 +29,11 @@ const MIME = {
   '.woff2': 'font/woff2',
   '.woff': 'font/woff',
 };
-
 function startServer() {
   const server = createServer((req, res) => {
     const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
     let filePath = normalize(join(DIST, urlPath));
-    if (!filePath.startsWith(DIST)) {
+    if (filePath !== DIST && !filePath.startsWith(DIST + sep)) {
       res.statusCode = 403;
       return res.end('forbidden');
     }
@@ -49,11 +45,18 @@ function startServer() {
       filePath = join(DIST, 'index.html');
     }
     res.setHeader('content-type', MIME[extname(filePath)] || 'application/octet-stream');
-    createReadStream(filePath).pipe(res);
+    createReadStream(filePath)
+      .on('error', () => {
+        res.statusCode = 500;
+        res.end('read error');
+      })
+      .pipe(res);
   });
-  return new Promise((resolve) => server.listen(PORT, () => resolve(server)));
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(PORT, () => resolve(server));
+  });
 }
-
 function startChrome() {
   const args = [
     '--headless=new',
@@ -66,7 +69,6 @@ function startChrome() {
   const proc = spawn(CHROME, args, { stdio: ['ignore', 'ignore', 'pipe'] });
   return proc;
 }
-
 async function getWsUrl() {
   for (let i = 0; i < 50; i++) {
     try {
@@ -80,7 +82,6 @@ async function getWsUrl() {
   }
   throw new Error('Chrome CDP endpoint never came up');
 }
-
 // Minimal CDP client over WebSocket.
 class CDP {
   constructor(ws) {
@@ -96,6 +97,10 @@ class CDP {
         msg.error ? reject(new Error(msg.error.message)) : resolve(msg.result);
       }
     });
+    ws.addEventListener('close', () => {
+      for (const { reject } of this.pending.values()) reject(new Error('WebSocket closed'));
+      this.pending.clear();
+    });
   }
   send(method, params = {}, sessionId) {
     const id = ++this.id;
@@ -107,7 +112,6 @@ class CDP {
     });
   }
 }
-
 function connect(url) {
   return new Promise((resolve, reject) => {
     const ws = new WebSocket(url);
@@ -115,7 +119,6 @@ function connect(url) {
     ws.addEventListener('error', reject);
   });
 }
-
 async function measurePage(cdp, sessionId, url) {
   // Fresh navigation; clear cache so we measure cold load each run.
   await cdp.send('Network.clearBrowserCache', {}, sessionId);
@@ -158,7 +161,6 @@ async function measurePage(cdp, sessionId, url) {
     if (Date.now() > deadline) throw new Error(`timeout measuring ${url}`);
   }
 }
-
 function stats(nums) {
   const sorted = [...nums].sort((a, b) => a - b);
   const median = sorted[Math.floor(sorted.length / 2)];
@@ -166,7 +168,6 @@ function stats(nums) {
   const max = sorted[sorted.length - 1];
   return { median, min, max };
 }
-
 async function main() {
   if (!existsSync(DIST)) {
     console.error(`${DIST} not found — run \`bash scripts/build-measure.sh\` first.`);
@@ -193,7 +194,6 @@ async function main() {
     const { sessionId } = await cdp.send('Target.attachToTarget', { targetId, flatten: true });
     await cdp.send('Page.enable', {}, sessionId);
     await cdp.send('Network.enable', {}, sessionId);
-
     const base = `http://127.0.0.1:${PORT}`;
     const results = [];
     for (const page of PAGES) {
@@ -216,7 +216,6 @@ async function main() {
       const fs = fcps.length ? stats(fcps) : { median: null };
       results.push({ page, load: ls.median, ready: rs.median, fcp: fs.median, transferKB });
     }
-
     console.log(
       `\nPage-load (cold cache, ${RUNS} runs, ${CPU_THROTTLE}x CPU throttle, headless Chrome, static SPA)`
     );
@@ -243,7 +242,6 @@ async function main() {
     server.close();
   }
 }
-
 main().catch((e) => {
   console.error(e);
   process.exit(1);

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -1,0 +1,250 @@
+#!/usr/bin/env node
+// ponytail: zero-dep page-load measurement. Static-serves dist/ with SPA
+// fallback, drives headless Chrome over CDP, reports per-page load timing.
+// No puppeteer/playwright/lighthouse — uses node's global WebSocket + /usr/bin/google-chrome.
+// Upgrade path: swap in Lighthouse if you need FCP/LCP/TBT category scores.
+import { spawn } from 'node:child_process';
+import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { extname, join, normalize } from 'node:path';
+import { setTimeout as sleep } from 'node:timers/promises';
+
+const log = (...a) => process.stderr.write(`[measure] ${a.join(' ')}\n`);
+
+const DIST = join(process.cwd(), process.env.MEASURE_DIST || '.output/public');
+const PORT = Number(process.env.MEASURE_PORT || 4178);
+const RUNS = Number(process.env.MEASURE_RUNS || 5);
+const CPU_THROTTLE = Number(process.env.MEASURE_CPU_THROTTLE || 4);
+const CHROME = process.env.CHROME_BIN || '/usr/bin/google-chrome';
+const PAGES = (process.env.MEASURE_PAGES || '/,/tasks,/hideout,/needed-items,/settings,/team').split(
+  ','
+);
+
+const MIME = {
+  '.js': 'text/javascript',
+  '.css': 'text/css',
+  '.json': 'application/json',
+  '.html': 'text/html',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.webp': 'image/webp',
+  '.ico': 'image/x-icon',
+  '.woff2': 'font/woff2',
+  '.woff': 'font/woff',
+};
+
+function startServer() {
+  const server = createServer((req, res) => {
+    const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+    let filePath = normalize(join(DIST, urlPath));
+    if (!filePath.startsWith(DIST)) {
+      res.statusCode = 403;
+      return res.end('forbidden');
+    }
+    if (existsSync(filePath) && statSync(filePath).isDirectory()) {
+      filePath = join(filePath, 'index.html');
+    }
+    if (!existsSync(filePath)) {
+      // SPA fallback
+      filePath = join(DIST, 'index.html');
+    }
+    res.setHeader('content-type', MIME[extname(filePath)] || 'application/octet-stream');
+    createReadStream(filePath).pipe(res);
+  });
+  return new Promise((resolve) => server.listen(PORT, () => resolve(server)));
+}
+
+function startChrome() {
+  const args = [
+    '--headless=new',
+    '--disable-gpu',
+    '--no-sandbox',
+    '--remote-debugging-port=9333',
+    `--user-data-dir=/tmp/measure-chrome-${process.pid}`,
+    'about:blank',
+  ];
+  const proc = spawn(CHROME, args, { stdio: ['ignore', 'ignore', 'pipe'] });
+  return proc;
+}
+
+async function getWsUrl() {
+  for (let i = 0; i < 50; i++) {
+    try {
+      const r = await fetch('http://127.0.0.1:9333/json/version');
+      const j = await r.json();
+      if (j.webSocketDebuggerUrl) return j.webSocketDebuggerUrl;
+    } catch {
+      // not ready
+    }
+    await sleep(100);
+  }
+  throw new Error('Chrome CDP endpoint never came up');
+}
+
+// Minimal CDP client over WebSocket.
+class CDP {
+  constructor(ws) {
+    this.ws = ws;
+    this.id = 0;
+    this.pending = new Map();
+    this.sessions = new Map();
+    ws.addEventListener('message', (e) => {
+      const msg = JSON.parse(e.data);
+      if (msg.id && this.pending.has(msg.id)) {
+        const { resolve, reject } = this.pending.get(msg.id);
+        this.pending.delete(msg.id);
+        msg.error ? reject(new Error(msg.error.message)) : resolve(msg.result);
+      }
+    });
+  }
+  send(method, params = {}, sessionId) {
+    const id = ++this.id;
+    const payload = { id, method, params };
+    if (sessionId) payload.sessionId = sessionId;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      this.ws.send(JSON.stringify(payload));
+    });
+  }
+}
+
+function connect(url) {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    ws.addEventListener('open', () => resolve(ws));
+    ws.addEventListener('error', reject);
+  });
+}
+
+async function measurePage(cdp, sessionId, url) {
+  // Fresh navigation; clear cache so we measure cold load each run.
+  await cdp.send('Network.clearBrowserCache', {}, sessionId);
+  // Fixed CPU throttle for deterministic, machine-independent numbers.
+  await cdp.send('Emulation.setCPUThrottlingRate', { rate: CPU_THROTTLE }, sessionId);
+  await cdp.send('Page.navigate', { url }, sessionId);
+  // Poll until the SPA has actually rendered content (loading fallback gone +
+  // real DOM inside #__nuxt), not just the load event.
+  const deadline = Date.now() + 30000;
+  for (;;) {
+    await sleep(60);
+    const { result } = await cdp.send(
+      'Runtime.evaluate',
+      {
+        expression: `(() => {
+          const n = performance.getEntriesByType('navigation')[0];
+          if (!n || !n.loadEventEnd) return null;
+          const root = document.getElementById('__nuxt');
+          const loader = document.querySelector('.tt-loading-fallback');
+          const loaderVisible = loader && loader.offsetParent !== null;
+          const rendered = root && root.children.length > 0 && !loaderVisible
+            && (root.innerText || '').trim().length > 0;
+          if (!rendered) return null;
+          const paints = performance.getEntriesByType('paint');
+          const fcp = paints.find(p => p.name === 'first-contentful-paint');
+          return JSON.stringify({
+            domContentLoaded: n.domContentLoadedEventEnd,
+            load: n.loadEventEnd,
+            fcp: fcp ? fcp.startTime : null,
+            ready: performance.now(),
+            transferKB: Math.round((performance.getEntriesByType('resource')
+              .reduce((s,r)=>s+(r.transferSize||0), n.transferSize||0))/1024),
+          });
+        })()`,
+        returnByValue: true,
+      },
+      sessionId
+    );
+    if (result && result.value) return JSON.parse(result.value);
+    if (Date.now() > deadline) throw new Error(`timeout measuring ${url}`);
+  }
+}
+
+function stats(nums) {
+  const sorted = [...nums].sort((a, b) => a - b);
+  const median = sorted[Math.floor(sorted.length / 2)];
+  const min = sorted[0];
+  const max = sorted[sorted.length - 1];
+  return { median, min, max };
+}
+
+async function main() {
+  if (!existsSync(DIST)) {
+    console.error(`${DIST} not found — run \`bash scripts/build-measure.sh\` first.`);
+    process.exit(1);
+  }
+  log('starting static server on', PORT);
+  const server = await startServer();
+  log('launching chrome', CHROME);
+  const chrome = startChrome();
+  chrome.stderr?.on('data', (d) => {
+    const s = d.toString();
+    if (/error|fail|crash/i.test(s)) log('chrome:', s.trim().slice(0, 200));
+  });
+  chrome.on('exit', (c) => log('chrome exited code', c));
+  let ws;
+  try {
+    log('waiting for CDP endpoint');
+    const wsUrl = await getWsUrl();
+    log('CDP up:', wsUrl);
+    ws = await connect(wsUrl);
+    log('websocket connected');
+    const cdp = new CDP(ws);
+    const { targetId } = await cdp.send('Target.createTarget', { url: 'about:blank' });
+    const { sessionId } = await cdp.send('Target.attachToTarget', { targetId, flatten: true });
+    await cdp.send('Page.enable', {}, sessionId);
+    await cdp.send('Network.enable', {}, sessionId);
+
+    const base = `http://127.0.0.1:${PORT}`;
+    const results = [];
+    for (const page of PAGES) {
+      const url = base + page;
+      // warmup (discarded)
+      await measurePage(cdp, sessionId, url);
+      const loads = [];
+      const readys = [];
+      const fcps = [];
+      let transferKB = 0;
+      for (let i = 0; i < RUNS; i++) {
+        const m = await measurePage(cdp, sessionId, url);
+        loads.push(m.load);
+        readys.push(m.ready);
+        if (m.fcp != null) fcps.push(m.fcp);
+        transferKB = m.transferKB;
+      }
+      const ls = stats(loads);
+      const rs = stats(readys);
+      const fs = fcps.length ? stats(fcps) : { median: null };
+      results.push({ page, load: ls.median, ready: rs.median, fcp: fs.median, transferKB });
+    }
+
+    console.log(
+      `\nPage-load (cold cache, ${RUNS} runs, ${CPU_THROTTLE}x CPU throttle, headless Chrome, static SPA)`
+    );
+    console.log(
+      'page'.padEnd(16),
+      'ready(ms)'.padStart(10),
+      'load(ms)'.padStart(10),
+      'fcp(ms)'.padStart(10),
+      'xfer(KB)'.padStart(10)
+    );
+    for (const r of results) {
+      console.log(
+        r.page.padEnd(16),
+        `${Math.round(r.ready)}`.padStart(10),
+        `${Math.round(r.load)}`.padStart(10),
+        `${r.fcp != null ? Math.round(r.fcp) : '-'}`.padStart(10),
+        `${r.transferKB}`.padStart(10)
+      );
+    }
+    console.log('');
+  } finally {
+    if (ws) ws.close();
+    chrome.kill('SIGKILL');
+    server.close();
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -4,8 +4,9 @@
 // No puppeteer/playwright/lighthouse — uses node's global WebSocket + /usr/bin/google-chrome.
 // Upgrade path: swap in Lighthouse if you need FCP/LCP/TBT category scores.
 import { spawn } from 'node:child_process';
-import { createReadStream, existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
+import { createReadStream, existsSync, realpathSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
+import { createServer as createNetServer } from 'node:net';
 import { extname, join, resolve as resolvePath, sep } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 const log = (...a) => process.stderr.write(`[measure] ${a.join(' ')}\n`);
@@ -88,24 +89,48 @@ function startServer() {
     server.listen(PORT, '127.0.0.1', () => resolve(server));
   });
 }
-function startChrome() {
+function getFreePort() {
+  return new Promise((resolve, reject) => {
+    const probe = createNetServer();
+    probe.once('error', reject);
+    probe.listen(0, '127.0.0.1', () => {
+      const address = probe.address();
+      probe.close(() => {
+        if (address && typeof address === 'object') resolve(address.port);
+        else reject(new Error('Could not allocate Chrome CDP port'));
+      });
+    });
+  });
+}
+function startChrome(cdpPort) {
   const args = [
     '--headless=new',
     '--disable-gpu',
     '--no-sandbox',
-    '--remote-debugging-port=0',
+    `--remote-debugging-port=${cdpPort}`,
     `--user-data-dir=${CHROME_DIR}`,
     'about:blank',
   ];
   const proc = spawn(CHROME, args, { stdio: ['ignore', 'ignore', 'pipe'] });
   return proc;
 }
-async function getWsUrl() {
-  const activePortFile = join(CHROME_DIR, 'DevToolsActivePort');
+async function getWsUrl(cdpPort) {
+  const endpoint = `http://127.0.0.1:${cdpPort}/json/version`;
   for (let i = 0; i < 50; i++) {
     try {
-      const [port, path] = readFileSync(activePortFile, 'utf8').trim().split('\n');
-      if (port && path) return `ws://127.0.0.1:${port}${path}`;
+      const response = await fetch(endpoint);
+      const { webSocketDebuggerUrl } = await response.json();
+      if (typeof webSocketDebuggerUrl === 'string') {
+        const url = new URL(webSocketDebuggerUrl);
+        if (
+          url.protocol === 'ws:' &&
+          url.hostname === '127.0.0.1' &&
+          url.port === String(cdpPort) &&
+          /^\/devtools\/browser\/[a-f0-9-]+$/i.test(url.pathname)
+        ) {
+          return `ws://127.0.0.1:${cdpPort}${url.pathname}`;
+        }
+      }
     } catch {
       // not ready
     }
@@ -206,8 +231,9 @@ async function main() {
   }
   log('starting static server on', PORT);
   const server = await startServer();
-  log('launching chrome', CHROME);
-  const chrome = startChrome();
+  const cdpPort = await getFreePort();
+  log('launching chrome', CHROME, 'cdp', cdpPort);
+  const chrome = startChrome(cdpPort);
   chrome.stderr?.on('data', (d) => {
     const s = d.toString();
     if (/error|fail|crash/i.test(s)) log('chrome:', s.trim().slice(0, 200));
@@ -221,7 +247,7 @@ async function main() {
   let ws;
   try {
     log('waiting for CDP endpoint');
-    const wsUrl = await getWsUrl();
+    const wsUrl = await getWsUrl(cdpPort);
     log('CDP up:', wsUrl);
     ws = await connect(wsUrl);
     log('websocket connected');

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -6,7 +6,7 @@
 import { spawn } from 'node:child_process';
 import { createReadStream, existsSync, realpathSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { extname, join, sep } from 'node:path';
+import { extname, join, resolve, sep } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 const log = (...a) => process.stderr.write(`[measure] ${a.join(' ')}\n`);
 const DIST = join(process.cwd(), process.env.MEASURE_DIST || '.output/public');
@@ -37,7 +37,7 @@ function startServer() {
     const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
     let filePath;
     try {
-      filePath = realpathSync(join(DIST, urlPath));
+      filePath = resolve(realpathSync(join(DIST, urlPath)));
     } catch {
       filePath = null;
     }
@@ -54,7 +54,7 @@ function startServer() {
     }
     if (existsSync(filePath) && statSync(filePath).isDirectory()) {
       try {
-        filePath = realpathSync(join(filePath, 'index.html'));
+        filePath = resolve(realpathSync(join(filePath, 'index.html')));
       } catch {
         filePath = indexHtml;
       }

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -31,29 +31,37 @@ const MIME = {
 };
 function startServer() {
   const distReal = realpathSync(DIST);
+  const distPrefix = distReal + sep;
+  const indexHtml = join(distReal, 'index.html');
   const server = createServer((req, res) => {
     const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
     let filePath;
     try {
       filePath = realpathSync(join(DIST, urlPath));
-      if (statSync(filePath).isDirectory()) {
-        filePath = realpathSync(join(filePath, 'index.html'));
-      }
     } catch {
       filePath = null;
     }
     if (!filePath) {
-      // SPA fallback
-      try {
-        filePath = realpathSync(join(DIST, 'index.html'));
-      } catch {
-        res.statusCode = 404;
-        return res.end('not found');
-      }
+      // SPA fallback for paths that don't exist
+      filePath = indexHtml;
     }
-    if (filePath !== distReal && !filePath.startsWith(distReal + sep)) {
+    if (filePath === distReal) {
+      filePath = indexHtml;
+    }
+    if (!filePath.startsWith(distPrefix)) {
       res.statusCode = 403;
       return res.end('forbidden');
+    }
+    if (existsSync(filePath) && statSync(filePath).isDirectory()) {
+      try {
+        filePath = realpathSync(join(filePath, 'index.html'));
+      } catch {
+        filePath = indexHtml;
+      }
+      if (!filePath.startsWith(distPrefix)) {
+        res.statusCode = 403;
+        return res.end('forbidden');
+      }
     }
     res.setHeader('content-type', MIME[extname(filePath)] || 'application/octet-stream');
     createReadStream(filePath)

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -51,7 +51,13 @@ function startServer() {
     return existsSync(requested) ? requested : indexHtml;
   };
   const server = createServer((req, res) => {
-    const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+    let urlPath;
+    try {
+      urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
+    } catch {
+      res.statusCode = 400;
+      return res.end('bad request');
+    }
     const filePath = resolveRequest(urlPath);
     if (!filePath) {
       res.statusCode = 403;
@@ -206,6 +212,11 @@ async function main() {
     if (/error|fail|crash/i.test(s)) log('chrome:', s.trim().slice(0, 200));
   });
   chrome.on('exit', (c) => log('chrome exited code', c));
+  chrome.on('error', (e) => {
+    log('chrome spawn error', e.message);
+    server.close();
+    process.exit(1);
+  });
   let ws;
   try {
     log('waiting for CDP endpoint');

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -4,9 +4,9 @@
 // No puppeteer/playwright/lighthouse — uses node's global WebSocket + /usr/bin/google-chrome.
 // Upgrade path: swap in Lighthouse if you need FCP/LCP/TBT category scores.
 import { spawn } from 'node:child_process';
-import { createReadStream, existsSync, statSync } from 'node:fs';
+import { createReadStream, existsSync, realpathSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { extname, join, normalize, sep } from 'node:path';
+import { extname, join, sep } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 const log = (...a) => process.stderr.write(`[measure] ${a.join(' ')}\n`);
 const DIST = join(process.cwd(), process.env.MEASURE_DIST || '.output/public');
@@ -30,19 +30,30 @@ const MIME = {
   '.woff': 'font/woff',
 };
 function startServer() {
+  const distReal = realpathSync(DIST);
   const server = createServer((req, res) => {
     const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
-    let filePath = normalize(join(DIST, urlPath));
-    if (filePath !== DIST && !filePath.startsWith(DIST + sep)) {
+    let filePath;
+    try {
+      filePath = realpathSync(join(DIST, urlPath));
+      if (statSync(filePath).isDirectory()) {
+        filePath = realpathSync(join(filePath, 'index.html'));
+      }
+    } catch {
+      filePath = null;
+    }
+    if (!filePath) {
+      // SPA fallback
+      try {
+        filePath = realpathSync(join(DIST, 'index.html'));
+      } catch {
+        res.statusCode = 404;
+        return res.end('not found');
+      }
+    }
+    if (filePath !== distReal && !filePath.startsWith(distReal + sep)) {
       res.statusCode = 403;
       return res.end('forbidden');
-    }
-    if (existsSync(filePath) && statSync(filePath).isDirectory()) {
-      filePath = join(filePath, 'index.html');
-    }
-    if (!existsSync(filePath)) {
-      // SPA fallback
-      filePath = join(DIST, 'index.html');
     }
     res.setHeader('content-type', MIME[extname(filePath)] || 'application/octet-stream');
     createReadStream(filePath)
@@ -213,8 +224,8 @@ async function main() {
       }
       const ls = stats(loads);
       const rs = stats(readys);
-      const fs = fcps.length ? stats(fcps) : { median: null };
-      results.push({ page, load: ls.median, ready: rs.median, fcp: fs.median, transferKB });
+      const fcpStats = fcps.length ? stats(fcps) : { median: null };
+      results.push({ page, load: ls.median, ready: rs.median, fcp: fcpStats.median, transferKB });
     }
     console.log(
       `\nPage-load (cold cache, ${RUNS} runs, ${CPU_THROTTLE}x CPU throttle, headless Chrome, static SPA)`

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -10,10 +10,11 @@ import { createServer as createNetServer } from 'node:net';
 import { extname, join, resolve as resolvePath, sep } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 const log = (...a) => process.stderr.write(`[measure] ${a.join(' ')}\n`);
+const num = (v, d) => (v == null || v === '' || Number.isNaN(Number(v)) ? d : Number(v));
 const DIST = join(process.cwd(), process.env.MEASURE_DIST || '.output/public');
-const PORT = Number(process.env.MEASURE_PORT || 4178);
-const RUNS = Number(process.env.MEASURE_RUNS || 5);
-const CPU_THROTTLE = Number(process.env.MEASURE_CPU_THROTTLE || 4);
+const PORT = num(process.env.MEASURE_PORT, 4178);
+const RUNS = num(process.env.MEASURE_RUNS, 5);
+const CPU_THROTTLE = num(process.env.MEASURE_CPU_THROTTLE, 4);
 const CHROME = process.env.CHROME_BIN || '/usr/bin/google-chrome';
 const CHROME_DIR = `/tmp/measure-chrome-${process.pid}`;
 const PAGES = (

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -4,7 +4,7 @@
 // No puppeteer/playwright/lighthouse — uses node's global WebSocket + /usr/bin/google-chrome.
 // Upgrade path: swap in Lighthouse if you need FCP/LCP/TBT category scores.
 import { spawn } from 'node:child_process';
-import { createReadStream, existsSync, realpathSync, statSync } from 'node:fs';
+import { createReadStream, existsSync, readFileSync, realpathSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
 import { extname, join, resolve as resolvePath, sep } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
@@ -14,9 +14,10 @@ const PORT = Number(process.env.MEASURE_PORT || 4178);
 const RUNS = Number(process.env.MEASURE_RUNS || 5);
 const CPU_THROTTLE = Number(process.env.MEASURE_CPU_THROTTLE || 4);
 const CHROME = process.env.CHROME_BIN || '/usr/bin/google-chrome';
-const PAGES = (process.env.MEASURE_PAGES || '/,/tasks,/hideout,/needed-items,/settings,/team').split(
-  ','
-);
+const CHROME_DIR = `/tmp/measure-chrome-${process.pid}`;
+const PAGES = (
+  process.env.MEASURE_PAGES || '/,/tasks,/hideout,/needed-items,/settings,/team'
+).split(',');
 const MIME = {
   '.js': 'text/javascript',
   '.css': 'text/css',
@@ -84,7 +85,7 @@ function startServer() {
   });
   return new Promise((resolve, reject) => {
     server.once('error', reject);
-    server.listen(PORT, () => resolve(server));
+    server.listen(PORT, '127.0.0.1', () => resolve(server));
   });
 }
 function startChrome() {
@@ -92,19 +93,19 @@ function startChrome() {
     '--headless=new',
     '--disable-gpu',
     '--no-sandbox',
-    '--remote-debugging-port=9333',
-    `--user-data-dir=/tmp/measure-chrome-${process.pid}`,
+    '--remote-debugging-port=0',
+    `--user-data-dir=${CHROME_DIR}`,
     'about:blank',
   ];
   const proc = spawn(CHROME, args, { stdio: ['ignore', 'ignore', 'pipe'] });
   return proc;
 }
 async function getWsUrl() {
+  const activePortFile = join(CHROME_DIR, 'DevToolsActivePort');
   for (let i = 0; i < 50; i++) {
     try {
-      const r = await fetch('http://127.0.0.1:9333/json/version');
-      const j = await r.json();
-      if (j.webSocketDebuggerUrl) return j.webSocketDebuggerUrl;
+      const [port, path] = readFileSync(activePortFile, 'utf8').trim().split('\n');
+      if (port && path) return `ws://127.0.0.1:${port}${path}`;
     } catch {
       // not ready
     }

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -33,22 +33,29 @@ function startServer() {
   const distReal = realpathSync(DIST);
   const distPrefix = distReal + sep;
   const indexHtml = join(distReal, 'index.html');
+  // Maps a request path to a file inside dist, or null if it escapes dist.
+  // `requested` is assigned once and only read after the startsWith guard.
+  const resolveRequest = (urlPath) => {
+    const requested = resolvePath(join(distReal, urlPath));
+    if (requested === distReal) {
+      return indexHtml;
+    }
+    if (!requested.startsWith(distPrefix)) {
+      return null;
+    }
+    if (existsSync(requested) && statSync(requested).isDirectory()) {
+      const dirIndex = join(requested, 'index.html');
+      return existsSync(dirIndex) ? dirIndex : indexHtml;
+    }
+    // SPA fallback for routes without a generated file
+    return existsSync(requested) ? requested : indexHtml;
+  };
   const server = createServer((req, res) => {
     const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
-    let filePath = resolvePath(join(distReal, urlPath));
-    if (filePath === distReal) {
-      filePath = indexHtml;
-    }
-    if (!filePath.startsWith(distPrefix)) {
+    const filePath = resolveRequest(urlPath);
+    if (!filePath) {
       res.statusCode = 403;
       return res.end('forbidden');
-    }
-    if (existsSync(filePath) && statSync(filePath).isDirectory()) {
-      filePath = join(filePath, 'index.html');
-    }
-    if (!existsSync(filePath)) {
-      // SPA fallback
-      filePath = indexHtml;
     }
     // Reject symlinks that resolve outside dist (realpath used for validation only).
     let realPath;

--- a/scripts/measure-pageload.mjs
+++ b/scripts/measure-pageload.mjs
@@ -6,7 +6,7 @@
 import { spawn } from 'node:child_process';
 import { createReadStream, existsSync, realpathSync, statSync } from 'node:fs';
 import { createServer } from 'node:http';
-import { extname, join, resolve, sep } from 'node:path';
+import { extname, join, resolve as resolvePath, sep } from 'node:path';
 import { setTimeout as sleep } from 'node:timers/promises';
 const log = (...a) => process.stderr.write(`[measure] ${a.join(' ')}\n`);
 const DIST = join(process.cwd(), process.env.MEASURE_DIST || '.output/public');
@@ -35,16 +35,7 @@ function startServer() {
   const indexHtml = join(distReal, 'index.html');
   const server = createServer((req, res) => {
     const urlPath = decodeURIComponent((req.url || '/').split('?')[0]);
-    let filePath;
-    try {
-      filePath = resolve(realpathSync(join(DIST, urlPath)));
-    } catch {
-      filePath = null;
-    }
-    if (!filePath) {
-      // SPA fallback for paths that don't exist
-      filePath = indexHtml;
-    }
+    let filePath = resolvePath(join(distReal, urlPath));
     if (filePath === distReal) {
       filePath = indexHtml;
     }
@@ -53,15 +44,22 @@ function startServer() {
       return res.end('forbidden');
     }
     if (existsSync(filePath) && statSync(filePath).isDirectory()) {
-      try {
-        filePath = resolve(realpathSync(join(filePath, 'index.html')));
-      } catch {
-        filePath = indexHtml;
-      }
-      if (!filePath.startsWith(distPrefix)) {
-        res.statusCode = 403;
-        return res.end('forbidden');
-      }
+      filePath = join(filePath, 'index.html');
+    }
+    if (!existsSync(filePath)) {
+      // SPA fallback
+      filePath = indexHtml;
+    }
+    // Reject symlinks that resolve outside dist (realpath used for validation only).
+    let realPath;
+    try {
+      realPath = realpathSync(filePath);
+    } catch {
+      realPath = null;
+    }
+    if (!realPath || !realPath.startsWith(distPrefix)) {
+      res.statusCode = 404;
+      return res.end('not found');
     }
     res.setHeader('content-type', MIME[extname(filePath)] || 'application/octet-stream');
     createReadStream(filePath)

--- a/scripts/run-measure.sh
+++ b/scripts/run-measure.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-cd "$(dirname "$0")/.."
+cd "$(dirname "$0")/.." || exit 1
 pkill -9 -f google-chrome 2>/dev/null
 pkill -9 -f measure-chrome 2>/dev/null
 sleep 1

--- a/scripts/run-measure.sh
+++ b/scripts/run-measure.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+cd "$(dirname "$0")/.."
+pkill -9 -f google-chrome 2>/dev/null
+pkill -9 -f measure-chrome 2>/dev/null
+sleep 1
+rm -rf /tmp/measure-chrome-*
+export MEASURE_RUNS="${MEASURE_RUNS:-1}"
+export MEASURE_PAGES="${MEASURE_PAGES:-/}"
+timeout 120 node scripts/measure-pageload.mjs
+echo "NODE_EXIT=$?"
+pkill -9 -f google-chrome 2>/dev/null

--- a/scripts/run-measure.sh
+++ b/scripts/run-measure.sh
@@ -1,11 +1,10 @@
 #!/bin/bash
 cd "$(dirname "$0")/.." || exit 1
-pkill -9 -f google-chrome 2>/dev/null
-pkill -9 -f measure-chrome 2>/dev/null
+pkill -9 -f 'user-data-dir=/tmp/measure-chrome-' 2>/dev/null
 sleep 1
 rm -rf /tmp/measure-chrome-*
 timeout 120 node scripts/measure-pageload.mjs
 NODE_EXIT=$?
 echo "NODE_EXIT=$NODE_EXIT"
-pkill -9 -f google-chrome 2>/dev/null || true
+pkill -9 -f 'user-data-dir=/tmp/measure-chrome-' 2>/dev/null || true
 exit "$NODE_EXIT"

--- a/scripts/run-measure.sh
+++ b/scripts/run-measure.sh
@@ -4,8 +4,8 @@ pkill -9 -f google-chrome 2>/dev/null
 pkill -9 -f measure-chrome 2>/dev/null
 sleep 1
 rm -rf /tmp/measure-chrome-*
-export MEASURE_RUNS="${MEASURE_RUNS:-1}"
-export MEASURE_PAGES="${MEASURE_PAGES:-/}"
 timeout 120 node scripts/measure-pageload.mjs
-echo "NODE_EXIT=$?"
-pkill -9 -f google-chrome 2>/dev/null
+NODE_EXIT=$?
+echo "NODE_EXIT=$NODE_EXIT"
+pkill -9 -f google-chrome 2>/dev/null || true
+exit "$NODE_EXIT"


### PR DESCRIPTION
## Summary

Add a zero-dependency page-load measurement workflow for key TarkovTracker routes.

## Changes

- Add `scripts/measure-pageload.mjs` to static-serve generated output and drive headless Chrome over CDP.
- Add `scripts/build-measure.sh` and `scripts/run-measure.sh` wrappers for the build + measurement workflow.
- Report ready/load/FCP timing and transferred KB for configured routes.
- Harden the scripts so build, Chrome, CDP, path handling, and wrapper failures fail clearly.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improvement to existing feature)
- [ ] Refactoring (code restructuring without changing functionality)
- [ ] Documentation update
- [ ] Dependency update
- [ ] Other (please describe):

## Area(s) Affected

- [ ] Frontend (UI/UX)
- [ ] Backend (Supabase/Nitro/Workers)
- [ ] Tasks/Quests
- [ ] Team Features
- [ ] Hideout
- [ ] Maps
- [ ] Traders
- [ ] API
- [ ] i18n/Translations
- [x] Other: developer tooling / performance measurement

## Related Issues

None.

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [ ] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. `node --check scripts/measure-pageload.mjs`
2. `bash -n scripts/build-measure.sh scripts/run-measure.sh`
3. `npx prettier --check scripts/measure-pageload.mjs`
4. Full measurement: `npm run build && bash scripts/run-measure.sh` (requires local Chrome)

## Screenshots/Videos

Not applicable.

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] I have updated relevant documentation
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

No Puppeteer, Playwright, or Lighthouse dependency was added. The script uses Node's built-in WebSocket plus the local Chrome binary; swap to Lighthouse later only if category scores are needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a build helper that generates the static site, captures logs, and reports generated pages on completion.
  * Added a page-load measurement tool that serves the built site, runs browser-based timing checks, and reports load/ready metrics per route.
  * Added a wrapper command to run measurements with automatic Chrome cleanup and a timeout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->