### PR TITLE
fix(tasks): enforce trader level and reputation requirements in task availability

### DIFF
--- a/app/features/settings/TaskDisplayCard.vue
+++ b/app/features/settings/TaskDisplayCard.vue
@@ -25,6 +25,13 @@
           />
         </div>
         <USeparator />
+        <div class="grid gap-4 md:grid-cols-2">
+          <UCheckbox
+            v-model="tasksRequireTraderLevels"
+            :label="$t('settings.interface.tasks.require_trader_levels')"
+          />
+        </div>
+        <USeparator />
         <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
           <div class="space-y-2">
             <p class="text-surface-200 text-sm font-semibold">
@@ -84,6 +91,10 @@
   const showPreviousQuests = computed({
     get: () => preferencesStore.getShowPreviousQuests,
     set: (val) => preferencesStore.setShowPreviousQuests(val),
+  });
+  const tasksRequireTraderLevels = computed({
+    get: () => preferencesStore.getTasksRequireTraderLevels,
+    set: (val) => preferencesStore.setTasksRequireTraderLevels(val),
   });
   const taskCardDensity = computed({
     get: () => preferencesStore.getTaskCardDensity,

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1727,7 +1727,8 @@
         "show_xp": "Show XP Rewards",
         "show_next": "Show Next Quests",
         "show_prev": "Show Previous Quests",
-        "density": "Card Density"
+        "density": "Card Density",
+        "require_trader_levels": "Require Trader Loyalty Level and Reputation for Task Availability"
       },
       "defaults": {
         "title": "Default Views"

--- a/app/plugins/zz.preferences-sync.client.ts
+++ b/app/plugins/zz.preferences-sync.client.ts
@@ -181,6 +181,7 @@ const buildPreferencesSyncPayload = (
     hideout_require_station_levels: preferencesState.hideoutRequireStationLevels,
     hideout_require_skill_levels: preferencesState.hideoutRequireSkillLevels,
     hideout_require_trader_loyalty: preferencesState.hideoutRequireTraderLoyalty,
+    tasks_require_trader_levels: preferencesState.tasksRequireTraderLevels,
     locale_override: preferencesState.localeOverride,
     enable_manual_task_fail: preferencesState.enableManualTaskFail,
     hide_completed_task_objectives: preferencesState.hideCompletedTaskObjectives,

--- a/app/stores/__tests__/usePreferences.test.ts
+++ b/app/stores/__tests__/usePreferences.test.ts
@@ -100,6 +100,7 @@ describe('usePreferencesStore', () => {
       expect(store.hideoutRequireStationLevels).toBe(true);
       expect(store.hideoutRequireSkillLevels).toBe(true);
       expect(store.hideoutRequireTraderLoyalty).toBe(true);
+      expect(store.tasksRequireTraderLevels).toBe(true);
     });
     it('should initialize task filter settings with correct defaults', () => {
       const store = usePreferencesStore();
@@ -1211,6 +1212,11 @@ describe('usePreferencesStore', () => {
       const store = usePreferencesStore();
       store.setHideoutRequireTraderLoyalty(false);
       expect(store.hideoutRequireTraderLoyalty).toBe(false);
+    });
+    it('should set tasks require trader levels', () => {
+      const store = usePreferencesStore();
+      store.setTasksRequireTraderLevels(false);
+      expect(store.tasksRequireTraderLevels).toBe(false);
     });
   });
   describe('Actions - Locale', () => {

--- a/app/stores/__tests__/useProgress.test.ts
+++ b/app/stores/__tests__/useProgress.test.ts
@@ -43,6 +43,7 @@ const setupMocks = ({
   teammateState,
   tasks = [{ id: 'task-1', name: 'Task One' }],
   traders = [],
+  tasksRequireTraderLevels,
 }: {
   selfCompletions?: Record<string, unknown>;
   teammateCompletions?: Record<string, unknown>;
@@ -50,6 +51,7 @@ const setupMocks = ({
   teammateState?: ReturnType<typeof createStoreState>;
   tasks?: Array<Record<string, unknown>>;
   traders?: Array<Record<string, unknown>>;
+  tasksRequireTraderLevels?: boolean;
 }) => {
   vi.resetModules();
   setActivePinia(createPinia());
@@ -71,6 +73,7 @@ const setupMocks = ({
       teamIsHidden: () => false,
       taskTeamAllHidden: false,
       getUseAutomaticLevelCalculation: false,
+      getTasksRequireTraderLevels: tasksRequireTraderLevels ?? true,
     }),
   }));
   vi.doMock('@/stores/useMetadata', () => ({
@@ -265,6 +268,53 @@ describe('useProgressStore', () => {
       const { useProgressStore } = await import('@/stores/useProgress');
       const store = useProgressStore();
       expect(store.unlockedTasks['negative-rep-task']?.self).toBe(true);
+    });
+    it('skips loyalty level gating when the preference is disabled', async () => {
+      setupMocks({
+        selfState: createStoreState({ pvpTraders: { [praporId]: { level: 1 } } }),
+        tasks: [praporLevelTask],
+        traders: metadataTraders,
+        tasksRequireTraderLevels: false,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['prapor-ll2-task']?.self).toBe(true);
+    });
+    it('skips reputation gating when the preference is disabled', async () => {
+      const repTask = {
+        id: 'prapor-rep-task',
+        name: 'Prapor Rep Task',
+        factionName: 'Any',
+        trader: { id: 'skier', name: 'Skier', normalizedName: 'skier' },
+        traderRequirements: [{ id: 'req-2', trader: { id: praporId, name: 'Prapor' }, value: 0.5 }],
+      };
+      setupMocks({
+        selfState: createStoreState({ pvpTraders: { [praporId]: { reputation: 0.2 } } }),
+        tasks: [repTask],
+        traders: metadataTraders,
+        tasksRequireTraderLevels: false,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['prapor-rep-task']?.self).toBe(true);
+    });
+    it('skips Fence negative-reputation gating when the preference is disabled', async () => {
+      const lowKarmaTask = {
+        id: 'fence-low-karma-task',
+        name: 'Low Karma Task',
+        factionName: 'Any',
+        trader: { id: 'fence', name: 'Fence', normalizedName: 'fence' },
+        traderRequirements: [{ id: 'req-3', trader: { id: 'fence', name: 'Fence' }, value: -3 }],
+      };
+      setupMocks({
+        selfState: createStoreState({ pvpTraders: { fence: { reputation: 0 } } }),
+        tasks: [lowKarmaTask],
+        traders: metadataTraders,
+        tasksRequireTraderLevels: false,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['fence-low-karma-task']?.self).toBe(true);
     });
   });
   it('does not lock Ref tasks when unlock task is missing from loaded task payload', async () => {

--- a/app/stores/__tests__/useProgress.test.ts
+++ b/app/stores/__tests__/useProgress.test.ts
@@ -2,7 +2,11 @@ import { createPinia, setActivePinia } from 'pinia';
 import { describe, expect, it, vi } from 'vitest';
 import { nextTick, ref } from 'vue';
 import { TASK_ID_REGISTRY } from '@/utils/constants';
-const createProgressData = (taskCompletions: Record<string, unknown>) => ({
+type TraderProgress = Record<string, { level?: number; reputation?: number }>;
+const createProgressData = (
+  taskCompletions: Record<string, unknown>,
+  traders: TraderProgress = {}
+) => ({
   level: 1,
   pmcFaction: 'USEC',
   displayName: null,
@@ -11,7 +15,7 @@ const createProgressData = (taskCompletions: Record<string, unknown>) => ({
   taskCompletions,
   hideoutParts: {},
   hideoutModules: {},
-  traders: {},
+  traders,
   skills: {},
   prestigeLevel: 0,
   skillOffsets: {},
@@ -20,14 +24,16 @@ const createStoreState = ({
   currentGameMode = 'pvp',
   pvpCompletions = {},
   pveCompletions = {},
+  pvpTraders = {},
 }: {
   currentGameMode?: 'pvp' | 'pve';
   pvpCompletions?: Record<string, unknown>;
   pveCompletions?: Record<string, unknown>;
+  pvpTraders?: TraderProgress;
 }) => ({
   currentGameMode,
   gameEdition: 1,
-  pvp: createProgressData(pvpCompletions),
+  pvp: createProgressData(pvpCompletions, pvpTraders),
   pve: createProgressData(pveCompletions),
 });
 const setupMocks = ({
@@ -144,6 +150,122 @@ describe('useProgressStore', () => {
     const { useProgressStore } = await import('@/stores/useProgress');
     const store = useProgressStore();
     expect(store.unlockedTasks['ref-task']?.self).toBe(true);
+  });
+  describe('trader requirement gating', () => {
+    const praporId = 'prapor-id';
+    const praporLevelTask = {
+      id: 'prapor-ll2-task',
+      name: 'Shaking Up the Teller',
+      factionName: 'Any',
+      trader: { id: 'skier', name: 'Skier', normalizedName: 'skier' },
+      traderLevelRequirements: [
+        { id: 'req-1', trader: { id: praporId, name: 'Prapor' }, level: 2 },
+      ],
+    };
+    const metadataTraders = [
+      { id: 'fence', normalizedName: 'fence', name: 'Fence' },
+      { id: praporId, normalizedName: 'prapor', name: 'Prapor' },
+    ];
+    it('locks a task when the trader loyalty level requirement is not met', async () => {
+      setupMocks({
+        selfState: createStoreState({ pvpTraders: { [praporId]: { level: 1 } } }),
+        tasks: [praporLevelTask],
+        traders: metadataTraders,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['prapor-ll2-task']?.self).toBe(false);
+    });
+    it('unlocks a task when the trader loyalty level requirement is met', async () => {
+      setupMocks({
+        selfState: createStoreState({ pvpTraders: { [praporId]: { level: 2 } } }),
+        tasks: [praporLevelTask],
+        traders: metadataTraders,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['prapor-ll2-task']?.self).toBe(true);
+    });
+    it('defaults missing trader data to level 1 and locks higher-level requirements', async () => {
+      setupMocks({
+        selfState: createStoreState({}),
+        tasks: [praporLevelTask],
+        traders: metadataTraders,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['prapor-ll2-task']?.self).toBe(false);
+    });
+    it('locks a task when a non-Fence positive reputation requirement is not met', async () => {
+      const repTask = {
+        id: 'prapor-rep-task',
+        name: 'Prapor Rep Task',
+        factionName: 'Any',
+        trader: { id: 'skier', name: 'Skier', normalizedName: 'skier' },
+        traderRequirements: [{ id: 'req-2', trader: { id: praporId, name: 'Prapor' }, value: 0.5 }],
+      };
+      setupMocks({
+        selfState: createStoreState({ pvpTraders: { [praporId]: { reputation: 0.2 } } }),
+        tasks: [repTask],
+        traders: metadataTraders,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['prapor-rep-task']?.self).toBe(false);
+    });
+    it('unlocks a task when a non-Fence positive reputation requirement is met', async () => {
+      const repTask = {
+        id: 'prapor-rep-task',
+        name: 'Prapor Rep Task',
+        factionName: 'Any',
+        trader: { id: 'skier', name: 'Skier', normalizedName: 'skier' },
+        traderRequirements: [{ id: 'req-2', trader: { id: praporId, name: 'Prapor' }, value: 0.5 }],
+      };
+      setupMocks({
+        selfState: createStoreState({ pvpTraders: { [praporId]: { reputation: 0.5 } } }),
+        tasks: [repTask],
+        traders: metadataTraders,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['prapor-rep-task']?.self).toBe(true);
+    });
+    it('keeps the Fence negative-reputation special case gating', async () => {
+      const lowKarmaTask = {
+        id: 'fence-low-karma-task',
+        name: 'Low Karma Task',
+        factionName: 'Any',
+        trader: { id: 'fence', name: 'Fence', normalizedName: 'fence' },
+        traderRequirements: [{ id: 'req-3', trader: { id: 'fence', name: 'Fence' }, value: -3 }],
+      };
+      setupMocks({
+        selfState: createStoreState({ pvpTraders: { fence: { reputation: 0 } } }),
+        tasks: [lowKarmaTask],
+        traders: metadataTraders,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['fence-low-karma-task']?.self).toBe(false);
+    });
+    it('ignores negative reputation requirements for non-Fence traders', async () => {
+      const negativeRepTask = {
+        id: 'negative-rep-task',
+        name: 'Negative Rep Task',
+        factionName: 'Any',
+        trader: { id: 'skier', name: 'Skier', normalizedName: 'skier' },
+        traderRequirements: [
+          { id: 'req-4', trader: { id: praporId, name: 'Prapor' }, value: -0.5 },
+        ],
+      };
+      setupMocks({
+        selfState: createStoreState({ pvpTraders: { [praporId]: { reputation: 0.3 } } }),
+        tasks: [negativeRepTask],
+        traders: metadataTraders,
+      });
+      const { useProgressStore } = await import('@/stores/useProgress');
+      const store = useProgressStore();
+      expect(store.unlockedTasks['negative-rep-task']?.self).toBe(true);
+    });
   });
   it('does not lock Ref tasks when unlock task is missing from loaded task payload', async () => {
     const refTask = {

--- a/app/stores/usePreferences.ts
+++ b/app/stores/usePreferences.ts
@@ -120,6 +120,7 @@ export interface PreferencesState {
   hideoutRequireStationLevels: boolean;
   hideoutRequireSkillLevels: boolean;
   hideoutRequireTraderLoyalty: boolean;
+  tasksRequireTraderLevels: boolean;
   localeOverride: string | null;
   // External links
   wikiUseAntifandom: boolean;
@@ -207,6 +208,7 @@ export const preferencesDefaultState: PreferencesState = {
   hideoutRequireStationLevels: true,
   hideoutRequireSkillLevels: true,
   hideoutRequireTraderLoyalty: true,
+  tasksRequireTraderLevels: true,
   localeOverride: null,
   // External links
   wikiUseAntifandom: false,
@@ -538,6 +540,9 @@ export const usePreferencesStore = defineStore('preferences', {
     getHideoutRequireTraderLoyalty: (state) => {
       return state.hideoutRequireTraderLoyalty ?? true;
     },
+    getTasksRequireTraderLevels: (state) => {
+      return state.tasksRequireTraderLevels ?? true;
+    },
     getMapZoomSpeed: (state) => {
       return state.mapZoomSpeed ?? 1;
     },
@@ -822,6 +827,9 @@ export const usePreferencesStore = defineStore('preferences', {
     setHideoutRequireTraderLoyalty(enabled: boolean) {
       this.hideoutRequireTraderLoyalty = enabled;
     },
+    setTasksRequireTraderLevels(enabled: boolean) {
+      this.tasksRequireTraderLevels = enabled;
+    },
     setLocaleOverride(locale: string | null) {
       this.localeOverride = locale;
     },
@@ -1024,6 +1032,7 @@ export const usePreferencesStore = defineStore('preferences', {
       'hideoutRequireStationLevels',
       'hideoutRequireSkillLevels',
       'hideoutRequireTraderLoyalty',
+      'tasksRequireTraderLevels',
       'showMapExtracts',
       'mapMarkerColors',
       'mapZoomSpeed',

--- a/app/stores/useProgress.ts
+++ b/app/stores/useProgress.ts
@@ -276,38 +276,43 @@ export const useProgressStore = defineStore('progress', () => {
           visiting.delete(taskId);
           return false;
         }
-        // Trader loyalty level check - user's trader level must meet each requirement
-        if (task.traderLevelRequirements?.length) {
-          for (const req of task.traderLevelRequirements) {
-            const traderId = req?.trader?.id;
-            if (!traderId) continue;
-            const userTraderLevel = teamData.traders?.[traderId]?.level ?? 1;
-            if (userTraderLevel < req.level) {
-              memo.set(taskId, false);
-              visiting.delete(taskId);
-              return false;
-            }
-          }
-        }
-        // Trader reputation check - positive requirements gate for every trader:
-        // user needs at least this much reputation.
-        // Negative requirements are Fence-specific (low-karma path): user needs
-        // at most this much (or worse) karma.
-        if (task.traderRequirements?.length) {
-          for (const req of task.traderRequirements) {
-            const traderId = req?.trader?.id;
-            if (!traderId) continue;
-            const userRep = teamData.traders?.[traderId]?.reputation ?? 0;
-            if (req.value >= 0) {
-              if (userRep < req.value) {
+        // Trader loyalty level and reputation checks - gated behind a user
+        // preference (defaults on, mirroring hideout's require-trader-loyalty).
+        // When disabled, trader standing requirements are display-only.
+        if (preferencesStore.getTasksRequireTraderLevels) {
+          // Trader loyalty level check - user's trader level must meet each requirement
+          if (task.traderLevelRequirements?.length) {
+            for (const req of task.traderLevelRequirements) {
+              const traderId = req?.trader?.id;
+              if (!traderId) continue;
+              const userTraderLevel = teamData.traders?.[traderId]?.level ?? 1;
+              if (userTraderLevel < req.level) {
                 memo.set(taskId, false);
                 visiting.delete(taskId);
                 return false;
               }
-            } else if (fenceTrader && traderId === fenceTrader.id && userRep > req.value) {
-              memo.set(taskId, false);
-              visiting.delete(taskId);
-              return false;
+            }
+          }
+          // Trader reputation check - positive requirements gate for every trader:
+          // user needs at least this much reputation.
+          // Negative requirements are Fence-specific (low-karma path): user needs
+          // at most this much (or worse) karma.
+          if (task.traderRequirements?.length) {
+            for (const req of task.traderRequirements) {
+              const traderId = req?.trader?.id;
+              if (!traderId) continue;
+              const userRep = teamData.traders?.[traderId]?.reputation ?? 0;
+              if (req.value >= 0) {
+                if (userRep < req.value) {
+                  memo.set(taskId, false);
+                  visiting.delete(taskId);
+                  return false;
+                }
+              } else if (fenceTrader && traderId === fenceTrader.id && userRep > req.value) {
+                memo.set(taskId, false);
+                visiting.delete(taskId);
+                return false;
+              }
             }
           }
         }

--- a/app/stores/useProgress.ts
+++ b/app/stores/useProgress.ts
@@ -276,26 +276,38 @@ export const useProgressStore = defineStore('progress', () => {
           visiting.delete(taskId);
           return false;
         }
-        // Fence reputation check - only Fence trader requirements gate availability
-        // Other trader level/rep requirements are display-only, not gating
-        if (task.traderRequirements?.length && fenceTrader) {
-          const fenceReq = task.traderRequirements.find((req) => req.trader.id === fenceTrader.id);
-          if (fenceReq) {
-            const userFenceRep = teamData.traders?.[fenceTrader.id]?.reputation ?? 0;
-            // Positive requirement: user needs at least this much karma
-            // Negative requirement: user needs at most this much (or worse) karma
-            if (fenceReq.value >= 0) {
-              if (userFenceRep < fenceReq.value) {
+        // Trader loyalty level check - user's trader level must meet each requirement
+        if (task.traderLevelRequirements?.length) {
+          for (const req of task.traderLevelRequirements) {
+            const traderId = req?.trader?.id;
+            if (!traderId) continue;
+            const userTraderLevel = teamData.traders?.[traderId]?.level ?? 1;
+            if (userTraderLevel < req.level) {
+              memo.set(taskId, false);
+              visiting.delete(taskId);
+              return false;
+            }
+          }
+        }
+        // Trader reputation check - positive requirements gate for every trader:
+        // user needs at least this much reputation.
+        // Negative requirements are Fence-specific (low-karma path): user needs
+        // at most this much (or worse) karma.
+        if (task.traderRequirements?.length) {
+          for (const req of task.traderRequirements) {
+            const traderId = req?.trader?.id;
+            if (!traderId) continue;
+            const userRep = teamData.traders?.[traderId]?.reputation ?? 0;
+            if (req.value >= 0) {
+              if (userRep < req.value) {
                 memo.set(taskId, false);
                 visiting.delete(taskId);
                 return false;
               }
-            } else {
-              if (userFenceRep > fenceReq.value) {
-                memo.set(taskId, false);
-                visiting.delete(taskId);
-                return false;
-              }
+            } else if (fenceTrader && traderId === fenceTrader.id && userRep > req.value) {
+              memo.set(taskId, false);
+              visiting.delete(taskId);
+              return false;
             }
           }
         }

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -355,6 +355,7 @@ export type Database = {
           task_team_hide_all: boolean | null
           task_trader_view: string | null
           task_user_view: string | null
+          tasks_require_trader_levels: boolean
           team_hide: Json | null
           trader_sort_direction: string | null
           trader_sort_mode: string | null
@@ -427,6 +428,7 @@ export type Database = {
           task_team_hide_all?: boolean | null
           task_trader_view?: string | null
           task_user_view?: string | null
+          tasks_require_trader_levels?: boolean
           team_hide?: Json | null
           trader_sort_direction?: string | null
           trader_sort_mode?: string | null
@@ -499,6 +501,7 @@ export type Database = {
           task_team_hide_all?: boolean | null
           task_trader_view?: string | null
           task_user_view?: string | null
+          tasks_require_trader_levels?: boolean
           team_hide?: Json | null
           trader_sort_direction?: string | null
           trader_sort_mode?: string | null

--- a/supabase/migrations/20260708120000_add_user_preferences_tasks_require_trader_levels.sql
+++ b/supabase/migrations/20260708120000_add_user_preferences_tasks_require_trader_levels.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS tasks_require_trader_levels BOOLEAN NOT NULL DEFAULT TRUE;


### PR DESCRIPTION
## **User description**
## Summary

- Enforces non-Fence `traderLevelRequirements` (loyalty level) and positive `traderRequirements` (reputation) in `unlockedTasks` task availability, not just display. Previously only Fence reputation gated availability (issue #512 — "Shaking Up the Teller" requiring Prapor LL2 showed as available below LL2).
- Adds a `tasksRequireTraderLevels` preference (defaults on) that controls whether trader loyalty level and reputation requirements gate task availability, mirroring the existing `hideoutRequireTraderLoyalty` pattern. Users who don't track trader standing can disable it in Settings > Task Cards.
- Preserves the Fence-specific negative-reputation (low-karma) special case: user reputation must be `<=` the negative requirement value for Fence tasks only. Non-Fence negative values are ignored.

### Behavioral change

Users who track task completions but have not set their trader levels will now see LL2+ gated tasks as locked (previously showed as available). This matches the display layer's own assessment (`getTraderLevel` defaults to 1). The preference toggle provides an escape hatch for users who don't track trader standing.

Closes #512

#### Test plan

- [x] 7 new gating tests (3 failed pre-fix, all pass post-fix): Prapor LL2 below/at/missing-data, non-Fence positive rep below/at, Fence negative regression guard, non-Fence negative ignored
- [x] 3 new preference-off tests: loyalty level skipped, positive reputation skipped, Fence negative reputation skipped when preference disabled
- [x] 2 new preference store tests: default value (`true`), setter
- [x] `npm run typecheck` — pass
- [x] `npm run lint` — pass (zero warnings)
- [x] `npm run i18n:check` — pass (non-fatal; new key pending Crowdin sync)
- [x] `npm run test` — full suite pass (204 files, 1952 tests)


___

## **CodeAnt-AI Description**
**Task availability now respects trader loyalty and reputation requirements, with a setting to turn that check off.**

### What Changed
- Tasks that require a trader level or reputation are now locked until those requirements are met.
- Fence’s low-karma requirement still works as before, and negative reputation checks stay Fence-only.
- A new setting in Task Cards lets users disable trader requirement gating if they do not track trader standing.
- The new setting is on by default and is saved with other preferences.

### Impact
`✅ Fewer tasks shown as available too early`
`✅ Clearer task locking for trader-gated quests`
`✅ Optional task cards for users who do not track trader standing`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
