### PR TITLE
docs: split README into user-first and developer sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,9 @@ Sign in (via Discord, Twitch, Google, or GitHub) when you want to:
 - **Back up your data** — server-side storage protects against browser data loss
 
 > **Signing in:** If you have local progress and create a new account, that progress uploads to
-> your account on first login. If you sign into an existing account that already has cloud
-> progress, the cloud data takes precedence — your local guest progress is not merged.
+> your account on first login. Returning users (same browser, same account) get a merge of local
+> and cloud progress. If you sign into an existing account from a new browser that already has
+> cloud progress, the cloud data takes precedence — your local guest progress is not merged.
 
 ### Getting help
 
@@ -60,7 +61,7 @@ Sign in (via Discord, Twitch, Google, or GitHub) when you want to:
 The rest of this README covers local development and contributing. If you only want to use
 TarkovTracker, visit **<https://tarkovtracker.org>** — no setup required.
 
-## Local development
+### Local development
 
 ```bash
 corepack enable        # enables pnpm via Corepack (Node >=24.12.0)
@@ -78,7 +79,7 @@ unavailable.
 **Tech stack:** Nuxt 4 (SPA, `ssr: false`), Vue 3 Composition API, TypeScript strict, Pinia,
 Supabase, Tailwind CSS v4, Vitest, Cloudflare Pages/Workers.
 
-## Common commands
+### Common commands
 
 | Task          | Command               |
 | ------------- | --------------------- |
@@ -94,7 +95,7 @@ Run `pnpm run lint`, `pnpm run typecheck`, and `pnpm run test` before pushing. T
 list (including i18n, Supabase types, OpenAPI validation, and the API gateway tests) is in
 [`AGENTS.md`](AGENTS.md) and [`docs/WORKFLOW_AUTOMATION.md`](docs/WORKFLOW_AUTOMATION.md).
 
-## Contributing
+### Contributing
 
 Each pull request must address **one change only** — a single fix, update, doc improvement, or
 feature. PRs that bundle unrelated changes may be asked to split or be closed.
@@ -108,7 +109,7 @@ feature. PRs that bundle unrelated changes may be asked to split or be closed.
 > [`good-first-issue`](https://github.com/tarkovtracker-org/TarkovTracker/labels/good-first-issue)
 > are the easiest way to get started.
 
-## Documentation
+### Documentation
 
 The short version: this README gets you running; the `docs/` folder explains how things work.
 
@@ -130,7 +131,7 @@ The short version: this README gets you running; the `docs/` folder explains how
 
 Start at [`docs/README.md`](docs/README.md) if you are not sure which doc you need.
 
-## Project structure
+### Project structure
 
 ```text
 app/         Nuxt 4 source (features, stores, server routes, shell, locales)
@@ -145,6 +146,6 @@ See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full module map and
 [`docs/SYSTEMS.md`](docs/SYSTEMS.md) for how the non-obvious systems (Tarkov.dev integration,
 multi-layer caching, overlay corrections, precompute) actually work.
 
-## License
+### License
 
 GNU General Public License v3.0 — see [`LICENSE.md`](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -36,8 +36,9 @@ Sign in (via Discord, Twitch, Google, or GitHub) when you want to:
 - **Use API tokens** — programmatically read your progress via the public API
 - **Back up your data** — server-side storage protects against browser data loss
 
-> Your local progress is preserved when you sign in. Existing local data merges into your account
-> on first login.
+> **Signing in:** If you have local progress and create a new account, that progress uploads to
+> your account on first login. If you sign into an existing account that already has cloud
+> progress, the cloud data takes precedence — your local guest progress is not merged.
 
 ### Getting help
 
@@ -54,7 +55,7 @@ Sign in (via Discord, Twitch, Google, or GitHub) when you want to:
 <!-- Everything below this line is for developers and contributors. -->
 <!-- If you just want to use TarkovTracker, visit https://tarkovtracker.org. -->
 
-# For Developers and Contributors
+## For Developers and Contributors
 
 The rest of this README covers local development and contributing. If you only want to use
 TarkovTracker, visit **<https://tarkovtracker.org>** — no setup required.

--- a/README.md
+++ b/README.md
@@ -2,33 +2,64 @@
 
 [![Crowdin](https://badges.crowdin.net/tarkovtrackerorg/localized.svg)](https://crowdin.com/project/tarkovtrackerorg)
 [![codecov](https://codecov.io/gh/tarkovtracker-org/TarkovTracker/graph/badge.svg)](https://codecov.io/gh/tarkovtracker-org/TarkovTracker)
-[![Greptile: The War on Bugs](https://www.greptile.com/badge.svg)](https://www.greptile.com/?utm_source=oss_badge&utm_medium=readme&utm_campaign=greptile_for_open_source)
 
-A friendly, comprehensive progress tracker for **Escape from Tarkov**. Track tasks and hideout
-progress, collaborate with your team in real time, and switch between PvP and PvE modes without
-losing your place. Built with Nuxt 4, Vue 3, Supabase, and Tailwind CSS.
-
-**Try it live at <https://tarkovtracker.org>.**
+TarkovTracker tracks Escape from Tarkov tasks, hideout upgrades, required items, levels, and team
+progress separately for PvP and PvE.
 
 [![TarkovTracker dashboard showing task progress, hideout modules, and team overview](.github/assets/dashboard.png)](https://tarkovtracker.org)
 
-> New here? Issues labeled [`good-first-issue`](https://github.com/tarkovtracker-org/TarkovTracker/labels/good-first-issue)
-> are the easiest way to get familiar with the codebase and the contribution process.
+**Try it live at <https://tarkovtracker.org>.**
 
-## Features
+---
 
-- **Dual game modes** — track PvP and PvE progress separately.
-- **Team collaboration** — share progress with teammates in real time via Supabase.
-- **Task & objective tracking** — see what is available, what is locked, and what is next.
-- **Hideout progress** — track module upgrades and the parts you still need.
-- **Player level & faction progress** — monitor leveling across factions.
-- **Interactive maps** — explore maps with spawn points and objectives.
-- **Streamer tools** — overlays for content creators.
-- **Multi-language** — English, German, Spanish, French, Russian, Ukrainian, and Chinese, with
-  community translations at [translate.tarkovtracker.org](https://translate.tarkovtracker.org).
-  API data can be fetched in any tarkov.dev-supported language.
+## Using TarkovTracker
 
-## Quick start
+You can start tracking your progress immediately — **no account required**. Your progress is saved
+in your browser's local storage and stays there between visits.
+
+### What works without an account
+
+- Track task and objective completion (PvP and PvE separately)
+- Track hideout module upgrades and the parts you still need
+- View player level, faction progress, and needed items
+- Browse interactive maps with spawn points and objectives
+- Customize display preferences and game mode
+- All data persists locally in your browser
+
+### What an account enables
+
+Sign in (via Discord, Twitch, Google, or GitHub) when you want to:
+
+- **Sync progress across devices** — your progress follows you to any browser
+- **Create or join a team** — share progress with teammates in real time
+- **Share your profile** — let others view your progress via a shareable link
+- **Use API tokens** — programmatically read your progress via the public API
+- **Back up your data** — server-side storage protects against browser data loss
+
+> Your local progress is preserved when you sign in. Existing local data merges into your account
+> on first login.
+
+### Getting help
+
+- **Questions or bugs?** See [`SUPPORT.md`](SUPPORT.md) for where to ask.
+- **Found a security issue?** See [`SECURITY.md`](SECURITY.md) for how to report it privately.
+- **Community:** Join us on [Discord](https://discord.gg/M8nBgA2sT6) or
+  [GitHub Discussions](https://github.com/tarkovtracker-org/TarkovTracker/discussions).
+- **Translations:** Help translate at
+  [translate.tarkovtracker.org](https://translate.tarkovtracker.org). Supported languages:
+  English, German, Spanish, French, Russian, Ukrainian, and Chinese.
+
+---
+
+<!-- Everything below this line is for developers and contributors. -->
+<!-- If you just want to use TarkovTracker, visit https://tarkovtracker.org. -->
+
+# For Developers and Contributors
+
+The rest of this README covers local development and contributing. If you only want to use
+TarkovTracker, visit **<https://tarkovtracker.org>** — no setup required.
+
+## Local development
 
 ```bash
 corepack enable        # enables pnpm via Corepack (Node >=24.12.0)
@@ -42,6 +73,9 @@ unavailable.
 
 > Only `NUXT_PUBLIC_SUPABASE_URL` and `NUXT_PUBLIC_SUPABASE_ANON_KEY` are required for login/sync.
 > Everything else is optional and documented in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+**Tech stack:** Nuxt 4 (SPA, `ssr: false`), Vue 3 Composition API, TypeScript strict, Pinia,
+Supabase, Tailwind CSS v4, Vitest, Cloudflare Pages/Workers.
 
 ## Common commands
 
@@ -69,24 +103,29 @@ feature. PRs that bundle unrelated changes may be asked to split or be closed.
 - **[Label system](.github/LABELS.md)** — issue types, scope, priority, ownership, and status.
 - **[Project board](.github/PROJECT_BOARD.md)** — how issues move from backlog to done.
 
+> New to the codebase? Issues labeled
+> [`good-first-issue`](https://github.com/tarkovtracker-org/TarkovTracker/labels/good-first-issue)
+> are the easiest way to get started.
+
 ## Documentation
 
 The short version: this README gets you running; the `docs/` folder explains how things work.
 
-| You want to…                                      | Read                                                                    |
-| ------------------------------------------------- | ----------------------------------------------------------------------- |
-| Get started                                       | This README                                                             |
-| Report a security vulnerability                   | [`SECURITY.md`](SECURITY.md)                                            |
-| Find where to get help                            | [`SUPPORT.md`](SUPPORT.md)                                              |
-| Read the code of conduct                          | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                              |
-| Understand the systems (caching, data, overlay)   | [`docs/SYSTEMS.md`](docs/SYSTEMS.md)                                    |
-| Understand the full architecture & data flow      | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)                          |
-| Use or extend the HTTP/API surface                | [`docs/API.md`](docs/API.md)                                            |
-| Understand rate limits / abuse controls           | [`docs/RATE_LIMITING.md`](docs/RATE_LIMITING.md)                        |
-| Deploy, configure env vars, or handle an incident | [`docs/runbook.md`](docs/runbook.md)                                    |
-| Understand CI/CD, hooks, and releases             | [`docs/WORKFLOW_AUTOMATION.md`](docs/WORKFLOW_AUTOMATION.md)            |
-| Contribute (issues, branches, PRs, labels)        | [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md)                    |
-| Work as (or configure) an AI agent                | [`AGENTS.md`](AGENTS.md) + [`docs/agent-context/`](docs/agent-context/) |
+| You want to…                                      | Read                                                                                       |
+| ------------------------------------------------- | ------------------------------------------------------------------------------------------ |
+| Get started                                       | This README                                                                                |
+| Report a security vulnerability                   | [`SECURITY.md`](SECURITY.md)                                                               |
+| Find where to get help                            | [`SUPPORT.md`](SUPPORT.md)                                                                 |
+| Read the code of conduct                          | [`CODE_OF_CONDUCT.md`](CODE_OF_CONDUCT.md)                                                 |
+| Understand the systems (caching, data, overlay)   | [`docs/SYSTEMS.md`](docs/SYSTEMS.md)                                                       |
+| Understand the full architecture & data flow      | [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)                                             |
+| Read the Tarkov data architecture decision        | [`docs/decisions/tarkov-data-architecture.md`](docs/decisions/tarkov-data-architecture.md) |
+| Use or extend the HTTP/API surface                | [`docs/API.md`](docs/API.md)                                                               |
+| Understand rate limits / abuse controls           | [`docs/RATE_LIMITING.md`](docs/RATE_LIMITING.md)                                           |
+| Deploy, configure env vars, or handle an incident | [`docs/runbook.md`](docs/runbook.md)                                                       |
+| Understand CI/CD, hooks, and releases             | [`docs/WORKFLOW_AUTOMATION.md`](docs/WORKFLOW_AUTOMATION.md)                               |
+| Contribute (issues, branches, PRs, labels)        | [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md)                                       |
+| Work as (or configure) an AI agent                | [`AGENTS.md`](AGENTS.md) + [`docs/agent-context/`](docs/agent-context/)                    |
 
 Start at [`docs/README.md`](docs/README.md) if you are not sure which doc you need.
 


### PR DESCRIPTION
## **User description**
## Summary

Restructures the README so users and developers each find their information quickly without wading through the other audience's content.

### Top half — for users

- New **"Using TarkovTracker"** section explains what works without an account (task/hideout/map tracking, localStorage persistence) and what an account enables (cross-device sync, teams, shared profiles, API tokens, backup).
- **"Getting help"** subsection links to `SUPPORT.md`, `SECURITY.md`, Discord, and GitHub Discussions.
- Opening sentence now describes what the app tracks, not what it is built with.
- OAuth providers (Discord, Twitch, Google, GitHub) verified against `app/features/settings/AccountDeletionCard.vue`.

### Clear divider

HTML comments mark the audience boundary so anyone reading the raw markdown sees the split.

### Bottom half — for developers and contributors

- Renamed **"Quick start"** to **"Local development"** to distinguish from the user's quick start (visiting the live site).
- Tech stack moved here from the intro.
- Commands, contributing, documentation routing table, project structure, and license remain here.
- `good-first-issue` callout moved to the Contributing section where it is relevant to developers, not users.

### Other changes

- Removed the Greptile promotional badge from the opening badge row (visually louder than the status-oriented badges; tooling acknowledgments don't belong in the user-facing badge row).
- Added the Tarkov data architecture decision to the documentation routing table (was added to `docs/README.md` in #571 but not the root README).

#### Test plan

- [x] `npx prettier --check README.md` passes
- [x] All relative links resolve (18 links checked, including new `docs/decisions/tarkov-data-architecture.md`)
- [x] OAuth providers verified against source code
- [x] husky + lint-staged pre-commit hook passed
- [ ] CI `link-check` (lychee) passes
- [ ] CI `format:check` passes

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/573?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Split the README into user-facing and developer sections**

### What Changed
- The top of the README now explains what TarkovTracker does, what works without an account, and what signing in adds
- Help, translation, and community links are grouped in a user-focused section
- The developer content now starts in its own section, with local setup, commands, contribution guidance, and the documentation map kept together
- The documentation map now includes the Tarkov data architecture decision
- The Greptile badge was removed from the top badge row

### Impact
`✅ Quicker answers for new users`
`✅ Clearer path for contributors`
`✅ Easier access to help and docs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized the README with a user-focused guide covering available features, sign-in benefits, and support resources.
  * Added a concise overview of the technology stack for developers.
  * Refreshed documentation links and guidance for contributors and AI agents.
  * Removed outdated introductory content and streamlined the transition to development instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change to README.md with no code, config, or logic modifications — safe to merge.

The change touches only README.md. Heading hierarchy is correct (one H1, two H2 sections, H3 sub-sections throughout). All linked files were verified to exist. OAuth providers are confirmed against source. No functional code is affected.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Restructures README into a user-first top half and a developer bottom half; removes Greptile badge; adds docs/decisions/tarkov-data-architecture.md to routing table; previously flagged duplicate-H1 issue is already resolved (the section is correctly H2). |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["# TarkovTracker (H1)"] --> B["## Using TarkovTracker (H2)"]
    B --> B1["### What works without an account"]
    B --> B2["### What an account enables"]
    B --> B3["### Getting help"]
    A --> C["## For Developers and Contributors (H2)"]
    C --> C1["### Local development"]
    C --> C2["### Common commands"]
    C --> C3["### Contributing"]
    C --> C4["### Documentation"]
    C --> C5["### Project structure"]
    C --> C6["### License"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["# TarkovTracker (H1)"] --> B["## Using TarkovTracker (H2)"]
    B --> B1["### What works without an account"]
    B --> B2["### What an account enables"]
    B --> B3["### Getting help"]
    A --> C["## For Developers and Contributors (H2)"]
    C --> C1["### Local development"]
    C --> C2["### Common commands"]
    C --> C3["### Contributing"]
    C --> C4["### Documentation"]
    C --> C5["### Project structure"]
    C --> C6["### License"]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: add returning-user merge case, nest..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/81312eb11c9a437f2fc1fe11ed0ce893554c0b41) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=45916084)</sub>

<!-- /greptile_comment -->