### PR TITLE
docs: align llms.txt with spec and add verification

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -49,11 +49,13 @@ jobs:
           fail: true
 
       - name: llms.txt Link Checker
+        if: ${{ success() || failure() }}
         uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
         with:
           # Dedicated config (lychee.llms.toml) drops the tarkovtracker.org
           # exclude that lychee.toml uses for docs, so internal links in
-          # llms.txt are actually verified.
+          # llms.txt are actually verified. Runs even if the docs link check
+          # above failed, since the two checks are independent.
           args: >-
             --config lychee.llms.toml
             --verbose

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -46,6 +46,7 @@ jobs:
             --verbose
             './docs/**/*.md'
             './*.md'
+          output: lychee/out-docs.md
           fail: true
 
       - name: llms.txt Link Checker
@@ -55,11 +56,13 @@ jobs:
           # Dedicated config (lychee.llms.toml) drops the tarkovtracker.org
           # exclude that lychee.toml uses for docs, so internal links in
           # llms.txt are actually verified. Runs even if the docs link check
-          # above failed, since the two checks are independent.
+          # above failed, since the two checks are independent. Separate output
+          # path so it does not overwrite the docs report.
           args: >-
             --config lychee.llms.toml
             --verbose
             './public/llms.txt'
+          output: lychee/out-llms.md
           fail: true
 
       - name: Upload Link Check Report
@@ -67,5 +70,5 @@ jobs:
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:
           name: link-check-report
-          path: ./lychee/out.md
+          path: ./lychee/
           retention-days: 7

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -5,14 +5,18 @@ on:
     paths:
       - 'docs/**/*.md'
       - '*.md'
+      - 'public/llms.txt'
       - 'lychee.toml'
+      - 'lychee.llms.toml'
       - '.github/workflows/link-check.yml'
   push:
     branches: [main]
     paths:
       - 'docs/**/*.md'
       - '*.md'
+      - 'public/llms.txt'
       - 'lychee.toml'
+      - 'lychee.llms.toml'
       - '.github/workflows/link-check.yml'
   schedule:
     - cron: '0 0 * * 0' # Weekly on Sunday at midnight UTC
@@ -42,6 +46,18 @@ jobs:
             --verbose
             './docs/**/*.md'
             './*.md'
+          fail: true
+
+      - name: llms.txt Link Checker
+        uses: lycheeverse/lychee-action@8646ba30535128ac92d33dfc9133794bfdd9b411
+        with:
+          # Dedicated config (lychee.llms.toml) drops the tarkovtracker.org
+          # exclude that lychee.toml uses for docs, so internal links in
+          # llms.txt are actually verified.
+          args: >-
+            --config lychee.llms.toml
+            --verbose
+            './public/llms.txt'
           fail: true
 
       - name: Upload Link Check Report

--- a/lychee.llms.toml
+++ b/lychee.llms.toml
@@ -1,0 +1,16 @@
+# Dedicated lychee config for public/llms.txt link verification.
+# The shared lychee.toml excludes tarkovtracker.org (production origin is
+# checked by deploy, not docs CI), which would skip every internal link in
+# llms.txt. This config drops that exclude so the llms.txt internal links are
+# actually verified, while keeping the same runtime settings and dev-host
+# exclusions as lychee.toml.
+#############################  Runtime  #############################
+no_progress = true
+max_concurrency = 4
+max_retries = 3
+retry_wait_time = 2
+accept = ["200", "204", "206", "301", "302", "308"]
+#############################  Exclusions  ##########################
+# Local/dev hosts only. Production origin (tarkovtracker.org) is intentionally
+# NOT excluded here so llms.txt internal links are checked.
+exclude = ['localhost', '127\.0\.0\.1', 'gnu\.org']

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,11 +2,11 @@
 
 > TarkovTracker is a Nuxt 4 single-page app for tracking Escape from Tarkov progression (tasks, hideout, storyline, needed items), with optional account sync, shared profiles, and team collaboration.
 
-This site is primarily a client app plus JSON APIs. Public game data is available under `/api/tarkov/*` and is proxied from tarkov.dev with overlay fixes and edge caching. API endpoints are intended for direct programmatic access, not crawling; `/api` is disallowed in `robots.txt`.
+This site is primarily a client app plus JSON APIs. Public game data is available under `/api/tarkov/*` and is proxied from tarkov.dev with overlay fixes and edge caching. API endpoints are intended for direct programmatic access, not crawling.
 
-For API requests, use `lang` and `gameMode` where supported. Common `gameMode` values are `regular` (PvP) and `pve`. Supported `lang` values match the UI locales below.
+For API requests, use `lang` and `gameMode` where supported. Common `gameMode` values are `regular` (PvP) and `pve`. Supported `lang` values: `cs`, `de`, `en`, `es`, `fr`, `hu`, `it`, `ja`, `ko`, `pl`, `pt`, `ro`, `ru`, `sk`, `tr`, `zh`. Unsupported values fall back to `en`.
 
-UI locales: `en`, `de`, `es`, `fr`, `ru`, `uk`, `zh`, `ko`.
+UI locales (separate from the API `lang` set): `en`, `de`, `es`, `fr`, `ru`, `uk`, `zh`, `ko`.
 
 Authentication-required areas include `/account`, `/profile`, `/team`, `/settings`, and authenticated team APIs.
 
@@ -39,7 +39,7 @@ Crawl and discovery directives live at `/robots.txt` and `/sitemap.xml`; see tho
 - [Prestige](https://tarkovtracker.org/api/tarkov/prestige): Prestige requirement data. Accepts `lang`.
 - [Cache Metadata](https://tarkovtracker.org/api/tarkov/cache-meta): Cache purge timestamp metadata.
 - [Contributors](https://tarkovtracker.org/api/contributors): Contributor listing.
-- [Changelog API](https://tarkovtracker.org/api/changelog): Changelog data feed. Accepts `limit` (entries) and `releases` (1-10).
+- [Changelog API](https://tarkovtracker.org/api/changelog): Changelog data feed. Accepts `limit` (1-50, default 10) and `releases` (1-10, default 3).
 
 ## Markdown Docs
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -2,13 +2,15 @@
 
 > TarkovTracker is a Nuxt 4 single-page app for tracking Escape from Tarkov progression (tasks, hideout, storyline, needed items), with optional account sync, shared profiles, and team collaboration.
 
-This site is primarily a client app plus JSON APIs. Public game data is available under `/api/tarkov/*` and is proxied from tarkov.dev with overlay fixes and edge caching.
+This site is primarily a client app plus JSON APIs. Public game data is available under `/api/tarkov/*` and is proxied from tarkov.dev with overlay fixes and edge caching. API endpoints are intended for direct programmatic access, not crawling; `/api` is disallowed in `robots.txt`.
 
-For API requests, use `lang` and `gameMode` where supported. Common `gameMode` values are `regular` (PvP) and `pve`.
+For API requests, use `lang` and `gameMode` where supported. Common `gameMode` values are `regular` (PvP) and `pve`. Supported `lang` values match the UI locales below.
 
-UI locales: `en`, `de`, `es`, `fr`, `ru`, `uk`, `zh`.
+UI locales: `en`, `de`, `es`, `fr`, `ru`, `uk`, `zh`, `ko`.
 
-Authentication-required areas include `/account`, `/team`, `/settings`, and authenticated team APIs.
+Authentication-required areas include `/account`, `/profile`, `/team`, `/settings`, and authenticated team APIs.
+
+Crawl and discovery directives live at `/robots.txt` and `/sitemap.xml`; see those files for the canonical list of indexable public pages.
 
 ## Primary Pages
 
@@ -22,23 +24,22 @@ Authentication-required areas include `/account`, `/team`, `/settings`, and auth
 - [TarkovMonitor Guide](https://tarkovtracker.org/resources/tarkovmonitor): Install and link TarkovMonitor to TarkovTracker.
 - [RatScanner Guide](https://tarkovtracker.org/resources/ratscanner): Install and use RatScanner overlays.
 - [CultistCircle Guide](https://tarkovtracker.org/resources/cultistcircle): Cultist Circle recipe calculator reference.
-- [Profile](https://tarkovtracker.org/profile): Signed-in profile and progression management.
 - [Changelog](https://tarkovtracker.org/changelog): Product and feature updates.
 
 ## Public JSON APIs
 
-- [Bootstrap](https://tarkovtracker.org/api/tarkov/bootstrap): Minimal level/xp bootstrap data.
-- [Tasks Core](https://tarkovtracker.org/api/tarkov/tasks-core): Core task, map, and trader data.
-- [Tasks Objectives](https://tarkovtracker.org/api/tarkov/tasks-objectives): Task objectives and fail conditions.
-- [Tasks Rewards](https://tarkovtracker.org/api/tarkov/tasks-rewards): Task reward payloads.
-- [Hideout API](https://tarkovtracker.org/api/tarkov/hideout): Hideout stations, requirements, and crafts.
-- [Items Lite](https://tarkovtracker.org/api/tarkov/items-lite): Lightweight item index.
-- [Items Full](https://tarkovtracker.org/api/tarkov/items): Full item data.
-- [Map Spawns](https://tarkovtracker.org/api/tarkov/map-spawns): Spawn/location data.
-- [Prestige](https://tarkovtracker.org/api/tarkov/prestige): Prestige requirement data.
+- [Bootstrap](https://tarkovtracker.org/api/tarkov/bootstrap): Minimal level/xp bootstrap data. Accepts `lang`, `gameMode`.
+- [Tasks Core](https://tarkovtracker.org/api/tarkov/tasks-core): Core task, map, and trader data. Accepts `lang`, `gameMode`.
+- [Tasks Objectives](https://tarkovtracker.org/api/tarkov/tasks-objectives): Task objectives and fail conditions. Accepts `lang`, `gameMode`.
+- [Tasks Rewards](https://tarkovtracker.org/api/tarkov/tasks-rewards): Task reward payloads. Accepts `lang`, `gameMode`.
+- [Hideout API](https://tarkovtracker.org/api/tarkov/hideout): Hideout stations, requirements, and crafts. Accepts `lang`, `gameMode`.
+- [Items Lite](https://tarkovtracker.org/api/tarkov/items-lite): Lightweight item index. Accepts `lang`, `gameMode`.
+- [Items Full](https://tarkovtracker.org/api/tarkov/items): Full item data. Accepts `lang`, `gameMode`.
+- [Map Spawns](https://tarkovtracker.org/api/tarkov/map-spawns): Spawn/location data. Accepts `lang`, `gameMode`.
+- [Prestige](https://tarkovtracker.org/api/tarkov/prestige): Prestige requirement data. Accepts `lang`.
 - [Cache Metadata](https://tarkovtracker.org/api/tarkov/cache-meta): Cache purge timestamp metadata.
 - [Contributors](https://tarkovtracker.org/api/contributors): Contributor listing.
-- [Changelog API](https://tarkovtracker.org/api/changelog): Changelog data feed.
+- [Changelog API](https://tarkovtracker.org/api/changelog): Changelog data feed. Accepts `limit` (entries) and `releases` (1-10).
 
 ## Markdown Docs
 
@@ -53,5 +54,3 @@ Authentication-required areas include `/account`, `/team`, `/settings`, and auth
 - [Credits](https://tarkovtracker.org/credits): Team and contributor acknowledgements.
 - [Privacy Policy](https://tarkovtracker.org/privacy): Privacy terms.
 - [Terms of Service](https://tarkovtracker.org/terms-of-service): Service terms.
-- [Robots](https://tarkovtracker.org/robots.txt): Crawl directives and sitemap pointer.
-- [Sitemap](https://tarkovtracker.org/sitemap.xml): Broad URL discovery for public pages.

--- a/tests/llms-txt.test.ts
+++ b/tests/llms-txt.test.ts
@@ -1,9 +1,11 @@
 import { readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { describe, expect, it } from 'vitest';
+import { API_SUPPORTED_LANGUAGES } from '@/utils/constants';
 import { SUPPORTED_LOCALES } from '@/utils/locales';
 const LLMS_TXT_PATH = join(process.cwd(), 'public', 'llms.txt');
 const TARKOV_API_DIR = join(process.cwd(), 'app', 'server', 'api', 'tarkov');
+const TOP_LEVEL_API_DIR = join(process.cwd(), 'app', 'server', 'api');
 const llmsTxt = readFileSync(LLMS_TXT_PATH, 'utf8');
 const HYPERLINK_RE = /^- \[([^\]]+)\]\(([^)]+)\)(?::\s*(.*))?$/;
 const H1_RE = /^# (.+)$/;
@@ -26,12 +28,16 @@ const splitSections = (src: string): Section[] => {
 };
 const nonEmptyLines = (src: string): string[] => src.split('\n').filter((l) => l.trim().length > 0);
 const listItems = (section: Section): string[] =>
-  section.lines.filter((l) => HYPERLINK_RE.test(l.trim()));
+  section.lines.filter((l) => l.trim().startsWith('- '));
 const parseLink = (line: string): { name: string; url: string; notes?: string } | null => {
   const match = line.trim().match(HYPERLINK_RE);
   if (!match) return null;
   return { name: match[1], url: match[2], notes: match[3] };
 };
+const getHandlers = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isFile() && d.name.endsWith('.get.ts'))
+    .map((d) => d.name.replace(/\.get\.ts$/, ''));
 describe('public/llms.txt', () => {
   it('starts with an H1 project name', () => {
     const lines = nonEmptyLines(llmsTxt);
@@ -66,16 +72,23 @@ describe('public/llms.txt', () => {
     for (const section of sections) {
       for (const item of listItems(section)) {
         const parsed = parseLink(item);
-        if (!parsed) continue;
-        expect(parsed.url, `non-https url: ${parsed.url}`).toMatch(/^https:\/\//);
+        expect(parsed, `unparseable list item: ${item}`).not.toBeNull();
+        expect(parsed?.url, `non-https url: ${parsed?.url}`).toMatch(/^https:\/\//);
       }
     }
   });
   it('declares every supported UI locale', () => {
-    const localeLine = nonEmptyLines(llmsTxt).find((l) => l.startsWith('UI locales:'));
+    const localeLine = nonEmptyLines(llmsTxt).find((l) => l.startsWith('UI locales'));
     expect(localeLine, 'missing UI locales line').toBeDefined();
     for (const locale of SUPPORTED_LOCALES) {
       expect(localeLine, `locale "${locale}" missing from llms.txt`).toContain(`\`${locale}\``);
+    }
+  });
+  it('declares every API-supported language', () => {
+    const langLine = nonEmptyLines(llmsTxt).find((l) => l.includes('Supported `lang` values:'));
+    expect(langLine, 'missing API lang line').toBeDefined();
+    for (const lang of API_SUPPORTED_LANGUAGES) {
+      expect(langLine, `API lang "${lang}" missing from llms.txt`).toContain(`\`${lang}\``);
     }
   });
   it('lists /profile among auth-required areas', () => {
@@ -94,23 +107,26 @@ describe('public/llms.txt', () => {
     expect(optional, 'missing Optional section').toBeDefined();
     for (const item of listItems(optional!)) {
       const parsed = parseLink(item);
+      expect(parsed, `unparseable list item: ${item}`).not.toBeNull();
       expect(parsed?.url, `infrastructure url in Optional: ${parsed?.url}`).not.toMatch(
         /robots\.txt$|sitemap\.xml$/
       );
     }
   });
-  it('advertises every tarkov API handler that exists on disk', () => {
-    const handlers = readdirSync(TARKOV_API_DIR)
-      .filter((f) => f.endsWith('.get.ts'))
-      .map((f) => f.replace(/\.get\.ts$/, ''));
+  it('advertises every public API handler that exists on disk', () => {
+    const tarkovHandlers = getHandlers(TARKOV_API_DIR);
+    const topLevelHandlers = getHandlers(TOP_LEVEL_API_DIR);
     const sections = splitSections(llmsTxt);
     const apiSection = sections.find((s) => s.heading === 'Public JSON APIs');
     expect(apiSection, 'missing Public JSON APIs section').toBeDefined();
     const advertised = new Set(
       listItems(apiSection!).map((l) => parseLink(l)?.url.split('/').at(-1))
     );
-    for (const handler of handlers) {
-      expect(advertised.has(handler), `handler "${handler}" not advertised in llms.txt`).toBe(true);
+    for (const handler of tarkovHandlers) {
+      expect(advertised.has(handler), `tarkov handler "${handler}" not advertised`).toBe(true);
+    }
+    for (const handler of topLevelHandlers) {
+      expect(advertised.has(handler), `top-level handler "${handler}" not advertised`).toBe(true);
     }
   });
 });

--- a/tests/llms-txt.test.ts
+++ b/tests/llms-txt.test.ts
@@ -1,0 +1,116 @@
+import { readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SUPPORTED_LOCALES } from '@/utils/locales';
+const LLMS_TXT_PATH = join(process.cwd(), 'public', 'llms.txt');
+const TARKOV_API_DIR = join(process.cwd(), 'app', 'server', 'api', 'tarkov');
+const llmsTxt = readFileSync(LLMS_TXT_PATH, 'utf8');
+const HYPERLINK_RE = /^- \[([^\]]+)\]\(([^)]+)\)(?::\s*(.*))?$/;
+const H1_RE = /^# (.+)$/;
+const H2_RE = /^## (.+)$/;
+const BLOCKQUOTE_RE = /^> (.*)$/;
+type Section = { heading: string | null; lines: string[] };
+const splitSections = (src: string): Section[] => {
+  const sections: Section[] = [];
+  let current: Section = { heading: null, lines: [] };
+  for (const line of src.split('\n')) {
+    if (H2_RE.test(line)) {
+      if (current.lines.some((l) => l.trim())) sections.push(current);
+      current = { heading: line.replace(/^## /, ''), lines: [] };
+    } else {
+      current.lines.push(line);
+    }
+  }
+  if (current.lines.some((l) => l.trim())) sections.push(current);
+  return sections;
+};
+const nonEmptyLines = (src: string): string[] => src.split('\n').filter((l) => l.trim().length > 0);
+const listItems = (section: Section): string[] =>
+  section.lines.filter((l) => HYPERLINK_RE.test(l.trim()));
+const parseLink = (line: string): { name: string; url: string; notes?: string } | null => {
+  const match = line.trim().match(HYPERLINK_RE);
+  if (!match) return null;
+  return { name: match[1], url: match[2], notes: match[3] };
+};
+describe('public/llms.txt', () => {
+  it('starts with an H1 project name', () => {
+    const lines = nonEmptyLines(llmsTxt);
+    expect(lines[0]).toMatch(H1_RE);
+    expect(lines[0]).toBe('# TarkovTracker');
+  });
+  it('has a blockquote summary immediately after the H1', () => {
+    const lines = nonEmptyLines(llmsTxt);
+    expect(lines[1]).toMatch(BLOCKQUOTE_RE);
+    expect(lines[1].length).toBeGreaterThan(20);
+  });
+  it('keeps the Optional section last', () => {
+    const sections = splitSections(llmsTxt);
+    expect(sections.at(-1)?.heading).toBe('Optional');
+  });
+  it('every H2 section list item is a valid hyperlink with optional notes', () => {
+    const sections = splitSections(llmsTxt);
+    for (const section of sections) {
+      if (section.heading === null) continue;
+      const items = listItems(section);
+      expect(items.length, `section "${section.heading}" has no list items`).toBeGreaterThan(0);
+      for (const item of items) {
+        const parsed = parseLink(item);
+        expect(parsed, `unparseable list item: ${item}`).not.toBeNull();
+        expect(parsed?.name.length, `empty link name: ${item}`).toBeGreaterThan(0);
+        expect(parsed?.url.length, `empty url: ${item}`).toBeGreaterThan(0);
+      }
+    }
+  });
+  it('every linked URL is absolute https', () => {
+    const sections = splitSections(llmsTxt);
+    for (const section of sections) {
+      for (const item of listItems(section)) {
+        const parsed = parseLink(item);
+        if (!parsed) continue;
+        expect(parsed.url, `non-https url: ${parsed.url}`).toMatch(/^https:\/\//);
+      }
+    }
+  });
+  it('declares every supported UI locale', () => {
+    const localeLine = nonEmptyLines(llmsTxt).find((l) => l.startsWith('UI locales:'));
+    expect(localeLine, 'missing UI locales line').toBeDefined();
+    for (const locale of SUPPORTED_LOCALES) {
+      expect(localeLine, `locale "${locale}" missing from llms.txt`).toContain(`\`${locale}\``);
+    }
+  });
+  it('lists /profile among auth-required areas', () => {
+    const authLine = nonEmptyLines(llmsTxt).find((l) =>
+      l.startsWith('Authentication-required areas')
+    );
+    expect(authLine, 'missing auth-required note').toBeDefined();
+    expect(authLine).toContain('/profile');
+    expect(authLine).toContain('/account');
+    expect(authLine).toContain('/team');
+    expect(authLine).toContain('/settings');
+  });
+  it('Optional section excludes infrastructure URLs (robots/sitemap)', () => {
+    const sections = splitSections(llmsTxt);
+    const optional = sections.find((s) => s.heading === 'Optional');
+    expect(optional, 'missing Optional section').toBeDefined();
+    for (const item of listItems(optional!)) {
+      const parsed = parseLink(item);
+      expect(parsed?.url, `infrastructure url in Optional: ${parsed?.url}`).not.toMatch(
+        /robots\.txt$|sitemap\.xml$/
+      );
+    }
+  });
+  it('advertises every tarkov API handler that exists on disk', () => {
+    const handlers = readdirSync(TARKOV_API_DIR)
+      .filter((f) => f.endsWith('.get.ts'))
+      .map((f) => f.replace(/\.get\.ts$/, ''));
+    const sections = splitSections(llmsTxt);
+    const apiSection = sections.find((s) => s.heading === 'Public JSON APIs');
+    expect(apiSection, 'missing Public JSON APIs section').toBeDefined();
+    const advertised = new Set(
+      listItems(apiSection!).map((l) => parseLink(l)?.url.split('/').at(-1))
+    );
+    for (const handler of handlers) {
+      expect(advertised.has(handler), `handler "${handler}" not advertised in llms.txt`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## **User description**
## Summary

Implements the fixes from the llms.txt review against the [llmstxt.org spec](https://llmstxt.org/).

**`public/llms.txt` content fixes (accuracy + spec alignment):**
- Add missing `ko` UI locale (was omitted while `ko.json` and `SUPPORTED_LOCALES` include it).
- Drop auth-required `/profile` from Primary Pages; add `/profile` to the auth-required note alongside `/account`, `/team`, `/settings` so an LLM doesn't follow a link to a login wall.
- Move `robots.txt` / `sitemap.xml` out of `## Optional` into a body note. Per spec, Optional is for skippable secondary *information*; infrastructure URLs aren't LLM-consumable content.
- Add per-endpoint param notes (`lang` / `gameMode` / `limit` / `releases`) to the Public JSON APIs section so an LLM can call the APIs correctly without fetching docs. Param coverage derived from each handler's `getQuery` usage.
- Note that `/api` is disallowed in `robots.txt` (inference use, not crawling) to remove the ambiguity of advertising API URLs while disallowing them in robots.

**Verification (drift prevention):**
- `tests/llms-txt.test.ts` — new Vitest spec that validates the llms.txt spec format: H1 present, blockquote summary, `## Optional` is the last section, every H2 list item is a valid `[name](url): notes` hyperlink with absolute https URLs, locale list matches `SUPPORTED_LOCALES`, auth-required note includes `/profile`, Optional excludes infrastructure URLs, and every `app/server/api/tarkov/*.get.ts` handler on disk is advertised in the file.
- `lychee.llms.toml` + a dedicated CI step in `link-check.yml` that actually verifies the internal `tarkovtracker.org` links in `llms.txt`. The shared `lychee.toml` excludes the production origin (checked by deploy, not docs CI), so the existing docs step skips every internal link in llms.txt. The new config drops that exclude for `public/llms.txt` only. `public/llms.txt`, `lychee.llms.toml` added to the workflow `paths` triggers.

#### Test plan
- [x] `pnpm exec vitest run tests/llms-txt.test.ts` — 9/9 pass
- [x] `pnpm run lint` — zero warnings
- [x] `pnpm run typecheck` — pass
- [x] `pnpm run i18n:check` — non-fatal (Crowdin-owned non-English gaps, unchanged)
- [x] `prettier --check` / `eslint --max-warnings=0` on the new test file — clean
- [ ] CI `link-check` job runs the new `llms.txt Link Checker` step against the production origin

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Align llms.txt with the site’s current pages, locales, and API notes**

### What Changed
- Added the missing `ko` UI locale, moved `/profile` into the auth-required note, and removed it from the public page list.
- Clarified that `/api` is for direct use, not crawling, and added a note that crawl rules live in `robots.txt` and `sitemap.xml`.
- Added usage notes for public JSON APIs so their supported query options are visible in `llms.txt` without checking docs.
- Removed `robots.txt` and `sitemap.xml` from the Optional section and added checks that keep `llms.txt` in sync with the site, API routes, and link targets.

### Impact
`✅ Fewer outdated links in llms.txt`
`✅ Clearer API usage for automated tools`
`✅ Lower risk of missing protected pages or locales`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Refreshed the crawler/API access guide, clarifying Nuxt client behavior, proxying of game data, and intended programmatic use.
  * Updated supported `lang`/`gameMode` values, UI locales, authentication-required sections, and revised the discovery guidance wording.
  * Expanded the Public JSON APIs and Changelog API parameter documentation.

* **Quality Improvements**
  * Added automated checks to enforce the `llms.txt` structure, required sections, allowed link formats, locales, auth areas, and API coverage.
  * Improved automated link validation for the crawler documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation and test-only change with no runtime code path modifications; safe to merge.

All changes are confined to a static text file, a new test, a lychee config, and a CI workflow step. No application logic is modified. The two previous thread findings (top-level handler coverage and limit param range) have both been addressed.

No files require special attention; the test file placement in tests/ vs __tests__/ is a style point worth noting for consistency.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| public/llms.txt | Content updated: ko locale added, /profile moved to auth-required note, robots/sitemap moved out of Optional into body prose, per-endpoint query param notes added. Changes are accurate against the codebase. |
| tests/llms-txt.test.ts | New Vitest spec covering 9 structural invariants of llms.txt; placed in root-level tests/ rather than the __tests__/ convention used by all other test files. splitSections silently drops heading-only sections, leaving a narrow test-coverage gap. |
| lychee.llms.toml | Dedicated lychee config that mirrors lychee.toml's runtime settings but omits the tarkovtracker.org exclusion, correctly enabling internal-link verification for llms.txt. |
| .github/workflows/link-check.yml | Adds llms.txt Link Checker step with dedicated config, triggers on llms.txt/lychee.llms.toml path changes, and switches artifact upload to directory path to capture both reports. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR push or schedule] --> B{paths trigger?}
    B -->|docs or root md files| C[Link Checker\nlychee.toml\nexcludes tarkovtracker.org]
    B -->|public/llms.txt or lychee.llms.toml| D[llms.txt Link Checker\nlychee.llms.toml\nverifies tarkovtracker.org]
    C --> E[Upload lychee/ artifacts on failure]
    D --> E
    G[pnpm run test] --> H[Vitest: tests/llms-txt.test.ts]
    H --> I[H1 / blockquote / Optional-last / hyperlink format]
    H --> J[SUPPORTED_LOCALES and API_SUPPORTED_LANGUAGES match]
    H --> K[auth-required includes /profile\nOptional excludes robots/sitemap]
    H --> L[Every .get.ts handler advertised\ntarkov/* and top-level api/*]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[PR push or schedule] --> B{paths trigger?}
    B -->|docs or root md files| C[Link Checker\nlychee.toml\nexcludes tarkovtracker.org]
    B -->|public/llms.txt or lychee.llms.toml| D[llms.txt Link Checker\nlychee.llms.toml\nverifies tarkovtracker.org]
    C --> E[Upload lychee/ artifacts on failure]
    D --> E
    G[pnpm run test] --> H[Vitest: tests/llms-txt.test.ts]
    H --> I[H1 / blockquote / Optional-last / hyperlink format]
    H --> J[SUPPORTED_LOCALES and API_SUPPORTED_LANGUAGES match]
    H --> K[auth-required includes /profile\nOptional excludes robots/sitemap]
    H --> L[Every .get.ts handler advertised\ntarkov/* and top-level api/*]
```

</a>
</details>

<sub>Reviews (3): Last reviewed commit: ["ci: separate lychee output paths for doc..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/e158aa639d74b6a44c55f6a5dca2f9667e3cc8fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46017794)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->