### PR TITLE
docs: soften good-first-issue callout to reflect actual availability

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,11 @@ feature. PRs that bundle unrelated changes may be asked to split or be closed.
 - **[Label system](.github/LABELS.md)** — issue types, scope, priority, ownership, and status.
 - **[Project board](.github/PROJECT_BOARD.md)** — how issues move from backlog to done.
 
-> New to the codebase? Issues labeled
+> New to the codebase? Start with
+> [`.github/CONTRIBUTING.md`](.github/CONTRIBUTING.md) for the development workflow and PR process.
+> When available, issues labeled
 > [`good-first-issue`](https://github.com/tarkovtracker-org/TarkovTracker/labels/good-first-issue)
-> are the easiest way to get started.
+> are scoped for newcomers.
 
 ### Documentation
 


### PR DESCRIPTION
## **User description**
## Summary

- The README callout pointed to the `good-first-issue` label as if issues existed, but zero issues currently have that label.
- Softened the wording to point to `CONTRIBUTING.md` as the starting point and mention `good-first-issue` as "when available" rather than implying they exist now.

#### Test plan
- [x] Prettier passes
- [x] Husky pre-commit hook passed
- [x] Link to CONTRIBUTING.md resolves
- [ ] CI `link-check` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/576" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Point new contributors to the right starting place**

### What Changed
- New contributor guidance now starts with `CONTRIBUTING.md` for the development workflow and pull request process
- The README no longer implies `good-first-issue` labels are always available; it now says they are listed only when they exist
- The newcomer callout now describes those issues as scoped for newcomers instead of the easiest way to get started

### Impact
`✅ Clearer contributor onboarding`
`✅ Fewer misleading issue links`
`✅ Easier first-time setup`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor guidance to direct newcomers to the contribution guide.
  * Retained beginner-friendly issue recommendations as an additional starting point when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the change is limited to a single README blockquote with no functional code touched.

The only change is rewording three lines of documentation in README.md. Both links (.github/CONTRIBUTING.md and the good-first-issue label URL) were already present in the repo and resolve correctly. The CI link-check item in the test plan is unchecked, but the links themselves are verifiably valid, so that is unlikely to be a blocker.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| README.md | Softens the "new contributor" callout: adds a link to `.github/CONTRIBUTING.md` as the primary starting point and qualifies `good-first-issue` as "when available" to reflect that the label is currently empty. |

</details>

<details><summary><h3>Flowchart</h3></summary>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[New contributor reads README] --> B[Visit .github/CONTRIBUTING.md]
    B --> C{good-first-issue\nlabel has issues?}
    C -- Yes --> D[Pick a good-first-issue]
    C -- No --> E[Browse all open issues\nor propose a new one]
    D --> F[Follow PR process in CONTRIBUTING.md]
    E --> F
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[New contributor reads README] --> B[Visit .github/CONTRIBUTING.md]
    B --> C{good-first-issue\nlabel has issues?}
    C -- Yes --> D[Pick a good-first-issue]
    C -- No --> E[Browse all open issues\nor propose a new one]
    D --> F[Follow PR process in CONTRIBUTING.md]
    E --> F
```

</a>
</details>

<sub>Reviews (1): Last reviewed commit: ["docs: soften good-first-issue callout to..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/ee2753629e70e2459022c8c4ed2e0fd967f8b6b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46171873)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->