### PR TITLE
feat(api): enforce inbound User-Agent and propagate shared UA to upstream fetches

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,7 @@ Naming:
 - Pinia stores in `app/stores/`, auto-registered by Nuxt. Use `pinia-plugin-persistedstate` where applicable.
 - Supabase client: `app/plugins/supabase.client.ts`. Regenerate types: `pnpm run supabase:types`.
 - API endpoints: `app/server/api/`. Use composables for shared data access patterns.
+- Public progress API clients must send a 5–200 character `User-Agent`; infrastructure routes are exempt. Usage reporting stores the latest normalized value per token/day.
 - Mock Supabase/network calls in tests. Keep tests deterministic.
 
 ## Error Handling

--- a/app/server/api/tarkov-dev/__tests__/profile.test.ts
+++ b/app/server/api/tarkov-dev/__tests__/profile.test.ts
@@ -91,7 +91,7 @@ describe('/api/tarkov-dev/profile', () => {
       expect.objectContaining({
         headers: {
           accept: 'application/json',
-          'user-agent': 'TarkovTracker/1.x (+https://tarkovtracker.org)',
+          'user-agent': 'TarkovTracker/1.0 (+https://tarkovtracker.org)',
         },
         signal: expect.any(AbortSignal),
       })
@@ -112,7 +112,7 @@ describe('/api/tarkov-dev/profile', () => {
       expect.objectContaining({
         headers: {
           accept: 'application/json',
-          'user-agent': 'TarkovTracker/1.x (+https://tarkovtracker.org)',
+          'user-agent': 'TarkovTracker/1.0 (+https://tarkovtracker.org)',
         },
         signal: expect.any(AbortSignal),
       })

--- a/app/server/api/tarkov-dev/profile.get.ts
+++ b/app/server/api/tarkov-dev/profile.get.ts
@@ -7,11 +7,11 @@ import {
   createSharedCacheHandle,
   type SharedCacheHandle,
 } from '@/server/utils/sharedEdgeStore';
+import { TARKOVTRACKER_USER_AGENT } from '@/server/utils/userAgent';
 import { resolveTarkovDevProfileSource } from '@/utils/tarkovDevProfileSource';
 import type { ApiProtectionConfig } from '@/server/middleware/api-protection';
 const logger = createLogger('TarkovDevProfileApi');
 const PROFILE_FETCH_TIMEOUT_MS = 10_000;
-const PROFILE_FETCH_USER_AGENT = 'TarkovTracker/1.x (+https://tarkovtracker.org)';
 const PROFILE_RATE_LIMIT_PER_MINUTE = 30;
 const PROFILE_RATE_LIMIT_PREFIX = 'tarkov-dev-profile-rate';
 const RATE_LIMIT_WINDOW_MS = 60_000;
@@ -75,7 +75,7 @@ export default defineEventHandler(async (event) => {
     response = await fetch(source.data.profileJsonUrl, {
       headers: {
         accept: 'application/json',
-        'user-agent': PROFILE_FETCH_USER_AGENT,
+        'user-agent': TARKOVTRACKER_USER_AGENT,
       },
       signal: AbortSignal.timeout(PROFILE_FETCH_TIMEOUT_MS),
     });

--- a/app/server/api/twitch/__tests__/live.test.ts
+++ b/app/server/api/twitch/__tests__/live.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TARKOVTRACKER_USER_AGENT } from '@/server/utils/userAgent';
 const { fetchMock, getQueryMock, setResponseHeadersMock, useRuntimeConfigMock } = vi.hoisted(
   () => ({
     fetchMock: vi.fn(),
@@ -48,6 +49,7 @@ describe('/api/twitch/live', () => {
     const [url, init] = fetchMock.mock.calls[0] ?? [];
     expect(url).toBe('https://gql.twitch.tv/gql');
     expect((init.headers as Record<string, string>)['Client-ID']).toBe('test-client-id');
+    expect((init.headers as Record<string, string>)['User-Agent']).toBe(TARKOVTRACKER_USER_AGENT);
     // Channel must be lowercased before querying.
     expect(init.body).toContain('"login":"teststreamer"');
   });

--- a/app/server/api/twitch/live.get.ts
+++ b/app/server/api/twitch/live.get.ts
@@ -1,6 +1,7 @@
 import { defineEventHandler, getQuery, setResponseHeaders } from 'h3';
 import { useRuntimeConfig } from '#imports';
 import { createLogger } from '@/server/utils/logger';
+import { TARKOVTRACKER_USER_AGENT } from '@/server/utils/userAgent';
 const logger = createLogger('twitch-live');
 const TWITCH_GQL_URL = 'https://gql.twitch.tv/gql';
 const CACHE_TTL_MS = 60_000;
@@ -26,7 +27,11 @@ export default defineEventHandler(async (event) => {
   try {
     const response = await fetch(TWITCH_GQL_URL, {
       method: 'POST',
-      headers: { 'Client-ID': twitchClientId as string, 'Content-Type': 'application/json' },
+      headers: {
+        'Client-ID': twitchClientId as string,
+        'Content-Type': 'application/json',
+        'User-Agent': TARKOVTRACKER_USER_AGENT,
+      },
       body: JSON.stringify({
         query: 'query($login:String!){user(login:$login){stream{id}}}',
         variables: { login: channel },

--- a/app/server/utils/__tests__/tarkov-json.test.ts
+++ b/app/server/utils/__tests__/tarkov-json.test.ts
@@ -14,7 +14,7 @@ import {
 } from '@/server/utils/tarkov-json';
 type TestJsonFetcher = <T = unknown>(
   url: string,
-  request: { headers: { Accept: string }; retry: number; timeout: number }
+  request: { headers: Record<string, string>; retry: number; timeout: number }
 ) => Promise<T>;
 const createFetcher = (responses: Record<string, unknown>) =>
   vi.fn(async (url: string) => {

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -14,6 +14,7 @@ import {
   inferObjectiveType,
   normalizeObjectiveList,
 } from './objectiveTypeInferrer';
+import { TARKOVTRACKER_USER_AGENT } from './userAgent';
 const logger = createLogger('Overlay');
 // Overlay data structure
 interface ModeOverlayData {
@@ -153,7 +154,7 @@ async function fetchOverlay(
     try {
       const response = await fetch(OVERLAY_URL_WITH_BUSTER, {
         signal: controller.signal,
-        headers: { Accept: 'application/json' },
+        headers: { Accept: 'application/json', 'User-Agent': TARKOVTRACKER_USER_AGENT },
       });
       if (!response.ok) {
         logger.warn(`Failed to fetch overlay: ${response.status}`);

--- a/app/server/utils/tarkov-json.ts
+++ b/app/server/utils/tarkov-json.ts
@@ -2,6 +2,7 @@ import { JSONPath } from 'jsonpath-plus';
 import { $fetch } from 'ofetch';
 import { useRuntimeConfig } from '#imports';
 import { createLogger } from '@/server/utils/logger';
+import { TARKOVTRACKER_USER_AGENT } from '@/server/utils/userAgent';
 import { buildSkillImageUrl } from '@/utils/tarkovUrls';
 import type { ValidGameMode } from '@/server/utils/tarkov-cache-config';
 import type {
@@ -55,9 +56,7 @@ type TarkovJsonEnvelope<T = unknown> = {
   translations?: string[];
 };
 type TarkovJsonRequest = {
-  headers: {
-    Accept: string;
-  };
+  headers: Record<string, string>;
   timeout: number;
   retry: number;
 };
@@ -235,7 +234,7 @@ async function fetchEnvelopePayload(
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
       return await fetcher<unknown>(url, {
-        headers: { Accept: 'application/json' },
+        headers: { Accept: 'application/json', 'User-Agent': TARKOVTRACKER_USER_AGENT },
         timeout: timeoutMs,
         retry: 0,
       });

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -237,12 +237,39 @@ describe('api-gateway', () => {
     expect(body.success).toBe(false);
     expect(body.error).toContain('User-Agent must be 5-200 characters');
   });
+  it('rejects requests with an oversized User-Agent header', async () => {
+    const res = await worker.fetch(
+      buildRequest('/token', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer PVP_abc123', 'User-Agent': 'x'.repeat(201) },
+      }),
+      BASE_ENV
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('User-Agent must be 5-200 characters');
+  });
+  it('validates User-Agent before issuing a legacy /api/v2 308 redirect', async () => {
+    const env: Env = { ...BASE_ENV, LEGACY_API_REDIRECT: 'true' };
+    const res = await worker.fetch(
+      new Request('https://tarkovtracker.org/api/v2/progress/task/task-1?foo=bar', {
+        method: 'POST',
+        headers: { ...AUTH_HEADERS, 'User-Agent': 'ab' },
+        body: JSON.stringify({ state: 'completed' }),
+      }),
+      env
+    );
+    expect(res.status).toBe(400);
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(body.error).toContain('User-Agent must be 5-200 characters');
+  });
   it('redirects legacy /api/v2 routes with 308 when LEGACY_API_REDIRECT is true', async () => {
     const env: Env = { ...BASE_ENV, LEGACY_API_REDIRECT: 'true' };
     const res = await worker.fetch(
       new Request('https://tarkovtracker.org/api/v2/progress/task/task-1?foo=bar', {
         method: 'POST',
-        headers: AUTH_HEADERS,
+        headers: { ...AUTH_HEADERS, 'User-Agent': 'TestClient/1.0 (+https://example.com)' },
         body: JSON.stringify({ state: 'completed' }),
       }),
       env
@@ -262,7 +289,10 @@ describe('api-gateway', () => {
     const res = await worker.fetch(
       new Request('https://tarkovtracker.org/api/progress', {
         method: 'GET',
-        headers: { Authorization: 'Bearer PVP_abc123' },
+        headers: {
+          Authorization: 'Bearer PVP_abc123',
+          'User-Agent': 'TestClient/1.0 (+https://example.com)',
+        },
       }),
       env
     );
@@ -536,7 +566,7 @@ describe('api-gateway', () => {
             id: 'task-main',
             name: 'Main Task',
             factionName: 'Any',
-              objectives: [],
+            objectives: [],
             taskRequirements: [],
           },
         ],

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -32,8 +32,13 @@ const BASE_ENV: Env = {
   SUPABASE_SERVICE_ROLE_KEY: 'service-key',
   ALLOWED_ORIGIN: '*',
 };
-const buildRequest = (path: string, init?: RequestInit) =>
-  new Request(`https://api.tarkovtracker.org${path}`, init);
+const buildRequest = (path: string, init?: RequestInit) => {
+  const headers = new Headers(init?.headers);
+  if (!headers.has('User-Agent')) {
+    headers.set('User-Agent', 'TestClient/1.0 (+https://example.com)');
+  }
+  return new Request(`https://api.tarkovtracker.org${path}`, { ...init, headers });
+};
 const jsonResponse = (payload: unknown, status = 200) =>
   new Response(JSON.stringify(payload), {
     status,
@@ -209,6 +214,29 @@ describe('api-gateway', () => {
     const res = await worker.fetch(buildRequest('/token', { method: 'GET' }), BASE_ENV);
     await expectErrorResponse(res, 401, 'Unauthorized');
   });
+  it('rejects requests with a missing User-Agent header', async () => {
+    const res = await worker.fetch(
+      new Request('https://api.tarkovtracker.org/token', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer PVP_abc123' },
+      }),
+      BASE_ENV
+    );
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('User-Agent must be 5-200 characters');
+  });
+  it('rejects requests with a too-short User-Agent header', async () => {
+    const res = await worker.fetch(
+      buildRequest('/token', { method: 'GET', headers: { 'User-Agent': 'ab' } }),
+      BASE_ENV
+    );
+    const body = (await res.json()) as { success: boolean; error: string };
+    expect(res.status).toBe(400);
+    expect(body.success).toBe(false);
+    expect(body.error).toContain('User-Agent must be 5-200 characters');
+  });
   it('redirects legacy /api/v2 routes with 308 when LEGACY_API_REDIRECT is true', async () => {
     const env: Env = { ...BASE_ENV, LEGACY_API_REDIRECT: 'true' };
     const res = await worker.fetch(
@@ -243,7 +271,10 @@ describe('api-gateway', () => {
   });
   it('serves legacy /api/v2 routes normally when LEGACY_API_REDIRECT is off', async () => {
     const res = await worker.fetch(
-      new Request('https://tarkovtracker.org/api/v2/progress', { method: 'GET' }),
+      new Request('https://tarkovtracker.org/api/v2/progress', {
+        method: 'GET',
+        headers: { 'User-Agent': 'TestClient/1.0 (+https://example.com)' },
+      }),
       BASE_ENV
     );
     await expectErrorResponse(res, 401, 'Unauthorized');

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -100,8 +100,13 @@ const makeFetchMock = ({
     }
     return new Response('Not Found', { status: 404 });
   });
-const buildRequest = (path: string, init?: RequestInit) =>
-  new Request(`https://api.tarkovtracker.org${path}`, init);
+const buildRequest = (path: string, init?: RequestInit) => {
+  const headers = new Headers(init?.headers);
+  if (!headers.has('User-Agent')) {
+    headers.set('User-Agent', 'TestClient/1.0 (+https://example.com)');
+  }
+  return new Request(`https://api.tarkovtracker.org${path}`, { ...init, headers });
+};
 const flushAsync = () => new Promise((resolve) => setTimeout(resolve, 0));
 describe('ApiGatewayRateLimiter durable object', () => {
   afterEach(() => {

--- a/workers/api-gateway/src/__tests__/userAgent.test.ts
+++ b/workers/api-gateway/src/__tests__/userAgent.test.ts
@@ -10,8 +10,8 @@ describe('normalizeInboundUserAgent', () => {
     expect(normalizeInboundUserAgent('  Client/1.0  ')).toBe('Client/1.0');
   });
 
-  it('caps oversized values', () => {
+  it('rejects oversized values', () => {
     const value = 'x'.repeat(INBOUND_USER_AGENT_MAX_LENGTH + 1);
-    expect(normalizeInboundUserAgent(value)).toBe('x'.repeat(INBOUND_USER_AGENT_MAX_LENGTH));
+    expect(normalizeInboundUserAgent(value)).toBeNull();
   });
 });

--- a/workers/api-gateway/src/__tests__/userAgent.test.ts
+++ b/workers/api-gateway/src/__tests__/userAgent.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { INBOUND_USER_AGENT_MAX_LENGTH, normalizeInboundUserAgent } from '../utils/userAgent';
+
+describe('normalizeInboundUserAgent', () => {
+  it.each([null, undefined, '', '   '])('returns null for %s', (value) => {
+    expect(normalizeInboundUserAgent(value)).toBeNull();
+  });
+
+  it('trims valid values', () => {
+    expect(normalizeInboundUserAgent('  Client/1.0  ')).toBe('Client/1.0');
+  });
+
+  it('caps oversized values', () => {
+    const value = 'x'.repeat(INBOUND_USER_AGENT_MAX_LENGTH + 1);
+    expect(normalizeInboundUserAgent(value)).toBe('x'.repeat(INBOUND_USER_AGENT_MAX_LENGTH));
+  });
+});

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -20,7 +20,11 @@ import { OPENAPI_JSON } from './openapi';
 import { resolveTier } from './services/supporter';
 import { recordUsage } from './services/usage';
 import { logger } from './utils/logger';
-import { normalizeInboundUserAgent } from './utils/userAgent';
+import {
+  INBOUND_USER_AGENT_MAX_LENGTH,
+  INBOUND_USER_AGENT_MIN_LENGTH,
+  normalizeInboundUserAgent,
+} from './utils/userAgent';
 import type {
   ApiToken,
   Env,
@@ -660,7 +664,8 @@ async function authenticateAndRateLimit(
   action: Action,
   envOrigin?: string,
   requestOrigin?: string,
-  ctx?: ExecutionContext
+  ctx?: ExecutionContext,
+  userAgent?: string | null
 ): Promise<AuthSuccess | Response> {
   const validation = await validateToken(env, rawToken, permission);
   if (!validation.valid) {
@@ -679,7 +684,7 @@ async function authenticateAndRateLimit(
       tier,
       kind,
       throttled,
-      userAgent: normalizeInboundUserAgent(request.headers.get('User-Agent')),
+      userAgent: userAgent ?? null,
     });
     if (ctx) {
       ctx.waitUntil(promise);
@@ -949,6 +954,20 @@ export default {
     if (!apiPath) {
       return new Response('Not Found', { status: 404, headers });
     }
+    const rawUserAgent = request.headers.get('User-Agent');
+    const inboundUserAgent = normalizeInboundUserAgent(rawUserAgent);
+    if (
+      !inboundUserAgent ||
+      inboundUserAgent.length < INBOUND_USER_AGENT_MIN_LENGTH ||
+      (rawUserAgent?.trim().length ?? 0) > INBOUND_USER_AGENT_MAX_LENGTH
+    ) {
+      return errorResponse(
+        'User-Agent must be 5-200 characters (e.g. "AppName/1.0 (+https://your-app.com)")',
+        400,
+        origin,
+        reqOrigin
+      );
+    }
     // Extract and validate token
     const authHeader = request.headers.get('Authorization');
     const rawToken = extractBearerToken(authHeader);
@@ -966,7 +985,8 @@ export default {
           'token-info',
           origin,
           reqOrigin,
-          ctx
+          ctx,
+          inboundUserAgent
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -983,7 +1003,8 @@ export default {
           'progress-read',
           origin,
           reqOrigin,
-          ctx
+          ctx,
+          inboundUserAgent
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -1001,7 +1022,8 @@ export default {
           'progress-read',
           origin,
           reqOrigin,
-          ctx
+          ctx,
+          inboundUserAgent
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -1020,7 +1042,8 @@ export default {
           'progress-write',
           origin,
           reqOrigin,
-          ctx
+          ctx,
+          inboundUserAgent
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -1051,7 +1074,8 @@ export default {
           'progress-write',
           origin,
           reqOrigin,
-          ctx
+          ctx,
+          inboundUserAgent
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -1111,7 +1135,8 @@ export default {
           'progress-write',
           origin,
           reqOrigin,
-          ctx
+          ctx,
+          inboundUserAgent
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;
@@ -1151,7 +1176,8 @@ export default {
           'progress-write',
           origin,
           reqOrigin,
-          ctx
+          ctx,
+          inboundUserAgent
         );
         if (auth instanceof Response) return auth;
         const { validation, rlHeaders } = auth;

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -20,11 +20,7 @@ import { OPENAPI_JSON } from './openapi';
 import { resolveTier } from './services/supporter';
 import { recordUsage } from './services/usage';
 import { logger } from './utils/logger';
-import {
-  INBOUND_USER_AGENT_MAX_LENGTH,
-  INBOUND_USER_AGENT_MIN_LENGTH,
-  normalizeInboundUserAgent,
-} from './utils/userAgent';
+import { INBOUND_USER_AGENT_MIN_LENGTH, normalizeInboundUserAgent } from './utils/userAgent';
 import type {
   ApiToken,
   Env,
@@ -932,41 +928,38 @@ export default {
       const apiMatch = path.match(/^\/api(?:\/v2)?(.*)$/);
       if (apiMatch) {
         apiPath = apiMatch[1] || '/';
-        // Host migration: once LEGACY_API_REDIRECT is flipped to "true",
-        // legacy /api and /api/v2 routes permanently redirect to the api
-        // subdomain. Clients should migrate proactively: some HTTP stacks
-        // (e.g. .NET HttpClient) drop Authorization on cross-host redirects.
-        if ((env.LEGACY_API_REDIRECT || '').trim().toLowerCase() === 'true') {
-          const target = `https://${apiHost}${apiPath}${url.search}`;
-          return new Response(null, {
-            status: 308,
-            headers: {
-              ...headers,
-              Location: target,
-              Deprecation: LEGACY_API_DEPRECATION_DATE,
-              Link: `<${target}>; rel="successor-version"`,
-              'Cache-Control': 'no-store',
-            },
-          });
-        }
       }
     }
     if (!apiPath) {
       return new Response('Not Found', { status: 404, headers });
     }
-    const rawUserAgent = request.headers.get('User-Agent');
-    const inboundUserAgent = normalizeInboundUserAgent(rawUserAgent);
-    if (
-      !inboundUserAgent ||
-      inboundUserAgent.length < INBOUND_USER_AGENT_MIN_LENGTH ||
-      (rawUserAgent?.trim().length ?? 0) > INBOUND_USER_AGENT_MAX_LENGTH
-    ) {
+    // Validate inbound User-Agent before any routing/redirect so legacy
+    // /api and /api/v2 entrypoints cannot bypass enforcement via 308.
+    const inboundUserAgent = normalizeInboundUserAgent(request.headers.get('User-Agent'));
+    if (!inboundUserAgent || inboundUserAgent.length < INBOUND_USER_AGENT_MIN_LENGTH) {
       return errorResponse(
         'User-Agent must be 5-200 characters (e.g. "AppName/1.0 (+https://your-app.com)")',
         400,
         origin,
         reqOrigin
       );
+    }
+    // Host migration: once LEGACY_API_REDIRECT is flipped to "true",
+    // legacy /api and /api/v2 routes permanently redirect to the api
+    // subdomain. Clients should migrate proactively: some HTTP stacks
+    // (e.g. .NET HttpClient) drop Authorization on cross-host redirects.
+    if (!isApiHost && (env.LEGACY_API_REDIRECT || '').trim().toLowerCase() === 'true') {
+      const target = `https://${apiHost}${apiPath}${url.search}`;
+      return new Response(null, {
+        status: 308,
+        headers: {
+          ...headers,
+          Location: target,
+          Deprecation: LEGACY_API_DEPRECATION_DATE,
+          Link: `<${target}>; rel="successor-version"`,
+          'Cache-Control': 'no-store',
+        },
+      });
     }
     // Extract and validate token
     const authHeader = request.headers.get('Authorization');

--- a/workers/api-gateway/src/openapi.ts
+++ b/workers/api-gateway/src/openapi.ts
@@ -2,7 +2,7 @@ export const OPENAPI_SPEC = {
   openapi: '3.1.0',
   info: {
     title: 'TarkovTracker API Gateway',
-    version: '2.2.0',
+    version: '2.3.0',
     description:
       'Public API gateway for TarkovTracker progress, team progress, and token info.\n\n' +
       'Authentication: Send API tokens in the Authorization header as `Bearer <token>`.\n' +
@@ -18,6 +18,9 @@ export const OPENAPI_SPEC = {
       'Token cap: each account may have at most 3 active API tokens. Revoke an existing ' +
       'token before creating a new one if the cap is reached. Token creation is only ' +
       'allowed through the token-create Edge Function and is rate-limited to 3/hour.\n\n' +
+      'User-Agent: a 5-200 character User-Agent header identifying the client application ' +
+      'is required on all API endpoints. Requests outside that range are rejected with 400. ' +
+      'Use a descriptive string like "AppName/1.0 (+https://your-app.com)".\n\n' +
       'Docs: https://api.tarkovtracker.org/docs (or / on the api subdomain).',
     contact: {
       name: 'TarkovTracker',
@@ -54,6 +57,19 @@ export const OPENAPI_SPEC = {
         description: 'Authorization: Bearer <token>',
       },
     },
+    parameters: {
+      UserAgentHeader: {
+        name: 'User-Agent',
+        in: 'header',
+        required: true,
+        description:
+          'A 5-200 character User-Agent identifying the client application, ' +
+          'e.g. "RatScanner/2.1 (+https://ratscanner.io)". ' +
+          'Requests outside that range are rejected with 400.',
+        schema: { type: 'string', minLength: 5, maxLength: 200 },
+        example: 'RatScanner/2.1 (+https://ratscanner.io)',
+      },
+    },
     responses: {
       Unauthorized: {
         description: 'Unauthorized',
@@ -87,6 +103,14 @@ export const OPENAPI_SPEC = {
             schema: { $ref: '#/components/schemas/ErrorResponse' },
             examples: {
               invalidState: { value: { success: false, error: 'Invalid state' } },
+              invalidUserAgent: {
+                summary: 'Missing or invalid User-Agent header',
+                value: {
+                  success: false,
+                  error:
+                    'User-Agent must be 5-200 characters (e.g. "AppName/1.0 (+https://your-app.com)")',
+                },
+              },
             },
           },
         },

--- a/workers/api-gateway/src/openapi.ts
+++ b/workers/api-gateway/src/openapi.ts
@@ -19,8 +19,9 @@ export const OPENAPI_SPEC = {
       'token before creating a new one if the cap is reached. Token creation is only ' +
       'allowed through the token-create Edge Function and is rate-limited to 3/hour.\n\n' +
       'User-Agent: a 5-200 character User-Agent header identifying the client application ' +
-      'is required on all API endpoints. Requests outside that range are rejected with 400. ' +
-      'Use a descriptive string like "AppName/1.0 (+https://your-app.com)".\n\n' +
+      'is required on protected API endpoints (token, progress, team). Infrastructure routes ' +
+      '(/health, /openapi.json, /docs, /robots.txt) are exempt. Requests outside that range ' +
+      'are rejected with 400. Use a descriptive string like "AppName/1.0 (+https://your-app.com)".\n\n' +
       'Docs: https://api.tarkovtracker.org/docs (or / on the api subdomain).',
     contact: {
       name: 'TarkovTracker',
@@ -575,6 +576,7 @@ export const OPENAPI_SPEC = {
           'Requires GP permission. Counts against the tiered daily read quota (keyed by user) and the per-minute burst limit.',
         operationId: 'getTokenInfo',
         security: [{ bearerAuth: [] }],
+        parameters: [{ $ref: '#/components/parameters/UserAgentHeader' }],
         responses: {
           '200': {
             description: 'Token info',
@@ -584,6 +586,7 @@ export const OPENAPI_SPEC = {
               },
             },
           },
+          '400': { $ref: '#/components/responses/BadRequest' },
           '401': { $ref: '#/components/responses/Unauthorized' },
           '403': { $ref: '#/components/responses/Forbidden' },
           '429': { $ref: '#/components/responses/RateLimited' },
@@ -599,6 +602,7 @@ export const OPENAPI_SPEC = {
           'Requires GP permission. Counts against the tiered daily read quota (keyed by user) and the per-minute burst limit.',
         operationId: 'getProgress',
         security: [{ bearerAuth: [] }],
+        parameters: [{ $ref: '#/components/parameters/UserAgentHeader' }],
         responses: {
           '200': {
             description: 'Progress data',
@@ -608,6 +612,7 @@ export const OPENAPI_SPEC = {
               },
             },
           },
+          '400': { $ref: '#/components/responses/BadRequest' },
           '401': { $ref: '#/components/responses/Unauthorized' },
           '403': { $ref: '#/components/responses/Forbidden' },
           '429': { $ref: '#/components/responses/RateLimited' },
@@ -623,6 +628,7 @@ export const OPENAPI_SPEC = {
           'Requires TP permission. Counts against the tiered daily read quota (keyed by user) and the per-minute burst limit.',
         operationId: 'getTeamProgress',
         security: [{ bearerAuth: [] }],
+        parameters: [{ $ref: '#/components/parameters/UserAgentHeader' }],
         responses: {
           '200': {
             description: 'Team progress data',
@@ -632,6 +638,7 @@ export const OPENAPI_SPEC = {
               },
             },
           },
+          '400': { $ref: '#/components/responses/BadRequest' },
           '401': { $ref: '#/components/responses/Unauthorized' },
           '403': { $ref: '#/components/responses/Forbidden' },
           '429': { $ref: '#/components/responses/RateLimited' },
@@ -648,6 +655,7 @@ export const OPENAPI_SPEC = {
         operationId: 'updatePlayerLevel',
         security: [{ bearerAuth: [] }],
         parameters: [
+          { $ref: '#/components/parameters/UserAgentHeader' },
           {
             name: 'level',
             in: 'path',
@@ -683,6 +691,7 @@ export const OPENAPI_SPEC = {
         operationId: 'updateTask',
         security: [{ bearerAuth: [] }],
         parameters: [
+          { $ref: '#/components/parameters/UserAgentHeader' },
           {
             name: 'taskId',
             in: 'path',
@@ -730,6 +739,7 @@ export const OPENAPI_SPEC = {
         operationId: 'updateTaskObjective',
         security: [{ bearerAuth: [] }],
         parameters: [
+          { $ref: '#/components/parameters/UserAgentHeader' },
           {
             name: 'objectiveId',
             in: 'path',
@@ -776,6 +786,7 @@ export const OPENAPI_SPEC = {
           'Requires WP permission. Counts against the tiered daily write quota (keyed by user) and the per-minute burst limit.',
         operationId: 'updateTasksBatch',
         security: [{ bearerAuth: [] }],
+        parameters: [{ $ref: '#/components/parameters/UserAgentHeader' }],
         requestBody: {
           required: true,
           content: {

--- a/workers/api-gateway/src/utils/userAgent.ts
+++ b/workers/api-gateway/src/utils/userAgent.ts
@@ -1,8 +1,9 @@
 export const TARKOVTRACKER_USER_AGENT = 'TarkovTracker/1.0 (+https://tarkovtracker.org)';
 export const INBOUND_USER_AGENT_MIN_LENGTH = 5;
 export const INBOUND_USER_AGENT_MAX_LENGTH = 200;
-export function normalizeInboundUserAgent(value: string | null): string | null {
+export function normalizeInboundUserAgent(value: string | null | undefined): string | null {
   const trimmed = value?.trim();
   if (!trimmed) return null;
-  return trimmed.slice(0, INBOUND_USER_AGENT_MAX_LENGTH);
+  if (trimmed.length > INBOUND_USER_AGENT_MAX_LENGTH) return null;
+  return trimmed;
 }

--- a/workers/api-gateway/src/utils/userAgent.ts
+++ b/workers/api-gateway/src/utils/userAgent.ts
@@ -1,5 +1,6 @@
 export const TARKOVTRACKER_USER_AGENT = 'TarkovTracker/1.0 (+https://tarkovtracker.org)';
-const INBOUND_USER_AGENT_MAX_LENGTH = 200;
+export const INBOUND_USER_AGENT_MIN_LENGTH = 5;
+export const INBOUND_USER_AGENT_MAX_LENGTH = 200;
 export function normalizeInboundUserAgent(value: string | null): string | null {
   const trimmed = value?.trim();
   if (!trimmed) return null;


### PR DESCRIPTION
## **User description**
## Summary

- Gateway now rejects API requests with a missing or out-of-range (5-200 char) `User-Agent` header with `400`. This makes the inbound UA visible in usage reporting meaningful and discourages anonymous scrapers.
- OpenAPI spec bumped to `2.3.0`; documents the required `User-Agent` header (component parameter `UserAgentHeader`) and the `invalidUserAgent` bad-request example.
- Server-side fetchers (`tarkov-json`, `overlay`, `twitch/live`, `tarkov-dev/profile`) now send the shared `TARKOVTRACKER_USER_AGENT` constant instead of ad-hoc strings. The hardcoded `PROFILE_FETCH_USER_AGENT` constant in `profile.get.ts` is removed in favor of the shared value.
- Exports `INBOUND_USER_AGENT_MIN_LENGTH` from `workers/api-gateway/src/utils/userAgent.ts` and adds unit tests for `normalizeInboundUserAgent` and the new min/max bounds.

Restores the genuinely new half of the user-agent work that was stranded in an orphaned worktree (PR #555 already landed the storage/migration/recording half). The regressive bits from the old worktree base were dropped.

#### Test plan

- [x] `pnpm run test:api-gateway` — 116 tests pass (includes 2 new UA-gate tests + 6 new `userAgent.test.ts` tests)
- [x] `pnpm run typecheck` — passes
- [x] `pnpm run lint` — zero warnings
- [x] `pnpm run validate:openapi` — schema valid at 2.3.0
- [x] `pnpm vitest run app/server/utils/__tests__/tarkov-json.test.ts app/server/utils/__tests__/overlay.test.ts app/server/api/tarkov-dev/__tests__/profile.test.ts` — 48 tests pass

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/572?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Require a valid User-Agent on API requests and reuse one shared client agent for upstream fetches**

### What Changed
- API requests now fail with `400` when the `User-Agent` header is missing, too short, or too long, with a clear error message.
- The API docs now show `User-Agent` as a required header and include the new bad-request example.
- User-facing server requests to Tarkov.dev, Twitch, overlay data, and Tarkov.dev profiles now send the shared TarkovTracker user agent instead of separate values.
- Usage tracking now records the normalized inbound `User-Agent` for valid requests.

### Impact
`✅ Cleaner API usage reporting`
`✅ Fewer anonymous or malformed API requests`
`✅ Consistent upstream request identity`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Protected API requests now require a valid `User-Agent` header (5–200 characters) and are rejected with a clear `400 Bad Request` when missing/invalid.
  - Outbound requests to external services now consistently include the same application `User-Agent`.
- **Documentation**
  - Updated API documentation and published OpenAPI spec v2.3.0 to document the header requirement, exemptions, and `400` error responses.
  - Updated contributor guidance for required `User-Agent` usage in public progress clients.
- **Tests**
  - Expanded/adjusted gateway and endpoint tests to validate inbound header enforcement and outbound header behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the UA gate logic is correct for all boundary conditions, infrastructure exempt paths are returned before the check, and the OpenAPI spec now properly references the parameter on every protected operation.

The gate correctly handles all boundary cases: null/blank/oversized inputs return null from normalizeInboundUserAgent and are rejected; short strings pass the function but are caught by the length-comparison at the gate; valid strings flow through. The redirect-before-auth ordering is preserved and the new test suite covers the main rejection paths.

No files require special attention. The duplicate TARKOVTRACKER_USER_AGENT constant across workers/ and app/ is a minor maintenance note but does not affect correctness today.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workers/api-gateway/src/utils/userAgent.ts | Now returns null for overlong inputs (fixes prior truncation behaviour) and exports both length bounds; logic is clean and correct |
| workers/api-gateway/src/index.ts | UA validation placed before redirect and auth logic; infrastructure early-returns correctly precede the check; userAgent passed to authenticateAndRateLimit for usage recording |
| workers/api-gateway/src/openapi.ts | Version bumped to 2.3.0; UserAgentHeader parameter now correctly referenced via $ref on each protected operation; 400 response added |
| workers/api-gateway/src/__tests__/userAgent.test.ts | New unit test file covers null/empty/whitespace, trimming, and overlong inputs; missing an at-boundary test for exactly INBOUND_USER_AGENT_MAX_LENGTH chars |
| workers/api-gateway/src/__tests__/gateway.test.ts | buildRequest helper injects default UA; new tests cover missing, too-short, oversized, and pre-redirect UA rejection paths |
| app/server/api/tarkov-dev/profile.get.ts | Local PROFILE_FETCH_USER_AGENT removed; now uses shared TARKOVTRACKER_USER_AGENT from app/server/utils/userAgent.ts |
| app/server/utils/tarkov-json.ts | TarkovJsonRequest.headers type widened to Record<string,string>; User-Agent added to outbound fetch; consistent with other fetchers |
| app/server/utils/overlay.ts | User-Agent header added to overlay fetch using the shared constant; straightforward one-line change |
| app/server/api/twitch/live.get.ts | User-Agent added to Twitch GQL POST using shared constant; test updated to assert the new header |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant C as API Client
    participant GW as api-gateway (index.ts)
    participant UA as normalizeInboundUserAgent
    participant Auth as authenticateAndRateLimit
    participant Usage as recordUsage

    C->>GW: HTTP request (any protected path)
    GW->>GW: Resolve apiPath (infra routes exit early)
    GW->>UA: normalizeInboundUserAgent(User-Agent header)
    UA-->>GW: null (missing/blank/oversized) OR trimmed string

    alt "null OR length < 5"
        GW-->>C: 400 User-Agent must be 5-200 characters
    else valid UA
        GW->>GW: Check LEGACY_API_REDIRECT 308 if set
        GW->>Auth: authenticateAndRateLimit(..., inboundUserAgent)
        Auth->>Usage: recordUsage userAgent
        Auth-->>GW: AuthSuccess or 401/403/429
        GW-->>C: 200 / error response
    end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant C as API Client
    participant GW as api-gateway (index.ts)
    participant UA as normalizeInboundUserAgent
    participant Auth as authenticateAndRateLimit
    participant Usage as recordUsage

    C->>GW: HTTP request (any protected path)
    GW->>GW: Resolve apiPath (infra routes exit early)
    GW->>UA: normalizeInboundUserAgent(User-Agent header)
    UA-->>GW: null (missing/blank/oversized) OR trimmed string

    alt "null OR length < 5"
        GW-->>C: 400 User-Agent must be 5-200 characters
    else valid UA
        GW->>GW: Check LEGACY_API_REDIRECT 308 if set
        GW->>Auth: authenticateAndRateLimit(..., inboundUserAgent)
        Auth->>Usage: recordUsage userAgent
        Auth-->>GW: AuthSuccess or 401/403/429
        GW-->>C: 200 / error response
    end
```

</a>
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): address review feedback on Use..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/6d85db4151bd6e13f4c5adc16b24ef86d684c9f4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45914259)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->