### PR TITLE
fix(app): tighten fuzzy search matching

### DIFF
--- a/app/utils/__tests__/fuzzySearch.test.ts
+++ b/app/utils/__tests__/fuzzySearch.test.ts
@@ -13,7 +13,8 @@ describe('fuzzySearch', () => {
     });
     it('returns true for subsequence match', () => {
       expect(fuzzyMatch('Salewa First Aid Kit', 'salewa')).toBe(true);
-      expect(fuzzyMatch('Salewa First Aid Kit', 'sfak')).toBe(true); // s-f-a-k
+      expect(fuzzyMatch('Salewa First Aid Kit', 'sfak')).toBe(true);
+      expect(fuzzyMatch('Salewa', 'slea')).toBe(true);
     });
     it('returns false when words are missing', () => {
       expect(fuzzyMatch('AK-74M', 'ak 47')).toBe(false);
@@ -28,6 +29,15 @@ describe('fuzzySearch', () => {
       expect(fuzzyMatch('café', 'cafe')).toBe(true);
       expect(fuzzyMatch('Crème Brûlée', 'creme brulee')).toBe(true);
     });
+    it('rejects widely scattered subsequence matches', () => {
+      expect(fuzzyMatch('Kill 7 scavs on Interchange from over 40 meters', '7n40')).toBe(false);
+      expect(
+        fuzzyMatch(
+          'Secure keycard is buried in dorms inside the old Interchange loot extraction tunnel',
+          'skibiditoilet'
+        )
+      ).toBe(false);
+    });
   });
   describe('fuzzyMatchScore', () => {
     it('scores exact match highest', () => {
@@ -39,11 +49,13 @@ describe('fuzzySearch', () => {
     it('scores includes high', () => {
       expect(fuzzyMatchScore('my testing', 'test')).toBe(0.8);
     });
-    it('scores partial word matches', () => {
-      // "ak" matches, "47" does not match "AK-74"
-      const score = fuzzyMatchScore('AK-74', 'ak 47');
-      expect(score).toBeGreaterThan(0);
-      expect(score).toBeLessThan(0.8);
+    it('requires every word in a multi-word query', () => {
+      expect(fuzzyMatchScore('AK-74', 'ak 47')).toBe(0);
+      expect(fuzzyMatchScore('AK-74M assault rifle', 'ak 74m')).toBe(0.7);
+    });
+    it('scores initialisms while rejecting scattered subsequences', () => {
+      expect(fuzzyMatchScore('Salewa First Aid Kit', 'sfak')).toBe(0.7);
+      expect(fuzzyMatchScore('Kill 7 scavs on Interchange from over 40 meters', '7n40')).toBe(0);
     });
   });
 });

--- a/app/utils/fuzzySearch.ts
+++ b/app/utils/fuzzySearch.ts
@@ -4,53 +4,72 @@ function normalize(str: string): string {
     .normalize('NFD')
     .replace(/[\u0300-\u036f]/g, '');
 }
+const MAX_INITIALISM_LENGTH = 6;
+function getInitialism(text: string): string {
+  return (text.match(/[\p{L}\p{N}]+/gu) ?? []).map((word) => word[0]).join('');
+}
+function getSubsequenceScore(text: string, query: string): number {
+  let bestGapCount = Number.POSITIVE_INFINITY;
+  let bestConsecutiveCount = 0;
+  let startIndex = text.indexOf(query.charAt(0));
+  while (startIndex !== -1) {
+    let lastMatchIndex = startIndex;
+    let maxConsecutiveCount = 1;
+    let consecutiveCount = 1;
+    let queryIndex = 1;
+    for (let textIndex = startIndex + 1; textIndex < text.length; textIndex++) {
+      if (text[textIndex] !== query[queryIndex]) continue;
+      consecutiveCount = textIndex === lastMatchIndex + 1 ? consecutiveCount + 1 : 1;
+      maxConsecutiveCount = Math.max(maxConsecutiveCount, consecutiveCount);
+      lastMatchIndex = textIndex;
+      queryIndex++;
+      if (queryIndex === query.length) break;
+    }
+    if (queryIndex === query.length) {
+      const gapCount = lastMatchIndex - startIndex + 1 - query.length;
+      if (
+        gapCount < bestGapCount ||
+        (gapCount === bestGapCount && maxConsecutiveCount > bestConsecutiveCount)
+      ) {
+        bestGapCount = gapCount;
+        bestConsecutiveCount = maxConsecutiveCount;
+      }
+    }
+    startIndex = text.indexOf(query.charAt(0), startIndex + 1);
+  }
+  const maxGapCount = Math.max(2, Math.floor(query.length / 2));
+  if (bestGapCount > maxGapCount) return 0;
+  const compactness = query.length / (query.length + bestGapCount);
+  const consecutiveRatio = bestConsecutiveCount / query.length;
+  return 0.3 + compactness * 0.2 + consecutiveRatio * 0.2;
+}
 export function fuzzyMatch(text: string, query: string): boolean {
-  if (!query) return true;
+  const queryLower = normalize(query).trim();
+  if (!queryLower) return true;
   if (!text) return false;
   const textLower = normalize(text);
-  const queryLower = normalize(query);
   if (textLower.includes(queryLower)) return true;
   const words = queryLower.split(/\s+/).filter(Boolean);
   if (words.length > 1) {
     return words.every((word) => textLower.includes(word));
   }
-  let textIndex = 0;
-  let queryIndex = 0;
-  while (textIndex < textLower.length && queryIndex < queryLower.length) {
-    if (textLower[textIndex] === queryLower[queryIndex]) {
-      queryIndex++;
-    }
-    textIndex++;
-  }
-  return queryIndex === queryLower.length;
+  const initialism = getInitialism(textLower);
+  if (queryLower.length <= MAX_INITIALISM_LENGTH && initialism.startsWith(queryLower)) return true;
+  return getSubsequenceScore(textLower, queryLower) > 0;
 }
 export function fuzzyMatchScore(text: string, query: string): number {
-  if (!query) return 1;
+  const queryLower = normalize(query).trim();
+  if (!queryLower) return 1;
   if (!text) return 0;
   const textLower = normalize(text);
-  const queryLower = normalize(query);
   if (textLower === queryLower) return 1;
   if (textLower.startsWith(queryLower)) return 0.9;
   if (textLower.includes(queryLower)) return 0.8;
   const words = queryLower.split(/\s+/).filter(Boolean);
   if (words.length > 1) {
-    const matchedWords = words.filter((word) => textLower.includes(word));
-    return (matchedWords.length / words.length) * 0.7;
+    return words.every((word) => textLower.includes(word)) ? 0.7 : 0;
   }
-  let textIndex = 0;
-  let queryIndex = 0;
-  let consecutiveMatches = 0;
-  let maxConsecutive = 0;
-  while (textIndex < textLower.length && queryIndex < queryLower.length) {
-    if (textLower[textIndex] === queryLower[queryIndex]) {
-      queryIndex++;
-      consecutiveMatches++;
-      maxConsecutive = Math.max(maxConsecutive, consecutiveMatches);
-    } else {
-      consecutiveMatches = 0;
-    }
-    textIndex++;
-  }
-  if (queryIndex < queryLower.length) return 0;
-  return 0.3 + (maxConsecutive / queryLower.length) * 0.3;
+  const initialism = getInitialism(textLower);
+  if (queryLower.length <= MAX_INITIALISM_LENGTH && initialism.startsWith(queryLower)) return 0.7;
+  return getSubsequenceScore(textLower, queryLower);
 }


### PR DESCRIPTION
## **User description**
## Summary

- reject subsequence matches whose characters are spread too far across unrelated text
- require every term in a multi-word query before returning a nonzero score
- preserve exact, prefix, substring, diacritic, compact subsequence, and short initialism matches
- add regression coverage for the reported random-query and 7n40 false-positive shapes

## Root cause

The fuzzy matcher treated any ordered character subsequence as a match regardless of distance. The scored matcher also returned a positive score when only one term from a multi-word query matched, and task search includes every positive score.

## Validation

- npm run lint
- npm run typecheck
- 51 focused Vitest tests covering fuzzy search, needed-items search, and task filtering

Closes #516


___

## **CodeAnt-AI Description**
**Tighten fuzzy search so it stops matching unrelated text**

### What Changed
- Search now rejects matches when the letters are too spread out across a result, which prevents unrelated items from showing up for short or random-looking queries
- Multi-word searches now only match when every word is present, so partial word hits no longer return results
- Short initialism searches like `sfak` still work, while diacritic-insensitive, exact, prefix, and substring matches stay supported

### Impact
`✅ Fewer false search matches`
`✅ Cleaner task and item search results`
`✅ More reliable short acronym matching`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
