### PR TITLE
fix(app): populate skill image links from tarkov.dev CDN

### DIFF
--- a/app/server/utils/__tests__/tarkov-json.test.ts
+++ b/app/server/utils/__tests__/tarkov-json.test.ts
@@ -383,6 +383,12 @@ describe('tarkov JSON adapters', () => {
             type: 'findQuestItem',
             questItem: 'questItem1',
           },
+          {
+            id: 'objective3',
+            type: 'skill',
+            skill: 'Vitality',
+            level: 5,
+          },
         ],
         failConditions: [{ id: 'fail1', type: 'taskStatus', task: 'task2' }],
         startRewards: { items: [{ item: 'item2', count: 1000 }] },
@@ -445,6 +451,30 @@ describe('tarkov JSON adapters', () => {
     expect(rewards?.finishRewards?.items?.[0]?.item).toEqual({ id: 'item1' });
     expect(rewards?.failureOutcome?.skillLevelReward?.[0]?.skill).toMatchObject({
       name: 'Strength',
+    });
+  });
+  it('populates imageLink for skill objectives and skill level rewards', () => {
+    const objectives = adaptTaskObjectivesResponse(tasksPayload, {
+      hideoutPayload,
+      tradersPayload,
+    }).data.tasks[0];
+    expect(objectives?.objectives?.[2]).toMatchObject({
+      __typename: 'TaskObjectiveSkill',
+      skillLevel: {
+        name: 'Vitality',
+        level: 5,
+        skill: {
+          id: 'Vitality',
+          name: 'Vitality',
+          imageLink: 'https://assets.tarkov.dev/skill-Vitality-icon.webp',
+        },
+      },
+    });
+    const rewards = adaptTaskRewardsResponse(tasksPayload, { tradersPayload }).data.tasks[0];
+    expect(rewards?.failureOutcome?.skillLevelReward?.[0]?.skill).toMatchObject({
+      id: 'Strength',
+      name: 'Strength',
+      imageLink: 'https://assets.tarkov.dev/skill-Strength-icon.webp',
     });
   });
   it('adapts task objectives with full item/map lookups when provided', () => {

--- a/app/server/utils/tarkov-json.ts
+++ b/app/server/utils/tarkov-json.ts
@@ -2,6 +2,7 @@ import { JSONPath } from 'jsonpath-plus';
 import { $fetch } from 'ofetch';
 import { useRuntimeConfig } from '#imports';
 import { createLogger } from '@/server/utils/logger';
+import { buildSkillImageUrl } from '@/utils/tarkovUrls';
 import type { ValidGameMode } from '@/server/utils/tarkov-cache-config';
 import type {
   FinishRewards,
@@ -756,7 +757,7 @@ function adaptObjective(raw: JsonRecord, context: AdapterContext): TaskObjective
         ? {
             name: skillName,
             level: skillLevelValue,
-            skill: { id: skillName, name: skillName },
+            skill: { id: skillName, name: skillName, imageLink: buildSkillImageUrl(skillName) },
           }
         : raw.skillLevel,
     task: raw.task ? adaptTaskRef(raw.task, context) : undefined,
@@ -863,6 +864,7 @@ function adaptReward(raw: unknown, context: AdapterContext): FinishRewards | und
                 ? {
                     id: skillName,
                     name: skillName,
+                    imageLink: buildSkillImageUrl(skillName),
                   }
                 : undefined,
           });

--- a/app/utils/__tests__/tarkovUrls.test.ts
+++ b/app/utils/__tests__/tarkovUrls.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildItemImageUrl,
+  buildItemPageUrl,
+  buildSkillImageUrl,
+  buildTaskPageUrl,
+} from '@/utils/tarkovUrls';
+describe('buildItemImageUrl', () => {
+  it('builds a 512px image URL by default', () => {
+    expect(buildItemImageUrl('item1')).toBe('https://assets.tarkov.dev/item1-512.webp');
+  });
+  it('builds an icon URL when size is icon', () => {
+    expect(buildItemImageUrl('item1', 'icon')).toBe('https://assets.tarkov.dev/item1-icon.webp');
+  });
+  it('encodes the item id', () => {
+    expect(buildItemImageUrl('item with spaces')).toBe(
+      'https://assets.tarkov.dev/item%20with%20spaces-512.webp'
+    );
+  });
+});
+describe('buildItemPageUrl', () => {
+  it('builds the tarkov.dev item page URL', () => {
+    expect(buildItemPageUrl('item1')).toBe('https://tarkov.dev/item/item1');
+  });
+  it('encodes the item id', () => {
+    expect(buildItemPageUrl('item/slash')).toBe('https://tarkov.dev/item/item%2Fslash');
+  });
+});
+describe('buildTaskPageUrl', () => {
+  it('builds the tarkov.dev task page URL', () => {
+    expect(buildTaskPageUrl('task1')).toBe('https://tarkov.dev/task/task1');
+  });
+  it('encodes the task id', () => {
+    expect(buildTaskPageUrl('task with spaces')).toBe(
+      'https://tarkov.dev/task/task%20with%20spaces'
+    );
+  });
+});
+describe('buildSkillImageUrl', () => {
+  it('builds a skill icon URL from a skill id', () => {
+    expect(buildSkillImageUrl('Vitality')).toBe(
+      'https://assets.tarkov.dev/skill-Vitality-icon.webp'
+    );
+  });
+  it('builds URLs for known skill ids from the tarkov.dev GraphQL API', () => {
+    const knownSkillIds = [
+      'Health',
+      'Sniper',
+      'StressResistance',
+      'Perception',
+      'Surgery',
+      'Metabolism',
+      'Attention',
+      'Strength',
+      'Endurance',
+      'CovertMovement',
+    ];
+    for (const skillId of knownSkillIds) {
+      expect(buildSkillImageUrl(skillId)).toBe(
+        `https://assets.tarkov.dev/skill-${skillId}-icon.webp`
+      );
+    }
+  });
+  it('encodes the skill id', () => {
+    expect(buildSkillImageUrl('skill with spaces')).toBe(
+      'https://assets.tarkov.dev/skill-skill%20with%20spaces-icon.webp'
+    );
+  });
+});

--- a/app/utils/tarkovUrls.ts
+++ b/app/utils/tarkovUrls.ts
@@ -36,3 +36,11 @@ export function buildItemPageUrl(itemId: string): string {
 export function buildTaskPageUrl(taskId: string): string {
   return `${TARKOV_DEV_SITE_BASE}/task/${encodeURIComponent(taskId)}`;
 }
+/**
+ * Build a URL for a skill icon from the tarkov.dev CDN
+ * @param skillId - The skill ID (matches the json.tarkov.dev skill string)
+ * @returns Full URL to the skill icon image
+ */
+export function buildSkillImageUrl(skillId: string): string {
+  return `${TARKOV_DEV_ASSETS_BASE}/skill-${encodeURIComponent(skillId)}-icon.webp`;
+}


### PR DESCRIPTION
## **User description**
## Summary

- All skill cards in Settings > Progression showed "?" placeholders because `skill.imageLink` was always `undefined`
- Root cause: `json.tarkov.dev` provides skill names as bare strings with no image data; the server adapters built synthetic skill objects without `imageLink`
- The tarkov.dev CDN serves skill icons at a deterministic URL pattern (`skill-{id}-icon.webp`), and the JSON API skill strings match the GraphQL skill IDs exactly (verified against all 49 skills)
- Added `buildSkillImageUrl()` to `tarkovUrls.ts` (mirrors the existing `buildItemImageUrl()` pattern) and populated `imageLink` in both `adaptObjective()` and `adaptReward()` in `tarkov-json.ts`

No additional API calls — the URL is constructed at adaptation time and flows through the existing data pipeline and cache layer.

#### Test plan

- [x] Typecheck passes
- [x] Lint passes (0 warnings)
- [x] Existing tests pass (56 tests across `tarkov-json`, `useSkillCalculation`, `SkillsCard`, `skillHelpers`)
- [x] Manually verify skill images render in Settings > Progression (requires dev server + network)


___

## **CodeAnt-AI Description**
**Show skill icons instead of placeholder images in progression and rewards**

### What Changed
- Skill cards now load the correct icon from tarkov.dev instead of showing a missing-image placeholder
- Skill rewards and task objectives that reference a skill now include the same icon link, so the image appears consistently across the app
- The icon link is built directly from the skill name already provided by the data source, with no extra network request

### Impact
`✅ Fewer missing skill images`
`✅ Clearer progression screens`
`✅ Consistent skill icons in task rewards`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for displaying skill icons on task objectives and skill-based rewards.
  - Skill icons now use consistent asset URLs for skills such as Vitality and Strength.
- **Bug Fixes**
  - Corrected missing skill images when viewing task requirements and failure rewards.
  - Improved handling of skill names containing spaces or special characters in generated links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->