### PR TITLE
fix: harden review findings across app, API, and docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * **config:** address production-readiness review findings ([3af3b2c](https://github.com/tarkovtracker-org/TarkovTracker/commit/3af3b2ccdc6641cdd25917f9404877fde100563b))
 * **config:** avoid CodeQL TOCTOU findings in CF worker postprocess ([921155d](https://github.com/tarkovtracker-org/TarkovTracker/commit/921155d1d2bf397168539758adadd16af3b462b2))
 * **config:** declare empty preview APP_URL and analytics vars ([3c66b51](https://github.com/tarkovtracker-org/TarkovTracker/commit/3c66b517fe18e0d3a3c0735202d95482f3322c3a))
-* **ci:** harden link check and drop bogus changelog issue refs ([959c35e](https://github.com/tarkovtracker-org/TarkovTracker/commit/959c35e86664ac7c83711827eb48a3fa77be35c7)), closes [hi#cardinality](https://github.com/hi/issues/cardinality)
+* **ci:** harden link check and drop bogus changelog issue refs ([959c35e](https://github.com/tarkovtracker-org/TarkovTracker/commit/959c35e86664ac7c83711827eb48a3fa77be35c7))
 * **config:** quiet production build noise from sitemap runtime path ([e3a03a1](https://github.com/tarkovtracker-org/TarkovTracker/commit/e3a03a14df2a24412257b75dcef6c00528276262))
 * **config:** strip bare node: side-effect imports from CF worker ([2725338](https://github.com/tarkovtracker-org/TarkovTracker/commit/27253381fa619de04632b6cc035e4dae2bbdf48a)), closes [nitrojs/nitro#4164](https://github.com/nitrojs/nitro/issues/4164)
 * **config:** type readdir Dirent as utf8 string names ([480a563](https://github.com/tarkovtracker-org/TarkovTracker/commit/480a563ecee7d6881cada92f8134cfc953603046))
@@ -14,7 +14,7 @@
 
 ### Features
 
-* **api:** harden rate limiting with per-IP backstop, token cap, and 429 observability ([#523](https://github.com/tarkovtracker-org/TarkovTracker/issues/523)) ([b34c04d](https://github.com/tarkovtracker-org/TarkovTracker/commit/b34c04daa0625f81b0c33a6f187f8d44c458cf7a)), closes [hi#cardinality](https://github.com/hi/issues/cardinality)
+* **api:** harden rate limiting with per-IP backstop, token cap, and 429 observability ([#523](https://github.com/tarkovtracker-org/TarkovTracker/issues/523)) ([b34c04d](https://github.com/tarkovtracker-org/TarkovTracker/commit/b34c04daa0625f81b0c33a6f187f8d44c458cf7a))
 
 ## [1.55.7](https://github.com/tarkovtracker-org/TarkovTracker/compare/v1.55.6...v1.55.7) (2026-07-11)
 

--- a/app/utils/__tests__/fuzzySearch.test.ts
+++ b/app/utils/__tests__/fuzzySearch.test.ts
@@ -57,5 +57,11 @@ describe('fuzzySearch', () => {
       expect(fuzzyMatchScore('Salewa First Aid Kit', 'sfak')).toBe(0.7);
       expect(fuzzyMatchScore('Kill 7 scavs on Interchange from over 40 meters', '7n40')).toBe(0);
     });
+    it('keeps subsequence scores strictly below the initialism tier', () => {
+      const score = fuzzyMatchScore('Salewa', 'slea');
+      expect(score).toBeGreaterThan(0);
+      expect(score).toBeLessThan(0.7);
+      expect(score).toBeLessThanOrEqual(0.65);
+    });
   });
 });

--- a/app/utils/fuzzySearch.ts
+++ b/app/utils/fuzzySearch.ts
@@ -41,7 +41,7 @@ function getSubsequenceScore(text: string, query: string): number {
   if (bestGapCount > maxGapCount) return 0;
   const compactness = query.length / (query.length + bestGapCount);
   const consecutiveRatio = bestConsecutiveCount / query.length;
-  return 0.3 + compactness * 0.2 + consecutiveRatio * 0.2;
+  return 0.3 + compactness * 0.175 + consecutiveRatio * 0.175;
 }
 export function fuzzyMatch(text: string, query: string): boolean {
   const queryLower = normalize(query).trim();

--- a/scripts/precompute/__tests__/precompute.test.ts
+++ b/scripts/precompute/__tests__/precompute.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { isPrecomputedEnvelope } from '@/server/utils/precomputedTarkov';
+import { buildTasksCorePrecomputedKey, isPrecomputedEnvelope } from '@/server/utils/precomputedTarkov';
+import { VALID_GAME_MODES } from '@/server/utils/tarkov-cache-config';
+import { API_SUPPORTED_LANGUAGES } from '@/utils/constants';
 import { PRECOMPUTED_TTL_SECONDS, runPrecompute, validatePrecomputeFilter } from '../precompute';
 import type { KvWriter } from '../precompute';
 const { applyOverlayMock, createFetcherMock, fetcherMock } = vi.hoisted(() => {
@@ -43,13 +45,17 @@ describe('runPrecompute', () => {
     const kv = createKvMock();
     const result = await runPrecompute(kv, { lang: 'en' });
     expect(result.failures).toEqual([]);
-    expect(result.successes).toEqual([
-      'tasks-core-json-v2-en-regular',
-      'tasks-core-json-v2-en-pve',
-    ]);
+    expect(result.successes).toHaveLength(2);
+    expect(result.successes).toEqual(
+      expect.arrayContaining([
+        'tasks-core-json-v2-en-regular',
+        'tasks-core-json-v2-en-pve',
+      ])
+    );
     expect(kv.put).toHaveBeenCalledTimes(2);
-    const [key, value, options] = kv.put.mock.calls[0];
-    expect(key).toBe('tasks-core-json-v2-en-regular');
+    const putCall = kv.put.mock.calls.find(([key]) => key === 'tasks-core-json-v2-en-regular');
+    expect(putCall).toBeDefined();
+    const [, value, options] = putCall!;
     expect(options).toEqual({ expirationTtl: PRECOMPUTED_TTL_SECONDS });
     expect(PRECOMPUTED_TTL_SECONDS).toBe(604800);
     const envelope = JSON.parse(value as string);
@@ -62,6 +68,17 @@ describe('runPrecompute', () => {
     expect(createFetcherMock).toHaveBeenCalledTimes(1);
     expect(createFetcherMock).toHaveBeenCalledWith({ gameMode: 'pve', lang: 'de' });
     expect(applyOverlayMock).toHaveBeenCalledWith({ raw: true }, { gameMode: 'pve' });
+  });
+  it('expands to all supported lang and gameMode combinations when no filter is provided', async () => {
+    const kv = createKvMock();
+    const result = await runPrecompute(kv, {});
+    const expectedKeys = API_SUPPORTED_LANGUAGES.flatMap((lang) =>
+      VALID_GAME_MODES.map((gameMode) => buildTasksCorePrecomputedKey(lang, gameMode))
+    );
+    expect(result.failures).toEqual([]);
+    expect(result.successes).toHaveLength(expectedKeys.length);
+    expect(result.successes).toEqual(expect.arrayContaining(expectedKeys));
+    expect(kv.put).toHaveBeenCalledTimes(expectedKeys.length);
   });
   it('records a pipeline failure and continues with remaining combinations', async () => {
     applyOverlayMock

--- a/supabase/functions/account-delete-reconcile/index.ts
+++ b/supabase/functions/account-delete-reconcile/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import {
   authenticateUser,
   handleCorsPreflight,
@@ -378,7 +377,7 @@ const processDeletionJob = async (
   return { userId, status: 'completed' };
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;
   try {

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -5,7 +5,6 @@ import {
   createErrorResponse,
   createSuccessResponse,
 } from '../_shared/auth.ts';
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import type { Database } from '../_shared/database.types.ts';
 
 const AUTH_DELETE_MAX_ATTEMPTS = 4;
@@ -245,7 +244,7 @@ const markDeletionCompleted = async (supabase: TypedSupabaseClient, userId: stri
   }
 };
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;
   try {

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import {
   authenticateUser,
   handleCorsPreflight,
@@ -301,7 +300,7 @@ async function purgeTarkovDataCache(
   return aggregatedResult;
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;

--- a/supabase/functions/deno-stubs.d.ts
+++ b/supabase/functions/deno-stubs.d.ts
@@ -14,12 +14,6 @@ declare namespace Deno {
   ): void
 }
 
-declare module "https://deno.land/std@0.168.0/http/server.ts" {
-  export function serve(
-    handler: (req: Request) => Response | Promise<Response>
-  ): void
-}
-
 declare module "shared/auth" {
   export function authenticateUser(req: Request): Promise<{ user: { id: string }; supabase: unknown } | { error: string; status: number }>
   export function handleCorsPreflight(req: Request): Response | null

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -5,7 +5,6 @@
   "imports": {
     "@supabase/supabase-js": "npm:@supabase/supabase-js@2",
     "@supabase/functions-js/edge-runtime": "jsr:@supabase/functions-js@2/edge-runtime.d.ts",
-    "std/http/server": "https://deno.land/std@0.168.0/http/server.ts",
     "shared/auth": "./_shared/auth.ts"
   },
   "lint": {

--- a/supabase/functions/team-create/index.ts
+++ b/supabase/functions/team-create/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import {
   authenticateUser,
   handleCorsPreflight,
@@ -14,7 +13,7 @@ const MAX_TEAM_MEMBERS = 5;
 const VALID_GAME_MODES = ['pvp', 'pve'] as const;
 type GameMode = (typeof VALID_GAME_MODES)[number];
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;

--- a/supabase/functions/team-join/index.ts
+++ b/supabase/functions/team-join/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import {
     authenticateUser,
     handleCorsPreflight,
@@ -13,7 +12,7 @@ import { enforceUserMutationRateLimit } from "../_shared/rate-limit.ts"
 const VALID_GAME_MODES = ["pvp", "pve"] as const
 type GameMode = typeof VALID_GAME_MODES[number]
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   const corsResponse = handleCorsPreflight(req)
   if (corsResponse) return corsResponse

--- a/supabase/functions/team-kick/index.ts
+++ b/supabase/functions/team-kick/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import {
   authenticateUser,
   handleCorsPreflight,
@@ -11,7 +10,7 @@ import {
 } from '../_shared/auth.ts';
 import { enforceUserMutationRateLimit } from '../_shared/rate-limit.ts';
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;

--- a/supabase/functions/team-leave/index.ts
+++ b/supabase/functions/team-leave/index.ts
@@ -9,11 +9,10 @@ import {
   type AuthSuccess
 } from "../_shared/auth.ts"
 import { enforceUserMutationRateLimit } from "../_shared/rate-limit.ts"
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 const LEAVE_COOLDOWN_MINUTES = 5
 const VALID_GAME_MODES = ["pvp", "pve"] as const
 type GameMode = typeof VALID_GAME_MODES[number]
-serve(async (req) => {
+Deno.serve(async (req) => {
   // Handle CORS preflight requests
   const corsResponse = handleCorsPreflight(req)
   if (corsResponse) return corsResponse

--- a/supabase/functions/team-members/index.ts
+++ b/supabase/functions/team-members/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts";
 import {
   authenticateUser,
   handleCorsPreflight,
@@ -11,7 +10,7 @@ import {
 const TEAM_ID_REGEX = /^[a-zA-Z0-9-]{1,64}$/;
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const cors = handleCorsPreflight(req);
   if (cors) return cors;
 

--- a/supabase/functions/token-create/index.ts
+++ b/supabase/functions/token-create/index.ts
@@ -1,4 +1,3 @@
-import { serve } from "https://deno.land/std@0.168.0/http/server.ts"
 import {
   authenticateUser,
   createErrorResponse,
@@ -23,7 +22,7 @@ const hashToken = async (token: string) => {
     .join("")
 }
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   // CORS preflight
   const cors = handleCorsPreflight(req)
   if (cors) return cors

--- a/supabase/functions/token-revoke/index.ts
+++ b/supabase/functions/token-revoke/index.ts
@@ -1,4 +1,3 @@
-import { serve } from 'https://deno.land/std@0.168.0/http/server.ts';
 import {
   authenticateUser,
   createErrorResponse,
@@ -11,7 +10,7 @@ import {
 } from '../_shared/auth.ts';
 import { enforceUserMutationRateLimit } from '../_shared/rate-limit.ts';
 
-serve(async (req) => {
+Deno.serve(async (req) => {
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;
 

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -485,6 +485,18 @@ describe('api-gateway', () => {
     const payload = mergePayload as unknown as MergeRpcPayload;
     expect(payload.p_set).toBeNull();
   });
+  it('rejects POST /progress/tasks with malformed JSON body', async () => {
+    vi.stubGlobal('fetch', createBaseFetchMock());
+    const res = await worker.fetch(
+      buildRequest('/progress/tasks', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer PVP_abc123', 'Content-Type': 'application/json' },
+        body: '{not json',
+      }),
+      BASE_ENV
+    );
+    await expectErrorResponse(res, 400, 'Invalid JSON body');
+  });
   it('returns an error when the merge RPC matches no progress row', async () => {
     vi.stubGlobal(
       'fetch',

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -1152,7 +1152,12 @@ export default {
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
-        const body = await request.json();
+        let body: unknown;
+        try {
+          body = await request.json();
+        } catch {
+          return errorResponse('Invalid JSON body', 400, origin, reqOrigin, rlHeaders);
+        }
         // Support both legacy object format and new array format
         const updates = normalizeTaskUpdates(body);
         if (!updates) {


### PR DESCRIPTION
## **User description**
## Summary
- Cap fuzzy subsequence scores at 0.65 so they stay below the 0.7 initialism/multi-word tier.
- Return 400 for malformed JSON on `POST /progress/tasks` instead of falling through to 500.
- Migrate Supabase edge functions from Deno `std@0.168.0` `serve` to built-in `Deno.serve`.
- Harden precompute tests for order-independent success assertions and full unfiltered expansion.
- Strip bogus `hi#cardinality` changelog issue refs reintroduced in 1.56.0 notes.

## Test plan
- [x] `pnpm exec vitest run app/utils/__tests__/fuzzySearch.test.ts`
- [x] `pnpm run test:api-gateway`
- [x] `pnpm exec vitest run scripts/precompute/__tests__/precompute.test.ts`
- [ ] CI green on PR


___

## **CodeAnt-AI Description**
Fix a set of review issues across search scoring, API error handling, edge functions, tests, and changelog links

### What Changed
- Search results now keep fuzzy subsequence matches below the initialism score tier, so they no longer rank too highly.
- `POST /progress/tasks` now returns a client error for malformed JSON instead of failing with a server error.
- Supabase edge functions now use the built-in Deno server handler, and the project no longer depends on the older Deno std server import.
- Precompute tests now allow success results in any order and verify that all supported language and game-mode combinations are covered.
- Removed invalid changelog issue references that were being published in release notes.

### Impact
`✅ Fewer incorrect top search matches`
`✅ Clearer invalid-request errors`
`✅ Safer edge-function deployment`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
