### PR TITLE
chore(deps): upgrade pnpm to 11.14.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -23,10 +23,10 @@ Please be respectful and constructive in all interactions. We're building a tool
 
 ## Getting Started
 
-**Prerequisites:** Node.js >= 24.12.0, pnpm 10.34.5 (via Corepack; matches `packageManager`), Git.
+**Prerequisites:** Node.js >= 24.12.0, pnpm 11.14.0 (via Corepack; matches `packageManager`), Git.
 
 1. **Fork the repository** and clone your fork locally
-2. **Install dependencies**: `corepack enable && corepack prepare pnpm@10.34.5 --activate && pnpm install`
+2. **Install dependencies**: `corepack enable && corepack prepare pnpm@11.14.0 --activate && pnpm install`
 3. **Set up environment**: Copy `.env.example` to `.env` and add your Supabase credentials.
    Full env-var reference: [`docs/runbook.md`](../docs/runbook.md) and [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md).
 4. **Start dev server**: `pnpm run dev`

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -61,7 +61,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -94,7 +94,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -146,7 +146,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -192,7 +192,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -221,7 +221,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -114,7 +114,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -148,7 +148,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/precompute-tarkov-data.yml
+++ b/.github/workflows/precompute-tarkov-data.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@10.34.5 --activate
+          corepack prepare pnpm@11.14.0 --activate
 
       - name: Setup pnpm cache
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
@@ -46,11 +46,8 @@ jobs:
         run: |
           audit_dir="$RUNNER_TEMP/pnpm-audit"
           mkdir -p "$audit_dir"
-          cp pnpm-lock.yaml "$audit_dir/pnpm-lock.yaml"
-          jq 'del(.engines.pnpm) | .packageManager = "pnpm@11.1.0"' \
-            package.json > "$audit_dir/package.json"
+          cp pnpm-lock.yaml package.json "$audit_dir/"
           echo "audit_dir=$audit_dir" >> "$GITHUB_OUTPUT"
-          corepack prepare pnpm@11.1.0 --activate
 
       - name: Audit production dependencies
         working-directory: ${{ steps.prepare-audit.outputs.audit_dir }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,7 +26,7 @@ If this file conflicts with executable config (eslint, prettier, tsconfig, packa
 ## Project Snapshot
 
 - **Stack:** Nuxt 4 SPA (`ssr: false`), Vue 3 Composition API, TypeScript strict, Pinia, Supabase, Tailwind CSS v4, Vitest, Cloudflare Pages/Workers.
-- **Runtime:** Node >=24.12.0, packageManager `pnpm@10.34.5` (engines allow `pnpm >=10.34.5 <11`).
+- **Runtime:** Node >=24.12.0, packageManager `pnpm@11.14.0` (engines allow `pnpm >=10.34.5 <12`).
 - **Backend:** Supabase (auth, database, realtime). API proxy via Nitro server routes.
 - **Deployment:** Cloudflare Pages/Workers. The Pages build emits a static SPA shell and routes only
   `/api/*` plus `/overlay/*` through Pages Functions.

--- a/docs/agent-context/summary/codebase_info.md
+++ b/docs/agent-context/summary/codebase_info.md
@@ -28,7 +28,7 @@ and multi-device sync.
 | Public API | Cloudflare Worker (`workers/api-gateway`)    | Token auth + Durable Object rate limiter |
 | Payments   | Stripe                                       | Supporter subscriptions + one-time       |
 | Tests      | Vitest + Vue Test Utils + `@nuxt/test-utils` | happy-dom environment                    |
-| Deploy     | Cloudflare Pages/Workers                     | Node `>=24.12.0`, pnpm `>=10.34.5 <11`   |
+| Deploy     | Cloudflare Pages/Workers                     | Node `>=24.12.0`, pnpm `>=10.34.5 <12`   |
 
 **Languages:** TypeScript (strict) is dominant for app, server, workers; Vue SFCs for components;
 Deno/TypeScript for Supabase Edge Functions; small Node `.mjs` scripts; SQL migrations; shell scripts.
@@ -180,7 +180,7 @@ graph TD
 
 | Concern            | Tooling                                                                      |
 | ------------------ | ---------------------------------------------------------------------------- |
-| Package manager    | pnpm `>=10.34.5 <11` (`packageManager: pnpm@10.34.5`), Node `>=24.12.0`      |
+| Package manager    | pnpm `>=10.34.5 <12` (`packageManager: pnpm@11.14.0`), Node `>=24.12.0`      |
 | Dev/build          | `nuxt dev`, `nuxt build`, `nuxt generate`, `nuxt preview`                    |
 | Lint               | ESLint flat config (`eslint app --max-warnings=0`) + DESIGN.md lint          |
 | Format             | Prettier (+ `prettier-plugin-tailwindcss`), enforced via husky + lint-staged |

--- a/docs/agent-context/summary/dependencies.md
+++ b/docs/agent-context/summary/dependencies.md
@@ -2,7 +2,7 @@
 
 > External dependencies and how/why they are used. Versions live in `package.json` (root and
 > `workers/api-gateway/`) — this file explains _roles_, not exact versions, to stay durable.
-> Engines: Node `>=24.12.0`, pnpm `>=10.34.5 <11` (`packageManager: pnpm@10.34.5`).
+> Engines: Node `>=24.12.0`, pnpm `>=10.34.5 <12` (`packageManager: pnpm@11.14.0`).
 
 ## Runtime Dependencies (root)
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "pinia-plugin-persistedstate": "^4.7.1",
     "stripe": "^22.1.1",
     "vue": "^3.5.32",
-    "vue-i18n": "^11.3.2",
+    "vue-i18n": "catalog:",
     "vue-router": "^5.0.4"
   },
   "devDependencies": {
@@ -74,10 +74,10 @@
   },
   "engines": {
     "node": ">=24.12.0",
-    "pnpm": ">=10.34.5 <11"
+    "pnpm": ">=10.34.5 <12"
   },
   "name": "tarkovtracker-nuxt",
-  "packageManager": "pnpm@10.34.5",
+  "packageManager": "pnpm@11.14.0+sha512.66c1ac4c7d4762d6d7dde44c7f3e5a73591ed0a0806e751d4ed32d4f004f25b2285a906b1fd8a9e3e621df3b4e2858bf88e50e0cf626bedbe977fe434a5caf85",
   "private": true,
   "scripts": {
     "build": "nuxt build",
@@ -149,14 +149,5 @@
     "*.json": [
       "prettier --write"
     ]
-  },
-  "pnpm": {
-    "packageExtensions": {
-      "@codecov/nuxt-plugin@*": {
-        "peerDependencies": {
-          "nuxt": ">=3.0.0 <5.0.0"
-        }
-      }
-    }
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,13 +2,13 @@ packages:
   - .
   - workers/api-gateway
 
-onlyBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - sharp
-  - unrs-resolver
-  - vue-demi
-  - workerd
+catalog:
+  vue-i18n: ^11.3.2
+
+packageExtensions:
+  '@codecov/nuxt-plugin@*':
+    peerDependencies:
+      nuxt: '>=3.0.0 <5.0.0'
 
 overrides:
   '@nuxt/test-utils>h3-next': 'npm:h3@2.0.1-rc.20'
@@ -46,7 +46,15 @@ overrides:
   shell-quote: 'npm:shell-quote@^1'
   tar: '^7.5.19'
   vite: '^7.3.5'
-  vue-i18n: '$vue-i18n'
+  vue-i18n: 'catalog:'
   ws: '^8.20.1'
   yaml: '^2.8.3'
   '@apidevtools/swagger-parser>ajv': '^8.18.0'
+
+allowBuilds:
+  '@parcel/watcher': true
+  esbuild: true
+  sharp: true
+  unrs-resolver: true
+  vue-demi: true
+  workerd: true


### PR DESCRIPTION
## Summary

- Upgrade `packageManager` from `pnpm@10.34.5` to `pnpm@11.14.0` and bump `engines.pnpm` to `>=10.34.5 <12`
- Migrate pnpm 11 breaking changes: move `packageExtensions` out of `package.json` into `pnpm-workspace.yaml`, replace the removed `onlyBuiltDependencies` list with the new `allowBuilds` map, and migrate the deprecated `$vue-i18n` override to the `catalog:` protocol (version now lives in one place)
- Bump `corepack prepare pnpm@10.34.5` → `pnpm@11.14.0` across all CI workflows; simplify the `security.yml` audit step by removing the `jq` engines-pnpm workaround that existed solely to bypass the old `<11` restriction
- Update docs (`AGENTS.md`, `CONTRIBUTING.md`, `docs/agent-context/summary/*`) to reflect pnpm 11

The lockfile is unchanged — `pnpm-lock.yaml` v9.0 is shared by pnpm 10 and 11, so no lockfile migration is needed. Local `pnpm install` runs clean with zero warnings and all six build scripts (esbuild, sharp, workerd, @parcel/watcher, unrs-resolver, vue-demi) execute successfully.

#### Test plan

- [x] `pnpm install` (pnpm 11.14.0): clean, zero warnings, exit 0
- [x] `pnpm-lock.yaml` unchanged after install
- [x] `prettier --check` on all changed files: passed
- [x] husky + lint-staged pre-commit hook: ran successfully
- [ ] CI: `ci.yml` (typecheck/lint/test/build), `pr-checks.yml`, `security.yml` all green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded the project’s supported pnpm version to 11.14.0 across development, testing, security, and release workflows.
  * Expanded supported pnpm compatibility through version 11.
  * Standardized dependency management using workspace catalogs and updated package build permissions.
  * Improved security audit preparation by preserving package metadata during scans.

* **Documentation**
  * Updated contributor and project documentation with the new package-manager requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->