### PR TITLE
feat(ui): improve dashboard empty states, visual hierarchy, and search shortcut

### DIFF
--- a/app/features/dashboard/DashboardChangelog.vue
+++ b/app/features/dashboard/DashboardChangelog.vue
@@ -27,16 +27,16 @@
         </div>
       </div>
       <div v-if="isOpen" :id="PANEL_ID" class="mt-2 space-y-3 text-xs sm:text-sm">
-        <div v-if="pending" class="text-surface-400 text-xs">
+        <div v-if="pending" class="text-surface-300 text-xs">
           {{ t('page.dashboard.changelog.loading') }}
         </div>
-        <div v-else-if="error" class="text-surface-400 flex items-center gap-2 text-xs">
+        <div v-else-if="error" class="text-surface-300 flex items-center gap-2 text-xs">
           <span>{{ t('page.dashboard.changelog.error') }}</span>
           <UButton size="xs" color="neutral" variant="link" @click="retry">
             {{ t('page.dashboard.changelog.retry') }}
           </UButton>
         </div>
-        <div v-else-if="showEmpty" class="text-surface-400 text-xs">
+        <div v-else-if="showEmpty" class="text-surface-300 text-xs">
           {{ t('page.dashboard.changelog.empty') }}
         </div>
         <div v-else class="space-y-3">

--- a/app/features/dashboard/DashboardMilestoneCard.vue
+++ b/app/features/dashboard/DashboardMilestoneCard.vue
@@ -2,16 +2,16 @@
   <div
     :class="[
       'relative overflow-hidden rounded-md border px-4 py-3 transition-all',
-      isAchieved ? achievedClasses : 'bg-surface-900/50 border-white/12 opacity-50',
+      isAchieved ? achievedClasses : 'bg-surface-900/50 border-white/12 opacity-70',
     ]"
   >
     <div class="relative z-10">
       <UIcon
         :name="isAchieved ? achievedIcon : unachievedIcon"
-        :class="['mb-3 h-12 w-12', isAchieved ? iconColorClass : 'text-surface-600']"
+        :class="['mb-3 h-12 w-12', isAchieved ? iconColorClass : 'text-surface-500']"
       />
       <div class="mb-1 text-3xl font-bold text-white">{{ title }}</div>
-      <div class="text-surface-300 text-xs font-medium tracking-wider uppercase">
+      <div class="text-surface-200 text-xs font-medium tracking-wider uppercase">
         {{ subtitle }}
       </div>
     </div>

--- a/app/features/dashboard/DashboardNextActions.vue
+++ b/app/features/dashboard/DashboardNextActions.vue
@@ -83,11 +83,9 @@
                   <span class="leading-none">{{ badge }}</span>
                 </span>
               </div>
-              <div
-                class="grid gap-3 md:grid-cols-[minmax(0,1.12fr)_minmax(0,0.94fr)_minmax(0,0.94fr)]"
-              >
+              <div class="grid gap-3 md:grid-cols-[minmax(0,1.2fr)_minmax(0,1fr)]">
                 <div :class="['rounded-xl p-4 shadow-lg', toneClasses.proofCard]">
-                  <div class="text-surface-300 text-[11px] tracking-[0.2em] uppercase">
+                  <div class="text-surface-200 text-[11px] tracking-[0.2em] uppercase">
                     {{ t('page.dashboard.focus.stat.why') }}
                   </div>
                   <div class="mt-2 text-sm leading-6 font-medium text-white">
@@ -95,15 +93,7 @@
                   </div>
                 </div>
                 <div class="bg-surface-950/48 rounded-xl border border-white/8 p-4">
-                  <div class="text-surface-400 text-[11px] tracking-[0.2em] uppercase">
-                    {{ t('page.dashboard.focus.stat.progress') }}
-                  </div>
-                  <div class="text-surface-100 mt-2 text-sm leading-6">
-                    {{ primaryContribution }}
-                  </div>
-                </div>
-                <div class="bg-surface-950/48 rounded-xl border border-white/8 p-4">
-                  <div class="text-surface-400 text-[11px] tracking-[0.2em] uppercase">
+                  <div class="text-surface-200 text-[11px] tracking-[0.2em] uppercase">
                     {{ t('page.dashboard.focus.stat.status') }}
                   </div>
                   <div class="text-surface-100 mt-2 text-sm leading-6">
@@ -132,7 +122,7 @@
       <div class="bg-surface-950/60 rounded-2xl border border-white/10 p-4">
         <div class="mb-3 flex items-center justify-between gap-3">
           <div>
-            <div class="text-surface-400 text-[11px] tracking-[0.2em] uppercase">
+            <div class="text-surface-200 text-[11px] tracking-[0.2em] uppercase">
               {{ t('page.dashboard.focus.stat.secondary') }}
             </div>
             <div class="text-surface-200 mt-1 text-sm">
@@ -412,13 +402,6 @@
       'page.dashboard.focus.reason.impact_other',
       { count }
     );
-  const formatImpactContribution = (count: number) =>
-    getCountLabel(
-      count,
-      'page.dashboard.focus.contribution.impact_one',
-      'page.dashboard.focus.contribution.impact_other',
-      { count }
-    );
   const getCompactReasonText = (recommendation: DashboardRecommendation) => {
     if (recommendation.kind === 'filters') return t('page.dashboard.focus.reason.filters');
     if (recommendation.reason === 'complete') return t('page.dashboard.focus.reason.complete');
@@ -529,25 +512,6 @@
       { count: recommendation.progress.remaining }
     );
   };
-  const getContributionText = (recommendation: DashboardRecommendation) => {
-    if (recommendation.kind === 'filters') return t('page.dashboard.focus.contribution.filters');
-    if (recommendation.reason === 'complete')
-      return t('page.dashboard.focus.contribution.complete');
-    if (recommendation.unlockTraderName) {
-      return t('page.dashboard.focus.contribution.unlock_trader', {
-        trader: recommendation.unlockTraderName,
-      });
-    }
-    if (recommendation.impact > 0) return formatImpactContribution(recommendation.impact);
-    if (recommendation.isLightkeeper) return t('page.dashboard.focus.contribution.lightkeeper');
-    if (recommendation.isKappa) return t('page.dashboard.focus.contribution.kappa');
-    if (recommendation.chainTraderName) {
-      return t('page.dashboard.focus.contribution.trader', {
-        trader: recommendation.chainTraderName,
-      });
-    }
-    return t('page.dashboard.focus.contribution.default');
-  };
   const getStatusText = (recommendation: DashboardRecommendation) => {
     const blocker = getPrimaryBlocker(recommendation);
     switch (blocker.type) {
@@ -600,9 +564,6 @@
   );
   const primaryWhy = computed(() =>
     primaryRecommendation.value ? getProofText(primaryRecommendation.value) : ''
-  );
-  const primaryContribution = computed(() =>
-    primaryRecommendation.value ? getContributionText(primaryRecommendation.value) : ''
   );
   const primaryStatus = computed(() =>
     primaryRecommendation.value ? getStatusText(primaryRecommendation.value) : ''

--- a/app/features/dashboard/DashboardProgressBar.vue
+++ b/app/features/dashboard/DashboardProgressBar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-surface-700/50 relative overflow-hidden rounded-full" :class="sizeClass">
+  <div class="bg-surface-700/70 relative overflow-hidden rounded-full" :class="sizeClass">
     <div
       class="absolute inset-y-0 left-0 rounded-full transition-[width,background-color] duration-300 ease-out"
       :class="fillClass"

--- a/app/features/dashboard/DashboardProgressCard.vue
+++ b/app/features/dashboard/DashboardProgressCard.vue
@@ -19,7 +19,7 @@
           <UIcon :name="icon" class="h-7 w-7" :class="colorClasses.icon" />
         </div>
         <div>
-          <div class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
+          <div class="text-surface-200 text-xs font-semibold tracking-wider uppercase">
             {{ label }}
           </div>
           <div class="text-xl font-bold text-white">{{ completedDisplay }}/{{ totalDisplay }}</div>

--- a/app/features/dashboard/DashboardTraderCard.vue
+++ b/app/features/dashboard/DashboardTraderCard.vue
@@ -56,7 +56,7 @@
     </div>
     <div
       class="mb-2 flex items-center justify-between text-xs font-medium"
-      :class="isLocked ? 'text-surface-500' : isComplete ? 'text-surface-400' : 'text-surface-300'"
+      :class="isLocked ? 'text-surface-400' : isComplete ? 'text-surface-400' : 'text-surface-300'"
     >
       <span>{{ completedTasks }}/{{ totalTasks }} {{ $t('page.dashboard.traders.tasks') }}</span>
     </div>
@@ -124,7 +124,7 @@
         />
       </div>
       <div v-if="nextLevelInfo" class="pt-0.5">
-        <div class="text-surface-400 flex items-center justify-between text-[11px] tabular-nums">
+        <div class="text-surface-300 flex items-center justify-between text-[11px] tabular-nums">
           <span>
             {{
               $t('page.dashboard.traders.rep_progress_label', { level: nextLevelInfo.nextLevel })
@@ -164,6 +164,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { isTraderLocked } from '@/features/dashboard/traderLockStatus';
   import { useMetadataStore } from '@/stores/useMetadata';
   import { usePreferencesStore } from '@/stores/usePreferences';
   import { useTarkovStore } from '@/stores/useTarkov';
@@ -220,10 +221,13 @@
     const firstTask = availableUnlockTasks.value[0];
     return firstTask ?? null;
   });
-  const isLocked = computed(() => {
-    if (!availableUnlockTasks.value.length) return false;
-    return !availableUnlockTasks.value.some((task) => tarkovStore.isTaskComplete(task.id));
-  });
+  const isLocked = computed(() =>
+    isTraderLocked(props.trader, {
+      tasks: metadataStore.tasks,
+      isTaskComplete: (id) => tarkovStore.isTaskComplete(id),
+      gameMode: tarkovStore.getCurrentGameMode?.() ?? GAME_MODES.PVP,
+    })
+  );
   const currentLevel = computed(() => tarkovStore.getTraderLevel(props.trader.id));
   const currentReputation = computed(() => tarkovStore.getTraderReputation(props.trader.id));
   const maxLevel = computed(() => {
@@ -265,12 +269,14 @@
   });
   const percentageTextStyle = computed(() => {
     if (isLocked.value || isComplete.value) return {};
+    if (props.percentage <= 0) return {};
     const hue = (props.percentage / 100) * 120;
     return { color: `hsl(${hue}, 70%, 55%)` };
   });
   const percentageTextClass = computed(() => {
     if (isLocked.value) return 'text-surface-500';
     if (isComplete.value) return 'text-success-400/70';
+    if (props.percentage <= 0) return 'text-surface-400';
     return '';
   });
   const loyaltyButtonClasses = (lvl: number) => {

--- a/app/features/dashboard/__tests__/DashboardNextActions.test.ts
+++ b/app/features/dashboard/__tests__/DashboardNextActions.test.ts
@@ -35,7 +35,6 @@ const translations: Record<string, string> = {
   'page.dashboard.focus.reason.filters': 'Current filters are hiding viable tasks',
   'page.dashboard.focus.reason.impact_one': 'Opens 1 follow-up task',
   'page.dashboard.focus.reason.impact_other': 'Opens {count} follow-up tasks',
-  'page.dashboard.focus.stat.progress': 'Progress this adds',
   'page.dashboard.focus.stat.secondary': 'Other good options',
   'page.dashboard.focus.stat.secondary_empty': 'This is the clearest next step right now.',
   'page.dashboard.focus.stat.status': 'Status',

--- a/app/features/dashboard/__tests__/traderLockStatus.test.ts
+++ b/app/features/dashboard/__tests__/traderLockStatus.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { isTraderLocked } from '@/features/dashboard/traderLockStatus';
+import { GAME_MODES, TASK_ID_REGISTRY } from '@/utils/constants';
+import type { TraderLockStatusDeps } from '@/features/dashboard/traderLockStatus';
+const createDeps = (overrides: Partial<TraderLockStatusDeps> = {}): TraderLockStatusDeps => ({
+  tasks: [{ id: TASK_ID_REGISTRY.GETTING_ACQUAINTED }, { id: TASK_ID_REGISTRY.EASY_MONEY_PART_1 }],
+  isTaskComplete: () => false,
+  gameMode: GAME_MODES.PVP,
+  ...overrides,
+});
+describe('isTraderLocked', () => {
+  it('returns false for traders with no unlock task config', () => {
+    expect(isTraderLocked({ normalizedName: 'prapor' }, createDeps())).toBe(false);
+  });
+  it('returns true when the unlock task is not complete', () => {
+    expect(isTraderLocked({ normalizedName: 'lightkeeper' }, createDeps())).toBe(true);
+  });
+  it('returns false when the unlock task is complete', () => {
+    expect(
+      isTraderLocked(
+        { normalizedName: 'lightkeeper' },
+        createDeps({
+          isTaskComplete: (id) => id === TASK_ID_REGISTRY.GETTING_ACQUAINTED,
+        })
+      )
+    ).toBe(false);
+  });
+  it('assumes locked when metadata tasks have not loaded yet', () => {
+    expect(isTraderLocked({ normalizedName: 'lightkeeper' }, createDeps({ tasks: [] }))).toBe(true);
+    expect(isTraderLocked({ normalizedName: 'lightkeeper' }, createDeps({ tasks: null }))).toBe(
+      true
+    );
+    expect(
+      isTraderLocked({ normalizedName: 'lightkeeper' }, createDeps({ tasks: undefined }))
+    ).toBe(true);
+  });
+  it('does not assume locked for traders without unlock tasks when metadata is empty', () => {
+    expect(isTraderLocked({ normalizedName: 'prapor' }, createDeps({ tasks: [] }))).toBe(false);
+  });
+  it('resolves ref unlock task by game mode', () => {
+    expect(
+      isTraderLocked(
+        { normalizedName: 'ref' },
+        createDeps({
+          tasks: [{ id: TASK_ID_REGISTRY.EASY_MONEY_PART_1_PVP }],
+          isTaskComplete: () => false,
+          gameMode: GAME_MODES.PVP,
+        })
+      )
+    ).toBe(true);
+    expect(
+      isTraderLocked(
+        { normalizedName: 'ref' },
+        createDeps({
+          tasks: [{ id: TASK_ID_REGISTRY.EASY_MONEY_PART_1_PVP }],
+          isTaskComplete: (id) => id === TASK_ID_REGISTRY.EASY_MONEY_PART_1_PVP,
+          gameMode: GAME_MODES.PVP,
+        })
+      )
+    ).toBe(false);
+  });
+});

--- a/app/features/dashboard/traderLockStatus.ts
+++ b/app/features/dashboard/traderLockStatus.ts
@@ -14,7 +14,8 @@ export const isTraderLocked = (
     trader.normalizedName,
     deps.gameMode ?? GAME_MODES.PVP
   );
-  if (!unlockTaskIds.length || !deps.tasks?.length) return false;
+  if (!unlockTaskIds.length) return false;
+  if (!deps.tasks?.length) return true;
   const idSet = new Set(unlockTaskIds);
   const unlockTasks = deps.tasks.filter((task) => idSet.has(task.id));
   if (!unlockTasks.length) return false;

--- a/app/features/dashboard/traderLockStatus.ts
+++ b/app/features/dashboard/traderLockStatus.ts
@@ -1,0 +1,22 @@
+import { GAME_MODES, resolveTraderUnlockTaskIds } from '@/utils/constants';
+import type { Trader } from '@/types/tarkov';
+import type { GameMode } from '@/utils/constants';
+export interface TraderLockStatusDeps {
+  tasks: { id: string }[] | null | undefined;
+  isTaskComplete: (taskId: string) => boolean;
+  gameMode?: GameMode;
+}
+export const isTraderLocked = (
+  trader: Pick<Trader, 'normalizedName'>,
+  deps: TraderLockStatusDeps
+): boolean => {
+  const unlockTaskIds = resolveTraderUnlockTaskIds(
+    trader.normalizedName,
+    deps.gameMode ?? GAME_MODES.PVP
+  );
+  if (!unlockTaskIds.length || !deps.tasks?.length) return false;
+  const idSet = new Set(unlockTaskIds);
+  const unlockTasks = deps.tasks.filter((task) => idSet.has(task.id));
+  if (!unlockTasks.length) return false;
+  return !unlockTasks.some((task) => deps.isTaskComplete(task.id));
+};

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -76,7 +76,7 @@
   "omnibar": {
     "title": "Search",
     "description": "Search tasks, needed items, and hideout stations",
-    "trigger_label": "Search...",
+    "trigger_label": "Search tasks, items, traders…",
     "open_aria": "Open global search",
     "aria_label": "Global search",
     "placeholder": "Search tasks, needed items, hideout...",
@@ -617,6 +617,7 @@
         "rep_progress_label": "→ LL{level}",
         "scav_karma": "Scav Karma",
         "unlock_required": "Unlock required:",
+        "locked_summary": "{count} traders locked",
         "sort": {
           "aria_label": "Sort traders",
           "direction_aria_label": "Toggle sort direction",

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex min-h-[calc(100vh-250px)] overflow-x-hidden">
     <div class="min-w-0 flex-1 px-3 py-6 sm:px-6">
-      <div class="mx-auto max-w-[1400px]">
+      <div class="mx-auto max-w-[1400px] xl:max-w-[1600px] 2xl:max-w-[1800px]">
         <h1 class="sr-only">Tarkov Tracker - Escape from Tarkov Progress Tracker</h1>
         <DashboardNextActions />
         <DashboardChangelog />
@@ -150,10 +150,51 @@
           </div>
           <div
             v-show="!tradersSectionCollapsed"
-            class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4"
+            class="grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
           >
             <div
-              v-for="trader in traderStats"
+              v-for="trader in unlockedTraderStats"
+              :id="`dashboard-trader-${trader.id}`"
+              :key="trader.id"
+              class="content-visibility-auto-220 h-full"
+              :class="
+                highlightedTraderId === trader.id
+                  ? 'ring-primary-500 ring-offset-surface-950 rounded-lg ring-2 ring-offset-2'
+                  : ''
+              "
+            >
+              <DashboardTraderCard
+                :trader="trader"
+                :completed-tasks="trader.completedTasks"
+                :total-tasks="trader.totalTasks"
+                :percentage="trader.percentage"
+              />
+            </div>
+          </div>
+          <button
+            v-if="lockedTraderStats.length && !tradersSectionCollapsed"
+            type="button"
+            class="bg-surface-900/60 border-surface-700/40 hover:bg-surface-900 hover:border-surface-600 group mt-5 flex w-full cursor-pointer items-center gap-3 rounded-lg border px-4 py-3 text-left transition-colors"
+            :aria-expanded="showLockedTraders"
+            :aria-controls="'dashboard-locked-traders'"
+            @click="showLockedTraders = !showLockedTraders"
+          >
+            <UIcon name="i-mdi-lock" class="text-warning-400/80 h-5 w-5 shrink-0" />
+            <span class="text-sm font-semibold text-white">
+              {{ $t('page.dashboard.traders.locked_summary', { count: lockedTraderStats.length }) }}
+            </span>
+            <UIcon
+              :name="showLockedTraders ? 'i-mdi-chevron-up' : 'i-mdi-chevron-down'"
+              class="text-surface-300 group-hover:text-surface-100 ml-auto h-5 w-5 shrink-0 transition-colors"
+            />
+          </button>
+          <div
+            v-if="lockedTraderStats.length && showLockedTraders && !tradersSectionCollapsed"
+            id="dashboard-locked-traders"
+            class="mt-5 grid grid-cols-1 gap-5 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-5"
+          >
+            <div
+              v-for="trader in lockedTraderStats"
               :id="`dashboard-trader-${trader.id}`"
               :key="trader.id"
               class="content-visibility-auto-220 h-full"
@@ -262,9 +303,11 @@
 </template>
 <script setup lang="ts">
   import { useDashboardFilters } from '@/composables/useDashboardFilters';
+  import { isTraderLocked } from '@/features/dashboard/traderLockStatus';
+  import { useMetadataStore } from '@/stores/useMetadata';
   import { usePreferencesStore } from '@/stores/usePreferences';
   import { useTarkovStore } from '@/stores/useTarkov';
-  import { sortTraderStats } from '@/utils/constants';
+  import { GAME_MODES, sortTraderStats } from '@/utils/constants';
   import { calculatePercentageNum } from '@/utils/formatters';
   import { getQueryString } from '@/utils/routeHelpers';
   import type { TraderSortMode, TraderSortDirection } from '@/utils/constants';
@@ -276,6 +319,7 @@
   const progressSectionCollapsed = ref(false);
   const tradersSectionCollapsed = ref(false);
   const milestonesSectionCollapsed = ref(false);
+  const showLockedTraders = ref(false);
   const highlightedTraderId = ref<string | null>(null);
   const traderHighlightTimeout = ref<ReturnType<typeof setTimeout> | null>(null);
   // Page metadata
@@ -294,6 +338,7 @@
   const { hasDashboardFiltersActive } = useDashboardFilters();
   const preferencesStore = usePreferencesStore();
   const tarkovStore = useTarkovStore();
+  const metadataStore = useMetadataStore();
   const { t } = useI18n({ useScope: 'global' });
   const traderSortMode = computed({
     get: () => preferencesStore.getTraderSortMode,
@@ -321,6 +366,17 @@
       tarkovStore.getTraderReputation
     );
   });
+  const traderLockDeps = computed(() => ({
+    tasks: metadataStore.tasks,
+    isTaskComplete: (id: string) => tarkovStore.isTaskComplete(id),
+    gameMode: tarkovStore.getCurrentGameMode?.() ?? GAME_MODES.PVP,
+  }));
+  const unlockedTraderStats = computed(() =>
+    traderStats.value.filter((trader) => !isTraderLocked(trader, traderLockDeps.value))
+  );
+  const lockedTraderStats = computed(() =>
+    traderStats.value.filter((trader) => isTraderLocked(trader, traderLockDeps.value))
+  );
   const clearTraderHighlight = () => {
     if (traderHighlightTimeout.value) {
       clearTimeout(traderHighlightTimeout.value);
@@ -331,8 +387,12 @@
   const focusTraderFromRoute = async () => {
     const traderId = getQueryString(route.query.trader);
     if (!traderId || traderStats.value.length === 0) return;
-    if (!traderStats.value.some((trader) => trader.id === traderId)) return;
+    const targetTrader = traderStats.value.find((trader) => trader.id === traderId);
+    if (!targetTrader) return;
     tradersSectionCollapsed.value = false;
+    if (isTraderLocked(targetTrader, traderLockDeps.value)) {
+      showLockedTraders.value = true;
+    }
     await nextTick();
     const traderElement = document.getElementById(`dashboard-trader-${traderId}`);
     if (!traderElement) return;

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -371,6 +371,7 @@
     isTaskComplete: (id: string) => tarkovStore.isTaskComplete(id),
     gameMode: tarkovStore.getCurrentGameMode?.() ?? GAME_MODES.PVP,
   }));
+  const metadataTasksLoaded = computed(() => metadataStore.tasks.length > 0);
   const unlockedTraderStats = computed(() =>
     traderStats.value.filter((trader) => !isTraderLocked(trader, traderLockDeps.value))
   );
@@ -387,6 +388,7 @@
   const focusTraderFromRoute = async () => {
     const traderId = getQueryString(route.query.trader);
     if (!traderId || traderStats.value.length === 0) return;
+    if (!metadataTasksLoaded.value) return;
     const targetTrader = traderStats.value.find((trader) => trader.id === traderId);
     if (!targetTrader) return;
     tradersSectionCollapsed.value = false;
@@ -412,7 +414,7 @@
     });
   };
   watch(
-    [() => route.query.trader, traderStats],
+    [() => route.query.trader, traderStats, metadataTasksLoaded],
     async () => {
       await focusTraderFromRoute();
     },

--- a/app/shell/AppBar.vue
+++ b/app/shell/AppBar.vue
@@ -235,7 +235,7 @@
   const tarkovStore = useTarkovStore();
   const Omnibar = defineAsyncComponent(() => import('@/features/omnibar/Omnibar.vue'));
   const ActivityLogPanel = defineAsyncComponent(() => import('@/shell/ActivityLogPanel.vue'));
-  // Initialize global keyboard shortcuts (Undo: CTRL+Z, Search: CTRL+K or /)
+  // Initialize global keyboard shortcuts (Undo/Search defaults: Ctrl+Z/Ctrl+K, user-configurable)
   useKeybinds();
   const omnibarMounted = ref(false);
   const omnibarOpen = ref(false);

--- a/app/shell/AppBar.vue
+++ b/app/shell/AppBar.vue
@@ -145,10 +145,10 @@
         <NuxtLink
           v-else
           to="/supporter"
-          class="border-success-500 bg-success-600 hover:border-success-400 hover:bg-success-500 inline-flex h-7 items-center gap-1.5 rounded border px-2.5 text-xs font-semibold text-white shadow-sm shadow-black/30 transition-all duration-150 hover:-translate-y-px hover:shadow-md active:translate-y-0 active:shadow-sm"
+          class="border-surface-600 hover:border-surface-500 hover:bg-surface-700/60 text-surface-200 inline-flex h-7 items-center gap-1.5 rounded border px-2.5 text-xs font-medium transition-colors"
           :aria-label="t('footer.support_button')"
         >
-          <UIcon name="i-mdi-heart" class="h-3.5 w-3.5 shrink-0 text-white" />
+          <UIcon name="i-mdi-heart-outline" class="text-success-400 h-3.5 w-3.5 shrink-0" />
           <span class="hidden sm:inline">{{ t('footer.support_button') }}</span>
         </NuxtLink>
         <div class="bg-surface-700/50 mx-1 h-5 w-px" />
@@ -235,7 +235,7 @@
   const tarkovStore = useTarkovStore();
   const Omnibar = defineAsyncComponent(() => import('@/features/omnibar/Omnibar.vue'));
   const ActivityLogPanel = defineAsyncComponent(() => import('@/shell/ActivityLogPanel.vue'));
-  // Initialize global keyboard shortcuts (Undo: CTRL+Z, Search: CTRL+Q or /)
+  // Initialize global keyboard shortcuts (Undo: CTRL+Z, Search: CTRL+K or /)
   useKeybinds();
   const omnibarMounted = ref(false);
   const omnibarOpen = ref(false);

--- a/app/stores/__tests__/usePreferences.test.ts
+++ b/app/stores/__tests__/usePreferences.test.ts
@@ -370,6 +370,32 @@ describe('usePreferencesStore', () => {
         },
       });
     });
+    it('migrates legacy ctrl+q omnibar keybind to ctrl+k', () => {
+      localStorageMock.setItem(
+        STORAGE_KEYS.preferences,
+        serializeUserScopedStorage({ keybindOmnibar: 'ctrl+q' }, 'user-1', 1234)
+      );
+      currentUserId.value = 'user-1';
+      const store = usePreferencesStore();
+      expect(store.keybindOmnibar).toBe(DEFAULT_KEYBINDS.omnibar);
+      expect(store.keybindOmnibar).toBe('ctrl+k');
+      const migratedValue = JSON.parse(localStorageMock.getItem(STORAGE_KEYS.preferences) || '{}');
+      expect(migratedValue).toMatchObject({
+        _userId: 'user-1',
+        data: {
+          keybindOmnibar: 'ctrl+k',
+        },
+      });
+    });
+    it('preserves a customized omnibar keybind during migration', () => {
+      localStorageMock.setItem(
+        STORAGE_KEYS.preferences,
+        serializeUserScopedStorage({ keybindOmnibar: 'ctrl+shift+p' }, 'user-1', 1234)
+      );
+      currentUserId.value = 'user-1';
+      const store = usePreferencesStore();
+      expect(store.keybindOmnibar).toBe('ctrl+shift+p');
+    });
   });
   describe('Auth Transition Preservation', () => {
     it('preserves the prior scoped snapshot in memory after logout', () => {

--- a/app/stores/usePreferences.ts
+++ b/app/stores/usePreferences.ts
@@ -27,7 +27,7 @@ import {
 } from '@/types/taskFilter';
 import { clearPreferencesStorage } from '@/utils/clientStorage';
 import { TRADER_SORT_DIRECTIONS, TRADER_SORT_MODES } from '@/utils/constants';
-import { DEFAULT_KEYBINDS, sanitizeKeybind } from '@/utils/keybinds';
+import { DEFAULT_KEYBINDS, LEGACY_OMNIBAR_KEYBIND, sanitizeKeybind } from '@/utils/keybinds';
 import { logger } from '@/utils/logger';
 import { STORAGE_KEYS } from '@/utils/storageKeys';
 import {
@@ -384,6 +384,21 @@ export const usePreferencesStore = defineStore('preferences', {
             }
           }
           if (shouldPersistMigratedState) {
+            localStorage.setItem(
+              STORAGE_KEYS.preferences,
+              serializePersistedPreferencesSnapshot(
+                persistedState,
+                persistedSnapshot.ownerUserId,
+                persistedSnapshot.persistedAt
+              )
+            );
+          }
+          if (
+            typeof persistedState.keybindOmnibar === 'string' &&
+            persistedState.keybindOmnibar === LEGACY_OMNIBAR_KEYBIND
+          ) {
+            state.keybindOmnibar = DEFAULT_KEYBINDS.omnibar;
+            persistedState.keybindOmnibar = DEFAULT_KEYBINDS.omnibar;
             localStorage.setItem(
               STORAGE_KEYS.preferences,
               serializePersistedPreferencesSnapshot(

--- a/app/utils/keybinds.ts
+++ b/app/utils/keybinds.ts
@@ -4,9 +4,12 @@ const isModifierToken = (token: string): token is ModifierToken =>
   (MODIFIER_TOKENS as readonly string[]).includes(token);
 const normalizeKeyToken = (key: string): string => (key === ' ' ? 'space' : key.toLowerCase());
 export const DEFAULT_KEYBINDS = {
-  omnibar: 'ctrl+q',
+  omnibar: 'ctrl+k',
   undo: 'ctrl+z',
 } as const;
+// Previous shipped default for the omnibar. Used by the preferences migration
+// to move persisted snapshots off the old binding onto the new default.
+export const LEGACY_OMNIBAR_KEYBIND = 'ctrl+q';
 export const serializeKeybindEvent = (event: KeyboardEvent): string => {
   const parts: string[] = [];
   if (event.ctrlKey) parts.push('ctrl');
@@ -66,9 +69,9 @@ export const matchesKeybind = (event: KeyboardEvent, shortcut: string): boolean 
   );
 };
 // Keys that browsers/operating systems commonly reserve when combined with a
-// primary modifier (Ctrl on Windows/Linux, Cmd/Meta on macOS). The app ships
-// Ctrl+Q as a default, so 'q' is intentionally excluded.
-const SYSTEM_RESERVED_PRIMARY_KEYS = ['t', 'w', 'n', 'f', 'r', 'l', 's', 'p', 'd', 'tab'];
+// primary modifier (Ctrl on Windows/Linux, Cmd/Meta on macOS). 'q' is included
+// because Ctrl+Q quits most Linux/Windows browsers.
+const SYSTEM_RESERVED_PRIMARY_KEYS = ['t', 'w', 'n', 'f', 'r', 'l', 's', 'p', 'd', 'q', 'tab'];
 const SYSTEM_RESERVED_ALT_KEYS = ['tab', 'f4'];
 // Reports whether a shortcut is likely to collide with a browser/OS shortcut.
 // Treats Ctrl and Meta (Cmd) equivalently so the check is consistent across platforms.


### PR DESCRIPTION
## **User description**
## Summary

Addresses the dashboard UI/UX review with 7 quick wins focused on making the empty/zero state feel intentional, aligning visual priority with user goals, and fixing a risky keyboard shortcut.

- **Neutralize red 0% → gray:** Trader percentage text is neutral at 0%; the red→green hue scale only applies above 0%. Progress bar track opacity bumped from 50% → 70% so empty tracks read as tracks, not missing content.
- **Demote Support button:** The non-supporter "Support Development" CTA in the AppBar is restyled from a loud solid green button to a quiet outline button. "Log In" now wins visual priority for logged-out users. The supporter-tier badge is unchanged.
- **Widen container + denser grid:** Dashboard container expands to 1600px at xl and 1800px at 2xl. Trader grid adds a 5th column at 2xl.
- **De-duplicate hero stat boxes:** Removed the redundant "Progress this adds" box from the recommendation hero card (it repeated the impact count already shown in the "Why" box and the badge chip). Hero now has two boxes: Why + Status.
- **Ctrl+Q → Ctrl+K + migration:** Default omnibar shortcut changed from `Ctrl+Q` (quits Linux/Windows browsers) to `Ctrl+K`. A one-time migration in the preferences store moves persisted snapshots off the old default. Users who customized to a different shortcut keep their choice. `q` is now flagged as a system-reserved key in the keybind conflict checker. Search trigger label clarified to "Search tasks, items, traders…".
- **Collapse locked traders:** Locked traders (Lightkeeper, BTR Driver, Ref) are now collapsed into a single "N traders locked" toggle row that expands on click. Route-driven trader highlight (`?trader=`) auto-expands the locked row if the target is locked. Extracted a shared `isTraderLocked` helper as single source of truth.
- **Raise contrast:** Bumped dim all-caps labels and state text from `text-surface-400/500/600` to `text-surface-200/300` across dashboard components. Unachieved milestone cards: `opacity-50` → `opacity-70` and icon `text-surface-600` → `text-surface-500`.

#### Test plan
- [x] `pnpm run typecheck` — pass
- [x] `pnpm run lint` — pass (0 warnings)
- [x] `pnpm run i18n:check` — pass
- [x] `pnpm run validate:openapi` — pass
- [x] `pnpm vitest run` for dashboard features, AppBar, keybinds, preferences (224 tests), useKeybinds, KeybindsCard, index page (20 tests) — all pass
- [ ] CI green


___

## **CodeAnt-AI Description**
**Refine dashboard layout, search, and shortcut behavior**

### What Changed
- Locked traders are now grouped into a single expandable row instead of always taking space in the trader grid, and a locked trader link will automatically open that row.
- The dashboard now shows a clearer search shortcut and uses `Ctrl+K` by default instead of `Ctrl+Q`; existing custom shortcut choices are kept during migration.
- Empty and low-progress dashboard content is easier to read, with stronger contrast on muted text, clearer progress bars, and 0% trader progress shown in neutral gray.
- The recommendation card now shows only the most useful status details, and the dashboard can use more horizontal space on large screens.
- The supporter button in the top bar is now visually quieter for non-supporters.

### Impact
`✅ Fewer dashboard layout gaps`
`✅ Safer default search shortcut`
`✅ Clearer locked trader navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Dashboard traders are now split into unlocked and locked sections, with a control to reveal locked traders.
  - Direct links to locked traders automatically switch to the locked-trader view and highlight the target.
  - Added a dashboard message showing how many traders are locked.

- **Improvements**
  - Refined dashboard visuals across progress, milestone, next actions, and loading/error states for clearer readability.
  - Global search (omnibar) trigger changed to **Ctrl+K** and relabeled to “Search tasks, items, traders…”.
  - Existing **Ctrl+Q** keybind preferences are automatically migrated to **Ctrl+K**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->