### PR TITLE
docs: define atomic release promotion recovery

### DIFF
--- a/ARCHITECTURE_REVIEW.md
+++ b/ARCHITECTURE_REVIEW.md
@@ -348,8 +348,8 @@ Release ID should be content-derived or otherwise immutable and include a manife
 4. Validate canonical models and all output projections.
 5. Write every immutable release artifact.
 6. Read back and verify required artifacts.
-7. Serialize promotion with a single-writer publish lock, or an equivalent compare-and-set that verifies `active-release` is still the expected prior release `A` before changing either pointer. If that check fails, abort and re-evaluate instead of overwriting a newer promotion.
-8. While holding that guarantee, set `previous-release` to `A`, then set `active-release` to the newly verified release `B` last. The two pointers must not both be advanced to `B`, or rollback would be ineffective.
+7. Acquire a single-writer promotion lock with a unique owner token and lease. Before changing either pointer, read `active-release` and verify it is the expected prior release `A`; if not, release the lock and abort because another publisher has won. A future compare-and-set implementation is acceptable only if it atomically claims the transition from `A` before either pointer write.
+8. While the lock/claim remains valid, write `previous-release = A`, verify it, then write `active-release = B` last and verify it. If the first write fails, leave `active-release` at `A` and abort. If the final write fails, keep or restore `active-release = A`, repair `previous-release` to its pre-promotion value when known, and report the release as not promoted. Never retry by blindly overwriting pointers after the lock/claim is lost; re-read state and start a new promotion attempt. The two pointers must not both be advanced to `B`, or rollback would be ineffective.
 9. Run production canaries.
 10. Retain active and previous releases without expiration.
 11. Optionally archive older releases in R2.


### PR DESCRIPTION
## **User description**
## Summary

Follow-up to the final review thread on #562.

- specify a leased, owner-token single-writer promotion lock
- require validating `active-release = A` before either pointer changes
- require any CAS alternative to atomically claim the transition from `A`
- define recovery when the previous or active pointer write fails
- forbid blind pointer overwrites after lock/claim loss

## Validation

- `pnpm format:check`

After merge, the #562 review thread will be replied to and resolved.


___

## **CodeAnt-AI Description**
Define how release promotion recovers from failed pointer writes

### What Changed
- Clarifies that a promotion must start by checking `active-release` is still the expected prior release before any pointer changes
- Adds recovery steps for failed writes: keep `active-release` on the old release if the first write fails, and restore it if the final write fails
- States that promotion attempts must stop once the lock or claim is lost, instead of retrying by overwriting pointers
- Keeps the rule that `previous-release` and `active-release` must not both advance to the new release

### Impact
`✅ Fewer broken release promotions`
`✅ Safer rollback after failed deploys`
`✅ Lower risk of overwriting a newer release`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release-promotion procedures to improve locking, verification, rollback, and failure handling.
  * Added safeguards to prevent conflicting or incomplete release pointer updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->