### PR TITLE
docs: reorganize README and add system spec doc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,8 +14,27 @@ Update this file or a scoped child `AGENTS.md` in the same PR when a change modi
 - localization workflow, Crowdin behavior, or locale file ownership
 - analytics tooling, MCP access, or external data integrations
 - deprecated patterns that agents must avoid
+- behavior of a system documented in `docs/SYSTEMS.md` (Tarkov.dev integration, data fetching
+  pipeline, multi-layer caching, overlay corrections, precompute workflow)
 
 If this file conflicts with executable config (eslint, prettier, tsconfig, package.json), trust the executable config, then update this file before finishing.
+
+### System spec sync (`docs/SYSTEMS.md`)
+
+`docs/SYSTEMS.md` is the plain-language spec for the non-obvious systems. It is written so a human
+can read it and an agent can verify any claim against the code. Each system section lists
+**invariants** the code must hold.
+
+- When you change a system documented there, update the matching section in the same PR. Do not let
+  the spec and the code drift.
+- If a claim in `SYSTEMS.md` is wrong, fix the doc. If an invariant is violated by the code, fix the
+  code. The code is the source of truth; the doc is the explanation of it.
+- Do not duplicate system behavior in code comments. Put the explanation in `SYSTEMS.md` and keep
+  code comments reserved for genuinely non-obvious local decisions, per the "No comments" rule
+  below. This is the balance between "no comments in files" (drift/stale-comment risk) and
+  "document how it works" (context for humans and agents).
+- When adding a new non-obvious system, add a section to `SYSTEMS.md` with a summary, a diagram, a
+  step-by-step flow, the implementing files, and the invariants.
 
 ## Source-of-Truth Priority
 
@@ -217,6 +236,7 @@ Naming:
 - Generated codebase knowledge base (start at the index): `docs/agent-context/summary/index.md`
 - Style, testing, and validation details: `docs/agent-context/style-and-validation.md`
 - Architecture: `docs/ARCHITECTURE.md`
+- System specs (caching, data fetching, overlay, precompute): `docs/SYSTEMS.md`
 - Rate limiting / abuse ownership: `docs/RATE_LIMITING.md`
 - Contributing: `.github/CONTRIBUTING.md`
 - Runbook: `docs/runbook.md`

--- a/README.md
+++ b/README.md
@@ -2,151 +2,102 @@
 
 [![Crowdin](https://badges.crowdin.net/tarkovtrackerorg/localized.svg)](https://crowdin.com/project/tarkovtrackerorg)
 [![codecov](https://codecov.io/gh/tarkovtracker-org/TarkovTracker/graph/badge.svg)](https://codecov.io/gh/tarkovtracker-org/TarkovTracker)
+[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
-A comprehensive Escape from Tarkov progress tracker built with Nuxt 4, featuring team collaboration, dual game mode support (PvP/PvE), and real-time synchronization via Supabase.
+A friendly, comprehensive progress tracker for **Escape from Tarkov**. Track tasks and hideout
+progress, collaborate with your team in real time, and switch between PvP and PvE modes without
+losing your place. Built with Nuxt 4, Vue 3, Supabase, and Tailwind CSS.
+
+> New here? Issues labeled [`good-first-issue`](https://github.com/tarkovtracker-org/TarkovTracker/labels/good-first-issue)
+> are the easiest way to get familiar with the codebase and the contribution process.
 
 ## Features
 
-- **Dual Game Mode Support**: Track progress separately for PvP and PvE modes
-- **Team Collaboration**: Share progress with teammates in real-time
-- **Task Tracking**: Monitor quest completions and objectives
-- **Hideout Progress**: Track module upgrades and parts
-- **Player Level Progress**: Monitor leveling across different factions
-- **Real-time Sync**: Automatic synchronization via Supabase
-- **Multi-language Support**: Available in English, German, Spanish, French, Russian, Ukrainian, and Chinese. API data can be fetched in additional tarkov.dev-supported languages. Community translations are available through [translate.tarkovtracker.org](https://translate.tarkovtracker.org).
+- **Dual game modes** — track PvP and PvE progress separately.
+- **Team collaboration** — share progress with teammates in real time via Supabase.
+- **Task & objective tracking** — see what is available, what is locked, and what is next.
+- **Hideout progress** — track module upgrades and the parts you still need.
+- **Player level & faction progress** — monitor leveling across factions.
+- **Interactive maps** — explore maps with spawn points and objectives.
+- **Streamer tools** — overlays for content creators.
+- **Multi-language** — English, German, Spanish, French, Russian, Ukrainian, and Chinese, with
+  community translations at [translate.tarkovtracker.org](https://translate.tarkovtracker.org).
+  API data can be fetched in any tarkov.dev-supported language.
 
-## Tech Stack
-
-- **Framework**: Nuxt 4 (SPA mode)
-- **UI**: Nuxt UI component library
-- **Styling**: Tailwind CSS v4
-- **State Management**: Pinia with three-store architecture
-- **Backend**: Supabase (authentication, database, real-time)
-- **API**: Nuxt server-side proxy to json.tarkov.dev static data
-- **Deployment**: Cloudflare Pages
-
-## Setup
-
-Install dependencies (Node >=24.12.0, enables pnpm via Corepack):
+## Quick start
 
 ```bash
-corepack enable
+corepack enable        # enables pnpm via Corepack (Node >=24.12.0)
 pnpm install
+pnpm run dev           # http://localhost:3000
 ```
 
-## Environment Variables
+Copy `.env.example` to `.env` and fill in your Supabase values. Without Supabase configured, the
+app runs in offline mode with localStorage only — auth, sync, realtime, and team features are
+unavailable.
 
-Copy `.env.example` to `.env` and fill in your values:
+> Only `NUXT_PUBLIC_SUPABASE_URL` and `NUXT_PUBLIC_SUPABASE_ANON_KEY` are required for login/sync.
+> Everything else is optional and documented in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
-```env
-# Required for login/sync features
-NUXT_PUBLIC_SUPABASE_URL=your_supabase_project_url
-NUXT_PUBLIC_SUPABASE_ANON_KEY=your_supabase_anonymous_key
+## Common commands
 
-# Optional: App configuration
-# NUXT_PUBLIC_APP_URL=http://localhost:3000
-# NUXT_TARKOV_JSON_BASE_URL=https://json.tarkov.dev
-# NUXT_PUBLIC_ALLOW_DIRECT_TOKEN_CREATE_FALLBACK=false
-# NUXT_PUBLIC_GA_MEASUREMENT_ID=G-XXXXXXXXXX
-# NUXT_PUBLIC_CLARITY_PROJECT_ID=xxxxxxxxxx
-```
+| Task          | Command               |
+| ------------- | --------------------- |
+| Dev server    | `pnpm run dev`        |
+| Build         | `pnpm run build`      |
+| Preview build | `pnpm run preview`    |
+| Lint          | `pnpm run lint`       |
+| Typecheck     | `pnpm run typecheck`  |
+| Tests         | `pnpm run test`       |
+| Test watch    | `pnpm run test:watch` |
 
-`NUXT_PUBLIC_APP_URL` only sets the public app/canonical URL. `NUXT_PUBLIC_GA_MEASUREMENT_ID`
-and `NUXT_PUBLIC_CLARITY_PROJECT_ID` only enable the Google Analytics and Microsoft Clarity
-integration codepaths; they do not start tracking by themselves. Tracking stays disabled until the
-user explicitly opts in through the analytics consent banner or footer "Analytics Preferences"
-control. That opt-in state is managed in `app/composables/useAnalyticsConsent.ts`, and
-`app/plugins/04.analytics-consent-mode.client.ts` keeps analytics consent mode denied until the
-user accepts.
+Run `pnpm run lint`, `pnpm run typecheck`, and `pnpm run test` before pushing. The full command
+list (including i18n, Supabase types, OpenAPI validation, and the API gateway tests) is in
+[`AGENTS.md`](AGENTS.md) and [`docs/WORKFLOW_AUTOMATION.md`](docs/WORKFLOW_AUTOMATION.md).
 
-`NUXT_PUBLIC_ALLOW_DIRECT_TOKEN_CREATE_FALLBACK` is disabled by default and should stay off in
-production. It exists only for controlled local/self-hosted or staggered rollout cases where the
-`token-create` Edge Function is temporarily unavailable and you intentionally accept bypassing
-function-level rate limiting for token creation.
+## Contributing
 
-## Cloudflare Workers
+Each pull request must address **one change only** — a single fix, update, doc improvement, or
+feature. PRs that bundle unrelated changes may be asked to split or be closed.
 
-The project uses one Cloudflare Worker for the public API surface:
-
-- `workers/api-gateway` — API request gateway
-  - `API_GATEWAY_LIMITER` (Durable Object)
-
-## Server API Runtime Notes
-
-- `app/server/api/team/members.ts` uses in-memory Maps for response caching and rate limiting.
-- `app/server/api/profile/[userId]/[mode].get.ts` uses in-memory Maps `sharedProfileRateLimiter` and `sharedProfileCache`.
-- Team and token mutations are rate-limited inside Supabase Edge Functions on a per-user basis.
-- In-memory Maps are local to each running instance and are not shared across serverless/horizontal deployments.
-- For production-wide consistency across both endpoints, use a distributed backend (for example Redis or Cloudflare KV)
-  for rate limiting and caching.
-
-## Development
-
-Start the development server:
-
-```bash
-pnpm run dev
-```
-
-The application will be available at `http://localhost:3000`.
-
-## Code Quality
-
-Run `pnpm run lint`, `pnpm run typecheck`, and `pnpm test` before pushing. See
-[`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) and
-[`docs/WORKFLOW_AUTOMATION.md`](docs/WORKFLOW_AUTOMATION.md) for the full command list, pre-commit
-hooks, and CI details.
-
-## Tarkov.dev Profile Cleanup
-
-The app now persists only the linked `tarkovUid` for tarkov.dev profiles. Legacy manual backups
-created before this cleanup may still contain imported profile snapshots. New imports ignore those
-legacy blobs, but regenerate backups after upgrading if you want future exports to be fully scrubbed.
-
-## Production
-
-Build for production:
-
-```bash
-pnpm run build
-```
-
-Preview production build locally:
-
-```bash
-pnpm run preview
-```
-
-## Project Structure
-
-- `app/` — Nuxt application (features, stores, composables, server routes, shell, locales)
-- `workers/` — Cloudflare Workers (public API gateway)
-- `supabase/` — database migrations and edge functions
-- `docs/` — project documentation
-
-See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) and [`AGENTS.md`](AGENTS.md) for the full map.
+- **[How to contribute](.github/CONTRIBUTING.md)** — issues, branches, PR process, and the PR
+  template.
+- **[Label system](.github/LABELS.md)** — issue types, scope, priority, ownership, and status.
+- **[Project board](.github/PROJECT_BOARD.md)** — how issues move from backlog to done.
 
 ## Documentation
 
-For detailed development guidelines and architecture references, see the [`docs/`](docs/) directory (start at [`docs/README.md`](docs/README.md)).
+The short version: this README gets you running; the `docs/` folder explains how things work.
 
-This repository includes both **contribution workflow guidance** and **technical documentation**.
+| You want to…                                      | Read                                                                    |
+| ------------------------------------------------- | ----------------------------------------------------------------------- |
+| Get started                                       | This README                                                             |
+| Understand the systems (caching, data, overlay)   | [`docs/SYSTEMS.md`](docs/SYSTEMS.md)                                    |
+| Understand the full architecture & data flow      | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)                          |
+| Use or extend the HTTP/API surface                | [`docs/API.md`](docs/API.md)                                            |
+| Understand rate limits / abuse controls           | [`docs/RATE_LIMITING.md`](docs/RATE_LIMITING.md)                        |
+| Deploy, configure env vars, or handle an incident | [`docs/runbook.md`](docs/runbook.md)                                    |
+| Understand CI/CD, hooks, and releases             | [`docs/WORKFLOW_AUTOMATION.md`](docs/WORKFLOW_AUTOMATION.md)            |
+| Contribute (issues, branches, PRs, labels)        | [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md)                    |
+| Work as (or configure) an AI agent                | [`AGENTS.md`](AGENTS.md) + [`docs/agent-context/`](docs/agent-context/) |
 
-[**How to Contribute (Issues, Branches, PR Process):**](.github/CONTRIBUTING.md) Open or pick an issue, get assigned, create a focused branch, Use the PR template, and link the issue.
+Start at [`docs/README.md`](docs/README.md) if you are not sure which doc you need.
 
-> [!IMPORTANT]
-> Each pull request must address **one change only** — a single fix, update, documentation improvement, or new feature.  
-> Pull requests that bundle unrelated changes may be asked to split or be closed.
+## Project structure
 
-[**Label System:**](.github/LABELS.md) Issue Types define the kind of work being done, while labels communicate scope, priority, ownership, and status throughout the lifecycle of the issue.
+```text
+app/         Nuxt 4 source (features, stores, server routes, shell, locales)
+supabase/    Database migrations and edge functions
+workers/     Cloudflare Workers (public API gateway)
+scripts/     Precompute and other tooling
+docs/        Project documentation
+public/      Static assets
+```
 
-[**GitHub Project Board:**](.github/PROJECT_BOARD.md) Issues progress through the board from backlog to completion, with transitions driven by issue and pull request activity.
-
-### Where to start (new contributors)
-
-> [!NOTE]
-> If you’re new to the project, look for issues labeled **`good-first-issue`**. These are intentionally scoped to be approachable and are the best way to get familiar with the codebase, contribution process, and review expectations.
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full module map and
+[`docs/SYSTEMS.md`](docs/SYSTEMS.md) for how the non-obvious systems (Tarkov.dev integration,
+multi-layer caching, overlay corrections, precompute) actually work.
 
 ## License
 
-This project remains licensed under the GNU General Public License v3.0. See [LICENSE.md](LICENSE.md) for the full license text.
+GNU General Public License v3.0 — see [`LICENSE.md`](LICENSE.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -5,17 +5,18 @@ canonical agent contract and project conventions live in the root [`AGENTS.md`](
 
 ## Which doc do I need?
 
-| I want to…                                        | Read                                                               |
-| ------------------------------------------------- | ------------------------------------------------------------------ |
-| Understand the project and get it running         | [`/README.md`](../README.md)                                       |
-| Contribute (issues, branches, PRs, labels)        | [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md)            |
-| Understand the architecture and data flow         | [`ARCHITECTURE.md`](./ARCHITECTURE.md)                             |
-| Use or extend the HTTP/API surface                | [`API.md`](./API.md)                                               |
-| Understand rate limits / abuse controls by layer  | [`RATE_LIMITING.md`](./RATE_LIMITING.md)                           |
-| Deploy, configure env vars, or handle an incident | [`runbook.md`](./runbook.md)                                       |
-| Understand CI/CD, hooks, and releases             | [`WORKFLOW_AUTOMATION.md`](./WORKFLOW_AUTOMATION.md)               |
-| Follow the visual/design system                   | [`/DESIGN.md`](../DESIGN.md)                                       |
-| Work as (or configure) an AI agent                | [`AGENTS.md`](../AGENTS.md) + [`agent-context/`](./agent-context/) |
+| I want to…                                                                        | Read                                                               |
+| --------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| Understand the project and get it running                                         | [`/README.md`](../README.md)                                       |
+| Contribute (issues, branches, PRs, labels)                                        | [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md)            |
+| Understand how a specific system works (caching, data fetch, overlay, precompute) | [`SYSTEMS.md`](./SYSTEMS.md)                                       |
+| Understand the deeper architecture, state model, and data flows                   | [`ARCHITECTURE.md`](./ARCHITECTURE.md)                             |
+| Use or extend the HTTP/API surface                                                | [`API.md`](./API.md)                                               |
+| Understand rate limits / abuse controls by layer                                  | [`RATE_LIMITING.md`](./RATE_LIMITING.md)                           |
+| Deploy, configure env vars, or handle an incident                                 | [`runbook.md`](./runbook.md)                                       |
+| Understand CI/CD, hooks, and releases                                             | [`WORKFLOW_AUTOMATION.md`](./WORKFLOW_AUTOMATION.md)               |
+| Follow the visual/design system                                                   | [`/DESIGN.md`](../DESIGN.md)                                       |
+| Work as (or configure) an AI agent                                                | [`AGENTS.md`](../AGENTS.md) + [`agent-context/`](./agent-context/) |
 
 ## Document map
 
@@ -23,7 +24,8 @@ canonical agent contract and project conventions live in the root [`AGENTS.md`](
 
 - [`/README.md`](../README.md) — public overview, features, quick start.
 - [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md) — contribution workflow, issues, labels, project board.
-- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — system architecture, state model, sync, caching, and the canonical environment-variable map.
+- [`SYSTEMS.md`](./SYSTEMS.md) — plain-language spec of the non-obvious systems (Tarkov.dev integration, data fetching, multi-layer caching, overlay, precompute) with diagrams and invariants. Covers **what systems exist, what they own, and how they interact**. Point at this when asking "why does the app do X?".
+- [`ARCHITECTURE.md`](./ARCHITECTURE.md) — deeper technical structure: state model, sync, data flows, implementation decisions, tradeoffs, and the canonical environment-variable map. `SYSTEMS.md` is the entry point for system behavior; `ARCHITECTURE.md` is the deeper reference for how the app is built.
 - [`API.md`](./API.md) — endpoint reference, caching, supported languages, game modes.
 - [`RATE_LIMITING.md`](./RATE_LIMITING.md) — ownership map for API, Edge, Pages, DB, and Auth rate-limit systems.
 - [`runbook.md`](./runbook.md) — required env vars, pre-deploy checks, incident triage and recovery.
@@ -38,7 +40,8 @@ canonical agent contract and project conventions live in the root [`AGENTS.md`](
 
 > To avoid drift, each fact has a single owner: code style and commit scopes live in `AGENTS.md`;
 > the environment-variable map lives in `ARCHITECTURE.md` and `runbook.md`; API details live in
-> `API.md`; rate-limit ownership lives in `RATE_LIMITING.md`. Other documents link to those owners
+> `API.md`; rate-limit ownership lives in `RATE_LIMITING.md`; plain-language system specs (caching,
+> data fetching, overlay, precompute) live in `SYSTEMS.md`. Other documents link to those owners
 > instead of restating them.
 
 ## Maintainer notes

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1,0 +1,383 @@
+# TarkovTracker Systems Spec
+
+This document explains **how the non-obvious systems in TarkovTracker actually work**, in plain
+language with diagrams. It is the spec you point at when you want to ask "why does the app do X?"
+and have an agent verify the answer against the code.
+
+> **How to use this doc**
+>
+> - Each system has: a short plain-English summary, a diagram, a step-by-step flow, a list of the
+>   files that implement it, and the **invariants** the code must hold. If the code and an invariant
+>   disagree, the code is the bug (or the invariant is stale — fix the doc in the same PR).
+> - File paths are relative to the repo root so agents can open them directly.
+> - When a system changes, update its section here in the same PR. `AGENTS.md` enforces this.
+
+## Systems covered
+
+1. [Tarkov.dev data integration](#1-tarkovdev-data-integration) — where game data comes from
+2. [Data fetching pipeline](#2-data-fetching-pipeline) — retries, timeouts, translations, dedup
+3. [Multi-layer caching](#3-multi-layer-caching) — the four cache layers and how they fall through
+4. [Overlay corrections](#4-overlay-corrections) — fixing wrong upstream data
+5. [Precompute workflow](#5-precompute-workflow) — warming KV off the request path
+
+---
+
+## 1. Tarkov.dev data integration
+
+**Summary.** TarkovTracker does not ship its own copy of the game database. Static game data
+(tasks, hideout stations, items, maps, traders, prestige levels, player levels, map spawns) comes
+from the community-maintained `json.tarkov.dev` static JSON API. The browser never calls
+`json.tarkov.dev` directly — every request goes through our own Nitro server routes under
+`/api/tarkov/*`. The server route fetches from upstream, adapts the raw JSON into the shape our
+client expects, applies corrections (see [Overlay](#4-overlay-corrections)), and returns it.
+
+**Why a proxy instead of calling upstream from the browser?**
+
+- We control caching headers and can serve stale-while-revalidate from the Cloudflare edge.
+- We can apply the overlay and adapt the payload once on the server instead of in every client.
+- We can keep the upstream retry/timeout budget server-side (see [Data fetching](#2)).
+- We avoid leaking the user's IP to a third party and avoid CORS quirks.
+
+### Endpoints
+
+| Endpoint                       | Purpose              | Cache TTL | Precomputed? |
+| ------------------------------ | -------------------- | --------- | ------------ |
+| `/api/tarkov/bootstrap`        | Player levels        | 12h       | no           |
+| `/api/tarkov/tasks-core`       | Tasks, maps, traders | 12h       | **yes**      |
+| `/api/tarkov/tasks-objectives` | Task objectives      | 12h       | no           |
+| `/api/tarkov/tasks-rewards`    | Task rewards         | 12h       | no           |
+| `/api/tarkov/hideout`          | Hideout stations     | 12h       | no           |
+| `/api/tarkov/items-lite`       | Items (minimal)      | 24h       | no           |
+| `/api/tarkov/items`            | Items (full)         | 24h       | no           |
+| `/api/tarkov/prestige`         | Prestige levels      | 24h       | no           |
+| `/api/tarkov/map-spawns`       | Map spawn points     | 12h       | no           |
+| `/api/tarkov/cache-meta`       | Cache purge status   | 5m edge   | no           |
+
+Only `tasks-core` is precomputed today (it is the largest, hottest, and most expensive payload).
+See [Precompute](#5-precompute-workflow).
+
+### Diagram
+
+```mermaid
+flowchart LR
+    Browser["Vue SPA<br/>(client)"] -->|GET /api/tarkov/*| Route["Nitro route<br/>app/server/api/tarkov/*.get.ts"]
+    Route --> Cache["edgeCache()<br/>app/server/utils/edgeCache.ts"]
+    Cache -->|miss| Fetch["tarkov-json.ts<br/>fetch + adapt"]
+    Fetch -->|HTTPS| Upstream["json.tarkov.dev"]
+    Fetch --> Overlay["applyOverlay()<br/>app/server/utils/overlay.ts"]
+    Overlay --> Cache
+    Cache --> Browser
+```
+
+### Files
+
+- `app/server/api/tarkov/*.get.ts` — one handler per endpoint; thin wrappers around `edgeCache`.
+- `app/server/utils/tarkov-json.ts` — upstream fetch + adapt into client types.
+- `app/server/utils/tarkov-cache-config.ts` — TTL constants and game-mode validation.
+- `app/types/tarkov.ts` — the adapted shapes the client stores.
+
+### Invariants
+
+- The browser must never call `json.tarkov.dev` directly. All static game data flows through
+  `/api/tarkov/*`.
+- Every endpoint handler returns its payload through `edgeCache()`; no handler fetches upstream
+  outside the cache wrapper.
+- Game mode is validated with `validateGameMode()` and defaults to `regular` on any invalid input.
+- Language is validated with `getValidatedLanguage()` and defaults to `en`.
+
+---
+
+## 2. Data fetching pipeline
+
+**Summary.** `tarkov-json.ts` is the only module that talks to `json.tarkov.dev`. It fetches the
+base (English) envelope, fetches the requested language envelope (and an English fallback if the
+requested language is not English), then applies translations onto the base data. It has bounded
+retries, a hard timeout, and deduplication of in-flight requests so a burst of cache misses for the
+same payload only hits upstream once.
+
+### Flow
+
+```mermaid
+sequenceDiagram
+    participant Handler as Nitro handler
+    participant Json as tarkov-json.ts
+    participant Upstream as json.tarkov.dev
+    Handler->>Json: fetchTarkovJsonEndpoint('tasks', { lang, gameMode })
+    Json->>Json: buildPath(gameMode, 'tasks') -> "regular/tasks"
+    Json->>Json: check inFlightEnvelopeFetches dedup map
+    Json->>Upstream: GET base envelope (retry 2x, 12s timeout)
+    Upstream-->>Json: { data, translations: ["$.tasks[*].name", ...] }
+    alt no translations array
+        Json-->>Handler: base data as-is
+    else has translations
+        par primary language
+            Json->>Upstream: GET "regular/tasks_<lang>"
+            Upstream-->>Json: { data: { "Task Name": "Translated" } }
+        and English fallback (if lang != en)
+            Json->>Upstream: GET "regular/tasks_en"
+            Upstream-->>Json: { data: { "Task Name": "English" } }
+        end
+        Json->>Json: applyTranslations(base, primary, fallback)
+        Json-->>Handler: translated data
+    end
+```
+
+### Retry, timeout, and dedup budget
+
+- `DEFAULT_TIMEOUT_MS = 12000` per attempt, `DEFAULT_MAX_RETRIES = 2` attempts per envelope.
+- Exponential backoff between attempts: 1s, then 2s, capped at 5s.
+- The total upstream budget is bounded under Cloudflare's 100s origin limit. Worst case per route
+  is roughly 2 legs (base + lang/en) × (2 retries × 12s + backoff) + overlay ≈ 55s, which fails
+  fast (502) instead of triggering a 524.
+- `inFlightEnvelopeFetches` is a module-level `Map<key, Promise>`. A concurrent cache miss for the
+  same URL shares one upstream request. The key is `${url}|${timeoutMs}|${maxRetries}`.
+
+### Translation application
+
+`json.tarkov.dev` returns a `translations` array of JSONPath strings (e.g. `$.tasks[*].name`) that
+point at string keys to look up in the language envelope. `applyTranslations` walks those paths and
+replaces the key with the translated string.
+
+- A fast path (`immutableUpdate`) handles the common JSONPath shapes (`*`, `prop[*]`, `prop`)
+  without a dependency.
+- If a path shape is not handled by the fast path, it falls back to `jsonpath-plus` for correctness.
+- Primary language wins; English is the fallback when a key is missing in the primary language.
+
+### Files
+
+- `app/server/utils/tarkov-json.ts` — fetch, retry, dedup, adapt, translate.
+- `app/server/utils/language-helpers.ts` — `getValidatedLanguage()`.
+
+### Invariants
+
+- Only `tarkov-json.ts` imports a fetcher for `json.tarkov.dev`. No other module hits upstream.
+- Every upstream call uses `fetchEnvelope` (which enforces timeout + retry + dedup). No raw `$fetch`
+  to upstream anywhere else.
+- A missing translation falls back to English, never to the raw translation key.
+- The upstream budget must stay under Cloudflare's 100s origin limit. If you add a new leg, budget
+  it here.
+
+---
+
+## 3. Multi-layer caching
+
+**Summary.** Game data is served from a four-layer cache that falls through on miss. The goal is:
+**a warm colo never blocks on upstream, and a slow or failing upstream never blocks the user.**
+
+### The four layers (in order)
+
+1. **Precomputed KV** (globally replicated) — only when `edgeCache({ precomputed: true })`. Reads
+   the `TARKOV_DATA` KV binding populated by the scheduled precompute workflow. See
+   [Precompute](#5-precompute-workflow).
+2. **Edge Cache API** (per-colo, Cloudflare `caches.default`) — the standard layer. Stores the
+   adapted + overlay-applied payload with `s-maxage = ttl + staleTtl`.
+3. **Upstream fetch** — on a cold miss, run the full pipeline (fetch → adapt → overlay) and write
+   the result back into the edge cache.
+4. **Dev fallback** — when running locally with no Cache API (`globalThis.caches` undefined), skip
+   caching entirely and always fetch. Sets `X-Cache-Status: DEV`.
+
+On top of these, the **client** has its own IndexedDB cache in `useMetadataStore` so the browser
+does not re-fetch on every navigation. That layer is documented in `ARCHITECTURE.md`.
+
+### Stale-while-revalidate
+
+When an edge cache entry exists but is older than `ttl`, the handler:
+
+1. Returns the stale payload immediately with `X-Cache-Status: STALE`.
+2. Kicks off a background refresh via `reviveCacheEntry()`, guarded by an `inFlightRevalidations`
+   set so only one refresh per key runs at a time.
+3. Uses `ctx.waitUntil()` on Cloudflare so the response is not cut off when the request returns.
+
+This is why a slow upstream never blocks a warm colo: the user gets stale data in milliseconds and
+the refresh happens after the response is sent.
+
+### Bypass
+
+`shouldBypassCache(event)` returns true when `NUXT_CACHE_BYPASS_ENABLED` is on AND the request sends
+`x-bypass-cache` / `x-cache-bypass` header, or `?nocache` / `?cacheBust` query. Bypass skips both KV
+and edge cache, fetches fresh, and sets `X-Cache-Status: BYPASS`. Used for forcing a refresh after a
+data correction.
+
+### Diagram
+
+```mermaid
+flowchart TD
+    Req["Request to /api/tarkov/*"] --> Bypass{Bypass requested?}
+    Bypass -->|yes| FetchFresh["Fetch fresh, return BYPASS"]
+    Bypass -->|no| Pre{precomputed option?}
+    Pre -->|yes| KV["Read TARKOV_DATA KV"]
+    Pre -->|no| Edge
+    KV --> Envelope{valid envelope?}
+    Envelope -->|yes| ReturnPre["Return PRECOMPUTE"]
+    Envelope -->|no / missing / error| Edge
+    Edge["Edge Cache API match()"] --> Hit{cached?}
+    Hit -->|yes| Stale{storedAt > ttl?}
+    Stale -->|no| ReturnHit["Return HIT"]
+    Stale -->|yes| ReturnStale["Return STALE + background refresh"]
+    Hit -->|no| Miss["Fetch fresh, write edge cache"]
+    Miss --> ReturnMiss["Return MISS"]
+    FetchFresh --> End
+    ReturnPre --> End
+    ReturnHit --> End
+    ReturnStale --> End
+    ReturnMiss --> End
+    End["Response with X-Cache-Status header"]
+```
+
+### Response headers
+
+| Header                | Meaning                                                             |
+| --------------------- | ------------------------------------------------------------------- |
+| `X-Cache-Status`      | One of `PRECOMPUTE`, `HIT`, `STALE`, `MISS`, `BYPASS`, `DEV`        |
+| `X-Cache-Key`         | Full cache key (`prefix-key`)                                       |
+| `Cache-Control`       | `public, max-age=ttl, s-maxage=ttl` for fresh; `no-cache` otherwise |
+| `X-Overlay-Status`    | Overlay result (`fresh` / `cached` / `stale` / `missing`)           |
+| `X-Overlay-Version`   | Overlay `$meta.version`                                             |
+| `X-Overlay-Generated` | Overlay `$meta.generated` timestamp                                 |
+| `X-Overlay-Sha256`    | Overlay `$meta.sha256`                                              |
+
+### Files
+
+- `app/server/utils/edgeCache.ts` — the `edgeCache()` function and `reviveCacheEntry()`.
+- `app/server/utils/edgeCacheKey.ts` — builds the synthetic `Request` used as the Cache API key.
+- `app/server/utils/edgeCacheSanitizers.ts` — sanitizes error messages before they reach the client.
+- `app/server/utils/precomputedTarkov.ts` — KV binding contract shared with `scripts/precompute`.
+- `app/server/utils/tarkov-cache-config.ts` — `CACHE_TTL_DEFAULT` (12h), `CACHE_TTL_EXTENDED` (24h).
+
+### Invariants
+
+- Cache layers must be checked in order: precomputed KV → edge Cache API → upstream. Never skip a
+  layer or reorder them.
+- A `STALE` response must always trigger exactly one background refresh (guarded by
+  `inFlightRevalidations`).
+- `X-Cache-Status` must be set on every response, including errors from the dev fallback path.
+- The cache key must include language and game mode so two locales or modes never share an entry.
+- The precomputed envelope is only trusted if `isPrecomputedEnvelope()` returns true; a corrupt
+  write falls through to the edge cache instead of serving `null`.
+
+---
+
+## 4. Overlay corrections
+
+**Summary.** `json.tarkov.dev` is community-maintained and sometimes wrong (e.g. a task's
+`minPlayerLevel` is off). The `tarkov-data-overlay` repo publishes a small JSON of corrections.
+TarkovTracker fetches that overlay on the server, deep-merges it onto the upstream data, and
+attaches overlay metadata to the response headers so we can tell which version was applied.
+
+### Flow
+
+```mermaid
+sequenceDiagram
+    participant Handler
+    participant Overlay as overlay.ts
+    participant GitHub as raw.githubusercontent.com<br/>tarkov-data-overlay
+    Handler->>Overlay: applyOverlay(basePayload, { gameMode, bypassCache })
+    Overlay->>Overlay: check module cache (1h TTL)
+    alt cache fresh
+        Overlay-->>Overlay: use cached overlay
+    else stale or missing
+        Overlay->>GitHub: GET dist/overlay.json (5s timeout)
+        GitHub-->>Overlay: overlay JSON + $meta
+        Note over Overlay: on fetch error, fall back to last good overlay
+    end
+    Overlay->>Overlay: deepMerge(base, mode-specific + global corrections)
+    Overlay->>Overlay: inferFoundInRaid / inferObjectiveType / normalizeObjectiveList
+    Overlay-->>Handler: corrected payload + dataOverlay meta
+```
+
+### Behavior details
+
+- Module-level cache (`cachedOverlay`, `cacheTimestamp`) with a 1-hour TTL
+  (`OVERLAY_CACHE_TTL = 3600000`).
+- On fetch failure, serves the last good overlay (stale) rather than failing the request.
+- Overlay supports mode-specific corrections under `modes[gameMode]` plus global corrections.
+- `tasksAdd` lets the overlay inject entirely new tasks not present upstream.
+- Objective post-processing (`objectiveTypeInferrer.ts`) normalizes objective lists and infers
+  `foundInRaid` flags so the client does not have to guess.
+- `bypassCache: true` (from `shouldBypassCache`) forces a fresh overlay fetch — used after publishing
+  a correction.
+
+### Files
+
+- `app/server/utils/overlay.ts` — fetch, cache, merge.
+- `app/server/utils/deepMerge.ts` — `deepMerge` + `isPlainObject`.
+- `app/server/utils/objectiveTypeInferrer.ts` — objective normalization.
+
+### Invariants
+
+- The overlay must never block the request path on a fresh fetch for more than
+  `FETCH_TIMEOUT_MS = 5000`. On timeout, fall back to the cached overlay.
+- A missing or malformed overlay must never cause a 5xx; the base payload is returned with
+  `X-Overlay-Status: missing`.
+- Overlay metadata (`status`, `version`, `generated`, `sha256`) must be propagated to response
+  headers so we can debug which correction was applied.
+
+---
+
+## 5. Precompute workflow
+
+**Summary.** `tasks-core` is the single largest, hottest, and most expensive payload — adapting it
+inside a request on a cold, low-traffic Cloudflare colo used to exceed the Workers Free tier CPU
+limit and trigger Error 1102. The fix: compute the final payload **off the request path** in a
+scheduled GitHub Actions workflow, write it to the `TARKOV_DATA` KV namespace, and have the request
+handler read it back through `edgeCache({ precomputed: true })`.
+
+### Why GitHub Actions and not a scheduled Worker?
+
+The account is on the Workers Free tier, whose CPU limit rules out a scheduled Worker doing the full
+adapt pipeline. A scheduled GitHub Actions workflow on `pnpm` has no such limit and can reuse the
+exact same `app/server/utils` pipeline via `tsx` with the repo's tsconfig paths, so the precompute
+output is byte-identical to what the request handler would have produced.
+
+### Flow
+
+```mermaid
+flowchart LR
+    Schedule["GitHub Actions schedule<br/>.github/workflows/precompute-tarkov-data.yml"] --> Run["scripts/precompute/run.ts"]
+    Run --> Pipeline["Reuses app/server/utils<br/>fetch → adapt → overlay"]
+    Pipeline --> Envelopes["buildPrecomputedEnvelope(payload)<br/>for each (lang, gameMode) combo"]
+    Envelopes --> KV["KV REST API<br/>PUT /accounts/.../values/:key"]
+    KV --> Namespace["TARKOV_DATA KV namespace<br/>(globally replicated)"]
+    Request["Request to /api/tarkov/tasks-core"] --> ReadKV["edgeCache precomputed path<br/>reads TARKOV_DATA binding"]
+    ReadKV --> Namespace
+```
+
+### Key contract
+
+- The KV binding name is `TARKOV_DATA` (`PRECOMPUTED_KV_BINDING`).
+- The envelope shape is `{ payload, storedAt, version }` with
+  `PRECOMPUTED_ENVELOPE_VERSION = 1`.
+- The cache key for `tasks-core` is built by `buildTasksCorePrecomputedKey(lang, gameMode)` and is
+  `tasks-core-json-v2-<lang>-<gameMode>`. Both the precompute script and the request handler import
+  this function from `precomputedTarkov.ts`, so the keys can never drift.
+- Writes go through the Cloudflare REST API (one PUT per key) because the bulk endpoint's request
+  size ceiling cannot hold all ~4.2MB envelopes in one call, and per-key writes isolate failures per
+  `(lang, gameMode)` combo.
+
+### Files
+
+- `scripts/precompute/precompute.ts` — pipeline orchestration and `KvWriter` interface.
+- `scripts/precompute/run.ts` — entry point invoked by the workflow.
+- `scripts/precompute/kv.ts` — Cloudflare KV REST writer.
+- `scripts/precompute/nuxt-imports.ts` — bridges Nuxt auto-imports for `tsx`.
+- `.github/workflows/precompute-tarkov-data.yml` — schedule and secrets.
+- `app/server/utils/precomputedTarkov.ts` — shared contract (binding name, envelope, key builder).
+
+### Invariants
+
+- The precompute script and the request handler must build the cache key with the same function
+  (`buildTasksCorePrecomputedKey`). Never hard-code the key on either side.
+- The envelope version must be bumped any time the envelope shape changes; old envelopes must be
+  rejected by `isPrecomputedEnvelope()` and fall through to the edge cache.
+- A missing or corrupt KV entry must fall through to the edge cache path, never 5xx.
+- The precompute pipeline must reuse `app/server/utils` — it must not re-implement the adapt/overlay
+  logic or the outputs will diverge from what the request handler would produce.
+
+---
+
+## When this doc is wrong
+
+If you read something here that does not match the code, the disagreement is a bug — either in the
+code (fix the code) or in this doc (fix the doc in the same PR). `AGENTS.md`'s Maintenance Contract
+requires updating this file whenever one of these systems changes. When in doubt, the code is the
+source of truth and this doc is the explanation of it.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -29,29 +29,34 @@ and have an agent verify the answer against the code.
 from the community-maintained `json.tarkov.dev` static JSON API. The browser never calls
 `json.tarkov.dev` directly — every request goes through our own Nitro server routes under
 `/api/tarkov/*`. The server route fetches from upstream, adapts the raw JSON into the shape our
-client expects, applies corrections (see [Overlay](#4-overlay-corrections)), and returns it.
+client expects, and (for most endpoints) applies corrections (see [Overlay](#4-overlay-corrections))
+before returning it.
 
 **Why a proxy instead of calling upstream from the browser?**
 
 - We control caching headers and can serve stale-while-revalidate from the Cloudflare edge.
 - We can apply the overlay and adapt the payload once on the server instead of in every client.
-- We can keep the upstream retry/timeout budget server-side (see [Data fetching](#2)).
+- We can keep the upstream retry/timeout budget server-side (see [Data fetching](#2-data-fetching-pipeline)).
 - We avoid leaking the user's IP to a third party and avoid CORS quirks.
 
 ### Endpoints
 
-| Endpoint                       | Purpose              | Cache TTL | Precomputed? |
-| ------------------------------ | -------------------- | --------- | ------------ |
-| `/api/tarkov/bootstrap`        | Player levels        | 12h       | no           |
-| `/api/tarkov/tasks-core`       | Tasks, maps, traders | 12h       | **yes**      |
-| `/api/tarkov/tasks-objectives` | Task objectives      | 12h       | no           |
-| `/api/tarkov/tasks-rewards`    | Task rewards         | 12h       | no           |
-| `/api/tarkov/hideout`          | Hideout stations     | 12h       | no           |
-| `/api/tarkov/items-lite`       | Items (minimal)      | 24h       | no           |
-| `/api/tarkov/items`            | Items (full)         | 24h       | no           |
-| `/api/tarkov/prestige`         | Prestige levels      | 24h       | no           |
-| `/api/tarkov/map-spawns`       | Map spawn points     | 12h       | no           |
-| `/api/tarkov/cache-meta`       | Cache purge status   | 5m edge   | no           |
+| Endpoint                       | Purpose              | Cache TTL | Precomputed? | Overlay? |
+| ------------------------------ | -------------------- | --------- | ------------ | -------- |
+| `/api/tarkov/bootstrap`        | Player levels        | 12h       | no           | no       |
+| `/api/tarkov/tasks-core`       | Tasks, maps, traders | 12h       | **yes**      | yes      |
+| `/api/tarkov/tasks-objectives` | Task objectives      | 12h       | no           | yes      |
+| `/api/tarkov/tasks-rewards`    | Task rewards         | 12h       | no           | yes      |
+| `/api/tarkov/hideout`          | Hideout stations     | 12h       | no           | yes      |
+| `/api/tarkov/items-lite`       | Items (minimal)      | 24h       | no           | yes      |
+| `/api/tarkov/items`            | Items (full)         | 24h       | no           | yes      |
+| `/api/tarkov/prestige`         | Prestige levels      | 24h       | no           | no       |
+| `/api/tarkov/map-spawns`       | Map spawn points     | 12h       | no           | no       |
+| `/api/tarkov/cache-meta`       | Cache purge status   | 5m edge   | no           | no       |
+
+Overlay is applied by the six task/hideout/item endpoints. `bootstrap`, `prestige`,
+`map-spawns`, and `cache-meta` fetch directly into `edgeCache` without the overlay step —
+their upstream data does not currently need corrections.
 
 Only `tasks-core` is precomputed today (it is the largest, hottest, and most expensive payload).
 See [Precompute](#5-precompute-workflow).
@@ -64,8 +69,10 @@ flowchart LR
     Route --> Cache["edgeCache()<br/>app/server/utils/edgeCache.ts"]
     Cache -->|miss| Fetch["tarkov-json.ts<br/>fetch + adapt"]
     Fetch -->|HTTPS| Upstream["json.tarkov.dev"]
-    Fetch --> Overlay["applyOverlay()<br/>app/server/utils/overlay.ts"]
-    Overlay --> Cache
+    Fetch --> Overlay{"Overlay?<br/>(6 of 10 endpoints)"}
+    Overlay -->|yes| ApplyOverlay["applyOverlay()<br/>app/server/utils/overlay.ts"]
+    Overlay -->|no| Cache
+    ApplyOverlay --> Cache
     Cache --> Browser
 ```
 
@@ -82,6 +89,8 @@ flowchart LR
   `/api/tarkov/*`.
 - Every endpoint handler returns its payload through `edgeCache()`; no handler fetches upstream
   outside the cache wrapper.
+- Overlay is applied only by endpoints that call `applyOverlay()` in their handler. Adding a new
+  endpoint does not imply adding overlay — only add it when the upstream data needs corrections.
 - Game mode is validated with `validateGameMode()` and defaults to `regular` on any invalid input.
 - Language is validated with `getValidatedLanguage()` and defaults to `en`.
 
@@ -153,7 +162,8 @@ replaces the key with the translated string.
 - Only `tarkov-json.ts` imports a fetcher for `json.tarkov.dev`. No other module hits upstream.
 - Every upstream call uses `fetchEnvelope` (which enforces timeout + retry + dedup). No raw `$fetch`
   to upstream anywhere else.
-- A missing translation falls back to English, never to the raw translation key.
+- A missing translation falls back to English when available; otherwise, the original
+  translation key is preserved.
 - The upstream budget must stay under Cloudflare's 100s origin limit. If you add a new leg, budget
   it here.
 
@@ -250,7 +260,9 @@ flowchart TD
   layer or reorder them.
 - A `STALE` response must always trigger exactly one background refresh (guarded by
   `inFlightRevalidations`).
-- `X-Cache-Status` must be set on every response, including errors from the dev fallback path.
+- `X-Cache-Status` must be set on every successful response. Error responses from the
+  catch block (502 on upstream failure) do not set it — the invariant covers the success
+  paths only.
 - The cache key must include language and game mode so two locales or modes never share an entry.
 - The precomputed envelope is only trusted if `isPrecomputedEnvelope()` returns true; a corrupt
   write falls through to the edge cache instead of serving `null`.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -212,7 +212,9 @@ data correction.
 
 ```mermaid
 flowchart TD
-    Req["Request to /api/tarkov/*"] --> Bypass{Bypass requested?}
+    Req["Request to /api/tarkov/*"] --> CacheAvail{Cache API available?}
+    CacheAvail -->|no| Dev["Fetch fresh, return DEV<br/>(local dev, no edge cache)"]
+    CacheAvail -->|yes| Bypass{Bypass requested?}
     Bypass -->|yes| FetchFresh["Fetch fresh, return BYPASS"]
     Bypass -->|no| Pre{precomputed option?}
     Pre -->|yes| KV["Read TARKOV_DATA KV"]
@@ -226,6 +228,7 @@ flowchart TD
     Stale -->|yes| ReturnStale["Return STALE + background refresh"]
     Hit -->|no| Miss["Fetch fresh, write edge cache"]
     Miss --> ReturnMiss["Return MISS"]
+    Dev --> End
     FetchFresh --> End
     ReturnPre --> End
     ReturnHit --> End


### PR DESCRIPTION
## **User description**
## Summary

- Revamp `README.md` as a user-first, scannable landing page and move infrastructure detail out to the docs that already own those facts. Add the Greptile badge.
- Add `docs/SYSTEMS.md`: a plain-language spec for the non-obvious systems (Tarkov.dev integration, data fetching pipeline, multi-layer caching, overlay corrections, precompute workflow) with mermaid diagrams and invariants the code must hold.
- Wire `SYSTEMS.md` into `docs/README.md` (routing table + document map) and sharpen the `SYSTEMS.md` vs `ARCHITECTURE.md` distinction so the two do not become interchangeable.
- Extend `AGENTS.md`'s Maintenance Contract so changes to a system documented in `SYSTEMS.md` require updating the spec in the same PR, and add a "System spec sync" subsection that sets the balance between "no comments in files" and "document how it works".

### What information moved

| Moved out of README | New owner |
| --- | --- |
| Full environment-variable tables | `docs/ARCHITECTURE.md`, `docs/runbook.md` |
| Analytics consent implementation detail | `docs/ARCHITECTURE.md` |
| Direct-token fallback warning | `docs/runbook.md` |
| Cloudflare Worker topology | `docs/ARCHITECTURE.md` |
| In-memory rate-limiting caveats | `docs/RATE_LIMITING.md` |
| Tarkov.dev legacy profile cleanup note | removed from the landing page (release-note material) |
| Detailed tech stack | `docs/ARCHITECTURE.md` |

### How `SYSTEMS.md` differs from `ARCHITECTURE.md`

- **`SYSTEMS.md`** — what major systems exist, what they own, and how they interact. Entry point for "why does the app do X?".
- **`ARCHITECTURE.md`** — deeper technical structure: state model, sync, data flows, implementation decisions, tradeoffs, and the canonical environment-variable map.

### What remains intentionally unchanged

- `docs/ARCHITECTURE.md` is not deduplicated in this PR. Its caching section is a higher-level treatment and remains the deeper reference; `SYSTEMS.md` is the behavior spec. A follow-up can trim overlap if it becomes confusing.
- No code, locale, or config changes. No contributor-guide restructuring, community-health docs, or issue-taxonomy changes — those are separate PRs per the repo's one-change-per-PR rule.

#### Test plan

- [x] `npx prettier --check` passes on all four changed files
- [x] All relative links in changed files resolve on disk
- [x] husky + lint-staged pre-commit hook passed
- [ ] CI `link-check` (lychee) passes
- [ ] CI `format:check` passes


___

## **CodeAnt-AI Description**
**Rework the README and add a system spec for core app behavior**

### What Changed
- The README is now a shorter, user-facing landing page with quick start steps, common commands, a doc map, and a clearer path for new contributors.
- Added `docs/SYSTEMS.md` as a plain-language spec for the app’s non-obvious systems, including Tarkov.dev data loading, caching, overlay corrections, and precompute behavior.
- Updated `docs/README.md` and `AGENTS.md` to point to the new system spec and require it to stay in sync whenever one of those systems changes.

### Impact
`✅ Faster onboarding`
`✅ Clearer project documentation`
`✅ Fewer stale system docs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added `docs/SYSTEMS.md`, a plain-English systems specification describing core runtime flows, caching/refresh behavior, retry/timeout rules, overlay corrections, and precompute consistency guarantees.
  * Updated `AGENTS.md` with guidance to keep system documentation synchronized with actual behavior and address invariant/spec mismatches.
  * Improved `docs/README.md` with clearer doc discovery (table layout) and expanded system-spec ownership notes.
  * Streamlined `README.md` into a shorter, structured overview with a simplified quick start (including offline-mode behavior), common commands, and easier navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->