### PR TITLE
docs: move ARCHITECTURE_REVIEW.md to docs/decisions/

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -5,21 +5,22 @@ canonical agent contract and project conventions live in the root [`AGENTS.md`](
 
 ## Which doc do I need?
 
-| I want to…                                                                        | Read                                                               |
-| --------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| Understand the project and get it running                                         | [`/README.md`](../README.md)                                       |
-| Report a security vulnerability                                                   | [`/SECURITY.md`](../SECURITY.md)                                   |
-| Find where to ask for help or report something                                    | [`/SUPPORT.md`](../SUPPORT.md)                                     |
-| Read the code of conduct                                                          | [`/CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md)                     |
-| Contribute (issues, branches, PRs, labels)                                        | [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md)            |
-| Understand how a specific system works (caching, data fetch, overlay, precompute) | [`SYSTEMS.md`](./SYSTEMS.md)                                       |
-| Understand the deeper architecture, state model, and data flows                   | [`ARCHITECTURE.md`](./ARCHITECTURE.md)                             |
-| Use or extend the HTTP/API surface                                                | [`API.md`](./API.md)                                               |
-| Understand rate limits / abuse controls by layer                                  | [`RATE_LIMITING.md`](./RATE_LIMITING.md)                           |
-| Deploy, configure env vars, or handle an incident                                 | [`runbook.md`](./runbook.md)                                       |
-| Understand CI/CD, hooks, and releases                                             | [`WORKFLOW_AUTOMATION.md`](./WORKFLOW_AUTOMATION.md)               |
-| Follow the visual/design system                                                   | [`/DESIGN.md`](../DESIGN.md)                                       |
-| Work as (or configure) an AI agent                                                | [`AGENTS.md`](../AGENTS.md) + [`agent-context/`](./agent-context/) |
+| I want to…                                                                        | Read                                                                               |
+| --------------------------------------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| Understand the project and get it running                                         | [`/README.md`](../README.md)                                                       |
+| Report a security vulnerability                                                   | [`/SECURITY.md`](../SECURITY.md)                                                   |
+| Find where to ask for help or report something                                    | [`/SUPPORT.md`](../SUPPORT.md)                                                     |
+| Read the code of conduct                                                          | [`/CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md)                                     |
+| Contribute (issues, branches, PRs, labels)                                        | [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md)                            |
+| Understand how a specific system works (caching, data fetch, overlay, precompute) | [`SYSTEMS.md`](./SYSTEMS.md)                                                       |
+| Understand the deeper architecture, state model, and data flows                   | [`ARCHITECTURE.md`](./ARCHITECTURE.md)                                             |
+| Read the Tarkov data architecture decision and implementation plan                | [`decisions/tarkov-data-architecture.md`](./decisions/tarkov-data-architecture.md) |
+| Use or extend the HTTP/API surface                                                | [`API.md`](./API.md)                                                               |
+| Understand rate limits / abuse controls by layer                                  | [`RATE_LIMITING.md`](./RATE_LIMITING.md)                                           |
+| Deploy, configure env vars, or handle an incident                                 | [`runbook.md`](./runbook.md)                                                       |
+| Understand CI/CD, hooks, and releases                                             | [`WORKFLOW_AUTOMATION.md`](./WORKFLOW_AUTOMATION.md)                               |
+| Follow the visual/design system                                                   | [`/DESIGN.md`](../DESIGN.md)                                                       |
+| Work as (or configure) an AI agent                                                | [`AGENTS.md`](../AGENTS.md) + [`agent-context/`](./agent-context/)                 |
 
 ## Document map
 
@@ -32,6 +33,7 @@ canonical agent contract and project conventions live in the root [`AGENTS.md`](
 - [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md) — contribution workflow, issues, labels, project board.
 - [`SYSTEMS.md`](./SYSTEMS.md) — plain-language spec of the non-obvious systems (Tarkov.dev integration, data fetching, multi-layer caching, overlay, precompute) with diagrams and invariants. Covers **what systems exist, what they own, and how they interact**. Point at this when asking "why does the app do X?".
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md) — deeper technical structure: state model, sync, data flows, implementation decisions, tradeoffs, and the canonical environment-variable map. `SYSTEMS.md` is the entry point for system behavior; `ARCHITECTURE.md` is the deeper reference for how the app is built.
+- [`decisions/tarkov-data-architecture.md`](./decisions/tarkov-data-architecture.md) — durable architecture decision and resumable implementation plan for the Tarkov data and progress system (KV releases, shared rules engine, Supabase write consolidation).
 - [`API.md`](./API.md) — endpoint reference, caching, supported languages, game modes.
 - [`RATE_LIMITING.md`](./RATE_LIMITING.md) — ownership map for API, Edge, Pages, DB, and Auth rate-limit systems.
 - [`runbook.md`](./runbook.md) — required env vars, pre-deploy checks, incident triage and recovery.

--- a/docs/decisions/tarkov-data-architecture.md
+++ b/docs/decisions/tarkov-data-architecture.md
@@ -2,11 +2,9 @@
 
 ## Document status
 
-- **Purpose:** durable architecture record and resumable implementation plan
-- **Decision status:** target architecture agreed; Phase 0 local safeguards implemented
-- **Last verified:** 2026-07-18
-- **Repository:** `tarkovtracker-org/TarkovTracker`, branch `tarkov-data-architecture`
-- **Do not treat the current branch as the final data architecture.** Direct Worker JSON fetching remains an interim compatibility path, not the intended end state.
+- **Purpose:** durable architecture record and resumable implementation plan for the Tarkov data and progress system.
+- **Decision status:** target architecture agreed; Phase 0 local safeguards implemented.
+- **Interim state:** direct Worker JSON fetching remains an interim compatibility path, not the intended end state.
 
 ## Executive decision
 
@@ -24,76 +22,6 @@ Platform responsibilities:
 | Shared TypeScript domain module | All progression, branch, invalidation, and edition semantics                 |
 
 Do not make Supabase the primary runtime store for globally static game definitions. A release audit table is reasonable, but full static payloads should not be a required Postgres read on every request.
-
----
-
-## Verified production inventory
-
-### GitHub Actions
-
-Workflow: `.github/workflows/precompute-tarkov-data.yml`
-
-- Triggered at `0 */12 * * *` and by manual dispatch.
-- Runs `pnpm run precompute:tarkov` on GitHub-hosted Ubuntu.
-- Installs the repository dependencies and writes through the Cloudflare KV REST API.
-- Has a 30-minute timeout and serialized concurrency group.
-- Opens or updates a GitHub issue when a scheduled run fails.
-- Repository variables are configured:
-  - `CLOUDFLARE_ACCOUNT_ID=fe638e80cee39a738275d92348d02bd4`
-  - `TARKOV_DATA_KV_NAMESPACE_ID=6034d8d7b7534946bf04110c33ac3b88`
-- The latest 15 scheduled runs inspected all succeeded.
-- Latest inspected run: `29645388404`, commit `4045861902cab7fd3b397ff0f403b7272b7a4bfb`, 2026-07-18 13:01–13:02 UTC.
-- The latest job successfully completed the `Precompute and write to KV` step.
-
-The workflow currently precomputes only `tasks-core` payloads. It does not create a release manifest, compact Worker rules, hideout rules, rollback pointer, or permanent release history.
-
-### Cloudflare
-
-Account: `DysektAI` (`fe638e80cee39a738275d92348d02bd4`)
-
-KV namespace:
-
-- Title: `TARKOV_DATA`
-- ID: `6034d8d7b7534946bf04110c33ac3b88`
-- 32 keys currently exist: 16 languages × `regular`/`pve`.
-- Keys use `tasks-core-json-v2-{lang}-{mode}`.
-- Every key has an approximately seven-day expiration.
-- No active-release or previous-release pointer exists.
-
-Pages project:
-
-- Project: `tarkovtracker`
-- Production and preview both bind `TARKOV_DATA` to the namespace above.
-- Production and preview both bind `API_GATEWAY_LIMITER` to the API Worker's Durable Object.
-
-API Worker:
-
-- Script: `api-gateway`
-- Smart Placement enabled.
-- Observability and invocation logs enabled at 100% sampling.
-- Bound to `API_GATEWAY_LIMITER` and Supabase credentials.
-- **Not bound to `TARKOV_DATA`.**
-
-Production Worker CPU, 2026-07-18 20:00–23:19 UTC:
-
-| Scope                   | Requests | Average |   p95 |   p99 |   Max |
-| ----------------------- | -------: | ------: | ----: | ----: | ----: |
-| All API Worker requests |   16,567 | 4.10 ms |  9 ms | 13 ms | 20 ms |
-| GET `/api/v2/progress`  |    8,551 | 5.34 ms | 10 ms | 14 ms | 20 ms |
-| Task-write paths        |    1,886 | 5.63 ms | 10 ms | 12 ms | 16 ms |
-
-These values require a canary rollout. The production Worker likely still benefits from the old broken task query returning empty data, so populated metadata must be measured before full deployment.
-
-### Supabase
-
-The live Supabase MCP is authenticated.
-
-- `user_progress` had approximately 15,833 rows when Phase 0 verification ran.
-- No Tarkov game-data tables currently exist.
-- `user_progress` stores PVP and PVE progress as JSONB.
-- `merge_progress_data` already performs row locking and partial atomic merges.
-- Browser code still performs direct full-row `user_progress` upserts.
-- The live `record_api_usage` RPC still has its old six-parameter signature. The local Worker now sends `p_user_agent`, so the pending migration must be applied before that Worker code reaches production.
 
 ---
 
@@ -278,14 +206,6 @@ type ProgressRuleset = {
   >;
 };
 ```
-
-Measured against current upstream data:
-
-- Raw tasks response: approximately 2,084 KB.
-- Raw hideout response: approximately 83 KB.
-- Basic task rules projection: approximately 136 KB.
-- Relevant stash/cultist hideout projection: approximately 1.5 KB.
-- Existing 510-task invalidation function benchmark: approximately 0.17 ms per evaluation in local Node.
 
 Compile graph indexes during precompute to reduce request CPU further.
 


### PR DESCRIPTION
## **User description**
## Summary

Moves the Tarkov data architecture record out of the repository root into `docs/decisions/tarkov-data-architecture.md`, separating durable architecture decisions from transient operational inventory.

**Problem:** `ARCHITECTURE_REVIEW.md` sat in the repo root next to permanent public documents but contained time-sensitive operational observations (account IDs, namespace IDs, workflow run IDs, CPU metrics, row counts, branch-specific status) that are easy to mistake for current production truth.

**What was kept (durable):**
- Executive decision and platform responsibilities
- Current data flow diagrams
- Confirmed defects and architectural gaps
- Target data model, release format, and runtime flows
- Why-not-Supabase rationale
- Validation gates
- Resumable implementation plan (phases 0–6)
- Decision log
- Primary code references

**What was removed (transient):**
- "Verified production inventory" section — account IDs, namespace IDs, workflow run IDs, commit hashes, CPU metrics, row counts. These belong in an issue, runbook note, or dated investigation record, not a durable architecture document.
- Branch-specific document status (`branch tarkov-data-architecture`)
- "Last verified" date

**Navigation:** `docs/README.md` routing table and document map updated to include the new location.

#### Test plan

- [x] `npx prettier --check` passes on changed files
- [x] All relative links in `docs/README.md` resolve (including new `./decisions/tarkov-data-architecture.md`)
- [x] No other files reference `ARCHITECTURE_REVIEW.md` (verified via grep)
- [x] Git correctly detects the move as a rename (84% similarity)
- [x] husky + lint-staged pre-commit hook passed
- [ ] CI `link-check` (lychee) passes
- [ ] CI `format:check` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Move the Tarkov data architecture record into the decisions folder**

### What Changed
- The Tarkov data architecture document now lives in `docs/decisions/` and is linked from the docs guide
- The document keeps the durable architecture decision and implementation plan, while removing time-sensitive production inventory and dated status details
- The document now reads as a stable reference for the Tarkov data and progress system instead of a snapshot of a specific verification run

### Impact
`✅ Easier finding of the Tarkov data architecture plan`
`✅ Fewer stale production details in published docs`
`✅ Clearer separation between lasting decisions and temporary investigation notes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only rename with no code changes; safe to merge.

The change is a file rename plus targeted content removal of stale operational data. All relative links in docs/README.md resolve correctly to the new path, no other file in the repo referenced the old location, and the durable architecture content is fully preserved.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/README.md | Adds one navigation row and one document-map entry pointing to the new decisions/ sub-path; all relative links are structurally correct from the docs/ directory. |
| docs/decisions/tarkov-data-architecture.md | Renamed from repo-root ARCHITECTURE_REVIEW.md; removes transient operational inventory (account/namespace IDs, workflow run IDs, CPU metrics, row counts) and branch-specific status lines, leaving only durable decision content. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["docs/README.md\n(navigation hub)"] -->|routing table row| B["docs/decisions/tarkov-data-architecture.md\n(new location)"]
    A -->|document map entry| B
    C["ARCHITECTURE_REVIEW.md\n(repo root — removed)"] -.->|renamed 84% similarity| B
    A --> D["docs/ARCHITECTURE.md"]
    A --> E["docs/SYSTEMS.md"]
    A --> F["docs/API.md"]
    A --> G["docs/runbook.md"]
    style C stroke-dasharray: 5 5, fill:#ffcccc
    style B fill:#ccffcc
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["docs/README.md\n(navigation hub)"] -->|routing table row| B["docs/decisions/tarkov-data-architecture.md\n(new location)"]
    A -->|document map entry| B
    C["ARCHITECTURE_REVIEW.md\n(repo root — removed)"] -.->|renamed 84% similarity| B
    A --> D["docs/ARCHITECTURE.md"]
    A --> E["docs/SYSTEMS.md"]
    A --> F["docs/API.md"]
    A --> G["docs/runbook.md"]
    style C stroke-dasharray: 5 5, fill:#ffcccc
    style B fill:#ccffcc
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: move ARCHITECTURE\_REVIEW.md to doc..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/ebc2359cc269d58b6358a242b474b581f257d8a5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45905918)</sub>

<!-- /greptile_comment -->