### PR TITLE
feat(ui): rework AppBar right cluster hierarchy and responsive behavior

### DIFF
--- a/app/components/ui/GlobalHelpLauncher.vue
+++ b/app/components/ui/GlobalHelpLauncher.vue
@@ -261,6 +261,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { logger } from '@/utils/logger';
   import type { PageHelpContent, PageHelpKey } from '@/composables/usePageHelpContent';
   type HelpRoute = string | { hash?: string; path: string; query?: Record<string, string> };
   interface OnboardingAction {
@@ -286,6 +287,7 @@
   const { te, t } = useI18n({ useScope: 'global' });
   const route = useRoute();
   const { $supabase } = useNuxtApp();
+  const toast = useToast();
   const { getPageHelpContent } = usePageHelpContent();
   const pageHelpStates: Record<PageHelpKey, ReturnType<typeof usePageHelpState>> = {
     dashboard: usePageHelpState('dashboard'),
@@ -517,10 +519,18 @@
     restoreFocusOnOnboardingClose.value = true;
     isOnboardingOpen.value = true;
   };
-  const openKeyboardShortcuts = () => {
+  const openKeyboardShortcuts = async () => {
     isMenuOpen.value = false;
     closeAllPageGuides(false);
-    void navigateTo({ path: '/settings', hash: '#keybinds' });
+    try {
+      await navigateTo({ path: '/settings', hash: '#keybinds' });
+    } catch (error) {
+      logger.error('[GlobalHelpLauncher] Failed to navigate to keyboard shortcuts:', error);
+      toast.add({
+        title: t('page_help.launcher.keyboard_shortcuts_error'),
+        color: 'error',
+      });
+    }
   };
   const closeMenuOnly = () => {
     isMenuOpen.value = false;

--- a/app/components/ui/GlobalHelpLauncher.vue
+++ b/app/components/ui/GlobalHelpLauncher.vue
@@ -1,78 +1,159 @@
 <template>
   <div class="flex items-center">
-    <UPopover
-      v-model:open="isMenuOpen"
-      :content="{ align: 'center', side: 'bottom', sideOffset: 10 }"
-    >
-      <UButton
-        :id="buttonId"
-        color="neutral"
-        variant="ghost"
-        size="sm"
-        icon="i-mdi-help-circle-outline"
-        :aria-label="helpButtonLabel"
-        :class="buttonToneClass"
+    <AppTooltip :text="helpCommunityAriaLabel" :disabled="isMenuOpen">
+      <UPopover
+        v-model:open="isMenuOpen"
+        :content="{ align: 'center', side: 'bottom', sideOffset: 10 }"
       >
-        <span class="hidden text-xs leading-none font-medium sm:inline">
-          {{ helpButtonLabel.toUpperCase() }}
-        </span>
-      </UButton>
-      <template #content>
-        <div class="w-[min(19rem,calc(100vw-1.5rem))] space-y-3 p-3">
-          <div class="space-y-1">
-            <div class="text-surface-50 text-sm font-semibold">
-              {{ launcherTitle }}
+        <UButton
+          :id="buttonId"
+          color="neutral"
+          variant="ghost"
+          size="md"
+          icon="i-mdi-help-circle-outline"
+          :aria-label="helpCommunityAriaLabel"
+          :class="buttonToneClass"
+          class="h-9"
+          trailing-icon="i-mdi-chevron-down"
+          :ui="{ trailingIcon: 'size-3.5' }"
+        >
+          <span class="hidden text-[13px] leading-none font-medium md:inline">
+            {{ helpButtonLabel }}
+          </span>
+        </UButton>
+        <template #content>
+          <div class="w-[min(19rem,calc(100vw-1.5rem))] space-y-3 p-3">
+            <div class="space-y-1">
+              <div class="text-surface-50 text-sm font-semibold">
+                {{ launcherTitle }}
+              </div>
+              <p class="text-surface-400 text-[11px] leading-5">
+                {{ launcherSummary }}
+              </p>
             </div>
-            <p class="text-surface-400 text-[11px] leading-5">
-              {{ launcherSummary }}
-            </p>
-          </div>
-          <div class="space-y-2">
-            <button
-              type="button"
-              class="border-surface-700/70 bg-surface-950/55 hover:border-primary-500/35 hover:bg-surface-800 focus-visible:ring-primary-500/50 flex w-full items-center gap-3 rounded-2xl border px-3 py-2.5 text-left transition focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-55"
-              :disabled="!currentPageHelpKey"
-              @click="openPageGuide"
-            >
-              <span
-                class="bg-primary-500/12 border-primary-500/20 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border"
+            <div class="space-y-2">
+              <button
+                type="button"
+                class="border-surface-700/70 bg-surface-950/55 hover:border-primary-500/35 hover:bg-surface-800 focus-visible:ring-primary-500/50 flex w-full items-center gap-3 rounded-2xl border px-3 py-2.5 text-left transition focus-visible:ring-2 focus-visible:outline-none disabled:cursor-not-allowed disabled:opacity-55"
+                :disabled="!currentPageHelpKey"
+                @click="openPageGuide"
               >
-                <UIcon name="i-mdi-crosshairs-question" class="text-primary-300 h-4 w-4" />
-              </span>
-              <span class="min-w-0 flex-1">
-                <span class="text-surface-50 block text-sm font-semibold">
-                  {{ pageGuideLabel }}
+                <span
+                  class="bg-primary-500/12 border-primary-500/20 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border"
+                >
+                  <UIcon name="i-mdi-crosshairs-question" class="text-primary-300 h-4 w-4" />
                 </span>
-                <span class="text-surface-300 line-clamp-2 block text-xs leading-5">
-                  {{ pageGuideDescription }}
+                <span class="min-w-0 flex-1">
+                  <span class="text-surface-50 block text-sm font-semibold">
+                    {{ pageGuideLabel }}
+                  </span>
+                  <span class="text-surface-300 line-clamp-2 block text-xs leading-5">
+                    {{ pageGuideDescription }}
+                  </span>
                 </span>
-              </span>
-              <UIcon name="i-mdi-chevron-right" class="text-surface-500 h-4 w-4 shrink-0" />
-            </button>
-            <button
-              type="button"
-              class="border-surface-700/70 bg-surface-950/55 hover:border-info-500/35 hover:bg-surface-800 focus-visible:ring-info-500/50 flex w-full items-center gap-3 rounded-2xl border px-3 py-2.5 text-left transition focus-visible:ring-2 focus-visible:outline-none"
-              @click="openOnboarding"
-            >
-              <span
-                class="bg-info-500/12 border-info-500/20 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border"
+                <UIcon name="i-mdi-chevron-right" class="text-surface-500 h-4 w-4 shrink-0" />
+              </button>
+              <button
+                type="button"
+                class="border-surface-700/70 bg-surface-950/55 hover:border-info-500/35 hover:bg-surface-800 focus-visible:ring-info-500/50 flex w-full items-center gap-3 rounded-2xl border px-3 py-2.5 text-left transition focus-visible:ring-2 focus-visible:outline-none"
+                @click="openOnboarding"
               >
-                <UIcon name="i-mdi-map-marker-path" class="text-info-300 h-4 w-4" />
-              </span>
-              <span class="min-w-0 flex-1">
-                <span class="text-surface-50 block text-sm font-semibold">
-                  {{ onboardingLabel }}
+                <span
+                  class="bg-info-500/12 border-info-500/20 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border"
+                >
+                  <UIcon name="i-mdi-map-marker-path" class="text-info-300 h-4 w-4" />
                 </span>
-                <span class="text-surface-300 line-clamp-2 block text-xs leading-5">
-                  {{ onboardingDescription }}
+                <span class="min-w-0 flex-1">
+                  <span class="text-surface-50 block text-sm font-semibold">
+                    {{ onboardingLabel }}
+                  </span>
+                  <span class="text-surface-300 line-clamp-2 block text-xs leading-5">
+                    {{ onboardingDescription }}
+                  </span>
                 </span>
-              </span>
-              <UIcon name="i-mdi-chevron-right" class="text-surface-500 h-4 w-4 shrink-0" />
-            </button>
+                <UIcon name="i-mdi-chevron-right" class="text-surface-500 h-4 w-4 shrink-0" />
+              </button>
+            </div>
+            <div class="space-y-1.5">
+              <button
+                type="button"
+                class="border-surface-700/70 bg-surface-950/55 hover:border-primary-500/35 hover:bg-surface-800 focus-visible:ring-primary-500/50 flex w-full items-center gap-3 rounded-xl border px-3 py-2 text-left transition focus-visible:ring-2 focus-visible:outline-none"
+                @click="openKeyboardShortcuts"
+              >
+                <span
+                  class="bg-surface-700/40 border-surface-600/60 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border"
+                >
+                  <UIcon name="i-mdi-keyboard-outline" class="text-surface-200 h-3.5 w-3.5" />
+                </span>
+                <span class="text-surface-100 min-w-0 flex-1 text-sm font-medium">
+                  {{ keyboardShortcutsLabel }}
+                </span>
+                <UIcon name="i-mdi-chevron-right" class="text-surface-500 h-3.5 w-3.5 shrink-0" />
+              </button>
+              <a
+                href="https://github.com/tarkovtracker-org/TarkovTracker/issues/new"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="border-surface-700/70 bg-surface-950/55 hover:border-primary-500/35 hover:bg-surface-800 focus-visible:ring-primary-500/50 flex items-center gap-3 rounded-xl border px-3 py-2 text-left transition focus-visible:ring-2 focus-visible:outline-none"
+                :aria-label="reportProblemLabel"
+                @click="closeMenuOnly"
+              >
+                <span
+                  class="bg-surface-700/40 border-surface-600/60 flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border"
+                >
+                  <UIcon name="i-mdi-bug-outline" class="text-surface-200 h-3.5 w-3.5" />
+                </span>
+                <span class="text-surface-100 min-w-0 flex-1 text-sm font-medium">
+                  {{ reportProblemLabel }}
+                </span>
+                <UIcon name="i-mdi-open-in-new" class="text-surface-500 h-3.5 w-3.5 shrink-0" />
+              </a>
+            </div>
+            <div class="border-surface-700/60 space-y-2 border-t pt-3">
+              <div class="text-surface-400 text-[11px] font-semibold tracking-[0.18em] uppercase">
+                {{ communitySectionLabel }}
+              </div>
+              <div class="space-y-1.5">
+                <a
+                  href="https://discord.gg/M8nBgA2sT6"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="border-surface-700/70 bg-surface-950/55 hover:border-primary-500/35 hover:bg-surface-800 focus-visible:ring-primary-500/50 flex items-center gap-3 rounded-2xl border px-3 py-2 text-left transition focus-visible:ring-2 focus-visible:outline-none"
+                  :aria-label="discordLabel"
+                >
+                  <span
+                    class="border-discord/30 bg-discord/12 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border"
+                  >
+                    <DiscordIcon class="text-discord h-4 w-4" />
+                  </span>
+                  <span class="text-surface-50 min-w-0 flex-1 text-sm font-semibold">
+                    {{ discordLabel }}
+                  </span>
+                  <UIcon name="i-mdi-open-in-new" class="text-surface-500 h-3.5 w-3.5 shrink-0" />
+                </a>
+                <a
+                  href="https://github.com/tarkovtracker-org/TarkovTracker"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  class="border-surface-700/70 bg-surface-950/55 hover:border-primary-500/35 hover:bg-surface-800 focus-visible:ring-primary-500/50 flex items-center gap-3 rounded-2xl border px-3 py-2 text-left transition focus-visible:ring-2 focus-visible:outline-none"
+                  :aria-label="githubLabel"
+                >
+                  <span
+                    class="border-surface-600/60 bg-surface-700/40 flex h-8 w-8 shrink-0 items-center justify-center rounded-xl border"
+                  >
+                    <UIcon name="i-mdi-github" class="text-surface-200 h-4 w-4" />
+                  </span>
+                  <span class="text-surface-50 min-w-0 flex-1 text-sm font-semibold">
+                    {{ githubLabel }}
+                  </span>
+                  <UIcon name="i-mdi-open-in-new" class="text-surface-500 h-3.5 w-3.5 shrink-0" />
+                </a>
+              </div>
+            </div>
           </div>
-        </div>
-      </template>
-    </UPopover>
+        </template>
+      </UPopover>
+    </AppTooltip>
     <UModal
       v-model:open="isOnboardingOpen"
       :ui="{ content: 'bg-transparent border-0 p-0 shadow-none ring-0 outline-none' }"
@@ -244,6 +325,16 @@
   });
   const isLoggedIn = computed(() => $supabase.user?.loggedIn ?? false);
   const helpButtonLabel = computed(() => t('page_help.button'));
+  const helpCommunityAriaLabel = computed(() =>
+    copy('app_bar.help_community_aria', 'Help & community')
+  );
+  const communitySectionLabel = computed(() => copy('app_bar.community_section', 'Community'));
+  const discordLabel = computed(() => copy('footer.call_to_action.discord', 'Discord'));
+  const githubLabel = computed(() => copy('footer.call_to_action.github', 'GitHub'));
+  const keyboardShortcutsLabel = computed(() =>
+    copy('app_bar.keyboard_shortcuts', 'Keyboard shortcuts')
+  );
+  const reportProblemLabel = computed(() => copy('app_bar.report_problem', 'Report a problem'));
   const closeLabel = computed(() => t('common.close'));
   const previousLabel = computed(() => t('common.previous'));
   const nextLabel = computed(() => t('common.next'));
@@ -425,6 +516,14 @@
     onboardingStepIndex.value = 0;
     restoreFocusOnOnboardingClose.value = true;
     isOnboardingOpen.value = true;
+  };
+  const openKeyboardShortcuts = () => {
+    isMenuOpen.value = false;
+    closeAllPageGuides(false);
+    void navigateTo({ path: '/settings', hash: '#keybinds' });
+  };
+  const closeMenuOnly = () => {
+    isMenuOpen.value = false;
   };
   const closeOnboarding = (restoreFocus = true) => {
     restoreFocusOnOnboardingClose.value = restoreFocus;

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -71,7 +71,13 @@
     "user_label": "User",
     "user_avatar_alt": "User avatar",
     "supporter_badge_label": "Supporter",
-    "supporter_badge_aria": "Manage your supporter subscription ({tier})"
+    "supporter_badge_aria": "Manage your supporter subscription ({tier})",
+    "help_community_aria": "Help & community",
+    "community_section": "Community",
+    "keyboard_shortcuts": "Keyboard shortcuts",
+    "report_problem": "Report a problem",
+    "more_aria": "More",
+    "login_aria": "Log in to your account"
   },
   "omnibar": {
     "title": "Search",
@@ -1648,7 +1654,7 @@
       "discord": "Discord",
       "github": "GitHub"
     },
-    "support_button": "Support Development",
+    "support_button": "Support",
     "support_tagline": "Help keep TarkovTracker free & updated",
     "terms_of_service": "Terms of Service",
     "privacy_policy": "Privacy Policy",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -239,7 +239,8 @@
       "page_guide": "Guide this page",
       "page_guide_unavailable": "No page guide here yet. Use onboarding instead.",
       "onboarding": "New user onboarding",
-      "onboarding_description": "Start with imports, finish the basics, then verify tasks."
+      "onboarding_description": "Start with imports, finish the basics, then verify tasks.",
+      "keyboard_shortcuts_error": "Could not open keyboard shortcuts. Please try again."
     },
     "onboarding": {
       "title": "Getting set up",

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -88,7 +88,9 @@
               <TaskDisplayCard />
               <MapSettingsCard />
               <ExternalLinksCard />
-              <KeybindsCard />
+              <div id="keybinds" class="scroll-mt-24">
+                <KeybindsCard />
+              </div>
             </section>
             <section
               v-if="visitedTabs.account"
@@ -224,6 +226,7 @@
   };
   const nestedTabHashes: Record<string, SettingsTabId> = {
     '#skills': 'progression',
+    '#keybinds': 'preferences',
   };
   const legacyTabHashes: Record<string, SettingsTabId> = {
     '#settings-progression': 'progression',

--- a/app/shell/AppBar.vue
+++ b/app/shell/AppBar.vue
@@ -308,6 +308,9 @@
   function handleAvatarError() {
     avatarFailed.value = true;
   }
+  watch(avatarSrc, () => {
+    avatarFailed.value = false;
+  });
   const userDisplayName = computed(() => {
     const fallbackLabel = t('app_bar.user_label');
     const hiddenLabel = t('app_bar.hidden_label');

--- a/app/shell/AppBar.vue
+++ b/app/shell/AppBar.vue
@@ -45,168 +45,143 @@
           </span>
         </button>
       </span>
-      <!-- Right: Status Icons & Settings -->
-      <div class="ml-auto flex items-center gap-1 sm:gap-2">
-        <div class="flex min-w-[3.5rem] items-center justify-end gap-1 sm:min-w-[4rem] sm:gap-2">
-          <span class="flex h-7 w-7 items-center justify-center">
-            <AppTooltip v-if="dataError" :text="t('app_bar.error_loading')">
-              <span class="inline-flex rounded">
-                <UIcon name="i-mdi-database-alert" class="text-error-500 h-5 w-5" />
-              </span>
-            </AppTooltip>
-          </span>
-          <span class="flex h-7 w-7 items-center justify-center">
-            <AppTooltip v-if="dataLoading || hideoutLoading" :text="t('app_bar.loading')">
-              <span class="inline-flex rounded">
-                <UIcon
-                  name="i-heroicons-arrow-path"
-                  class="text-primary-500 h-5 w-5 animate-spin"
+      <!-- Right: Status indicators + two control groups -->
+      <div class="ml-auto flex items-center gap-3">
+        <!-- Status indicators (non-interactive, shown only when active) -->
+        <div class="flex items-center justify-end gap-1">
+          <AppTooltip v-if="dataError" :text="t('app_bar.error_loading')">
+            <span class="flex h-9 w-9 items-center justify-center">
+              <UIcon name="i-mdi-database-alert" class="text-error-500 h-4 w-4" />
+            </span>
+          </AppTooltip>
+          <AppTooltip v-if="dataLoading || hideoutLoading" :text="t('app_bar.loading')">
+            <span class="flex h-9 w-9 items-center justify-center">
+              <UIcon name="i-heroicons-arrow-path" class="text-primary-500 h-4 w-4 animate-spin" />
+            </span>
+          </AppTooltip>
+        </div>
+        <!-- Group 1: Utilities (Bell + Help) -->
+        <div class="flex items-center gap-1">
+          <AppTooltip :text="t('activity_log.aria_label', 'Activity Log')">
+            <UPopover :content="{ align: 'end', side: 'bottom', sideOffset: 10 }">
+              <UButton
+                color="neutral"
+                variant="ghost"
+                size="md"
+                icon="i-heroicons-bell"
+                :aria-label="t('activity_log.aria_label', 'Activity Log')"
+                class="relative h-9 w-9"
+              >
+                <span v-if="activityLogStore.hasUnread" class="sr-only" aria-live="polite">
+                  {{ t('activity_log.unread_indicator', 'You have unread activity') }}
+                </span>
+                <span
+                  v-if="activityLogStore.hasUnread"
+                  aria-hidden="true"
+                  class="bg-error-500 ring-surface-900 absolute top-1.5 right-1.5 flex h-2 w-2 rounded-full ring-2"
                 />
-              </span>
-            </AppTooltip>
-          </span>
-        </div>
-        <div class="shrink-0">
-          <UPopover :content="{ align: 'end', side: 'bottom', sideOffset: 10 }">
-            <UButton
-              color="neutral"
-              variant="ghost"
-              size="sm"
-              icon="i-heroicons-bell"
-              :aria-label="t('activity_log.aria_label', 'Activity Log')"
-              class="relative"
-            >
-              <span v-if="activityLogStore.hasUnread" class="sr-only" aria-live="polite">
-                {{ t('activity_log.unread_indicator', 'You have unread activity') }}
-              </span>
-              <span
-                v-if="activityLogStore.hasUnread"
-                aria-hidden="true"
-                class="bg-error-500 ring-surface-900 absolute top-1 right-1 flex h-2 w-2 rounded-full ring-2"
-              />
-            </UButton>
-            <template #content>
-              <ActivityLogPanel />
-            </template>
-          </UPopover>
-        </div>
-        <div class="shrink-0">
+              </UButton>
+              <template #content>
+                <ActivityLogPanel />
+              </template>
+            </UPopover>
+          </AppTooltip>
           <GlobalHelpLauncher />
         </div>
-        <!-- Community Links -->
-        <AppTooltip :text="t('footer.call_to_action.discord')">
-          <a
-            href="https://discord.gg/M8nBgA2sT6"
-            target="_blank"
-            rel="noopener noreferrer"
-            :aria-label="t('footer.call_to_action.discord')"
-            class="hover:bg-surface-700 group flex h-7 w-7 items-center justify-center rounded transition-colors"
+        <!-- Group 2: Preferences & Actions (Language + Support + Account) -->
+        <div class="flex items-center gap-1.5">
+          <SelectMenuFixed
+            id="app-locale-select"
+            v-model="selectedLocale"
+            :items="localeItems"
+            :aria-label="t('settings.locale')"
+            value-key="value"
+            class="hidden shrink-0 sm:block"
+            :ui="localeSelectUi"
           >
-            <DiscordIcon class="text-discord group-hover:text-discord-hover" />
-          </a>
-        </AppTooltip>
-        <AppTooltip :text="t('footer.call_to_action.github')">
-          <a
-            href="https://github.com/tarkovtracker-org/TarkovTracker"
-            target="_blank"
-            rel="noopener noreferrer"
-            :aria-label="t('footer.call_to_action.github')"
-            class="hover:bg-surface-700 flex h-7 w-7 items-center justify-center rounded transition-colors"
-          >
-            <UIcon name="i-mdi-github" class="text-surface-300 h-4.5 w-4.5 hover:text-white" />
-          </a>
-        </AppTooltip>
-        <SelectMenuFixed
-          id="app-locale-select"
-          v-model="selectedLocale"
-          :items="localeItems"
-          :aria-label="t('settings.locale')"
-          value-key="value"
-          class="shrink-0"
-          :ui="localeSelectUi"
-        >
-          <template #leading>
-            <UIcon name="i-mdi-translate" class="text-surface-300 h-4 w-4 shrink-0" />
-          </template>
-        </SelectMenuFixed>
-        <NuxtLink
-          v-if="supporterTier"
-          to="/supporter"
-          :class="[
-            'inline-flex h-7 items-center gap-1.5 rounded border px-2.5 text-xs font-semibold text-white shadow-sm shadow-black/30 transition-all duration-150 hover:-translate-y-px hover:shadow-md active:translate-y-0 active:shadow-sm',
-            supporterBadgeClass,
-          ]"
-          :aria-label="supporterBadgeAriaLabel"
-          :title="supporterBadgeAriaLabel"
-        >
-          <UIcon :name="supporterBadgeIcon" class="h-3.5 w-3.5 shrink-0 text-white" />
-          <span class="hidden sm:inline">{{ supporterBadgeLabel }}</span>
-        </NuxtLink>
-        <NuxtLink
-          v-else
-          to="/supporter"
-          class="border-surface-600 hover:border-surface-500 hover:bg-surface-700/60 text-surface-200 inline-flex h-7 items-center gap-1.5 rounded border px-2.5 text-xs font-medium transition-colors"
-          :aria-label="t('footer.support_button')"
-        >
-          <UIcon name="i-mdi-heart-outline" class="text-success-400 h-3.5 w-3.5 shrink-0" />
-          <span class="hidden sm:inline">{{ t('footer.support_button') }}</span>
-        </NuxtLink>
-        <div class="bg-surface-700/50 mx-1 h-5 w-px" />
-        <div
-          class="flex items-center justify-end"
-          :class="isLoggedIn ? 'min-w-[2.75rem] sm:min-w-[10rem]' : ''"
-        >
-          <template v-if="isLoggedIn">
-            <UDropdownMenu :items="accountMenuItems" :content="{ align: 'end', sideOffset: 8 }">
+            <template #leading>
+              <UIcon name="i-mdi-translate" class="text-surface-400 h-4 w-4 shrink-0" />
+            </template>
+          </SelectMenuFixed>
+          <span v-if="supporterTier" class="hidden sm:inline-flex">
+            <AppTooltip :text="supporterBadgeAriaLabel">
+              <NuxtLink
+                to="/supporter"
+                :class="[
+                  'inline-flex h-9 items-center gap-1.5 rounded-md border px-0 text-[13px] font-semibold text-white transition-colors md:w-auto md:px-3',
+                  'w-9 justify-center',
+                  supporterBadgeClass,
+                ]"
+                :aria-label="supporterBadgeAriaLabel"
+              >
+                <UIcon :name="supporterBadgeIcon" class="h-4 w-4 shrink-0 text-white" />
+                <span class="hidden md:inline">{{ supporterBadgeLabel }}</span>
+              </NuxtLink>
+            </AppTooltip>
+          </span>
+          <span v-else class="hidden sm:inline-flex">
+            <AppTooltip :text="t('footer.support_button')">
+              <NuxtLink
+                to="/supporter"
+                class="border-success-500/50 bg-success-500/5 text-success-400 hover:bg-success-500/10 hover:border-success-500/70 inline-flex h-9 w-9 items-center justify-center gap-1.5 rounded-md border px-0 text-[13px] font-semibold transition-colors md:w-auto md:px-3"
+                :aria-label="t('footer.support_button')"
+              >
+                <UIcon name="i-mdi-heart" class="h-4 w-4 shrink-0" />
+                <span class="hidden md:inline">{{ t('footer.support_button') }}</span>
+              </NuxtLink>
+            </AppTooltip>
+          </span>
+          <span class="sm:hidden">
+            <AppTooltip :text="t('app_bar.more_aria', 'More')">
+              <UDropdownMenu :items="moreMenuItems" :content="{ align: 'end', sideOffset: 8 }">
+                <UButton
+                  color="neutral"
+                  variant="ghost"
+                  size="md"
+                  icon="i-mdi-dots-horizontal"
+                  :aria-label="t('app_bar.more_aria', 'More')"
+                  class="h-9 w-9"
+                />
+              </UDropdownMenu>
+            </AppTooltip>
+          </span>
+          <AppTooltip :text="t('navigation_drawer.account_menu')">
+            <UDropdownMenu
+              v-if="isLoggedIn"
+              :items="accountMenuItems"
+              :content="{ align: 'end', sideOffset: 8 }"
+            >
               <button
                 type="button"
-                class="bg-surface-800/50 border-surface-600 hover:bg-surface-800 flex min-h-8 items-center gap-2 rounded-md border px-2.5 py-1.5 transition-colors sm:w-full sm:max-w-40"
+                class="bg-surface-800/50 border-surface-600 hover:bg-surface-800 flex h-9 items-center gap-2 rounded-md border px-2 py-1.5 transition-colors sm:max-w-40"
                 :aria-label="t('navigation_drawer.account_menu')"
               >
                 <img
-                  :src="avatarSrc"
+                  :src="effectiveAvatarSrc"
                   :alt="t('app_bar.user_avatar_alt')"
-                  class="h-4 w-4 shrink-0 rounded-full"
+                  class="h-5 w-5 shrink-0 rounded-full"
                   loading="lazy"
+                  @error="handleAvatarError"
                 />
                 <span
-                  class="text-surface-200 hidden min-w-0 flex-1 truncate text-sm leading-none font-medium sm:inline"
+                  class="text-surface-200 hidden min-w-0 flex-1 truncate text-[13px] leading-none font-medium sm:inline"
                 >
                   {{ userDisplayName }}
                 </span>
-                <UIcon name="i-mdi-chevron-down" class="text-surface-400 h-3.5 w-3.5 shrink-0" />
+                <UIcon name="i-mdi-chevron-down" class="text-surface-400 h-4 w-4 shrink-0" />
               </button>
             </UDropdownMenu>
-          </template>
-          <template v-else>
-            <div class="flex w-full items-center justify-end gap-1 sm:gap-2">
-              <AppTooltip :text="t('navigation_drawer.settings')">
-                <NuxtLink
-                  to="/settings"
-                  class="hover:bg-surface-700 flex h-7 w-7 items-center justify-center rounded transition-colors"
-                  :aria-label="t('navigation_drawer.settings')"
-                >
-                  <UIcon
-                    name="i-mdi-cog-outline"
-                    class="text-surface-300 h-4.5 w-4.5 hover:text-white"
-                  />
-                </NuxtLink>
-              </AppTooltip>
-              <NuxtLink
-                to="/login"
-                class="hover:bg-surface-700 hidden min-h-8 items-center rounded px-2 py-1 text-sm leading-none text-white sm:inline-flex"
-              >
-                <span class="leading-none">{{ t('navigation_drawer.login') }}</span>
-              </NuxtLink>
-              <NuxtLink
-                to="/login"
-                class="hover:bg-surface-700 rounded p-1 text-white sm:hidden"
-                :aria-label="t('navigation_drawer.login')"
-              >
-                <UIcon name="i-mdi-fingerprint" class="h-4 w-4" />
-              </NuxtLink>
-            </div>
-          </template>
+          </AppTooltip>
+          <AppTooltip v-if="!isLoggedIn" :text="t('app_bar.login_aria', 'Log in to your account')">
+            <NuxtLink
+              to="/login"
+              class="bg-primary-600 hover:bg-primary-500 border-primary-500 flex h-9 items-center gap-1.5 rounded-md border px-3.5 text-[13px] leading-none font-semibold text-white transition-colors"
+              :aria-label="t('app_bar.login_aria', 'Log in to your account')"
+            >
+              <UIcon name="i-mdi-account-outline" class="h-4 w-4 shrink-0" />
+              <span class="leading-none">{{ t('navigation_drawer.login') }}</span>
+            </NuxtLink>
+          </AppTooltip>
         </div>
       </div>
     </div>
@@ -326,6 +301,13 @@
       ? '/img/default-avatar.svg'
       : $supabase.user.photoURL;
   });
+  const avatarFailed = ref(false);
+  const effectiveAvatarSrc = computed(() =>
+    avatarFailed.value ? '/img/default-avatar.svg' : avatarSrc.value
+  );
+  function handleAvatarError() {
+    avatarFailed.value = true;
+  }
   const userDisplayName = computed(() => {
     const fallbackLabel = t('app_bar.user_label');
     const hiddenLabel = t('app_bar.hidden_label');
@@ -356,6 +338,41 @@
         label: t('navigation_drawer.logout'),
         onSelect: () => {
           void logout();
+        },
+      },
+    ],
+  ]);
+  const moreMenuItems = computed<DropdownMenuItem[][]>(() => [
+    [
+      {
+        icon: 'i-mdi-translate',
+        label: t('settings.locale'),
+        children: (availableLocales as readonly string[]).map((localeCode) => ({
+          label: localeCode.toUpperCase(),
+          onSelect: () => {
+            void applyLocaleSelection(localeCode);
+          },
+        })),
+      },
+      {
+        icon: 'i-mdi-heart-outline',
+        label: t('footer.support_button'),
+        to: '/supporter',
+      },
+    ],
+    [
+      {
+        icon: 'i-mdi-discord',
+        label: t('footer.call_to_action.discord'),
+        onSelect: () => {
+          window.open('https://discord.gg/M8nBgA2sT6', '_blank', 'noopener');
+        },
+      },
+      {
+        icon: 'i-mdi-github',
+        label: t('footer.call_to_action.github'),
+        onSelect: () => {
+          window.open('https://github.com/tarkovtracker-org/TarkovTracker', '_blank', 'noopener');
         },
       },
     ],
@@ -517,16 +534,16 @@
     }));
   });
   const localeSelectUi = {
-    base: 'focus-visible:ring-primary-500 focus-visible:ring-offset-surface-900 bg-surface-800/60 border-surface-700 hover:bg-surface-800 flex min-h-8 items-center gap-1 rounded border px-2 py-1 ring-0 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2',
+    base: 'focus-visible:ring-primary-500 focus-visible:ring-offset-surface-900 bg-surface-800/30 border-surface-700/40 hover:bg-surface-800/60 hover:border-surface-600/60 flex min-h-9 items-center gap-1.5 rounded-md border px-2.5 py-1 ring-0 outline-none transition-colors focus-visible:ring-2 focus-visible:ring-offset-2',
     content:
       'max-h-80 bg-surface-900 border border-surface-700 rounded-lg shadow-xl z-[9999] min-w-[var(--reka-combobox-trigger-width)]',
     item: 'px-3 py-2 text-sm cursor-pointer transition-colors rounded text-surface-300 data-[highlighted]:bg-surface-800 data-[highlighted]:text-white data-[state=checked]:bg-surface-700 data-[state=checked]:text-white data-[state=checked]:font-medium',
     itemLabel: 'whitespace-nowrap uppercase',
     itemTrailingIcon: 'text-surface-400 shrink-0 size-4',
-    leading: 'shrink-0 text-surface-300',
+    leading: 'shrink-0 text-surface-400',
     trailing: 'shrink-0 text-surface-400',
-    trailingIcon: 'text-surface-400 shrink-0 size-4',
-    value: 'text-surface-200 text-xs leading-none font-medium uppercase',
+    trailingIcon: 'text-surface-400 shrink-0 size-3.5',
+    value: 'text-surface-300 text-[13px] leading-none font-medium uppercase',
     viewport: 'p-1 max-h-none overflow-visible',
   } as const;
   let latestLocaleSwitchRequestId = 0;

--- a/app/shell/__tests__/AppBar.test.ts
+++ b/app/shell/__tests__/AppBar.test.ts
@@ -71,10 +71,11 @@ vi.mock('vue-i18n', async (importOriginal) => ({
     te: () => false,
   }),
 }));
+const windowWidthRef = ref(1280);
 vi.mock('@vueuse/core', async (importOriginal) => ({
   ...(await importOriginal<typeof import('@vueuse/core')>()),
   useWindowSize: () => ({
-    width: ref(1280),
+    width: windowWidthRef,
   }),
 }));
 vi.mock('@/composables/useKeybinds', () => ({
@@ -170,6 +171,7 @@ const mountAppBar = async () => {
 };
 describe('AppBar locale switching', () => {
   beforeEach(async () => {
+    windowWidthRef.value = 1280;
     localeRef.value = 'en';
     routeState.name = 'tasks';
     routeState.params = {};
@@ -332,10 +334,11 @@ describe('AppBar logged out actions', () => {
   beforeEach(() => {
     mockSupabase.user.loggedIn = false;
   });
-  it('shows settings icon and login link when not logged in', async () => {
+  it('shows the account login control and no duplicate settings gear when not logged in', async () => {
     const wrapper = await mountAppBar();
-    expect(wrapper.find('[aria-label="navigation_drawer.settings"]').exists()).toBe(true);
+    expect(wrapper.find('[aria-label="app_bar.login_aria"]').exists()).toBe(true);
     expect(wrapper.text()).toContain('navigation_drawer.login');
+    expect(wrapper.find('[aria-label="navigation_drawer.settings"]').exists()).toBe(false);
     wrapper.unmount();
   });
 });
@@ -354,7 +357,13 @@ describe('AppBar supporter badge', () => {
     const wrapper = await mountAppBar();
     // te() mock returns false, so AppBar falls back to the capitalized tier name
     expect(wrapper.text()).toContain('Chad');
-    expect(wrapper.text()).not.toContain('footer.support_button');
+    // The support CTA (v-else branch) is not rendered when a supporter tier is active.
+    // The More menu always contains the support label, so we check the CTA link specifically.
+    const supportCtaLinks = wrapper.findAll('a').filter((a) => {
+      const text = a.text();
+      return text.includes('footer.support_button') && !a.attributes('data-menu-item');
+    });
+    expect(supportCtaLinks.length).toBe(0);
     wrapper.unmount();
   });
   it('falls back to the generic Supporter label for past supporters', async () => {
@@ -423,6 +432,101 @@ describe('AppBar page title', () => {
     expect(wrapper.text()).not.toContain('OwnDisplayName Profile PVP');
     expect(wrapper.text()).not.toContain('AccountName Profile PVP');
     expect(wrapper.text()).not.toContain('AccountUsername Profile PVP');
+    wrapper.unmount();
+  });
+});
+describe('AppBar responsive layout', () => {
+  beforeEach(() => {
+    mockSupabase.user.loggedIn = false;
+    supporterTierRef.value = null;
+  });
+  it('renders the More menu with Language, Support, Discord, and GitHub items', async () => {
+    const wrapper = await mountAppBar();
+    const moreMenuItems = wrapper.findAll('[data-menu-item]');
+    const labels = moreMenuItems.map((el) => el.attributes('data-menu-item'));
+    expect(labels).toContain('settings.locale');
+    expect(labels).toContain('footer.support_button');
+    expect(labels).toContain('footer.call_to_action.discord');
+    expect(labels).toContain('footer.call_to_action.github');
+    wrapper.unmount();
+  });
+  it('wraps the Support CTA in a hidden sm:inline-flex container for CSS responsive visibility', async () => {
+    const wrapper = await mountAppBar();
+    const supportWrappers = wrapper.findAll('span.hidden').filter((span) => {
+      const classAttr = span.attributes('class') || '';
+      return classAttr.includes('sm:inline-flex');
+    });
+    expect(supportWrappers.length).toBeGreaterThanOrEqual(1);
+    wrapper.unmount();
+  });
+  it('wraps the More menu in a sm:hidden container for CSS responsive visibility', async () => {
+    const wrapper = await mountAppBar();
+    const moreWrappers = wrapper.findAll('span').filter((span) => {
+      const classAttr = span.attributes('class') || '';
+      return classAttr.includes('sm:hidden');
+    });
+    expect(moreWrappers.length).toBe(1);
+    wrapper.unmount();
+  });
+  it('gives the bell a 36x36 hit target with aria-label and tooltip', async () => {
+    const wrapper = await mountAppBar();
+    const bell = wrapper.find('button[aria-label="activity_log.aria_label"]');
+    expect(bell.exists()).toBe(true);
+    const classAttr = bell.attributes('class') || '';
+    expect(classAttr).toContain('h-9');
+    expect(classAttr).toContain('w-9');
+    wrapper.unmount();
+  });
+  it('renders the Log In button with a filled primary background', async () => {
+    const wrapper = await mountAppBar();
+    const loginLink = wrapper.find('a[aria-label="app_bar.login_aria"]');
+    expect(loginLink.exists()).toBe(true);
+    const classAttr = loginLink.attributes('class') || '';
+    expect(classAttr).toContain('bg-primary-600');
+    expect(classAttr).toContain('h-9');
+    wrapper.unmount();
+  });
+});
+describe('AppBar authenticated state', () => {
+  beforeEach(() => {
+    mockSupabase.user.loggedIn = true;
+    mockSupabase.user.id = 'user-1';
+    mockSupabase.user.photoURL = '';
+    mockSupabase.user.displayName = '';
+    mockSupabase.user.username = '';
+    mockTarkovStore.getDisplayName.mockReturnValue('');
+    mockPreferencesStore.getStreamerMode = false;
+  });
+  it('renders the account menu trigger with avatar and chevron', async () => {
+    const wrapper = await mountAppBar();
+    const trigger = wrapper.find('button[aria-label="navigation_drawer.account_menu"]');
+    expect(trigger.exists()).toBe(true);
+    const classAttr = trigger.attributes('class') || '';
+    expect(classAttr).toContain('h-9');
+    expect(trigger.find('img').exists()).toBe(true);
+    expect(trigger.find('.i-mdi-chevron-down').exists() || trigger.text()).toBeTruthy();
+    wrapper.unmount();
+  });
+  it('truncates the display name with sm:inline and truncate class', async () => {
+    mockTarkovStore.getDisplayName.mockReturnValue('A'.repeat(50));
+    const wrapper = await mountAppBar();
+    const trigger = wrapper.find('button[aria-label="navigation_drawer.account_menu"]');
+    const nameSpan = trigger.find('span.truncate');
+    expect(nameSpan.exists()).toBe(true);
+    const classAttr = nameSpan.attributes('class') || '';
+    expect(classAttr).toContain('hidden');
+    expect(classAttr).toContain('sm:inline');
+    wrapper.unmount();
+  });
+  it('falls back to default avatar when avatar image fails to load', async () => {
+    mockSupabase.user.photoURL = 'https://example.com/broken.jpg';
+    const wrapper = await mountAppBar();
+    const img = wrapper.find('button[aria-label="navigation_drawer.account_menu"] img');
+    expect(img.exists()).toBe(true);
+    expect(img.attributes('src')).toBe('https://example.com/broken.jpg');
+    await img.trigger('error');
+    await flushPromises();
+    expect(img.attributes('src')).toBe('/img/default-avatar.svg');
     wrapper.unmount();
   });
 });

--- a/app/shell/__tests__/AppBar.test.ts
+++ b/app/shell/__tests__/AppBar.test.ts
@@ -160,7 +160,10 @@ const mountAppBar = async () => {
           template:
             '<div><slot /><template v-for="(group, groupIndex) in (items || [])" :key="groupIndex"><button v-for="item in group" :key="item.label" type="button" :data-menu-item="item.label" @click="item.onSelect?.()">{{ item.label }}</button></template></div>',
         },
-        UIcon: true,
+        UIcon: {
+          props: ['name'],
+          template: '<i :class="name" />',
+        },
         UKbd: true,
         UPopover: {
           template: '<div><slot /><slot name="content" /></div>',
@@ -504,7 +507,7 @@ describe('AppBar authenticated state', () => {
     const classAttr = trigger.attributes('class') || '';
     expect(classAttr).toContain('h-9');
     expect(trigger.find('img').exists()).toBe(true);
-    expect(trigger.find('.i-mdi-chevron-down').exists() || trigger.text()).toBeTruthy();
+    expect(trigger.find('.i-mdi-chevron-down').exists()).toBe(true);
     wrapper.unmount();
   });
   it('truncates the display name with sm:inline and truncate class', async () => {


### PR DESCRIPTION
## **User description**
## Summary

- Restructure the AppBar right cluster into two visual groups (utilities | preferences+actions) with consistent 36px controls, clear primary/secondary action hierarchy, and CSS-driven responsive collapse
- Promote Log In to filled primary CTA; de-emphasize Support to tinted outlined secondary (`bg-success-500/5`)
- Normalize all controls to `h-9` (36px), `rounded-md`, `text-[13px]` with consistent hover/focus and tooltips on every icon-only control
- Consolidate Discord/GitHub into Help menu and More menu; add Keyboard shortcuts (`→ /settings#keybinds`) and Report a problem items to Help menu
- Replace JS `isNarrowWidth` with CSS `sm:` breakpoint classes — no SSR flash, no hydration mismatch
- Add More menu (Language submenu + Support + Discord + GitHub) for viewports < 640px
- Add avatar error fallback (`effectiveAvatarSrc` + `handleAvatarError`)
- Shorten `footer.support_button` from "Support Development" to "Support"
- Add 8 responsive/authenticated component tests (24 total)

## Changes

| File | Purpose |
|------|---------|
| `app/shell/AppBar.vue` | Right cluster restructure, control normalization, responsive CSS, avatar fallback, More menu |
| `app/components/ui/GlobalHelpLauncher.vue` | Tooltip wrapper, Keyboard shortcuts + Report a problem items, `size="md"` normalization |
| `app/locales/en.json` | New keys: `help_community_aria`, `community_section`, `keyboard_shortcuts`, `report_problem`, `more_aria`, `login_aria`; shortened `support_button` |
| `app/pages/settings.vue` | `#keybinds` anchor + `nestedTabHashes` mapping |
| `app/shell/__tests__/AppBar.test.ts` | 8 new tests for responsive layout and authenticated state |

#### Test plan

- [x] `pnpm run typecheck` — passed
- [x] `pnpm run lint` (zero warnings) — passed
- [x] `pnpm run test` — 2104/2104 passed across 217 files
- [x] `pnpm run i18n:check` — passed (no snake_case violations)
- [x] `pnpm run validate:openapi` — passed
- [x] Playwright visual testing at 1024px, 768px, 640px, 375px, 320px — no overflow, all controls 36px height
- [x] Husky pre-commit hooks (prettier + eslint + i18n lint) — passed


___

## **CodeAnt-AI Description**
**Rework the AppBar actions into clearer groups with responsive mobile fallbacks**

### What Changed
- The top bar now separates utility actions from account and preference actions, with larger 36px controls and clearer primary/secondary emphasis
- Logged-out users now see a filled Log In button, while the Support button is shown in a lighter outlined style
- On smaller screens, language, support, Discord, and GitHub move into a More menu instead of crowding the bar
- The Help menu now includes Keyboard shortcuts and Report a problem, and opens the keyboard shortcuts section in Settings
- Logged-in users get an account menu with avatar fallback if the image fails to load
- The settings page now links directly to the keyboard shortcuts section from the Help menu

### Impact
`✅ Easier access to help and account actions on small screens`
`✅ Clearer sign-in and support buttons`
`✅ Fewer broken avatar images`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded the app-bar help menu with page guides, onboarding, keyboard shortcuts, problem reporting, and community links.
  * Added a responsive “More” menu consolidating utility and community actions.
  * Enabled navigation to the keyboard shortcuts section via URL hash/tab.
* **Bug Fixes**
  * Improved account avatar handling with a fallback when the image fails to load.
* **Style**
  * Refined app-bar layout and accessibility/label text, including updated locale selector and support button wording.
  * Updated settings page to provide a direct anchor target for keybinds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->