### PR TITLE
fix(api): address PR #561 review findings

### DIFF
--- a/ARCHITECTURE_REVIEW.md
+++ b/ARCHITECTURE_REVIEW.md
@@ -348,8 +348,8 @@ Release ID should be content-derived or otherwise immutable and include a manife
 4. Validate canonical models and all output projections.
 5. Write every immutable release artifact.
 6. Read back and verify required artifacts.
-7. Let `A` be the prior active release and `B` the newly verified release; set `previous-release` to `A`.
-8. Set `active-release` to `B` last. The two pointers must not both be advanced to `B`, or rollback would be ineffective.
+7. Serialize promotion with a single-writer publish lock, or an equivalent compare-and-set that verifies `active-release` is still the expected prior release `A` before changing either pointer. If that check fails, abort and re-evaluate instead of overwriting a newer promotion.
+8. While holding that guarantee, set `previous-release` to `A`, then set `active-release` to the newly verified release `B` last. The two pointers must not both be advanced to `B`, or rollback would be ineffective.
 9. Run production canaries.
 10. Retain active and previous releases without expiration.
 11. Optionally archive older releases in R2.

--- a/workers/api-gateway/src/__tests__/usage.test.ts
+++ b/workers/api-gateway/src/__tests__/usage.test.ts
@@ -62,6 +62,25 @@ describe('recordUsage', () => {
     expect(retryBody).toMatchObject({ p_user_id: 'user-1', p_reads: 1 });
   });
 
+  it('gives the legacy retry a fresh timeout signal', async () => {
+    const signals: AbortSignal[] = [];
+    const fetchMock = vi.fn(async (_input: RequestInfo | URL, init?: RequestInit) => {
+      signals.push(init?.signal as AbortSignal);
+      if (signals.length === 1) {
+        return Response.json({ code: 'PGRST202' }, { status: 404 });
+      }
+      return new Response(null, { status: 204 });
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await recordUsage(env, record);
+
+    expect(signals).toHaveLength(2);
+    expect(signals[0]).toBeInstanceOf(AbortSignal);
+    expect(signals[1]).toBeInstanceOf(AbortSignal);
+    expect(signals[1]).not.toBe(signals[0]);
+  });
+
   it('does not retry unrelated RPC failures', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const fetchMock = vi.fn(async (_input: RequestInfo | URL, _init?: RequestInit) =>

--- a/workers/api-gateway/src/services/usage.ts
+++ b/workers/api-gateway/src/services/usage.ts
@@ -17,8 +17,6 @@ export interface UsageRecord {
  * record_api_usage RPC. Best-effort: failures are logged, never surfaced.
  */
 export async function recordUsage(env: Env, record: UsageRecord): Promise<void> {
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), USAGE_RPC_TIMEOUT_MS);
   const rpcUrl = `${env.SUPABASE_URL}/rest/v1/rpc/record_api_usage`;
   const headers = {
     Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
@@ -33,25 +31,29 @@ export async function recordUsage(env: Env, record: UsageRecord): Promise<void> 
     p_writes: record.kind === 'write' && !record.throttled ? 1 : 0,
     p_throttled: record.throttled ? 1 : 0,
   };
+  const postUsage = async (payload: Record<string, unknown>): Promise<Response> => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), USAGE_RPC_TIMEOUT_MS);
+    try {
+      return await fetch(rpcUrl, {
+        method: 'POST',
+        headers,
+        signal: controller.signal,
+        body: JSON.stringify(payload),
+      });
+    } finally {
+      clearTimeout(timeout);
+    }
+  };
   try {
-    let response = await fetch(rpcUrl, {
-      method: 'POST',
-      headers,
-      signal: controller.signal,
-      body: JSON.stringify({ ...basePayload, p_user_agent: record.userAgent }),
-    });
+    let response = await postUsage({ ...basePayload, p_user_agent: record.userAgent });
     // During a staggered deploy, PostgREST can still expose the previous
     // six-argument RPC signature. Retry that exact signature so accounting is
     // preserved until the database migration reaches the environment.
     if (!response.ok && (response.status === 404 || response.status === 400)) {
       const error = (await response.clone().json().catch(() => null)) as { code?: unknown } | null;
       if (error?.code === 'PGRST202') {
-        response = await fetch(rpcUrl, {
-          method: 'POST',
-          headers,
-          signal: controller.signal,
-          body: JSON.stringify(basePayload),
-        });
+        response = await postUsage(basePayload);
       }
     }
     if (!response.ok) {
@@ -59,7 +61,5 @@ export async function recordUsage(env: Env, record: UsageRecord): Promise<void> 
     }
   } catch (error) {
     console.warn('recordUsage error', { error });
-  } finally {
-    clearTimeout(timeout);
   }
 }


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to #561 addressing its two remaining CodeRabbit findings.

- give each usage RPC attempt an independent 3-second abort budget
- test that the legacy fallback receives a fresh `AbortSignal`
- require a single-writer lock or compare-and-set validation for release-pointer promotion

## Validation

- `pnpm test:api-gateway --run` — 108 tests passed
- `pnpm typecheck`
- `pnpm lint`

After merge, the original #561 review thread and summary feedback will be replied to and reconciled for the historical record.


___

## **CodeAnt-AI Description**
**Keep usage retries within their own timeout and make release promotion safer**

### What Changed
- The legacy usage-reporting retry now gets its own fresh timeout, so the second attempt is not cancelled by the first attempt’s timer
- Usage reporting tests now verify that the retry uses a new abort signal
- The release-promotion guidance now requires checking that the active release is still the expected prior release before updating pointers, preventing a newer promotion from being overwritten

### Impact
`✅ Fewer dropped usage events during RPC fallback`
`✅ More reliable usage reporting retries`
`✅ Safer release promotions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved usage reporting reliability when deployments temporarily expose different request formats.
  * Retry attempts now use independent timeouts, reducing failures caused by reusing expired request signals.
  * Usage reporting errors continue to be handled without disrupting the surrounding experience.

* **Documentation**
  * Clarified release promotion and rollback procedures to prevent inconsistent release states during concurrent updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->