### PR TITLE
fix(config): quiet production build sitemap warning

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -5,11 +5,15 @@ on:
     paths:
       - 'docs/**/*.md'
       - '*.md'
+      - 'lychee.toml'
+      - '.github/workflows/link-check.yml'
   push:
     branches: [main]
     paths:
       - 'docs/**/*.md'
       - '*.md'
+      - 'lychee.toml'
+      - '.github/workflows/link-check.yml'
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
   workflow_dispatch:
@@ -30,18 +34,12 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
+          # Config (accept, retries, exclude_path/exclude) lives in lychee.toml so
+          # regexes are not mangled by YAML/shell escaping (see exclude_path for
+          # CHANGELOG.md). Only input globs stay here.
           args: >-
+            --config lychee.toml
             --verbose
-            --no-progress
-            --accept 200,204,206,301,302,308
-            --max-concurrency 4
-            --max-retries 3
-            --retry-wait-time 2
-            --exclude-path '(^|/)CHANGELOG\\.md$'
-            --exclude 'localhost'
-            --exclude '127\.0\.0\.1'
-            --exclude 'tarkovtracker\.org'
-            --exclude 'gnu\.org'
             './docs/**/*.md'
             './*.md'
           fail: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,20 @@
+## [1.55.7](https://github.com/tarkovtracker-org/TarkovTracker/compare/v1.55.6...v1.55.7) (2026-07-11)
+
+
+### Bug Fixes
+
+* **workers:** address review — safe load retry and conditional alarm wipe ([619ac81](https://github.com/tarkovtracker-org/TarkovTracker/commit/619ac81b86ea16786b2ae7b333c04561b1bdfe92))
+* **workers:** address review — safe test cleanup, storage error logging, throttled path coverage ([6b4f0a6](https://github.com/tarkovtracker-org/TarkovTracker/commit/6b4f0a68969a78a8aa20e06a47f0c00fc1d2d8b5))
+* **workers:** clear DO alarm metadata on rate-limit cleanup ([e7f644f](https://github.com/tarkovtracker-org/TarkovTracker/commit/e7f644f666de9ad5c9bdc8d9e0db3c90dcfa2c37))
+* **workers:** default DO rate-limit cleanup unless retain is set ([f521024](https://github.com/tarkovtracker-org/TarkovTracker/commit/f52102457e5d759c263ae8971ac6cc5119e48543))
+* **workers:** keep sliding rate-limit hits past stored resetAt ([0855aa5](https://github.com/tarkovtracker-org/TarkovTracker/commit/0855aa5fea170bb3f5fd417adfc254904309d15c))
+* **workers:** restore bounded retention for ephemeral DO rate-limit keys ([6641b48](https://github.com/tarkovtracker-org/TarkovTracker/commit/6641b484e9c2d98522dcb370f0c9919558c66272))
+
+
+### Performance Improvements
+
+* **workers:** eliminate DO cleanup alarms via lazy expiration ([ad51e62](https://github.com/tarkovtracker-org/TarkovTracker/commit/ad51e620f9f85cc1348fa892d0961044dd98080e))
+
 ## [1.55.6](https://github.com/tarkovtracker-org/TarkovTracker/compare/v1.55.5...v1.55.6) (2026-07-11)
 
 

--- a/app/utils/__tests__/stripBareNodeImports.test.ts
+++ b/app/utils/__tests__/stripBareNodeImports.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { stripBareNodeImports } from '@/utils/stripBareNodeImports';
+describe('stripBareNodeImports', () => {
+  it('removes bare side-effect node: imports', () => {
+    expect(stripBareNodeImports('import "node:process";')).toBe('');
+    expect(stripBareNodeImports("import 'node:buffer';")).toBe('');
+    expect(stripBareNodeImports('import"node:path";')).toBe('');
+    expect(stripBareNodeImports('import "node:process"')).toBe('');
+  });
+  it('preserves named and namespace node: imports', () => {
+    expect(stripBareNodeImports('import x from "node:fs";')).toBe('import x from "node:fs";');
+    expect(stripBareNodeImports('import { readFile } from "node:fs";')).toBe(
+      'import { readFile } from "node:fs";'
+    );
+    expect(stripBareNodeImports('import process from "node:process";')).toBe(
+      'import process from "node:process";'
+    );
+    expect(stripBareNodeImports('import * as fs from "node:fs";')).toBe(
+      'import * as fs from "node:fs";'
+    );
+  });
+  it('preserves dynamic imports and non-import node: strings', () => {
+    expect(stripBareNodeImports('await import("node:fs");')).toBe('await import("node:fs");');
+    expect(stripBareNodeImports('const a = "node:process";')).toBe('const a = "node:process";');
+  });
+  it('strips only bare imports from mixed source', () => {
+    const source = [
+      'import "node:process";',
+      'import { join } from "node:path";',
+      'import x from "node:fs";',
+      'export const ok = true;',
+    ].join('\n');
+    expect(stripBareNodeImports(source)).toBe(
+      [
+        '',
+        'import { join } from "node:path";',
+        'import x from "node:fs";',
+        'export const ok = true;',
+      ].join('\n')
+    );
+  });
+  it('returns source unchanged when node: is absent', () => {
+    const source = 'export const value = 1;';
+    expect(stripBareNodeImports(source)).toBe(source);
+  });
+});

--- a/app/utils/stripBareNodeImports.ts
+++ b/app/utils/stripBareNodeImports.ts
@@ -1,0 +1,7 @@
+const BARE_NODE_IMPORT_RE = /import\s*["']node:[^"']+["']\s*;?/g;
+export const stripBareNodeImports = (source: string): string => {
+  if (!source.includes('node:')) {
+    return source;
+  }
+  return source.replace(BARE_NODE_IMPORT_RE, '');
+};

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -403,12 +403,14 @@ pnpm run test:api-gateway
 ### Cloudflare Pages
 
 ```yaml
+# Cloudflare Pages project build configuration (dashboard / CI build settings).
+# Runtime app vars live in wrangler.toml [vars], not here.
 Build command: pnpm run build
 Build output: dist
 Root directory: /
-Node.js version: 24.x
-Environment variables:
-  PNPM_VERSION: 10.34.5
+# Optional build-tool pin (Pages build image). Detection also works from
+# pnpm-lock.yaml + packageManager without this env var.
+# PNPM_VERSION: 10.34.5
 ```
 
 ### Environment Variables

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -408,6 +408,7 @@ pnpm run test:api-gateway
 Build command: pnpm run build
 Build output: dist
 Root directory: /
+Node.js version: 24.x
 # Optional build-tool pin (Pages build image). Detection also works from
 # pnpm-lock.yaml + packageManager without this env var.
 # PNPM_VERSION: 10.34.5

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,25 @@
+# Shared lychee config for CI (.github/workflows/link-check.yml) and local runs.
+# Prefer this file for exclude patterns so YAML/shell escaping cannot corrupt regexes.
+
+#############################  Runtime  #############################
+
+no_progress = true
+max_concurrency = 4
+max_retries = 3
+retry_wait_time = 2
+accept = ["200", "204", "206", "301", "302", "308"]
+
+#############################  Exclusions  ##########################
+
+# Generated release notes: issue shortrefs and historical URLs churn often.
+exclude_path = [
+  '(^|/)CHANGELOG\.md$',
+]
+
+# Local/dev hosts and production app origin (checked by deploy, not docs).
+exclude = [
+  'localhost',
+  '127\.0\.0\.1',
+  'tarkovtracker\.org',
+  'gnu\.org',
+]

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -346,6 +346,7 @@ export default defineNuxtConfig({
     name: 'Tarkov Tracker',
   },
   sitemap: {
+    zeroRuntime: true,
     xslColumns: [
       { label: 'URL', width: '65%' },
       { label: 'Last Modified', select: 'sitemap:lastmod', width: '25%' },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveTrustProxySetting } from './app/utils/apiProtectionConfig';
@@ -248,22 +248,29 @@ export default defineNuxtConfig({
         if (!String(nitro.options.preset || '').includes('cloudflare')) {
           return;
         }
-        // Side-effect-only: import"node:foo" / import "node:foo";
-        // Named imports (import x from "node:foo", import { y } from "node:foo")
-        // do not match because a binding/from clause sits between import and the quote.
         const bareNodeImportRe = /import\s*["']node:[^"']+["']\s*;?/g;
         const walk = (dir: string) => {
-          for (const entry of readdirSync(dir)) {
-            const full = join(dir, entry);
-            if (statSync(full).isDirectory()) {
+          let entries: ReturnType<typeof readdirSync>;
+          try {
+            entries = readdirSync(dir, { withFileTypes: true });
+          } catch {
+            return;
+          }
+          for (const entry of entries) {
+            const full = join(dir, entry.name);
+            if (entry.isDirectory()) {
               walk(full);
               continue;
             }
-            if (!/\.(m?js|cjs)$/.test(entry)) continue;
-            const source = readFileSync(full, 'utf8');
-            if (!source.includes('node:')) continue;
-            const next = source.replace(bareNodeImportRe, '');
-            if (next !== source) writeFileSync(full, next);
+            if (!/\.(m?js|cjs)$/.test(entry.name)) continue;
+            try {
+              const source = readFileSync(full, 'utf8');
+              if (!source.includes('node:')) continue;
+              const next = source.replace(bareNodeImportRe, '');
+              if (next !== source) writeFileSync(full, next);
+            } catch {
+              // Skip if the path vanished mid-walk (should not happen mid-build).
+            }
           }
         };
         walk(nitro.options.output.serverDir);

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,6 +1,6 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-import { readFileSync } from 'node:fs';
-import { resolve } from 'node:path';
+import { readdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
+import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveTrustProxySetting } from './app/utils/apiProtectionConfig';
 import { SUPPORTED_LOCALES } from './app/utils/locales';
@@ -241,6 +241,32 @@ export default defineNuxtConfig({
           include: ['/*'],
           exclude: ['/_fonts/*', '/_nuxt/*', '/img/*', '/favicon.ico', '/robots.txt'],
         },
+      },
+    },
+    hooks: {
+      compiled(nitro) {
+        if (!String(nitro.options.preset || '').includes('cloudflare')) {
+          return;
+        }
+        // Side-effect-only: import"node:foo" / import "node:foo";
+        // Named imports (import x from "node:foo", import { y } from "node:foo")
+        // do not match because a binding/from clause sits between import and the quote.
+        const bareNodeImportRe = /import\s*["']node:[^"']+["']\s*;?/g;
+        const walk = (dir: string) => {
+          for (const entry of readdirSync(dir)) {
+            const full = join(dir, entry);
+            if (statSync(full).isDirectory()) {
+              walk(full);
+              continue;
+            }
+            if (!/\.(m?js|cjs)$/.test(entry)) continue;
+            const source = readFileSync(full, 'utf8');
+            if (!source.includes('node:')) continue;
+            const next = source.replace(bareNodeImportRe, '');
+            if (next !== source) writeFileSync(full, next);
+          }
+        };
+        walk(nitro.options.output.serverDir);
       },
     },
   },

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -14,6 +14,7 @@ import {
   resolveSupabaseRuntimeConfig,
   TARKOV_IMAGE_DOMAINS,
 } from './app/utils/runtimeConfig';
+import { stripBareNodeImports } from './app/utils/stripBareNodeImports';
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const appDir = resolve(__dirname, 'app');
 const testsDir = resolve(__dirname, 'tests');
@@ -248,7 +249,6 @@ export default defineNuxtConfig({
         if (!String(nitro.options.preset || '').includes('cloudflare')) {
           return;
         }
-        const bareNodeImportRe = /import\s*["']node:[^"']+["']\s*;?/g;
         const walk = (dir: string) => {
           let entries: Dirent[];
           try {
@@ -265,8 +265,7 @@ export default defineNuxtConfig({
             if (!/\.(m?js|cjs)$/.test(entry.name)) continue;
             try {
               const source = readFileSync(full, 'utf8');
-              if (!source.includes('node:')) continue;
-              const next = source.replace(bareNodeImportRe, '');
+              const next = stripBareNodeImports(source);
               if (next !== source) writeFileSync(full, next);
             } catch {
               // Skip if the path vanished mid-walk (should not happen mid-build).

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -1,5 +1,5 @@
 // https://nuxt.com/docs/api/configuration/nuxt-config
-import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { readdirSync, readFileSync, writeFileSync, type Dirent } from 'node:fs';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { resolveTrustProxySetting } from './app/utils/apiProtectionConfig';
@@ -250,9 +250,9 @@ export default defineNuxtConfig({
         }
         const bareNodeImportRe = /import\s*["']node:[^"']+["']\s*;?/g;
         const walk = (dir: string) => {
-          let entries: ReturnType<typeof readdirSync>;
+          let entries: Dirent[];
           try {
-            entries = readdirSync(dir, { withFileTypes: true });
+            entries = readdirSync(dir, { withFileTypes: true, encoding: 'utf8' });
           } catch {
             return;
           }

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -46,16 +46,18 @@ STRIPE_PRICE_CHAD_MONTHLY = "price_1Ta4aGLaRBke56G2ncgwP5DO"
 STRIPE_PRICE_CHAD_6MONTH = "price_1Ta4aHLaRBke56G2oKmYuqvl"
 STRIPE_PRICE_CHAD_YEARLY = "price_1Ta4aILaRBke56G2pxce76Pi"
 
-# Preview deployments: omit APP_URL so CF_PAGES_URL is used instead.
-# This gives each preview its own edge cache namespace, correct API
-# host trust, and correct Stripe redirect URLs.
-# Analytics IDs are intentionally omitted: previews run on *.pages.dev
-# hostnames which `shouldEnableAnalyticsIntegrations` already filters out
-# at runtime, but leaving the IDs unset in preview vars is defense in
-# depth so preview traffic can never reach production GA/Clarity.
-# vars is non-inheritable so all keys must be repeated here.
+# Preview deployments: vars is non-inheritable, so keys are repeated here.
+# APP_URL is present but empty so CF_PAGES_URL is used for per-preview URLs,
+# edge cache namespaces, API host trust, and Stripe redirects.
+# Analytics IDs are present but empty so preview builds never instrument
+# production GA/Clarity (defense in depth beyond hostname checks).
+# Empty string values also silence Wrangler's "missing env.preview.vars" warnings
+# without copying production values into preview.
 [env.preview.vars]
 NODE_ENV = "production"
+APP_URL = ""
+GA_MEASUREMENT_ID = ""
+CLARITY_PROJECT_ID = ""
 SUPABASE_URL = "https://knptqelvsodccnoehmbj.supabase.co"
 SUPABASE_ANON_KEY = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImtucHRxZWx2c29kY2Nub2VobWJqIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjM0NTQ2OTMsImV4cCI6MjA3OTAzMDY5M30.jnlspZYu4J7i7bKfJ0p7j5R_r0YmvJj0ph5uw3XUPeY"
 STRIPE_PRICE_SCAV_MONTHLY = "price_1TaNKuLaRBke56G21GOVCUbK"


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to the pnpm migration production deploy review. Cleans the one **actionable** build warning from the Cloudflare Pages log and clarifies dashboard build settings docs.

### Changes

1. **`sitemap.zeroRuntime: true`** in `nuxt.config.ts`
   - Removes the `@nuxtjs/sitemap` “No dynamic sources detected…” warning
   - SPA has no runtime/dynamic sitemap sources; generate at build time
   - Local production build now emits `dist/sitemap.xml` and drops unused sitemap runtime code from the Nitro server bundle (~1.16 MB → ~1.13 MB `nitro.mjs` in local measurement)

2. **Docs** (`docs/ARCHITECTURE.md`)
   - Document `pnpm run build` as the Pages build command
   - Clarify build settings vs `wrangler.toml` runtime `[vars]`
   - Note `PNPM_VERSION` as optional (lockfile + `packageManager` already detect pnpm)

### Intentionally *not* “fixed” here

These remain upstream / structural and are not silenced with hacky config:

| Warning | Why left alone |
|---|---|
| `nuxt:module-preload-polyfill` sourcemap | Upstream Nuxt; disabling the polyfill changes browser support |
| VueUse `#__PURE__` Rollup notes | Upstream `@vueuse/core` packaging |
| Client chunk > 500 kB | Real bundle-size signal; needs product-level split work, not a limit bump |
| CF `ignored-bare-import` for `node:process` | Pages platform wrangler/unenv warning at upload time |
| corepack `EBADENGINE` on build image | Cloudflare bootstrap tooling |

Dashboard **Build command** should already be `pnpm run build` (user-applied after merge of #533). This PR makes the repo docs match.

#### Test plan

- [x] Local `pnpm run build` (production-like env) succeeds
- [x] `zeroRuntime enabled` info replaces the old dynamic-sources warning
- [x] `dist/sitemap.xml` present after build
- [x] CI green
- [ ] Cloudflare production build log no longer shows sitemap dynamic-sources warning


___

## **CodeAnt-AI Description**
**Generate the sitemap at build time and clarify Pages build settings**

### What Changed
- The sitemap is now generated during the build instead of at runtime, removing the Cloudflare Pages warning about missing dynamic sitemap sources
- The site still publishes `sitemap.xml`, but without carrying unused sitemap runtime code
- The architecture docs now clearly separate Cloudflare Pages build settings from runtime app variables and note that the pnpm version pin is optional

### Impact
`✅ Quieter production builds`
`✅ Fewer misleading sitemap warnings`
`✅ Clearer Cloudflare Pages setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated Cloudflare Pages architecture/build guidance, including where runtime app variables should be configured.
  - Refined preview deployment notes to explain per-preview URLs and why analytics IDs are left blank for preview builds.

- **Bug Fixes**
  - Improved Cloudflare-targeted builds by removing only bare Node ESM import statements during compilation.
  - Adjusted sitemap behavior for more reliable static deployment.

- **Tests**
  - Added coverage for the Node import stripping behavior to ensure correct handling of various import forms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->