### PR TITLE
fix(app): throttle client log beacons and cache CORS preflights

### DIFF
--- a/app/server/api/logs/client.post.ts
+++ b/app/server/api/logs/client.post.ts
@@ -18,7 +18,7 @@ type ClientLogBody = {
 const clientLogLevels: ClientLogLevel[] = ['debug', 'info', 'warn', 'error'];
 const logger = createLogger('ClientLogsApi');
 const CLIENT_LOG_RATE_LIMIT_PREFIX = 'client-logs-rate';
-const CLIENT_LOG_RATE_LIMIT_PER_MINUTE = 60;
+const CLIENT_LOG_RATE_LIMIT_PER_MINUTE = 10;
 const RATE_LIMIT_WINDOW_MS = 60_000;
 const toClientLogLevel = (value: unknown): ClientLogLevel => {
   if (typeof value === 'string' && clientLogLevels.includes(value as ClientLogLevel)) {

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -119,11 +119,11 @@ const sendClientLog = (level: LogLevel, args: unknown[]): void => {
   if (!shouldClientLog(level)) {
     return;
   }
-  if (!canSendClientLog()) {
-    return;
-  }
   const sinkUrl = resolveClientLogSinkUrl();
   if (!sinkUrl) {
+    return;
+  }
+  if (!canSendClientLog()) {
     return;
   }
   const payload: ClientLogPayload = {

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -89,11 +89,37 @@ const resolveLogLevel = (): LogLevel => {
 };
 const shouldClientLog = (level: LogLevel): boolean =>
   levelPriority[level] >= levelPriority[resolveLogLevel()];
+const CLIENT_LOG_MAX_PER_SESSION = 30;
+const CLIENT_LOG_MAX_PER_MINUTE = 5;
+const CLIENT_LOG_WINDOW_MS = 60_000;
+let clientLogSessionCount = 0;
+let clientLogWindowTimestamps: number[] = [];
+const canSendClientLog = (): boolean => {
+  if (clientLogSessionCount >= CLIENT_LOG_MAX_PER_SESSION) {
+    return false;
+  }
+  const now = Date.now();
+  clientLogWindowTimestamps = clientLogWindowTimestamps.filter(
+    (ts) => now - ts < CLIENT_LOG_WINDOW_MS
+  );
+  if (clientLogWindowTimestamps.length >= CLIENT_LOG_MAX_PER_MINUTE) {
+    return false;
+  }
+  clientLogWindowTimestamps.push(now);
+  clientLogSessionCount++;
+  return true;
+};
 const sendClientLog = (level: LogLevel, args: unknown[]): void => {
   if (import.meta.env.MODE === 'test') {
     return;
   }
   if (typeof window === 'undefined') {
+    return;
+  }
+  if (!shouldClientLog(level)) {
+    return;
+  }
+  if (!canSendClientLog()) {
     return;
   }
   const sinkUrl = resolveClientLogSinkUrl();

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -340,6 +340,7 @@ function corsHeaders(envOrigin?: string, requestOrigin?: string): Record<string,
     'Access-Control-Allow-Origin': resolveOrigin(envOrigin, requestOrigin),
     'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
     'Access-Control-Allow-Headers': 'Content-Type,Authorization',
+    'Access-Control-Max-Age': '86400',
     'Access-Control-Expose-Headers':
       'Retry-After, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset',
   };


### PR DESCRIPTION
## **User description**
## Summary

- **Gate `sendClientLog` behind `shouldClientLog()`** — `logger.warn()` was sending network beacons unconditionally regardless of the configured log level, causing a single browser tab to generate ~17,000 POST requests/day to `/api/logs/client`
- **Add client-side throttle** — max 30 beacons per page session, max 5 per minute, capping any single tab regardless of how many `logger.warn()`/`logger.error()` calls fire
- **Lower server-side rate limit** on `/api/logs/client` from 60/min to 10/min per IP (defense in depth)
- **Add `Access-Control-Max-Age: 86400`** to api-gateway CORS headers so browsers cache preflight responses for 24 hours, eliminating the 1:1 OPTIONS-to-GET ratio from cross-origin consumers like tarkov.dev

## Context

During a request-volume investigation, two major sources of uncached Worker/Pages invocations were identified:

1. **A residential Swedish IP** — a residential browser tab left open 24/7, sending ~700 `logger.warn()` beacons/hour (17,000/day) to `/api/logs/client`. Root cause: `sendClientLog` was not gated by `shouldClientLog()`, so warn-level beacons fired even when the log level was set to `error`.

2. **CORS preflights** — cross-origin API consumers (notably `tarkov.dev`) were sending a 1:1 OPTIONS preflight for every GET request because no `Access-Control-Max-Age` header was set, doubling Worker invocations.

#### Test plan

- [x] `app/server/api/logs/__tests__/client.post.test.ts` — 5 tests pass
- [x] `npm run test:api-gateway` — 55 tests pass
- [x] `npm run typecheck` — passes
- [x] Pre-commit hook (prettier + eslint) — passes
- [ ] Deploy and monitor Worker invocation counts for 24-48 hours


___

## **CodeAnt-AI Description**
**Reduce unnecessary log traffic and let browsers reuse CORS preflight responses**

### What Changed
- Client log beacons now stop when the current log level would not send them, so warn-level events no longer generate network requests when logging is set to error
- Client log sending is capped per browser tab to 30 total beacons per session and 5 per minute, which limits runaway logging from a single open page
- The server now allows fewer client log requests per minute, reducing repeated log bursts from the same IP
- Cross-origin API responses now include a 24-hour preflight cache setting, so browsers can reuse CORS checks instead of repeating them for every request

### Impact
`✅ Fewer background log requests`
`✅ Lower chance of log-related rate limits`
`✅ Fewer repeated CORS preflight checks`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added client-side rate limiting to reduce excessive client log submissions per session and per minute.
  * Tightened the server-side rate limit for client log requests to further prevent log flooding.
* **Performance**
  * Updated CORS settings to cache preflight responses for up to 24 hours, reducing repeated preflight traffic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->