### PR TITLE
fix: setup script writes .env, reads pnpm version from package.json

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -29,10 +29,11 @@ to <mailto:support@tarkovtracker.org> or via Discord DM to a maintainer.
 **Prerequisites:** Node.js >= 24.12.0, pnpm 11.14.0 (via Corepack; matches `packageManager`), Git.
 
 1. **Fork the repository** and clone your fork locally
-2. **Install dependencies**: `corepack enable && corepack prepare pnpm@11.14.0 --activate && pnpm install`
+2. **Install dependencies**: `corepack enable && pnpm install` (Corepack resolves the pnpm version from `packageManager` in `package.json`)
 3. **Set up environment**: run `pnpm run setup` (creates `.env` from
-   `.env.example`) or copy `.env.example` to `.env` manually, then add your
-   Supabase credentials. Nuxt auto-loads `.env` on `pnpm run dev`.
+   `.env.example` if it does not already exist) or copy `.env.example` to `.env`
+   manually (only if `.env` does not exist), then add your Supabase credentials.
+   Nuxt auto-loads `.env` on `pnpm run dev`.
    Full env-var reference: [`docs/runbook.md`](../docs/runbook.md) and [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md).
 4. **Start dev server**: `pnpm run dev`
 5. **Read [`AGENTS.md`](../AGENTS.md)** for detailed development guidelines

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -30,11 +30,9 @@ to <mailto:support@tarkovtracker.org> or via Discord DM to a maintainer.
 
 1. **Fork the repository** and clone your fork locally
 2. **Install dependencies**: `corepack enable && corepack prepare pnpm@11.14.0 --activate && pnpm install`
-3. **Set up environment**: copy `.env.example` to `.env` and add your Supabase
-   credentials. Nuxt auto-loads `.env` on `pnpm run dev`. (The `pnpm run setup`
-   script writes `.env.local` instead, which Nuxt does **not** auto-load — see
-   [`docs/WORKFLOW_AUTOMATION.md`](../docs/WORKFLOW_AUTOMATION.md) for the
-   distinction and the workaround.)
+3. **Set up environment**: run `pnpm run setup` (creates `.env` from
+   `.env.example`) or copy `.env.example` to `.env` manually, then add your
+   Supabase credentials. Nuxt auto-loads `.env` on `pnpm run dev`.
    Full env-var reference: [`docs/runbook.md`](../docs/runbook.md) and [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md).
 4. **Start dev server**: `pnpm run dev`
 5. **Read [`AGENTS.md`](../AGENTS.md)** for detailed development guidelines

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -229,48 +229,18 @@ pnpm run setup
 1. Prerequisites check (Node.js, pnpm via Corepack, git)
 2. Install dependencies
 3. Setup git hooks (Husky)
-4. Create `.env.local` with local development defaults
+4. Create `.env` from `.env.example` (migrates a legacy `.env.local` if present;
+   never overwrites an existing `.env`)
 5. Install worker dependencies
 
 **Manual steps after setup:**
 
-The setup script writes `.env.local`, but `pnpm run dev` does not load it (see
-the note below). Pick **one** of the two paths:
-
-**Option A — rename to `.env` (recommended):**
-
-1. Rename the generated `.env.local` to `.env`
-2. Update `.env` with your Supabase credentials
-3. Run `pnpm run dev`
-4. Visit <http://localhost:3000>
-
-**Option B — keep `.env.local`, pass `--dotenv` explicitly:**
-
-1. Update `.env.local` with your Supabase credentials
-2. Run `pnpm exec nuxt dev --dotenv .env.local` (the `pnpm exec` prefix is
-   required because `nuxt` is not on the interactive shell PATH)
+1. Update `.env` with your Supabase credentials if you need login or sync
+2. Run `pnpm run dev`
 3. Visit <http://localhost:3000>
 
-> **`.env` vs `.env.local` — important difference.**
->
-> - **Nuxt auto-loads `.env` only.** `pnpm run dev` runs `nuxt dev` without a
->   `--dotenv` flag, so Nuxt's default dotenv loader (c12 `setupDotenv`) reads
->   `.env` and ignores `.env.local`.
-> - The automated `pnpm run setup` script writes `.env.local`. For Nuxt to load
->   it, either rename it to `.env` (Option A) or run
->   `pnpm exec nuxt dev --dotenv .env.local` (Option B).
-> - Manual setup documented in [`README.md`](../README.md) and
->   [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md) copies `.env.example`
->   to `.env`, which Nuxt loads automatically — this is the recommended path.
->
-> Do not commit either file — both are in `.gitignore`. The canonical env-var
-> reference lives in [`ARCHITECTURE.md`](./ARCHITECTURE.md) and
-> [`runbook.md`](./runbook.md).
->
-> **Known issue:** the setup script writes `.env.local` but `pnpm run dev` does
-> not pass `--dotenv .env.local`, so the generated file is not loaded
-> automatically. This is a pre-existing script bug tracked separately from this
-> documentation; until it is fixed, use Option A or Option B above.
+> Do not commit `.env` — it is in `.gitignore`. The canonical env-var reference
+> lives in [`ARCHITECTURE.md`](./ARCHITECTURE.md) and [`runbook.md`](./runbook.md).
 
 ## Deployment Process
 

--- a/scripts/setup-dev-environment.sh
+++ b/scripts/setup-dev-environment.sh
@@ -27,12 +27,23 @@ check_prerequisites() {
     fi
 
     corepack enable
-    corepack prepare pnpm@10.34.5 --activate
 
-    pnpm_version=$(pnpm -v)
-    required_pnpm="10.34.5"
-    if ! printf '%s\n' "$required_pnpm" "$pnpm_version" | sort -V -C; then
-        echo "WARNING: pnpm version $pnpm_version found, but $required_pnpm or higher is recommended"
+    required_pnpm="$(
+        node -e "
+            const packageJson = require('./package.json');
+            const match = packageJson.packageManager.match(/^pnpm@([^+]+)/);
+            if (!match) {
+                process.exit(1);
+            }
+            process.stdout.write(match[1]);
+        "
+    )"
+
+    actual_pnpm="$(pnpm --version)"
+
+    if [ "$actual_pnpm" != "$required_pnpm" ]; then
+        echo "ERROR: Expected pnpm $required_pnpm, but found $actual_pnpm"
+        exit 1
     fi
 
     echo "All prerequisites installed"
@@ -50,28 +61,36 @@ install_dependencies() {
 setup_environment() {
     echo "Setting up environment variables..."
 
-    if [ ! -f .env.local ]; then
-        cat > .env.local << 'EOF'
-# Supabase Configuration
-NUXT_PUBLIC_SUPABASE_URL=http://localhost:54321
-NUXT_PUBLIC_SUPABASE_ANON_KEY=your_anon_key_here
+    local env_file=".env"
+    local legacy_env_file=".env.local"
+    local env_example=".env.example"
 
-# App Configuration
-NUXT_PUBLIC_APP_URL=http://localhost:3000
-
-# Cloudflare Workers (for local development)
-CLOUDFLARE_ACCOUNT_ID=your_account_id_here
-CLOUDFLARE_API_TOKEN=your_api_token_here
-
-# Development
-NUXT_PUBLIC_LOG_LEVEL=debug
-NODE_ENV=development
-EOF
-        echo "Created .env.local"
-        echo "WARNING: Please update .env.local with your Supabase credentials"
-    else
-        echo "INFO: .env.local already exists"
+    # Never overwrite a contributor's existing configuration.
+    if [ -f "$env_file" ]; then
+        if [ -f "$legacy_env_file" ]; then
+            echo "INFO: Both $env_file and $legacy_env_file exist; Nuxt will use $env_file for pnpm run dev"
+        else
+            echo "INFO: $env_file already exists; leaving it unchanged"
+        fi
+        return
     fi
+
+    # Migrate files created by older versions of this setup script.
+    if [ -f "$legacy_env_file" ]; then
+        mv "$legacy_env_file" "$env_file"
+        echo "Migrated legacy $legacy_env_file to $env_file"
+        echo "WARNING: Review $env_file and add your Supabase credentials"
+        return
+    fi
+
+    if [ ! -f "$env_example" ]; then
+        echo "ERROR: $env_example was not found"
+        exit 1
+    fi
+
+    cp "$env_example" "$env_file"
+    echo "Created $env_file from $env_example"
+    echo "WARNING: Review $env_file and add your Supabase credentials"
 }
 
 main() {
@@ -83,7 +102,7 @@ main() {
     echo "Development environment setup complete!"
     echo ""
     echo "Next steps:"
-    echo "1. Update .env.local with your Supabase credentials"
+    echo "1. Update .env with your Supabase credentials if you need login or sync"
     echo "2. Run 'pnpm run dev' to start the development server"
     echo "3. Visit http://localhost:3000"
     echo ""

--- a/scripts/setup-dev-environment.sh
+++ b/scripts/setup-dev-environment.sh
@@ -31,8 +31,14 @@ check_prerequisites() {
     required_pnpm="$(
         node -e "
             const packageJson = require('./package.json');
-            const match = packageJson.packageManager.match(/^pnpm@([^+]+)/);
+            const pm = packageJson.packageManager;
+            if (typeof pm !== 'string') {
+                console.error('ERROR: packageManager field is missing or not a string in package.json');
+                process.exit(1);
+            }
+            const match = pm.match(/^pnpm@([^+]+)/);
             if (!match) {
+                console.error('ERROR: packageManager field does not match pnpm@<version>');
                 process.exit(1);
             }
             process.stdout.write(match[1]);
@@ -43,6 +49,7 @@ check_prerequisites() {
 
     if [ "$actual_pnpm" != "$required_pnpm" ]; then
         echo "ERROR: Expected pnpm $required_pnpm, but found $actual_pnpm"
+        echo "  Run: corepack prepare pnpm@$required_pnpm --activate"
         exit 1
     fi
 
@@ -64,6 +71,14 @@ setup_environment() {
     local env_file=".env"
     local legacy_env_file=".env.local"
     local env_example=".env.example"
+
+    # Reject paths that exist but are not regular files (e.g. directories).
+    for f in "$env_file" "$legacy_env_file" "$env_example"; do
+        if [ -e "$f" ] && [ ! -f "$f" ]; then
+            echo "ERROR: $f exists but is not a regular file"
+            exit 1
+        fi
+    done
 
     # Never overwrite a contributor's existing configuration.
     if [ -f "$env_file" ]; then


### PR DESCRIPTION
## Summary

Fixes two issues in `scripts/setup-dev-environment.sh` that were previously documented as workarounds.

### 1. Environment file — script now writes `.env` instead of `.env.local`

**Problem:** The script wrote `.env.local` via a hard-coded heredoc, but Nuxt auto-loads `.env` only (c12 `setupDotenv` defaults `fileName` to `.env`). The generated file was not loaded by `pnpm run dev`, requiring contributors to rename it or use `pnpm exec nuxt dev --dotenv .env.local`. The heredoc had also diverged from `.env.example`, creating two templates that were already out of sync.

**Fix:** The script now copies `.env.example` to `.env` — the file Nuxt actually loads. This makes `.env.example` the single template; every env-var addition or removal requires updating only one source.

**Behavior:**
- Never overwrites an existing `.env`
- Migrates a legacy `.env.local` to `.env` only when `.env` does not exist (preserves existing values, removes the ambiguity of two local config files)
- When both `.env` and `.env.local` exist, reports it and leaves both untouched (protects contributors who intentionally use `.env.local` with `--dotenv`)
- `pnpm run dev` works immediately after setup — no rename, no special command

### 2. pnpm version drift — script reads version from `package.json`

**Problem:** The script hard-coded `pnpm@10.34.5` while `package.json` pins `pnpm@11.14.0` via `packageManager`. The script would activate the wrong version and warn about a mismatch it caused.

**Fix:** Removed the hard-coded version. The script now reads the required pnpm version from `package.json`'s `packageManager` field and validates the actual version matches. Uses `corepack enable` alone — Corepack resolves the version from `packageManager`, so no second source of truth is needed.

### Documentation cleanup

- `docs/WORKFLOW_AUTOMATION.md`: removed the `.env` vs `.env.local` workaround (Option A/B, known-issue callout, `pnpm exec nuxt dev --dotenv .env.local` instructions). The script now creates `.env` directly; `pnpm run dev` works without renaming or special commands.
- `.github/CONTRIBUTING.md`: removed the mismatch warning. Getting Started now documents both `pnpm run setup` and manual `cp .env.example .env` as equivalent paths that both produce `.env`.

### Verification

Tested all 4 cases specified in the review:

```bash
# 1. Clean setup — .env created from .env.example, no .env.local
rm -f .env .env.local && pnpm run setup
test -f .env && test ! -f .env.local  # PASS

# 2. Idempotency — existing .env not overwritten
echo "# custom marker" >> .env && pnpm run setup
grep -q "# custom marker" .env  # PASS

# 3. Legacy migration — .env.local renamed to .env
rm -f .env && printf 'NUXT_PUBLIC_SUPABASE_URL=legacy\n' > .env.local && pnpm run setup
grep -q 'NUXT_PUBLIC_SUPABASE_URL=legacy' .env && test ! -f .env.local  # PASS

# 4. Both exist — both left untouched, reported
printf '...current\n' > .env && printf '...legacy\n' > .env.local && pnpm run setup
# .env unchanged, .env.local still exists  # PASS
```

Also verified:
- pnpm version from `package.json`: 11.14.0, actual: 11.14.0 — match
- `bash -n` shell syntax check passes
- `npx prettier --check` passes on changed docs
- husky + lint-staged pre-commit hook passed

#### Test plan

- [x] 4 setup-environment test cases pass
- [x] pnpm version check reads correctly from package.json
- [x] Shell syntax valid (`bash -n`)
- [x] Prettier passes on changed Markdown
- [ ] CI `Test` passes (script change could affect CI setup)
- [ ] CI `Lint & Format` passes
- [ ] CI `Validate` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated getting started and development environment guides to use `.env`, including adding Supabase credentials and running locally (http://localhost:3000).
  - Simplified contributor instructions and clarified environment handling guidance.

- **Improvements**
  - Setup now preserves an existing `.env` and migrates a legacy `.env.local` to `.env` when needed.
  - Added stricter pnpm version validation to ensure the installed version exactly matches the project requirement.
  - Improved setup messaging, including checks for missing environment templates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the script changes are non-destructive (never overwrites existing config), the version-extraction regex is correct, and all documented edge cases are guarded.

All three files contain targeted, well-scoped changes: the shell script's env-file and pnpm-version logic is correct and defensive, the documentation accurately describes the new behaviour, and both previously flagged review concerns have been addressed.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/setup-dev-environment.sh | Rewrites env-file and pnpm-version handling: reads required pnpm version dynamically from package.json, validates exact match, and copies .env.example to .env with migration and guard logic. All four env-file cases are handled correctly; regex correctly strips the sha512 hash from the packageManager field. |
| .github/CONTRIBUTING.md | Simplifies step 2 (removes corepack prepare pnpm@11.14.0 --activate) and step 3 (now points to .env, not .env.local); documentation accurately reflects the new script behaviour. |
| docs/WORKFLOW_AUTOMATION.md | Removes the Option A/B workaround, the known-issue callout, and the pnpm exec nuxt dev --dotenv .env.local instructions; replaces them with a concise 3-step manual flow that matches the fixed script behaviour. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm run setup] --> B[check_prerequisites]
    B --> C{corepack, node, git present?}
    C -- No --> D[exit 1]
    C -- Yes --> E[corepack enable]
    E --> F[node -e: read packageManager from package.json]
    F --> G{field valid?}
    G -- No --> D
    G -- Yes --> H[pnpm --version]
    H --> I{version == required?}
    I -- No --> J[exit 1 + remediation hint]
    I -- Yes --> K[install_dependencies\npnpm install --frozen-lockfile\nhusky setup]
    K --> L[setup_environment]
    L --> M{.env is directory?}
    M -- Yes --> D
    M -- No --> N{.env exists?}
    N -- Yes, .env.local also exists --> O[INFO: both exist, leave untouched]
    N -- Yes, no .env.local --> P[INFO: .env unchanged]
    N -- No --> Q{.env.local exists?}
    Q -- Yes --> R[mv .env.local to .env\nmigration complete]
    Q -- No --> S{.env.example exists?}
    S -- No --> D
    S -- Yes --> T[cp .env.example to .env\ncreated from template]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[pnpm run setup] --> B[check_prerequisites]
    B --> C{corepack, node, git present?}
    C -- No --> D[exit 1]
    C -- Yes --> E[corepack enable]
    E --> F[node -e: read packageManager from package.json]
    F --> G{field valid?}
    G -- No --> D
    G -- Yes --> H[pnpm --version]
    H --> I{version == required?}
    I -- No --> J[exit 1 + remediation hint]
    I -- Yes --> K[install_dependencies\npnpm install --frozen-lockfile\nhusky setup]
    K --> L[setup_environment]
    L --> M{.env is directory?}
    M -- Yes --> D
    M -- No --> N{.env exists?}
    N -- Yes, .env.local also exists --> O[INFO: both exist, leave untouched]
    N -- Yes, no .env.local --> P[INFO: .env unchanged]
    N -- No --> Q{.env.local exists?}
    Q -- Yes --> R[mv .env.local to .env\nmigration complete]
    Q -- No --> S{.env.example exists?}
    S -- No --> D
    S -- Yes --> T[cp .env.example to .env\ncreated from template]
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix: address review findings on setup sc..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/18dedf8299ecc1500862f68321da5c078e191b44) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45895105)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->