### PR TITLE
docs: add community health files and standardize support routing

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,11 +54,12 @@
 /AGENTS.md                @DysektAI
 /app/locales/en.json      @DysektAI
 
-# Public-facing docs and community health files (voice / policy integrity)
+# Public-facing docs and community health files (voice / policy integrity).
+# Paths under /.github/ (CONTRIBUTING.md, ISSUE_TEMPLATE/) are already covered
+# by the /.github/ catch-all above and are intentionally not restated here —
+# restating them would silently override a future team expansion of that rule.
 /README.md                @DysektAI
 /docs/                    @DysektAI
-/.github/CONTRIBUTING.md  @DysektAI
-/.github/ISSUE_TEMPLATE/  @DysektAI
 /SECURITY.md              @DysektAI
 /SUPPORT.md               @DysektAI
 /CODE_OF_CONDUCT.md       @DysektAI

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,3 +53,12 @@
 # Agent contract + source locale (drift / instruction integrity)
 /AGENTS.md                @DysektAI
 /app/locales/en.json      @DysektAI
+
+# Public-facing docs and community health files (voice / policy integrity)
+/README.md                @DysektAI
+/docs/                    @DysektAI
+/.github/CONTRIBUTING.md  @DysektAI
+/.github/ISSUE_TEMPLATE/  @DysektAI
+/SECURITY.md              @DysektAI
+/SUPPORT.md               @DysektAI
+/CODE_OF_CONDUCT.md       @DysektAI

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -19,7 +19,10 @@ Thank you for your interest in contributing to TarkovTracker! This document prov
 
 ## Code of Conduct
 
-Please be respectful and constructive in all interactions. We're building a tool for the Tarkov community together.
+Participation in this project is governed by the [`Code of Conduct`](../CODE_OF_CONDUCT.md).
+Please read it before contributing. In short: be respectful and constructive —
+we are building a tool for the Tarkov community together. Report conduct issues
+to <mailto:support@tarkovtracker.org> or via Discord DM to a maintainer.
 
 ## Getting Started
 
@@ -27,7 +30,11 @@ Please be respectful and constructive in all interactions. We're building a tool
 
 1. **Fork the repository** and clone your fork locally
 2. **Install dependencies**: `corepack enable && corepack prepare pnpm@11.14.0 --activate && pnpm install`
-3. **Set up environment**: Copy `.env.example` to `.env` and add your Supabase credentials.
+3. **Set up environment**: either run `pnpm run setup` (writes `.env.local` with
+   local defaults) or copy `.env.example` to `.env` manually, then add your
+   Supabase credentials. Both paths work; `.env.local` takes precedence over
+   `.env`. See [`docs/WORKFLOW_AUTOMATION.md`](../docs/WORKFLOW_AUTOMATION.md)
+   for the distinction.
    Full env-var reference: [`docs/runbook.md`](../docs/runbook.md) and [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md).
 4. **Start dev server**: `pnpm run dev`
 5. **Read [`AGENTS.md`](../AGENTS.md)** for detailed development guidelines

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,11 +30,11 @@ to <mailto:support@tarkovtracker.org> or via Discord DM to a maintainer.
 
 1. **Fork the repository** and clone your fork locally
 2. **Install dependencies**: `corepack enable && corepack prepare pnpm@11.14.0 --activate && pnpm install`
-3. **Set up environment**: either run `pnpm run setup` (writes `.env.local` with
-   local defaults) or copy `.env.example` to `.env` manually, then add your
-   Supabase credentials. Both paths work; `.env.local` takes precedence over
-   `.env`. See [`docs/WORKFLOW_AUTOMATION.md`](../docs/WORKFLOW_AUTOMATION.md)
-   for the distinction.
+3. **Set up environment**: copy `.env.example` to `.env` and add your Supabase
+   credentials. Nuxt auto-loads `.env` on `pnpm run dev`. (The `pnpm run setup`
+   script writes `.env.local` instead, which Nuxt does **not** auto-load — see
+   [`docs/WORKFLOW_AUTOMATION.md`](../docs/WORKFLOW_AUTOMATION.md) for the
+   distinction and the workaround.)
    Full env-var reference: [`docs/runbook.md`](../docs/runbook.md) and [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md).
 4. **Start dev server**: `pnpm run dev`
 5. **Read [`AGENTS.md`](../AGENTS.md)** for detailed development guidelines

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Discord Community
-    url: https://discord.gg/tarkovtracker
+    url: https://discord.gg/M8nBgA2sT6
     about: Join our Discord for questions, discussions, and community support
   - name: TarkovTracker Website
     url: https://tarkovtracker.org

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,6 +16,8 @@ Update this file or a scoped child `AGENTS.md` in the same PR when a change modi
 - deprecated patterns that agents must avoid
 - behavior of a system documented in `docs/SYSTEMS.md` (Tarkov.dev integration, data fetching
   pipeline, multi-layer caching, overlay corrections, precompute workflow)
+- community health policy: security reporting (`SECURITY.md`), support routing
+  (`SUPPORT.md`), or code of conduct (`CODE_OF_CONDUCT.md`)
 
 If this file conflicts with executable config (eslint, prettier, tsconfig, package.json), trust the executable config, then update this file before finishing.
 
@@ -239,6 +241,9 @@ Naming:
 - System specs (caching, data fetching, overlay, precompute): `docs/SYSTEMS.md`
 - Rate limiting / abuse ownership: `docs/RATE_LIMITING.md`
 - Contributing: `.github/CONTRIBUTING.md`
+- Security policy: `SECURITY.md`
+- Support routing: `SUPPORT.md`
+- Code of conduct: `CODE_OF_CONDUCT.md`
 - Runbook: `docs/runbook.md`
 - API docs: `docs/API.md`
 - Workflow automation: `docs/WORKFLOW_AUTOMATION.md`

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement either:
+
+- by email to <mailto:support@tarkovtracker.org>, or
+- by private message to a maintainer on our [Discord](https://discord.gg/M8nBgA2sT6).
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact:** Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence:** A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact:** A violation through a single incident or series of
+actions.
+
+**Consequence:** A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary ban
+
+**Community Impact:** A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence:** A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this ban.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent ban
+
+**Community Impact:** Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence:** A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
+
+[homepage]: https://www.contributor-covenant.org
+[mozilla coc]: https://github.com/mozilla/diversity

--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ The short version: this README gets you running; the `docs/` folder explains how
 | You want to…                                      | Read                                                                    |
 | ------------------------------------------------- | ----------------------------------------------------------------------- |
 | Get started                                       | This README                                                             |
+| Report a security vulnerability                   | [`SECURITY.md`](SECURITY.md)                                            |
+| Find where to get help                            | [`SUPPORT.md`](SUPPORT.md)                                              |
+| Read the code of conduct                          | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                              |
 | Understand the systems (caching, data, overlay)   | [`docs/SYSTEMS.md`](docs/SYSTEMS.md)                                    |
 | Understand the full architecture & data flow      | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)                          |
 | Use or extend the HTTP/API surface                | [`docs/API.md`](docs/API.md)                                            |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -18,7 +18,7 @@ Report vulnerabilities through either of these private channels:
 2. **Email** — <mailto:security@tarkovtracker.org>
 
 > If GitHub private vulnerability reporting is not enabled when you try it, fall
-> back to email and let us know the in-app route was unavailable so we can re-enable it.
+> back to email and let us know the GitHub reporting route was unavailable so we can re-enable it.
 
 Please include as much of the following as you can:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,76 @@
+# Security Policy
+
+## Supported versions
+
+TarkovTracker is a continuously deployed web application. Only the latest deployed
+version of `main` is supported with security fixes. We do not backport fixes to
+older releases or tags.
+
+## Reporting a vulnerability
+
+**Do not open a public GitHub issue for a security vulnerability.**
+
+Report vulnerabilities through either of these private channels:
+
+1. **GitHub private vulnerability reporting** —
+   <https://github.com/tarkovtracker-org/TarkovTracker/security/advisories/new>
+   (preferred; routes directly to the maintainers with a private advisory workflow).
+2. **Email** — <mailto:security@tarkovtracker.org>
+
+> If GitHub private vulnerability reporting is not enabled when you try it, fall
+> back to email and let us know the in-app route was unavailable so we can re-enable it.
+
+Please include as much of the following as you can:
+
+- Affected URL or component (e.g. `/api/tarkov/*`, Supabase Edge Function, the
+  `api-gateway` Worker, the auth flow)
+- Steps to reproduce
+- Potential impact (what an attacker could do)
+- Proof of concept, if safe to share
+- Suggested mitigation, if known
+
+## Response expectations
+
+- **Acknowledgment:** within 72 hours of the initial report.
+- **Triage:** within 7 days, with an initial assessment of severity and scope.
+- **Disclosure coordination:** we will work with you on a coordinated disclosure
+  timeline. Please do not disclose the vulnerability publicly until a fix is
+  deployed or we have agreed that disclosure is appropriate.
+- **Fix:** severity and deployment window determine timing. Critical issues are
+  treated as hotfixes; lower-severity issues may ship in the next regular release.
+
+## Out of scope
+
+- Social engineering of maintainers or contributors
+- Denial-of-service via load testing or volumetric flooding of the live site
+- Reports without a reproducible impact or with only theoretical harm
+- Issues in third-party services that are not reachable through TarkovTracker's
+  own code (report those to the upstream service instead)
+- Findings from automated scanners that have not been manually validated
+
+## Scope
+
+In scope:
+
+- The TarkovTracker web application (`app/`)
+- Nitro server routes and middleware (`app/server/`)
+- Cloudflare Workers (`workers/`)
+- Supabase Edge Functions (`supabase/functions/`)
+- Authentication and session handling
+- API token creation and handling
+- The Stripe billing webhook path
+- The Supabase database schema and Row Level Security policies
+
+Out of scope (report upstream):
+
+- `json.tarkov.dev` data issues — report to the tarkov.dev project
+- `tarkov-data-overlay` content issues — report at
+  <https://github.com/tarkovtracker-org/tarkov-data-overlay>
+- Supabase platform vulnerabilities — report to Supabase
+- Cloudflare platform vulnerabilities — report to Cloudflare
+
+## Acknowledgments
+
+We are grateful to security researchers who report vulnerabilities responsibly.
+With your permission, we will credit you in the GitHub Security Advisory and/or
+release notes. Let us know in your report if you would prefer to remain anonymous.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -10,7 +10,8 @@ tracker focused on bugs and features.
 | ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
 | Usage question or general discussion        | [Discord](https://discord.gg/M8nBgA2sT6) or [GitHub Discussions](https://github.com/tarkovtracker-org/TarkovTracker/discussions)               |
 | Reproducible bug                            | [Bug report form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=bug_report.yml)                                       |
-| Feature idea                                | [Feature request form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=feature_request.yml)                             |
+| Feature idea (something new)                | [Feature request form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=feature_request.yml)                             |
+| Improvement to an existing feature          | [Enhancement form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=enhancement.yml)                                     |
 | Incorrect in-game data (quest/item)         | [tarkov-data-overlay repository](https://github.com/tarkovtracker-org/tarkov-data-overlay)                                                     |
 | TarkovTracker displaying correct data wrong | [Data issue form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=data_issue.yml)                                       |
 | Security vulnerability                      | See [`SECURITY.md`](./SECURITY.md) — **do not open a public issue**                                                                            |

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,34 @@
+# Support
+
+Not sure where to ask? Use the table below to route your question or report to the
+right place. Routing it correctly gets you a faster answer and keeps the issue
+tracker focused on bugs and features.
+
+## Where to go
+
+| Need                                        | Where                                                                                                                                          |
+| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Usage question or general discussion        | [Discord](https://discord.gg/M8nBgA2sT6) or [GitHub Discussions](https://github.com/tarkovtracker-org/TarkovTracker/discussions)               |
+| Reproducible bug                            | [Bug report form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=bug_report.yml)                                       |
+| Feature idea                                | [Feature request form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=feature_request.yml)                             |
+| Incorrect in-game data (quest/item)         | [tarkov-data-overlay repository](https://github.com/tarkovtracker-org/tarkov-data-overlay)                                                     |
+| TarkovTracker displaying correct data wrong | [Data issue form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=data_issue.yml)                                       |
+| Security vulnerability                      | See [`SECURITY.md`](./SECURITY.md) — **do not open a public issue**                                                                            |
+| Account-specific support                    | [support@tarkovtracker.org](mailto:support@tarkovtracker.org)                                                                                  |
+| Development question                        | [Discord](https://discord.gg/M8nBgA2sT6) or issue comments                                                                                     |
+| Conduct or harassment report                | [support@tarkovtracker.org](mailto:support@tarkovtracker.org) or Discord DM to a maintainer — see [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) |
+
+## Before opening an issue
+
+1. **Search existing issues** to avoid duplicates.
+2. **Check the live app** at <https://tarkovtracker.org> to confirm the behavior
+   on the current deployment.
+3. **Pick the right template.** A bug is not a feature request, and an
+   in-game-data error belongs in the data-overlay repository, not here.
+
+## What we cannot help with
+
+- The game Escape from Tarkov itself — we are a progress tracker, not Battlestate
+  Games. Contact BSG for game account or launcher issues.
+- `json.tarkov.dev` data correctness — report upstream.
+- Supabase, Cloudflare, or Stripe platform outages — check their status pages.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -6,18 +6,18 @@ tracker focused on bugs and features.
 
 ## Where to go
 
-| Need                                        | Where                                                                                                                                          |
-| ------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Usage question or general discussion        | [Discord](https://discord.gg/M8nBgA2sT6) or [GitHub Discussions](https://github.com/tarkovtracker-org/TarkovTracker/discussions)               |
-| Reproducible bug                            | [Bug report form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=bug_report.yml)                                       |
-| Feature idea (something new)                | [Feature request form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=feature_request.yml)                             |
-| Improvement to an existing feature          | [Enhancement form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=enhancement.yml)                                     |
-| Incorrect in-game data (quest/item)         | [tarkov-data-overlay repository](https://github.com/tarkovtracker-org/tarkov-data-overlay)                                                     |
-| TarkovTracker displaying correct data wrong | [Data issue form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=data_issue.yml)                                       |
-| Security vulnerability                      | See [`SECURITY.md`](./SECURITY.md) — **do not open a public issue**                                                                            |
-| Account-specific support                    | [support@tarkovtracker.org](mailto:support@tarkovtracker.org)                                                                                  |
-| Development question                        | [Discord](https://discord.gg/M8nBgA2sT6) or issue comments                                                                                     |
-| Conduct or harassment report                | [support@tarkovtracker.org](mailto:support@tarkovtracker.org) or Discord DM to a maintainer — see [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) |
+| Need                                      | Where                                                                                                                                          |
+| ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
+| Usage question or general discussion      | [Discord](https://discord.gg/M8nBgA2sT6) or [GitHub Discussions](https://github.com/tarkovtracker-org/TarkovTracker/discussions)               |
+| Reproducible bug                          | [Bug report form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=bug_report.yml)                                       |
+| Feature idea (something new)              | [Feature request form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=feature_request.yml)                             |
+| Improvement to an existing feature        | [Enhancement form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=enhancement.yml)                                     |
+| Incorrect in-game data (quest/item)       | [tarkov-data-overlay repository](https://github.com/tarkovtracker-org/tarkov-data-overlay)                                                     |
+| TarkovTracker displaying data incorrectly | [Data issue form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=data_issue.yml)                                       |
+| Security vulnerability                    | See [`SECURITY.md`](./SECURITY.md) — **do not open a public issue**                                                                            |
+| Account-specific support                  | [support@tarkovtracker.org](mailto:support@tarkovtracker.org)                                                                                  |
+| Development question                      | [Discord](https://discord.gg/M8nBgA2sT6) or issue comments                                                                                     |
+| Conduct or harassment report              | [support@tarkovtracker.org](mailto:support@tarkovtracker.org) or Discord DM to a maintainer — see [`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) |
 
 ## Before opening an issue
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,6 +8,9 @@ canonical agent contract and project conventions live in the root [`AGENTS.md`](
 | I want to…                                                                        | Read                                                               |
 | --------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
 | Understand the project and get it running                                         | [`/README.md`](../README.md)                                       |
+| Report a security vulnerability                                                   | [`/SECURITY.md`](../SECURITY.md)                                   |
+| Find where to ask for help or report something                                    | [`/SUPPORT.md`](../SUPPORT.md)                                     |
+| Read the code of conduct                                                          | [`/CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md)                     |
 | Contribute (issues, branches, PRs, labels)                                        | [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md)            |
 | Understand how a specific system works (caching, data fetch, overlay, precompute) | [`SYSTEMS.md`](./SYSTEMS.md)                                       |
 | Understand the deeper architecture, state model, and data flows                   | [`ARCHITECTURE.md`](./ARCHITECTURE.md)                             |
@@ -23,6 +26,9 @@ canonical agent contract and project conventions live in the root [`AGENTS.md`](
 ### Human-facing
 
 - [`/README.md`](../README.md) — public overview, features, quick start.
+- [`/SECURITY.md`](../SECURITY.md) — vulnerability reporting policy and scope.
+- [`/SUPPORT.md`](../SUPPORT.md) — routing table for questions, bugs, features, and account support.
+- [`/CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) — Contributor Covenant 2.1 with enforcement contacts.
 - [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md) — contribution workflow, issues, labels, project board.
 - [`SYSTEMS.md`](./SYSTEMS.md) — plain-language spec of the non-obvious systems (Tarkov.dev integration, data fetching, multi-layer caching, overlay, precompute) with diagrams and invariants. Covers **what systems exist, what they own, and how they interact**. Point at this when asking "why does the app do X?".
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md) — deeper technical structure: state model, sync, data flows, implementation decisions, tradeoffs, and the canonical environment-variable map. `SYSTEMS.md` is the entry point for system behavior; `ARCHITECTURE.md` is the deeper reference for how the app is built.

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -238,18 +238,26 @@ pnpm run setup
 2. Run `pnpm run dev`
 3. Visit <http://localhost:3000>
 
-> **`.env` vs `.env.local` — both work, they serve different setup paths.**
+> **`.env` vs `.env.local` — important difference.**
 >
-> - The automated `pnpm run setup` script writes `.env.local` (Nuxt's
->   git-ignored, machine-local override file). Use this path if you are new to
->   the project.
+> - **Nuxt auto-loads `.env` only.** `pnpm run dev` runs `nuxt dev` without a
+>   `--dotenv` flag, so Nuxt's default dotenv loader (c12 `setupDotenv`) reads
+>   `.env` and ignores `.env.local`.
+> - The automated `pnpm run setup` script writes `.env.local`. For Nuxt to load
+>   it, either rename it to `.env` or run `nuxt dev --dotenv .env.local`.
 > - Manual setup documented in [`README.md`](../README.md) and
 >   [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md) copies `.env.example`
->   to `.env`. Use this path if you prefer the explicit copy step.
+>   to `.env`, which Nuxt loads automatically — this is the recommended path.
 >
-> Nuxt loads both files; `.env.local` takes precedence over `.env`. Do not commit
-> either file — both are in `.gitignore`. The canonical env-var reference lives
-> in [`ARCHITECTURE.md`](./ARCHITECTURE.md) and [`runbook.md`](./runbook.md).
+> Do not commit either file — both are in `.gitignore`. The canonical env-var
+> reference lives in [`ARCHITECTURE.md`](./ARCHITECTURE.md) and
+> [`runbook.md`](./runbook.md).
+>
+> **Known issue:** the setup script writes `.env.local` but `pnpm run dev` does
+> not pass `--dotenv .env.local`, so the generated file is not loaded
+> automatically. This is a pre-existing script bug tracked separately from this
+> documentation; until it is fixed, use the manual `.env` path or rename the
+> generated `.env.local` to `.env`.
 
 ## Deployment Process
 

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -234,9 +234,12 @@ pnpm run setup
 
 **Manual steps after setup:**
 
-1. Update `.env.local` with Supabase credentials
-2. Run `pnpm run dev`
-3. Visit <http://localhost:3000>
+1. Rename the generated `.env.local` to `.env` (or run
+   `nuxt dev --dotenv .env.local` instead of `pnpm run dev`) — see the note
+   below for why this is required.
+2. Update `.env` with your Supabase credentials
+3. Run `pnpm run dev`
+4. Visit <http://localhost:3000>
 
 > **`.env` vs `.env.local` — important difference.**
 >

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -234,12 +234,22 @@ pnpm run setup
 
 **Manual steps after setup:**
 
-1. Rename the generated `.env.local` to `.env` (or run
-   `nuxt dev --dotenv .env.local` instead of `pnpm run dev`) — see the note
-   below for why this is required.
+The setup script writes `.env.local`, but `pnpm run dev` does not load it (see
+the note below). Pick **one** of the two paths:
+
+**Option A — rename to `.env` (recommended):**
+
+1. Rename the generated `.env.local` to `.env`
 2. Update `.env` with your Supabase credentials
 3. Run `pnpm run dev`
 4. Visit <http://localhost:3000>
+
+**Option B — keep `.env.local`, pass `--dotenv` explicitly:**
+
+1. Update `.env.local` with your Supabase credentials
+2. Run `pnpm exec nuxt dev --dotenv .env.local` (the `pnpm exec` prefix is
+   required because `nuxt` is not on the interactive shell PATH)
+3. Visit <http://localhost:3000>
 
 > **`.env` vs `.env.local` — important difference.**
 >
@@ -247,7 +257,8 @@ pnpm run setup
 >   `--dotenv` flag, so Nuxt's default dotenv loader (c12 `setupDotenv`) reads
 >   `.env` and ignores `.env.local`.
 > - The automated `pnpm run setup` script writes `.env.local`. For Nuxt to load
->   it, either rename it to `.env` or run `nuxt dev --dotenv .env.local`.
+>   it, either rename it to `.env` (Option A) or run
+>   `pnpm exec nuxt dev --dotenv .env.local` (Option B).
 > - Manual setup documented in [`README.md`](../README.md) and
 >   [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md) copies `.env.example`
 >   to `.env`, which Nuxt loads automatically — this is the recommended path.
@@ -259,8 +270,7 @@ pnpm run setup
 > **Known issue:** the setup script writes `.env.local` but `pnpm run dev` does
 > not pass `--dotenv .env.local`, so the generated file is not loaded
 > automatically. This is a pre-existing script bug tracked separately from this
-> documentation; until it is fixed, use the manual `.env` path or rename the
-> generated `.env.local` to `.env`.
+> documentation; until it is fixed, use Option A or Option B above.
 
 ## Deployment Process
 

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -238,6 +238,19 @@ pnpm run setup
 2. Run `pnpm run dev`
 3. Visit <http://localhost:3000>
 
+> **`.env` vs `.env.local` — both work, they serve different setup paths.**
+>
+> - The automated `pnpm run setup` script writes `.env.local` (Nuxt's
+>   git-ignored, machine-local override file). Use this path if you are new to
+>   the project.
+> - Manual setup documented in [`README.md`](../README.md) and
+>   [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md) copies `.env.example`
+>   to `.env`. Use this path if you prefer the explicit copy step.
+>
+> Nuxt loads both files; `.env.local` takes precedence over `.env`. Do not commit
+> either file — both are in `.gitignore`. The canonical env-var reference lives
+> in [`ARCHITECTURE.md`](./ARCHITECTURE.md) and [`runbook.md`](./runbook.md).
+
 ## Deployment Process
 
 ### Automatic Deployment


### PR DESCRIPTION
## **User description**
## Summary

Adds the missing community-health layer and fixes the support-routing drift flagged in the docs review.

### New files

- **`SECURITY.md`** — vulnerability reporting policy. Two channels: GitHub private vulnerability reporting (preferred) and `security@tarkovtracker.org`. Includes response expectations (72h ack, 7d triage), scope (in/out), and out-of-scope items. **Do not open a public issue for security vulnerabilities.**
- **`SUPPORT.md`** — routing table mapping each kind of question or report (usage, bug, feature, data issue, security, account, conduct) to the right channel. Prevents support requests from becoming bug issues and bugs from disappearing into Discord.
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1 with enforcement via `support@tarkovtracker.org` and Discord DM to a maintainer. Replaces the one-line "be respectful" note in CONTRIBUTING.md.

### Drift fixes

- **Discord URL standardized** — `.github/ISSUE_TEMPLATE/config.yml` used `discord.gg/tarkovtracker`; CONTRIBUTING.md used `discord.gg/M8nBgA2sT6`. Both resolve, but they were inconsistent. Standardized on `discord.gg/M8nBgA2sT6` across all files (per maintainer decision).
- **`.env` vs `.env.local` clarified** — `docs/WORKFLOW_AUTOMATION.md` documents the automated setup script writing `.env.local`; `README.md` and `CONTRIBUTING.md` document the manual `.env.example` → `.env` copy. Both are valid Nuxt paths and both are gitignored; `.env.local` takes precedence. The docs previously stated both without explaining when to use which. Added a callout explaining the distinction.

### Wiring

- **`.github/CONTRIBUTING.md`** — Code of Conduct section now links to `CODE_OF_CONDUCT.md` instead of restating a one-liner. Getting Started documents both env setup paths.
- **`.github/CODEOWNERS`** — added review ownership for `README.md`, `docs/`, `CONTRIBUTING.md`, `ISSUE_TEMPLATE/`, and the new community files so changes to public-facing voice and policy request maintainer review. (Note: CODEOWNERS only *requests* review; branch protection is required to make it mandatory — see the existing comment at the top of the file.)
- **`AGENTS.md`** — added community health policy to the Maintenance Contract trigger list and the Deeper References list so agents keep these files in sync when they touch security/support/conduct policy.
- **`README.md`, `docs/README.md`** — added the three new files to the documentation routing tables.

### Decisions applied (from maintainer)

- Security reporting: both GitHub private reporting + `security@tarkovtracker.org`
- Discord canonical: `discord.gg/M8nBgA2sT6`
- CoC: Contributor Covenant 2.1, enforcement via Discord + `support@tarkovtracker.org` email fallback

### What is intentionally not in this PR

- No restructuring of CONTRIBUTING.md (separate PR per the agreed sequence).
- No issue-taxonomy changes (separate PR).
- No `blank_issues_enabled: false` change — kept as `true` pending review of whether blank issues serve a useful purpose (the support routing table now gives people a clear alternative).
- No code, locale, or config changes beyond the YAML/Markdown/CODEOWNERS above.

#### Test plan

- [x] `npx prettier --check` passes on all changed/new Markdown and YAML
- [x] All relative links in changed files resolve on disk
- [x] husky + lint-staged pre-commit hook passed
- [ ] CI `link-check` (lychee) passes
- [ ] CI `format:check` passes
- [ ] CI `PR Meta` passes (community files match repo conventions)

___

## **CodeAnt-AI Description**
**Add security, support, and conduct guidance for the project**

### What Changed
- Added dedicated documents for reporting security issues, finding the right support channel, and community conduct expectations
- Linked these new guides from the main README, docs index, and contributor guide so they are easier to find
- Clarified where to report each kind of issue or question, including bugs, feature ideas, account help, and data problems
- Standardized the Discord invite link and explained when to use `.env` versus `.env.local` during setup
- Added review ownership for public-facing docs and community policy files to keep them aligned

### Impact
`✅ Clearer security reporting`
`✅ Faster routing for help requests`
`✅ Fewer support issues sent to the wrong place`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Published a full security policy covering supported versions, private vulnerability reporting, scope, and coordinated disclosure expectations.
  * Added a Contributor Code of Conduct and updated contribution/community guidance to reference it and explain how to report conduct concerns.
  * Added a support & issue-routing guide, including what the project can’t support, plus links from README and docs.
  * Improved setup documentation for environment variables (`.env` vs `.env.local`) and corrected local dev instructions.
* **Community**
  * Updated the community contact link.
  * Strengthened review coverage for key public documentation and policy files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only PR with no code changes; all three new community health files are accurate and internally consistent.

All changes are Markdown, YAML, and CODEOWNERS additions. The new files are well-structured, internally consistent, and correctly wired into every existing routing surface. Both previously raised review concerns (missing enhancement.yml row in SUPPORT.md and redundant CODEOWNERS entries) were addressed in earlier commits on this branch. The .env vs .env.local documentation accurately reflects Nuxt's actual default dotenv loading behavior and clearly labels the pre-existing setup-script limitation as a known issue tracked separately.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/CODEOWNERS | Adds CODEOWNERS entries for public-facing docs and community health files; correctly avoids restating paths already covered by the /.github/ catch-all (per previous review). |
| .github/CONTRIBUTING.md | Code of Conduct section now links to CODE_OF_CONDUCT.md; Getting Started step 3 documents both .env setup paths with a clear reference to WORKFLOW_AUTOMATION.md for the .env.local workaround. |
| .github/ISSUE_TEMPLATE/config.yml | Standardizes the Discord URL from discord.gg/tarkovtracker to discord.gg/M8nBgA2sT6, matching all other files in this PR. |
| AGENTS.md | Adds community health policy files to the Maintenance Contract trigger list and the Deeper References section so agents keep these files in sync. |
| CODE_OF_CONDUCT.md | New file: standard Contributor Covenant 2.1 with enforcement contacts (support@tarkovtracker.org and Discord DM). |
| SECURITY.md | New file: well-structured security policy with two reporting channels (GitHub private advisory + email), response SLAs, and clear in/out-of-scope boundaries. |
| SUPPORT.md | New file: routing table covering all issue types including enhancement.yml (addressed from previous review); clear 'what we cannot help with' section. |
| README.md | Adds three rows to the documentation routing table for SECURITY.md, SUPPORT.md, and CODE_OF_CONDUCT.md. |
| docs/README.md | Adds the three new community health files to both the routing table and the Human-facing docs listing. |
| docs/WORKFLOW_AUTOMATION.md | Significantly expands the post-setup instructions to document the .env vs .env.local distinction, offering Option A (rename) and Option B (--dotenv flag), with a callout noting the pre-existing script bug. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User needs help] --> B{What kind of request?}
    B -->|Usage question or discussion| C[Discord or GitHub Discussions]
    B -->|Reproducible bug| D[Bug report form]
    B -->|Feature idea - something new| E[Feature request form]
    B -->|Improvement to existing feature| F[Enhancement form]
    B -->|Incorrect in-game data| G[tarkov-data-overlay repo]
    B -->|TarkovTracker displaying data incorrectly| H[Data issue form]
    B -->|Security vulnerability| I[SECURITY.md — private channel only]
    B -->|Account support| J[support email]
    B -->|Development question| K[Discord or issue comments]
    B -->|Conduct report| L[support email or Discord DM]
    I --> M{Reporting channel}
    M -->|Preferred| N[GitHub private vulnerability reporting]
    M -->|Fallback| O[security email]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[User needs help] --> B{What kind of request?}
    B -->|Usage question or discussion| C[Discord or GitHub Discussions]
    B -->|Reproducible bug| D[Bug report form]
    B -->|Feature idea - something new| E[Feature request form]
    B -->|Improvement to existing feature| F[Enhancement form]
    B -->|Incorrect in-game data| G[tarkov-data-overlay repo]
    B -->|TarkovTracker displaying data incorrectly| H[Data issue form]
    B -->|Security vulnerability| I[SECURITY.md — private channel only]
    B -->|Account support| J[support email]
    B -->|Development question| K[Discord or issue comments]
    B -->|Conduct report| L[support email or Discord DM]
    I --> M{Reporting channel}
    M -->|Preferred| N[GitHub private vulnerability reporting]
    M -->|Fallback| O[security email]
```

</a>
</details>

<sub>Reviews (4): Last reviewed commit: ["docs: restructure setup steps as either/..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/ed6d043fe8f53b84e6e8c41528ab31a7d76fda94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45859925)</sub>

<!-- /greptile_comment -->