### PR TITLE
fix(tasks): backfill trader standing when marking available

### DIFF
--- a/app/composables/__tests__/useTaskActions.test.ts
+++ b/app/composables/__tests__/useTaskActions.test.ts
@@ -11,6 +11,9 @@ const createTarkovStore = (options: {
   isTaskComplete?: boolean | ((taskId: string) => boolean);
   isTaskFailed?: boolean;
   taskCompletions?: Record<string, unknown>;
+  traderLevels?: Record<string, number>;
+  traderReputations?: Record<string, number>;
+  traders?: Array<{ id: string; name: string; normalizedName: string }>;
 }) => {
   const objectiveCounts = new Map<string, number>(Object.entries(options.objectiveCounts ?? {}));
   return {
@@ -26,6 +29,10 @@ const createTarkovStore = (options: {
     getCurrentGameMode: vi.fn(() => 'pvp'),
     playerLevel: vi.fn(() => options.playerLevel ?? 1),
     setLevel: vi.fn(),
+    getTraderLevel: vi.fn((traderId: string) => options.traderLevels?.[traderId] ?? 1),
+    setTraderLevel: vi.fn(),
+    getTraderReputation: vi.fn((traderId: string) => options.traderReputations?.[traderId] ?? 0),
+    setTraderReputation: vi.fn(),
     isTaskComplete: vi.fn((taskId: string) => {
       if (typeof options.isTaskComplete === 'function') {
         return options.isTaskComplete(taskId);
@@ -48,8 +55,12 @@ const createTarkovStore = (options: {
     })),
   };
 };
-const createMetadataStore = (tasks: Task[]) => ({
+const createMetadataStore = (
+  tasks: Task[],
+  traders: Array<{ id: string; name: string; normalizedName: string }> = []
+) => ({
   tasks,
+  traders,
 });
 const setup = async (
   task: Task,
@@ -57,14 +68,16 @@ const setup = async (
   options: Parameters<typeof createTarkovStore>[0],
   preferencesOverrides: Partial<{
     getPinnedTaskIds: string[];
+    getTasksRequireTraderLevels: boolean;
   }> = {}
 ) => {
   const onAction = vi.fn();
   const tarkovStore = createTarkovStore(options);
-  const metadataStore = createMetadataStore(tasks);
+  const metadataStore = createMetadataStore(tasks, options.traders);
   const togglePinnedTask = vi.fn();
   const preferencesStore = {
     getPinnedTaskIds: [],
+    getTasksRequireTraderLevels: true,
     togglePinnedTask,
     ...preferencesOverrides,
   };
@@ -213,6 +226,94 @@ describe('useTaskActions', () => {
     expect(onAction).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'available', taskId: 'task-main' })
     );
+  });
+  it('marks the Fence-gated Is This a Reference task available', async () => {
+    const fenceId = '579dc571d53a0658a154fbec';
+    const task: Task = {
+      id: '66d9cbb67b491f9d5304f6e6',
+      name: 'Is This a Reference?',
+      minPlayerLevel: 25,
+      taskRequirements: [],
+      traderRequirements: [
+        {
+          id: '66dace4d03b34844877a50fc',
+          trader: { id: fenceId, name: 'Fence' },
+          value: 1,
+        },
+      ],
+    };
+    const { actions, tarkovStore } = await setup(task, [task], {
+      playerLevel: 28,
+      traderReputations: { [fenceId]: 0 },
+      traders: [{ id: fenceId, name: 'Fence', normalizedName: 'fence' }],
+    });
+    actions.markTaskAvailable();
+    expect(tarkovStore.setTraderReputation).toHaveBeenCalledWith(fenceId, 1);
+  });
+  it('backfills trader loyalty and positive reputation without lowering met values', async () => {
+    const praporId = '54cb50c76803fa8b248b4571';
+    const skierId = '58330581ace78e27b8b10cee';
+    const task: Task = {
+      id: 'trader-gated-task',
+      traderLevelRequirements: [
+        { id: 'level-prapor', trader: { id: praporId, name: 'Prapor' }, level: 2 },
+        { id: 'level-skier', trader: { id: skierId, name: 'Skier' }, level: 2 },
+      ],
+      traderRequirements: [
+        { id: 'rep-prapor', trader: { id: praporId, name: 'Prapor' }, value: 0.5 },
+        { id: 'rep-skier', trader: { id: skierId, name: 'Skier' }, value: 0.2 },
+      ],
+    };
+    const { actions, tarkovStore } = await setup(task, [task], {
+      traderLevels: { [praporId]: 1, [skierId]: 3 },
+      traderReputations: { [praporId]: 0.2, [skierId]: 0.4 },
+    });
+    actions.markTaskAvailable();
+    expect(tarkovStore.setTraderLevel).toHaveBeenCalledWith(praporId, 2);
+    expect(tarkovStore.setTraderLevel).not.toHaveBeenCalledWith(skierId, expect.any(Number));
+    expect(tarkovStore.setTraderReputation).toHaveBeenCalledWith(praporId, 0.5);
+    expect(tarkovStore.setTraderReputation).not.toHaveBeenCalledWith(skierId, expect.any(Number));
+  });
+  it('backfills Fence negative reputation requirements only', async () => {
+    const fenceId = '579dc571d53a0658a154fbec';
+    const praporId = '54cb50c76803fa8b248b4571';
+    const task: Task = {
+      id: 'low-karma-task',
+      traderRequirements: [
+        { id: 'rep-fence', trader: { id: fenceId, name: 'Fence' }, value: -2 },
+        { id: 'rep-prapor', trader: { id: praporId, name: 'Prapor' }, value: -1 },
+      ],
+    };
+    const { actions, tarkovStore } = await setup(task, [task], {
+      traderReputations: { [fenceId]: 0, [praporId]: 0 },
+      traders: [{ id: fenceId, name: 'Fence', normalizedName: 'fence' }],
+    });
+    actions.markTaskAvailable();
+    expect(tarkovStore.setTraderReputation).toHaveBeenCalledWith(fenceId, -2);
+    expect(tarkovStore.setTraderReputation).not.toHaveBeenCalledWith(praporId, expect.any(Number));
+  });
+  it('does not backfill trader requirements when gating is disabled', async () => {
+    const fenceId = '579dc571d53a0658a154fbec';
+    const task: Task = {
+      id: 'optional-trader-gating-task',
+      traderLevelRequirements: [
+        { id: 'level-fence', trader: { id: fenceId, name: 'Fence' }, level: 2 },
+      ],
+      traderRequirements: [{ id: 'rep-fence', trader: { id: fenceId, name: 'Fence' }, value: 1 }],
+    };
+    const { actions, tarkovStore } = await setup(
+      task,
+      [task],
+      {
+        traderLevels: { [fenceId]: 1 },
+        traderReputations: { [fenceId]: 0 },
+        traders: [{ id: fenceId, name: 'Fence', normalizedName: 'fence' }],
+      },
+      { getTasksRequireTraderLevels: false }
+    );
+    actions.markTaskAvailable();
+    expect(tarkovStore.setTraderLevel).not.toHaveBeenCalled();
+    expect(tarkovStore.setTraderReputation).not.toHaveBeenCalled();
   });
   it('marks a task failed and invokes onAction', async () => {
     const task: Task = {

--- a/app/composables/useTaskActions.ts
+++ b/app/composables/useTaskActions.ts
@@ -118,6 +118,28 @@ export function useTaskActions(
       tarkovStore.setLevel(minLevel);
     }
   };
+  const ensureTraderRequirements = () => {
+    if (!preferencesStore.getTasksRequireTraderLevels) return;
+    const currentTask = task();
+    for (const requirement of currentTask.traderLevelRequirements ?? []) {
+      const traderId = requirement.trader?.id;
+      if (!traderId) continue;
+      if (tarkovStore.getTraderLevel(traderId) < requirement.level) {
+        tarkovStore.setTraderLevel(traderId, requirement.level);
+      }
+    }
+    const fenceId = metadataStore.traders.find((trader) => trader.normalizedName === 'fence')?.id;
+    for (const requirement of currentTask.traderRequirements ?? []) {
+      const traderId = requirement.trader?.id;
+      if (!traderId) continue;
+      const reputation = tarkovStore.getTraderReputation(traderId);
+      if (requirement.value >= 0 && reputation < requirement.value) {
+        tarkovStore.setTraderReputation(traderId, requirement.value);
+      } else if (requirement.value < 0 && traderId === fenceId && reputation > requirement.value) {
+        tarkovStore.setTraderReputation(traderId, requirement.value);
+      }
+    }
+  };
   const isTaskManuallyFailed = (taskId: string) => {
     const completion = tarkovStore.getCurrentProgressData().taskCompletions?.[taskId];
     if (!completion || typeof completion !== 'object') return false;
@@ -220,6 +242,7 @@ export function useTaskActions(
       task: currentTask,
     });
     ensureMinLevel();
+    ensureTraderRequirements();
     emitAction({
       taskId: currentTask.id,
       taskName,


### PR DESCRIPTION
## **User description**
## Summary

- backfill unmet trader loyalty and positive reputation requirements when marking a task available
- preserve Fence low-karma requirement semantics and the trader-gating opt-out
- cover the exact `Is This a Reference?` report plus the other standing branches

## Validation

- `npm run test -- app/stores/__tests__/useProgress.test.ts app/composables/__tests__/useTaskActions.test.ts app/composables/__tests__/useTaskFiltering.test.ts`
- `npm run lint`
- `npm run typecheck`

Closes #510


___

## **CodeAnt-AI Description**
**Backfill trader requirements when making a task available**

### What Changed
- Marking a task as available now fills in missing trader level and reputation requirements so the task can be unlocked immediately.
- Fence negative reputation requirements are handled separately and only lowered when needed; other traders keep their current reputation if it already meets the requirement.
- Trader requirement backfilling is skipped when trader level requirements are turned off in preferences.

### Impact
`✅ Fewer blocked task unlocks`
`✅ Clearer task availability behavior`
`✅ Safer Fence reputation handling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
