### PR TITLE
fix(app): preserve storyline progress across devices when syncing prestige level

### DIFF
--- a/app/stores/__tests__/useTarkov.mergeProgressData.test.ts
+++ b/app/stores/__tests__/useTarkov.mergeProgressData.test.ts
@@ -135,4 +135,33 @@ describe('mergeProgressData progress epoch', () => {
     expect(merged.prestigeLevel).toBe(2);
     expect(merged.progressEpoch).toBe(5);
   });
+  it('wipes storyChapters when a higher-epoch reset wins (prestige/reset contract)', () => {
+    const local = createProgressData({
+      'chapter-1': { complete: true, timestamp: 1000 },
+    });
+    local.progressEpoch = 2;
+    const remote = createProgressData({});
+    remote.progressEpoch = 3;
+    const merged = mergeProgressData(local, remote);
+    expect(merged.progressEpoch).toBe(3);
+    expect(merged.storyChapters).toEqual({});
+  });
+  it('merges storyChapters when epochs are equal and only prestigeLevel differs', () => {
+    const local = createProgressData({
+      'chapter-1': { complete: true, timestamp: 1000 },
+    });
+    local.prestigeLevel = 1;
+    local.progressEpoch = 2;
+    const remote = createProgressData({
+      'chapter-2': { complete: true, timestamp: 2000 },
+    });
+    remote.prestigeLevel = 2;
+    remote.progressEpoch = 2;
+    const merged = mergeProgressData(local, remote);
+    expect(merged.progressEpoch).toBe(2);
+    expect(merged.storyChapters).toMatchObject({
+      'chapter-1': { complete: true, timestamp: 1000 },
+      'chapter-2': { complete: true, timestamp: 2000 },
+    });
+  });
 });

--- a/app/stores/__tests__/useTarkov.syncPvpPrestigeLevel.test.ts
+++ b/app/stores/__tests__/useTarkov.syncPvpPrestigeLevel.test.ts
@@ -41,7 +41,7 @@ describe('useTarkov syncPvpPrestigeLevel', () => {
     supabaseContext.user.id = 'user-1';
     upsert.mockResolvedValue({ data: null, error: null });
   });
-  it('updates only PvP prestige data and bumps the PvP epoch', async () => {
+  it('updates only PvP prestige data without bumping the PvP epoch', async () => {
     const store = useTarkovStore();
     store.$patch((state) => {
       state.currentGameMode = 'pve';
@@ -78,7 +78,7 @@ describe('useTarkov syncPvpPrestigeLevel', () => {
           displayName: 'Raider',
           level: 33,
           prestigeLevel: 2,
-          progressEpoch: 10,
+          progressEpoch: 9,
         }),
         tarkov_uid: 12345,
         user_id: 'user-1',
@@ -86,7 +86,7 @@ describe('useTarkov syncPvpPrestigeLevel', () => {
     );
     expect(store.pvp.level).toBe(33);
     expect(store.pvp.prestigeLevel).toBe(2);
-    expect(store.pvp.progressEpoch).toBe(10);
+    expect(store.pvp.progressEpoch).toBe(9);
     expect(store.pve.level).toBe(21);
     expect(store.pve.progressEpoch).toBe(2);
   });
@@ -101,7 +101,7 @@ describe('useTarkov syncPvpPrestigeLevel', () => {
     await store.syncPvpPrestigeLevel(3);
     expect(from).not.toHaveBeenCalled();
     expect(store.pvp.prestigeLevel).toBe(3);
-    expect(store.pvp.progressEpoch).toBe(5);
+    expect(store.pvp.progressEpoch).toBe(4);
   });
   it('keeps local PvP state unchanged when the remote update fails', async () => {
     const store = useTarkovStore();

--- a/app/stores/tarkov/progressMerge.ts
+++ b/app/stores/tarkov/progressMerge.ts
@@ -6,6 +6,7 @@ import {
   type UserState,
 } from '@/stores/progressState';
 import { GAME_MODES, type GameMode } from '@/utils/constants';
+import { logger } from '@/utils/logger';
 import { sanitizeOwnedProgressData } from '@/utils/progressSanitizers';
 import type { RawTaskCompletion } from '@/utils/taskStatus';
 const API_UPDATE_HISTORY_LIMIT = 50;
@@ -52,8 +53,32 @@ export const toProgressEpoch = (modeData: UserProgressData | undefined): number 
   }
   return Math.max(0, Math.trunc(modeData.progressEpoch));
 };
+// Contract: progressEpoch is bumped ONLY by a full progress reset/prestige wipe
+// (resetOnlineProfile, performReset, buildPrestigeResetData). mergeProgressData
+// treats a higher epoch as an authoritative win and discards the losing side's
+// data, including storyChapters. Bumping it for a non-wiping change (e.g. a
+// prestige-level-only edit) silently loses the other device's storyline progress.
 export const getNextProgressEpoch = (modeData: UserProgressData | undefined): number => {
   return Math.min(2147483647, toProgressEpoch(modeData) + 1);
+};
+const countStoryChapters = (chapters: UserProgressData['storyChapters'] | undefined): number =>
+  chapters ? Object.keys(chapters).length : 0;
+const warnDroppedStoryChapters = (
+  winner: 'local' | 'remote',
+  dropped: UserProgressData['storyChapters'] | undefined,
+  kept: UserProgressData['storyChapters'] | undefined,
+  localEpoch: number,
+  remoteEpoch: number
+): void => {
+  const droppedCount = countStoryChapters(dropped);
+  if (droppedCount === 0) return;
+  logger.warn('[progressMerge] epoch early-return dropped non-empty storyChapters', {
+    winner,
+    droppedStoryChapters: droppedCount,
+    keptStoryChapters: countStoryChapters(kept),
+    localEpoch,
+    remoteEpoch,
+  });
 };
 export const mergeTimestampedCompletion = <T extends TimestampedCompletionEntry>(
   local: T | undefined,
@@ -262,9 +287,23 @@ export function mergeProgressData(
   const localEpoch = toProgressEpoch(local);
   const remoteEpoch = toProgressEpoch(remote);
   if (remoteEpoch > localEpoch) {
+    warnDroppedStoryChapters(
+      'remote',
+      local.storyChapters,
+      remote.storyChapters,
+      localEpoch,
+      remoteEpoch
+    );
     return { ...structuredClone(remote), progressEpoch: remoteEpoch };
   }
   if (localEpoch > remoteEpoch) {
+    warnDroppedStoryChapters(
+      'local',
+      remote.storyChapters,
+      local.storyChapters,
+      localEpoch,
+      remoteEpoch
+    );
     return { ...structuredClone(local), progressEpoch: localEpoch };
   }
   const mergeTaskCompletion = (

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -303,7 +303,10 @@ const tarkovActions = {
     }
     const nextPvpData = cloneStateSnapshot(this.pvp);
     nextPvpData.prestigeLevel = nextPrestigeLevel;
-    nextPvpData.progressEpoch = getNextProgressEpoch(this.pvp);
+    // ponytail: do NOT bump progressEpoch here. The epoch contract is "a full
+    // reset/prestige wipe happened and wins over older progress"; bumping it for
+    // a prestige-level-only edit makes mergeProgressData's epoch early-return
+    // silently drop the other device's storyChapters (storyline progress loss).
     const { $supabase } = useNuxtApp();
     if ($supabase.user.loggedIn && $supabase.user.id) {
       const nextState = cloneStateSnapshot(this.$state);


### PR DESCRIPTION
## **User description**
## Summary

Fixes silent cross-device loss of `/storyline` progress. Root cause: `syncPvpPrestigeLevel` bumped `progressEpoch` despite only mutating `prestigeLevel` (no task/hideout/story wipe), so `mergeProgressData`'s epoch early-return discarded the other device's `storyChapters` at the next startup or realtime sync.

## Root cause (confirmed)

`progressEpoch` is a reset/wipe epoch: when local and remote epochs differ, `mergeProgressData` (`app/stores/tarkov/progressMerge.ts`) takes the higher-epoch blob whole and **skips** the field-merge branch that contains `mergeStoryChapterProgress`. That is correct for a real reset/prestige wipe — prestiging is designed to restart the storyline (it wipes all quest/task progress per BSG's Prestige dev diary).

The bug: `syncPvpPrestigeLevel` (`app/stores/useTarkov.ts`) called `getNextProgressEpoch(this.pvp)` while only changing `prestigeLevel` on a `cloneStateSnapshot`. A user who corrected their prestige level on another device would see their storyline completion vanish on this device at next sync.

Full call-site inventory — `getNextProgressEpoch` is invoked in exactly 4 places:
- `resetOnlineProfile` — full reset ✅ epoch bump correct
- `performReset` (resetPvP/PvE/all) — full reset ✅ correct
- `buildPrestigeResetData` — full prestige wipe ✅ correct
- `syncPvpPrestigeLevel` — prestige-level-only edit ❌ was the bug

## Fix

**Option A** (chosen over a marker-based Option B by independent review from GitLab Duo Fable-5 and GPT-5.5, both high confidence): remove the epoch bump from `syncPvpPrestigeLevel`. Restores the contract — only genuine full resets/prestige wipes bump the epoch. Real wipes still propagate `storyChapters: {}` across devices (prestige's intended story restart preserved); a prestige-level-only edit no longer claims a reset "win" and storyline merges normally via the equal-epoch branch.

Option B (a `resetReason`/`storyWipedAt` marker) was rejected as over-engineered: it would touch `sanitizeOwnedProgressData`, the `sanitize_user_progress_mode_data` DB function + a migration, `buildUpsertPayload`, `mergeProgressData`, and every reset site — all to compensate for one call site's misuse.

## Changes

- `app/stores/useTarkov.ts` — `syncPvpPrestigeLevel`: drop the `progressEpoch` bump; `ponytail:` comment naming the contract.
- `app/stores/tarkov/progressMerge.ts` — contract doc on `getNextProgressEpoch`; `warnDroppedStoryChapters` telemetry that `logger.warn`s only when an epoch early-return discards a **non-empty** losing-side `storyChapters` (winner/dropped/kept counts + both epochs), to catch any future non-reset epoch bump in prod.
- Tests:
  - `useTarkov.syncPvpPrestigeLevel.test.ts` — prestige-level change no longer bumps `progressEpoch` (logged-in and logged-out paths).
  - `useTarkov.mergeProgressData.test.ts` — (1) higher-epoch reset with empty story wipes the losing side's story (prestige/reset contract preserved); (2) equal epochs with differing `prestigeLevel` merges `storyChapters` instead of dropping either.

## Caveat

Already-lost storyline progress from **past** `syncPvpPrestigeLevel` epoch bumps is not recovered by this change — epochs only need to be comparable going forward, not historically clean. The fix stops future loss; the telemetry will surface any residual non-reset epoch bumps.

## Validation

- `npm run typecheck` — clean
- `npx eslint` on changed files — 0 errors, 0 warnings
- `vitest run app/stores/__tests__/` — 25 files, 452 tests passed (incl. new/updated cases; telemetry warn confirmed in the reset-wins test output)
- No locale changes; no new dependencies; no schema migration


___

## **CodeAnt-AI Description**
**Keep storyline progress when prestige level is synced across devices**

### What Changed
- Prestige-level-only updates no longer mark progress as a full reset, so storyline progress from another device is kept instead of being wiped.
- Full resets and prestige wipes still clear storyline progress as expected.
- A warning now appears if a reset wins and would drop existing storyline chapters, making this loss visible instead of silent.
- Added regression tests to cover both the preserved-storyline case and the real reset case.

### Impact
`✅ Fewer storyline progress losses`
`✅ Safer cross-device prestige sync`
`✅ Clearer reset warnings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
