### PR TITLE
fix(ci): skip automation for locale-only PRs

### DIFF
--- a/.codeant/configuration.json
+++ b/.codeant/configuration.json
@@ -1,18 +1,20 @@
 {
-  "review_configuration": {
-    "include": [],
-    "exclude": [
-      "app/locales/cs.json",
-      "app/locales/de.json",
-      "app/locales/es.json",
-      "app/locales/fr.json",
-      "app/locales/it.json",
-      "app/locales/ko.json",
-      "app/locales/pl.json",
-      "app/locales/pt.json",
-      "app/locales/ru.json",
-      "app/locales/uk.json",
-      "app/locales/zh.json"
-    ]
+  "file_filters": {
+    "config": {
+      "include_files": [],
+      "exclude_files": [
+        "app/locales/cs.json",
+        "app/locales/de.json",
+        "app/locales/es.json",
+        "app/locales/fr.json",
+        "app/locales/it.json",
+        "app/locales/ko.json",
+        "app/locales/pl.json",
+        "app/locales/pt.json",
+        "app/locales/ru.json",
+        "app/locales/uk.json",
+        "app/locales/zh.json"
+      ]
+    }
   }
 }

--- a/.codeant/configuration.json
+++ b/.codeant/configuration.json
@@ -1,20 +1,8 @@
 {
   "file_filters": {
     "config": {
-      "include_files": [],
-      "exclude_files": [
-        "app/locales/cs.json",
-        "app/locales/de.json",
-        "app/locales/es.json",
-        "app/locales/fr.json",
-        "app/locales/it.json",
-        "app/locales/ko.json",
-        "app/locales/pl.json",
-        "app/locales/pt.json",
-        "app/locales/ru.json",
-        "app/locales/uk.json",
-        "app/locales/zh.json"
-      ]
+      "include_files": "",
+      "exclude_files": "app/locales/cs.json,app/locales/de.json,app/locales/es.json,app/locales/fr.json,app/locales/it.json,app/locales/ko.json,app/locales/pl.json,app/locales/pt.json,app/locales/ru.json,app/locales/uk.json,app/locales/zh.json"
     }
   }
 }

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,6 +19,13 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 
 All jobs run in parallel; the `Workers` job no longer waits for `Validate` to finish.
 
+### Crowdin locale PRs
+
+PRs whose changes are limited to the non-English locale exports in `app/locales/` do not trigger
+`CI`, `PR Checks`, `Security`, or `Dependabot Auto Merge`. This prevents each burst of Crowdin
+synchronization commits from starting redundant repository-owned jobs. Changes to source code,
+workflow files, or `app/locales/en.json` still run the normal checks.
+
 ### Security (`security.yml`)
 
 **Trigger:** Push to main/develop, PRs, weekly schedule
@@ -72,7 +79,16 @@ Workflow-specific secrets are not required for the Gitleaks step anymore. The wo
 
 ## AI Review Bots
 
-CodeRabbit automatic reviews are disabled in `.coderabbit.yaml`; invoke it on demand with `@coderabbitai review`. CodeAnt and Kilo Code PR reviews are controlled by their GitHub App dashboards, not GitHub Actions in this repo. Keep those apps disabled or remove this repository from their automatic review selections, then invoke them manually from their PR comments or dashboards when needed.
+CodeRabbit skips PRs whose titles contain `Crowdin` via `.coderabbit.yaml`; normal automatic reviews
+remain enabled. CodeAnt excludes the non-English locale exports via `.codeant/configuration.json`,
+but its GitHub App can still post PR metadata. Kilo Code reviews are controlled by its GitHub App
+dashboard and have no repository workflow switch. GitHub-managed Copilot review and the duplicate
+CodeQL workflow (`dynamic/github-code-scanning/codeql`) are also controlled outside this repository;
+the checked-in `Security` workflow already runs CodeQL for normal code PRs. To stop those apps and
+workflows from consuming usage on the automated `locales` PR, remove this repository from their
+automatic review selection or disable the duplicate integration in each vendor/GitHub dashboard.
+Socket PR alerts are limited to dependency manifest changes by the root `socket.yml`; Snyk and
+Supabase preview behavior is controlled by their integration settings.
 
 ## Commands
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,18 @@ on:
     branches: [main, develop, 'wip/**']
   pull_request:
     branches: [main, develop]
+    paths-ignore:
+      - 'app/locales/cs.json'
+      - 'app/locales/de.json'
+      - 'app/locales/es.json'
+      - 'app/locales/fr.json'
+      - 'app/locales/it.json'
+      - 'app/locales/ko.json'
+      - 'app/locales/pl.json'
+      - 'app/locales/pt.json'
+      - 'app/locales/ru.json'
+      - 'app/locales/uk.json'
+      - 'app/locales/zh.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -3,6 +3,18 @@ name: Dependabot Auto Merge
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+    paths-ignore:
+      - 'app/locales/cs.json'
+      - 'app/locales/de.json'
+      - 'app/locales/es.json'
+      - 'app/locales/fr.json'
+      - 'app/locales/it.json'
+      - 'app/locales/ko.json'
+      - 'app/locales/pl.json'
+      - 'app/locales/pt.json'
+      - 'app/locales/ru.json'
+      - 'app/locales/uk.json'
+      - 'app/locales/zh.json'
 
 permissions:
   checks: read

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -3,6 +3,18 @@ name: PR Checks
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+    paths-ignore:
+      - 'app/locales/cs.json'
+      - 'app/locales/de.json'
+      - 'app/locales/es.json'
+      - 'app/locales/fr.json'
+      - 'app/locales/it.json'
+      - 'app/locales/ko.json'
+      - 'app/locales/pl.json'
+      - 'app/locales/pt.json'
+      - 'app/locales/ru.json'
+      - 'app/locales/uk.json'
+      - 'app/locales/zh.json'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,6 +4,18 @@ on:
   push:
     branches: [main, develop]
   pull_request:
+    paths-ignore:
+      - 'app/locales/cs.json'
+      - 'app/locales/de.json'
+      - 'app/locales/es.json'
+      - 'app/locales/fr.json'
+      - 'app/locales/it.json'
+      - 'app/locales/ko.json'
+      - 'app/locales/pl.json'
+      - 'app/locales/pt.json'
+      - 'app/locales/ru.json'
+      - 'app/locales/uk.json'
+      - 'app/locales/zh.json'
   schedule:
     - cron: '0 0 * * 0'
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,6 +132,7 @@ Naming:
 - `pnpm run i18n:check` is fatal only for snake_case naming violations in `en.json`. Missing/orphaned keys in non-English files are informational.
 - Locale keys must be snake_case. Provide fallback strings in `t('key', 'Fallback')` calls.
 - When adding user-facing copy: add key to `en.json` only, run `pnpm run i18n:check`. Crowdin handles propagation.
+- Crowdin-only PRs that change only non-English exports are excluded from repository-owned CI, PR metadata, security, and Dependabot workflows via their `paths-ignore` filters. Changes to source code or `en.json` still run normal checks.
 - Add keys consistently with existing namespace patterns. Keep locale keys stable to avoid churn.
 - Avoid hard-coded user-facing strings in components.
 - The sole exception to not editing non-English locale files is fixing a broken Crowdin export PR; even then, only touch the file(s) Crowdin produced.
@@ -155,6 +156,7 @@ Naming:
 - When investigating user issues, correlate across GA4, Clarity, and Cloudflare when possible.
 - Always state date range, property/project/zone, and source used in analytics conclusions.
 - When using Tarkov API or MCP tools, state only what the API returned. Missing API data is not proof the content doesn't exist in-game.
+- The root `socket.yml` limits Socket PR alerts to dependency manifest changes; CodeAnt locale filters live in `.codeant/configuration.json`. Kilo, Snyk, and Supabase PR integrations remain vendor-dashboard settings.
 - Use browser-based dashboard inspection only as a fallback when MCP/API access is missing or insufficient.
 
 ## Git Workflow

--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,8 @@
+version: 2
+
+triggerPaths:
+  - 'package.json'
+  - 'pnpm-lock.yaml'
+  - 'pnpm-workspace.yaml'
+  - 'workers/api-gateway/package.json'
+  - 'supabase/functions/deno.json'


### PR DESCRIPTION
## **User description**
## Summary
- Skip repository-owned CI, PR metadata, security, and Dependabot workflows when a PR changes only non-English Crowdin locale exports.
- Limit Socket PR alerts to dependency manifest changes.
- Update CodeAnt locale filtering and document vendor-managed review integrations.

This is intentionally targeted at the automated Crowdin PR shape while preserving normal checks for source code, workflow changes, and `app/locales/en.json`.

## Test plan
- [x] Prettier checks passed for changed YAML, JSON, and Markdown files.
- [x] Confirmed PR #496's locale-only file set is fully matched by each `paths-ignore` filter.
- [ ] GitHub Actions CI for this PR passes.

## Follow-up
The GitHub-managed dynamic CodeQL/Copilot workflows and vendor apps must be disabled or filtered in their respective dashboards; they cannot be fully controlled by repository workflow YAML.


___

## **CodeAnt-AI Description**
**Skip repository-owned automation for Crowdin locale-only PRs**

### What Changed
- PRs that change only non-English locale exports no longer trigger the main CI, PR checks, security, or Dependabot auto-merge workflows
- Locale-only PRs also avoid most automated review noise by narrowing locale filtering for CodeAnt and limiting Socket alerts to dependency manifest changes
- The workflow notes were updated to explain which review tools still need to be managed from their own dashboards and which changes still run normal checks

### Impact
`✅ Fewer redundant checks on translation-only PRs`
`✅ Faster Crowdin locale syncs`
`✅ Less review noise on locale updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Locale-only pull requests (non-English `app/locales/` JSON updates) now bypass selected automated validation, security, and merge workflows.
  - PRs that include application code or `app/locales/en.json` continue to run the usual checks.
  - Added automation trigger paths for alerts based on key dependency/workspace configuration changes.
- **Documentation**
  - Updated workflow documentation to clarify how checks and automated review behavior apply to localization-only pull requests.
  - Documented the localization filtering configuration approach and the revised dependency monitoring scope.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->