### PR TITLE
docs: split CONTRIBUTING.md into focused development and PR docs

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,331 +1,75 @@
 # Contributing to TarkovTracker
 
-Thank you for your interest in contributing to TarkovTracker! This document provides guidelines and information for contributors.
+Thank you for your interest in contributing to TarkovTracker! This document is the entry point for
+contributors. It covers the basics and links to focused guides for details.
 
-## Table of Contents
+> Contributors using an AI coding agent must also follow [`../AGENTS.md`](../AGENTS.md). Human setup
+> and pull-request requirements are documented here and in the linked pages below.
 
-- [Code of Conduct](#code-of-conduct)
-- [Getting Started](#getting-started)
-- [Development Workflow](#development-workflow)
-- [Issue Guidelines](#issue-guidelines)
-- [Pull Request Process](#pull-request-process)
-- [Issue Types & Label System](#issue-types--label-system)
-- [Project Board](#project-board)
-- [Coding Standards](#coding-standards)
-- [Common Tasks](#common-tasks)
-- [Debugging](#debugging)
-- [Guidelines for AI Coding Agents](#guidelines-for-ai-coding-agents)
-- [Questions?](#questions)
+## Ways to Contribute
 
-## Code of Conduct
+- **Report issues** — bugs, features, enhancements, or data issues. Pick the right template from the
+  issue tracker.
+- **Submit pull requests** — fix a bug, add a feature, or improve docs.
+- **Translate** — add keys to `app/locales/en.json` only; Crowdin propagates the other locales. See
+  [`../docs/contributing/development.md`](../docs/contributing/development.md) for the i18n workflow.
 
-Participation in this project is governed by the [`Code of Conduct`](../CODE_OF_CONDUCT.md).
-Please read it before contributing. In short: be respectful and constructive —
-we are building a tool for the Tarkov community together. Report conduct issues
-to <mailto:support@tarkovtracker.org> or via Discord DM to a maintainer.
-
-## Getting Started
-
-**Prerequisites:** Node.js >= 24.12.0, pnpm 11.14.0 (via Corepack; matches `packageManager`), Git.
-
-1. **Fork the repository** and clone your fork locally
-2. **Install dependencies**: `corepack enable && pnpm install` (Corepack resolves the pnpm version from `packageManager` in `package.json`)
-3. **Set up environment**: run `pnpm run setup` (creates `.env` from
-   `.env.example` if it does not already exist) or copy `.env.example` to `.env`
-   manually (only if `.env` does not exist), then add your Supabase credentials.
-   Nuxt auto-loads `.env` on `pnpm run dev`.
-   Full env-var reference: [`docs/runbook.md`](../docs/runbook.md) and [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md).
-4. **Start dev server**: `pnpm run dev`
-5. **Read [`AGENTS.md`](../AGENTS.md)** for detailed development guidelines
-
-> Most features work without Supabase configured; auth and sync are simply disabled.
-
-## Development Workflow
-
-### 1. Find or Create an Issue
-
-- Check existing issues before creating new ones
-- Use appropriate issue templates (Bug Report, Feature Request, Enhancement, Data Issue)
-- Clearly describe the problem or feature
-
-### 2. Get Assigned
-
-- Comment on the issue to express interest
-- Wait for maintainer assignment to avoid duplicate work
-- Issues labeled `good-first-issue` are great for newcomers
-
-### 3. Create a Branch
-
-```bash
-git checkout -b type/short-description
-```
-
-Branch naming convention:
-
-- `fix/issue-description` - Bug fixes
-- `feat/feature-name` - New features
-- `enhance/improvement` - Enhancements
-- `refactor/area-name` - Code refactoring
-- `docs/topic` - Documentation
-- `chore/task` - Maintenance tasks
-
-### 4. Make Your Changes
-
-- Follow coding standards (see [Coding Standards](#coding-standards))
-- Write meaningful commit messages
-- Test your changes thoroughly
-- Each pull request must focus on a single change (fix, update, documentation, or feature). Unrelated changes may be requested to be split or closed.
-
-### 5. Submit a Pull Request
-
-- Use the PR template
-- Link related issues
-- Provide clear description and test plan
-- Add screenshots/videos for UI changes
-- Ensure all checks pass
-
-## Issue Guidelines
-
-### Creating Issues
-
-**Use the right template:**
-
-- **Bug Report** - Something isn't working
-- **Feature Request** - New feature or major addition
-- **Enhancement** - Improvement to existing feature
-- **Data Issue** - Incorrect quest/item/game data
-
-**Provide details:**
-
-- Clear, descriptive title
-- Steps to reproduce (for bugs)
-- Expected vs actual behavior
-- Screenshots when relevant
-- Game mode (PvP/PvE)
-- Browser/environment info
-
-### Issue Labels
-
-The issue **Type** (bug, feature, enhancement, dependencies, documentation) comes from the template you choose. Maintainers then add labels from the streamlined set documented in [LABELS.md](LABELS.md):
-
-- **Area** (optional, can be multiple): `area:ui`, `area:api`, `area:database`, `area:auth`, `area:realtime`, `area:i18n`
-- **Priority** (optional): `priority:high`, `priority:medium` (default), `priority:low`
-- **Special** (optional): `good-first-issue`, `help-wanted`, `never-stale`, `upstream`
-
-Workflow status (inbox, blocked, in progress, etc.) is tracked by Project board columns, not labels. Data-only issues that belong in the data-overlay repo get `upstream` and are closed with an explanation.
-
-## Pull Request Process
-
-### Before Submitting
-
-1. **Self-review your code**
-   - Remove debug logs and commented code
-   - Check for typos and formatting
-   - Ensure no secrets or credentials
-
-2. **Test thoroughly**
-   - Test manually in browser
-   - Run `pnpm run lint` (must pass with zero warnings)
-   - Run `pnpm run typecheck`
-   - Run `pnpm test` if your change touches executable code
-   - Test in both PvP and PvE modes if relevant
-
-3. **Update documentation**
-   - Update README if adding features
-   - Update AGENTS.md if changing architecture or repo-wide agent guidance
-
-### PR Requirements
-
-- Title and commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g. `feat(tasks): add objective filter`) — enforced by commitlint
-- All template sections completed
-- Linked to related issue(s)
-- Passes all CI checks
-- No merge conflicts
-- Approved by at least one maintainer
-
-### Review Process
-
-1. Maintainers will review your PR
-2. Address any feedback or requested changes
-3. Once approved, maintainers will merge
-4. Your contribution will be in the next release!
-
-## Issue Types & Label System
-
-We use GitHub's native **Issue Types** for categorization and a streamlined **label system** (13 labels total). See [LABELS.md](LABELS.md) for the complete reference.
-
-### Issue Types (required - choose one)
-
-- 🐛 **bug** - An unexpected problem or behavior
-- ✨ **feature** - Adds or improves functionality in the codebase
-- ⚡ **enhancement** - Improvement or optimization to existing features
-- 📦 **dependencies** - Package updates and dependency management
-- 📝 **documentation** - Documentation, guides, or README updates
-
-### Area Labels (optional - technical boundaries)
-
-All area labels use light green color for visual grouping:
-
-- `area:ui` - Vue components, pages, styling
-- `area:api` - Nitro server routes, workers, API endpoints
-- `area:database` - Supabase schema, migrations, queries
-- `area:auth` - Authentication and authorization
-- `area:realtime` - Team sync, Supabase broadcasts
-- `area:i18n` - Translations and localization
-
-### Priority Labels (optional)
-
-- `priority:high` - Critical bugs, security, important features
-- `priority:medium` - Normal priority (default)
-- `priority:low` - Nice to have
-
-### Special Labels (optional)
-
-- `good-first-issue` - Good for newcomers
-- `help-wanted` - Community help needed
-- `never-stale` - Exempt from stale auto-close (long-lived backlog work)
-- `upstream` - Issue belongs in data-overlay repo (close with explanation)
-
-### Workflow States
-
-Status labels (needs-info, blocked, in-progress) are **NOT** used. Instead, these are managed via GitHub Project board columns:
-
-- **Inbox** - New issues awaiting triage
-- **Waiting for Info** - Need clarification from reporter
-- **Blocked** - Waiting on external dependency
-- **Backlog** - Triaged, not yet prioritized
-- **Todo** - Ready to work on
-- **In Progress** - Actively being worked on
-- **In Review** - PR awaiting review
-- **Done** - Completed/merged
-
-## Project Board
-
-Our GitHub Project uses these columns:
-
-- **📥 Inbox** - New issues awaiting triage
-- **📋 Backlog** - Triaged but not yet prioritized
-- **📝 Todo** - Ready to work on, prioritized
-- **🚧 In Progress** - Actively being worked on
-- **👀 In Review** - PR open, awaiting review
-- **✅ Done** - Completed/merged
-
-Issues move automatically based on actions:
-
-- Creating an issue → Inbox
-- Opening a PR → In Progress
-- Marking PR ready for review → In Review
-- Merging PR → Done
-
-## Coding Standards
-
-**See AGENTS.md for comprehensive coding standards. Key points:**
-
-### TypeScript & Vue
-
-- Use `<script setup lang="ts">` with TypeScript
-- **No `<style>` blocks**—Tailwind v4 is the only styling approach
-- 2-space indentation, 100-char line width
-- Single quotes, semicolons, trailing commas (es5)
-
-### Imports & Structure
-
-- No blank lines between import groups
-- Alphabetically sorted imports
-- Use `@/` aliases instead of relative parent imports (`../../`)
-- PascalCase components, camelCase functions, kebab-case files
-
-### Styling
-
-- **Tailwind v4 only**—no `<style>` blocks, SCSS, or scoped CSS
-- Use Tailwind theme layer for colors—no hex values in templates
-- Complex animations go in `app/assets/css/tailwind.css` using `@theme` or `@keyframes`
-- Responsive design (mobile-first)
-
-### Error Handling
-
-- Log errors with `logger` from `@/utils/logger`
-- Provide user-friendly error messages
-- Handle edge cases gracefully
-
-### Testing
-
-- Write tests for new features
-- Keep tests deterministic
-- Mock network/Supabase calls
-- Run `pnpm test` before submitting
-
-### Git Commits
-
-- Follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): summary`. The commit-msg hook runs commitlint locally and CI re-checks every commit.
-- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `wip`.
-- Use an allowed scope from `commitlint.config.js` (e.g. `app`, `ui`, `api`, `tasks`, `team`, `i18n`, `docs`) or omit the scope if none fits — do not invent scopes.
-- Keep the subject imperative and not ALL-CAPS; header max 100 chars.
-- Reference issue numbers when applicable and keep commits focused and atomic.
-
-## Common Tasks
-
-- **Add a feature:** create a slice in `app/features/`, add a route in `app/pages/`, and a nav link in `app/shell/NavDrawer.vue`.
-- **Add a store:** create it in `app/stores/`; configure persistence if it should survive reloads.
-- **Add an API endpoint:** create the route in `app/server/api/` and add types in `app/types/`.
-- **Add translations:** add snake_case keys to `app/locales/en.json` **only**, then run `pnpm run i18n:check`. Use `$t('key.path', 'Fallback')`. Crowdin propagates the other locales — never edit them by hand.
-- **Tarkov.dev import/linking:** follow the rules in [`docs/ARCHITECTURE.md`](../docs/ARCHITECTURE.md) (persist only `tarkovUid`; the import destination mode is chosen at import time, not stored).
-
-## Debugging
-
-- Install the [Vue DevTools](https://devtools.vuejs.org/) browser extension for component and Pinia store inspection.
-- Use the shared logger from `@/utils/logger`, not `console`:
-
-  ```typescript
-  import { logger } from '@/utils/logger';
-
-  logger.debug('Debug message', { context: 'value' });
-  logger.error('Error message', error);
-  ```
-
-## Guidelines for AI Coding Agents
-
-When working with AI coding assistants on this project:
-
-### Context Files
-
-- `AGENTS.md` is the single source of truth for repo-wide agent instructions.
-- `.claude/CLAUDE.md` is a thin shim that imports `AGENTS.md` for Claude Code (moved from root to reduce clutter).
-- `GEMINI.md` is intentionally not tracked. If you use Gemini CLI, point it at `AGENTS.md` with `.gemini/settings.json`:
-
-```json
-{
-  "context": {
-    "fileName": ["AGENTS.md"]
-  }
-}
-```
-
-- Do not configure Gemini CLI to load both `AGENTS.md` and `GEMINI.md` if one imports the other, or instructions may be duplicated.
-
-### Ask Before Acting
-
-- **Clarify complex or ambiguous requests** before proceeding—don't assume intent
-- If a task has multiple valid interpretations, ask which approach is preferred
-- When uncertain about scope, confirm boundaries before making changes
-- It's better to ask one clarifying question than to redo work
-
-### Communicate Proactively
-
-- Surface potential issues or trade-offs early
-- If you encounter blockers or unexpected complexity, report them
-- Propose alternatives when the requested approach has significant downsides
-
-### Stay Focused
-
-- Complete one task fully before moving to the next
-- Avoid scope creep—stick to what was requested
-- Flag related issues you notice, but don't fix them without permission
-
-## Questions?
+## Where to Ask Questions
 
 - Join our [Discord](https://discord.gg/M8nBgA2sT6)
 - Ask in issue comments
-- Check existing documentation
+- Check [`../SUPPORT.md`](../SUPPORT.md) for routing (usage questions, bugs, features, account
+  support, security)
+
+## How to Find and Claim Work
+
+1. Check existing issues before creating new ones
+2. Use the appropriate issue template (Bug Report, Feature Request, Enhancement, Data Issue)
+3. Comment on an issue to express interest and wait for maintainer assignment to avoid duplicate work
+4. Issues labeled `good-first-issue` are great for newcomers
+
+For the complete label reference, see [`LABELS.md`](LABELS.md). For project-board workflow states and
+automation, see [`PROJECT_BOARD.md`](PROJECT_BOARD.md).
+
+## Development Setup (Summary)
+
+**Prerequisites:** Node.js >= 24.12.0, pnpm 11.14.0 (via Corepack), Git.
+
+```bash
+corepack enable && pnpm install
+pnpm run setup   # creates .env from .env.example
+pnpm run dev     # localhost:3000
+```
+
+> Most features work without Supabase configured; auth and sync are simply disabled.
+
+For the full setup guide, coding standards, common tasks, debugging, and commit conventions, see
+[`../docs/contributing/development.md`](../docs/contributing/development.md).
+
+## Pull Request Process (Summary)
+
+1. Create a branch: `git checkout -b type/short-description`
+   (`fix/`, `feat/`, `enhance/`, `refactor/`, `docs/`, `chore/`)
+2. Make your changes following the coding standards
+3. Self-review, test (`pnpm run lint`, `pnpm run typecheck`, `pnpm test`), and update docs
+4. Open a PR using the template, link related issues, and ensure all CI checks pass
+5. Address review feedback; a maintainer merges once approved
+
+For detailed PR requirements, the template fields, the review process, and the pre-submit checklist,
+see [`../docs/contributing/pull-requests.md`](../docs/contributing/pull-requests.md).
+
+## Review Expectations
+
+- Each PR focuses on a single change; unrelated changes may be requested to be split or closed.
+- Maintainers review for correctness, style, tests, and scope.
+- Address all feedback on the same PR branch; do not open follow-up PRs for in-scope feedback.
+- Your contribution ships in the next release once merged.
+
+## Security and Conduct
+
+- **Security vulnerabilities:** see [`../SECURITY.md`](../SECURITY.md) — do not open a public issue.
+- **Code of Conduct:** governed by [`../CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md). Be respectful
+  and constructive. Report conduct issues to <mailto:support@tarkovtracker.org> or via Discord DM to
+  a maintainer.
 
 Thank you for contributing to TarkovTracker! 🎮

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -51,7 +51,8 @@ For the full setup guide, coding standards, common tasks, debugging, and commit 
    (`fix/`, `feat/`, `enhance/`, `refactor/`, `docs/`, `chore/`)
 2. Make your changes following the coding standards
 3. Self-review, run the smallest relevant validation (`pnpm run lint` for code, `pnpm run typecheck`
-   for TS, `pnpm test` for executable code), and update docs
+   for Nuxt/TS, `pnpm --filter api-gateway run typecheck` for Workers, `pnpm test` for executable
+   code), and update docs
 4. Open a PR using the template, link related issues, and ensure all CI checks pass
 5. Address review feedback; a maintainer merges once approved
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -36,9 +36,8 @@ automation, see [`PROJECT_BOARD.md`](PROJECT_BOARD.md).
 **Prerequisites:** Node.js >= 24.12.0, pnpm 11.14.0 (via Corepack), Git.
 
 ```bash
-corepack enable && pnpm install
-pnpm run setup   # creates .env from .env.example
-pnpm run dev     # localhost:3000
+corepack enable && pnpm run setup   # installs deps + creates .env
+pnpm run dev                        # localhost:3000
 ```
 
 > Most features work without Supabase configured; auth and sync are simply disabled.
@@ -51,7 +50,8 @@ For the full setup guide, coding standards, common tasks, debugging, and commit 
 1. Create a branch: `git checkout -b type/short-description`
    (`fix/`, `feat/`, `enhance/`, `refactor/`, `docs/`, `chore/`)
 2. Make your changes following the coding standards
-3. Self-review, test (`pnpm run lint`, `pnpm run typecheck`, `pnpm test`), and update docs
+3. Self-review, run the smallest relevant validation (`pnpm run lint` for code, `pnpm run typecheck`
+   for TS, `pnpm test` for executable code), and update docs
 4. Open a PR using the template, link related issues, and ensure all CI checks pass
 5. Address review feedback; a maintainer merges once approved
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -241,7 +241,9 @@ Naming:
 - Architecture: `docs/ARCHITECTURE.md`
 - System specs (caching, data fetching, overlay, precompute): `docs/SYSTEMS.md`
 - Rate limiting / abuse ownership: `docs/RATE_LIMITING.md`
-- Contributing: `.github/CONTRIBUTING.md`
+- Contributing (human workflow entry point): `.github/CONTRIBUTING.md`
+- Local development setup and coding standards: `docs/contributing/development.md`
+- Pull-request requirements: `docs/contributing/pull-requests.md`
 - Security policy: `SECURITY.md`
 - Support routing: `SUPPORT.md`
 - Code of conduct: `CODE_OF_CONDUCT.md`

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,8 @@ canonical agent contract and project conventions live in the root [`AGENTS.md`](
 | Find where to ask for help or report something                                    | [`/SUPPORT.md`](../SUPPORT.md)                                                     |
 | Read the code of conduct                                                          | [`/CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md)                                     |
 | Contribute (issues, branches, PRs, labels)                                        | [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md)                            |
+| Set up your development environment                                               | [`contributing/development.md`](./contributing/development.md)                     |
+| Understand the PR process and requirements                                        | [`contributing/pull-requests.md`](./contributing/pull-requests.md)                 |
 | Understand how a specific system works (caching, data fetch, overlay, precompute) | [`SYSTEMS.md`](./SYSTEMS.md)                                                       |
 | Understand the deeper architecture, state model, and data flows                   | [`ARCHITECTURE.md`](./ARCHITECTURE.md)                                             |
 | Read the Tarkov data architecture decision and implementation plan                | [`decisions/tarkov-data-architecture.md`](./decisions/tarkov-data-architecture.md) |
@@ -30,7 +32,9 @@ canonical agent contract and project conventions live in the root [`AGENTS.md`](
 - [`/SECURITY.md`](../SECURITY.md) — vulnerability reporting policy and scope.
 - [`/SUPPORT.md`](../SUPPORT.md) — routing table for questions, bugs, features, and account support.
 - [`/CODE_OF_CONDUCT.md`](../CODE_OF_CONDUCT.md) — Contributor Covenant 2.1 with enforcement contacts.
-- [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md) — contribution workflow, issues, labels, project board.
+- [`.github/CONTRIBUTING.md`](../.github/CONTRIBUTING.md) — contribution workflow entry point (issues, branches, PRs, labels, project board).
+- [`contributing/development.md`](./contributing/development.md) — local development setup, coding standards, common tasks, debugging, and commit conventions.
+- [`contributing/pull-requests.md`](./contributing/pull-requests.md) — branching strategy, PR requirements, template fields, review process, and pre-submit checklist.
 - [`SYSTEMS.md`](./SYSTEMS.md) — plain-language spec of the non-obvious systems (Tarkov.dev integration, data fetching, multi-layer caching, overlay, precompute) with diagrams and invariants. Covers **what systems exist, what they own, and how they interact**. Point at this when asking "why does the app do X?".
 - [`ARCHITECTURE.md`](./ARCHITECTURE.md) — deeper technical structure: state model, sync, data flows, implementation decisions, tradeoffs, and the canonical environment-variable map. `SYSTEMS.md` is the entry point for system behavior; `ARCHITECTURE.md` is the deeper reference for how the app is built.
 - [`decisions/tarkov-data-architecture.md`](./decisions/tarkov-data-architecture.md) — durable architecture decision and resumable implementation plan for the Tarkov data and progress system (KV releases, shared rules engine, Supabase write consolidation).

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -14,59 +14,32 @@ conventions for TarkovTracker. For the contribution workflow overview, see
 ## Installation & Environment Setup
 
 1. **Fork the repository** and clone your fork locally
-2. **Install dependencies**: `corepack enable && pnpm install` (Corepack resolves the pnpm version
-   from `packageManager` in `package.json`)
-3. **Set up environment**: run `pnpm run setup` (creates `.env` from `.env.example` if it does not
-   already exist) or copy `.env.example` to `.env` manually (only if `.env` does not exist), then add
-   your Supabase credentials. Nuxt auto-loads `.env` on `pnpm run dev`. Full env-var reference:
-   [`../runbook.md`](../runbook.md) and [`../ARCHITECTURE.md`](../ARCHITECTURE.md).
-4. **Start dev server**: `pnpm run dev` (serves on `localhost:3000`)
-5. **Read [`../../AGENTS.md`](../../AGENTS.md)** for detailed development guidelines
+2. **Install dependencies and set up environment**: `corepack enable && pnpm run setup` (Corepack
+   resolves the pnpm version from `packageManager` in `package.json`; `setup` installs with the
+   frozen lockfile and creates `.env` from `.env.example` if it does not already exist). Then add
+   your Supabase credentials to `.env`. Nuxt auto-loads `.env` on `pnpm run dev`. Full env-var
+   reference: [`../runbook.md`](../runbook.md) and [`../ARCHITECTURE.md`](../ARCHITECTURE.md).
+3. **Start dev server**: `pnpm run dev` (serves on `localhost:3000`)
+4. **Read [`../../AGENTS.md`](../../AGENTS.md)** for detailed development guidelines
 
 > Most features work without Supabase configured; auth and sync are simply disabled.
 
 ## Coding Standards
 
-**See [`../../AGENTS.md`](../../AGENTS.md) for comprehensive coding standards. Key points:**
+Coding standards are documented in [`../../AGENTS.md`](../../AGENTS.md) (Coding Conventions,
+Nuxt/Vue Rules, TypeScript, Error Handling, Localization sections). That file is the canonical
+source — do not duplicate its rules here. Key reminders for new contributors:
 
-### TypeScript & Vue
-
-- Use `<script setup lang="ts">` with TypeScript
-- **No `<style>` blocks**—Tailwind v4 is the only styling approach
-- 2-space indentation, 100-char line width
-- Single quotes, semicolons, trailing commas (es5)
-
-### Imports & Structure
-
-- No blank lines between import groups
-- Alphabetically sorted imports
-- Use `@/` aliases instead of relative parent imports (`../../`)
-- PascalCase components, camelCase functions, kebab-case files
-
-### Styling
-
-- **Tailwind v4 only**—no `<style>` blocks, SCSS, or scoped CSS
-- Use Tailwind theme layer for colors—no hex values in templates
-- Complex animations go in `app/assets/css/tailwind.css` using `@theme` or `@keyframes`
-- Responsive design (mobile-first)
-
-### Error Handling
-
+- `<script setup lang="ts">` with TypeScript strict
+- Tailwind v4 only — no `<style>` blocks, SCSS, or scoped CSS
+- Use `@/` aliases instead of relative parent imports
+- 2-space indent, 100-char lines, single quotes, semicolons, trailing commas (es5)
 - Log errors with `logger` from `@/utils/logger`
-- Provide user-friendly error messages
-- Handle edge cases gracefully
-
-### Testing
-
-- Write tests for new features
-- Keep tests deterministic
-- Mock network/Supabase calls
-- Run `pnpm test` before submitting
 
 ## Common Tasks
 
 - **Add a feature:** create a slice in `app/features/`, add a route in `app/pages/`, and a nav link
-  in `app/shell/NavDrawer.vue`.
+  in `app/features/drawer/DrawerLinks.vue`.
 - **Add a store:** create it in `app/stores/`; configure persistence if it should survive reloads.
 - **Add an API endpoint:** create the route in `app/server/api/` and add types in `app/types/`.
 - **Add translations:** add snake_case keys to `app/locales/en.json` **only**, then run

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -27,7 +27,7 @@ conventions for TarkovTracker. For the contribution workflow overview, see
 ## Coding Standards
 
 Coding standards are documented in [`../../AGENTS.md`](../../AGENTS.md) (Coding Conventions,
-Nuxt/Vue Rules, TypeScript, Error Handling, Localization sections). That file is the canonical
+Nuxt / Vue Rules, TypeScript, Error Handling, Localization sections). That file is the canonical
 source — do not duplicate its rules here. Key reminders for new contributors:
 
 - `<script setup lang="ts">` with TypeScript strict

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -1,0 +1,100 @@
+# Development Setup & Coding Standards
+
+This guide covers local development setup, coding standards, common tasks, debugging, and commit
+conventions for TarkovTracker. For the contribution workflow overview, see
+[`../../.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md). For pull-request requirements, see
+[`./pull-requests.md`](./pull-requests.md).
+
+## Prerequisites
+
+- **Node.js** >= 24.12.0
+- **pnpm** 11.14.0 (via Corepack; matches `packageManager` in `package.json`)
+- **Git**
+
+## Installation & Environment Setup
+
+1. **Fork the repository** and clone your fork locally
+2. **Install dependencies**: `corepack enable && pnpm install` (Corepack resolves the pnpm version
+   from `packageManager` in `package.json`)
+3. **Set up environment**: run `pnpm run setup` (creates `.env` from `.env.example` if it does not
+   already exist) or copy `.env.example` to `.env` manually (only if `.env` does not exist), then add
+   your Supabase credentials. Nuxt auto-loads `.env` on `pnpm run dev`. Full env-var reference:
+   [`../runbook.md`](../runbook.md) and [`../ARCHITECTURE.md`](../ARCHITECTURE.md).
+4. **Start dev server**: `pnpm run dev` (serves on `localhost:3000`)
+5. **Read [`../../AGENTS.md`](../../AGENTS.md)** for detailed development guidelines
+
+> Most features work without Supabase configured; auth and sync are simply disabled.
+
+## Coding Standards
+
+**See [`../../AGENTS.md`](../../AGENTS.md) for comprehensive coding standards. Key points:**
+
+### TypeScript & Vue
+
+- Use `<script setup lang="ts">` with TypeScript
+- **No `<style>` blocks**—Tailwind v4 is the only styling approach
+- 2-space indentation, 100-char line width
+- Single quotes, semicolons, trailing commas (es5)
+
+### Imports & Structure
+
+- No blank lines between import groups
+- Alphabetically sorted imports
+- Use `@/` aliases instead of relative parent imports (`../../`)
+- PascalCase components, camelCase functions, kebab-case files
+
+### Styling
+
+- **Tailwind v4 only**—no `<style>` blocks, SCSS, or scoped CSS
+- Use Tailwind theme layer for colors—no hex values in templates
+- Complex animations go in `app/assets/css/tailwind.css` using `@theme` or `@keyframes`
+- Responsive design (mobile-first)
+
+### Error Handling
+
+- Log errors with `logger` from `@/utils/logger`
+- Provide user-friendly error messages
+- Handle edge cases gracefully
+
+### Testing
+
+- Write tests for new features
+- Keep tests deterministic
+- Mock network/Supabase calls
+- Run `pnpm test` before submitting
+
+## Common Tasks
+
+- **Add a feature:** create a slice in `app/features/`, add a route in `app/pages/`, and a nav link
+  in `app/shell/NavDrawer.vue`.
+- **Add a store:** create it in `app/stores/`; configure persistence if it should survive reloads.
+- **Add an API endpoint:** create the route in `app/server/api/` and add types in `app/types/`.
+- **Add translations:** add snake_case keys to `app/locales/en.json` **only**, then run
+  `pnpm run i18n:check`. Use `$t('key.path', 'Fallback')`. Crowdin propagates the other locales —
+  never edit them by hand.
+- **Tarkov.dev import/linking:** follow the rules in [`../ARCHITECTURE.md`](../ARCHITECTURE.md)
+  (persist only `tarkovUid`; the import destination mode is chosen at import time, not stored).
+
+## Debugging
+
+- Install the [Vue DevTools](https://devtools.vuejs.org/) browser extension for component and Pinia
+  store inspection.
+- Use the shared logger from `@/utils/logger`, not `console`:
+
+  ```typescript
+  import { logger } from '@/utils/logger';
+
+  logger.debug('Debug message', { context: 'value' });
+  logger.error('Error message', error);
+  ```
+
+## Commit Conventions
+
+- Follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): summary`. The
+  commit-msg hook runs commitlint locally and CI re-checks every commit.
+- Allowed types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`,
+  `revert`, `wip`.
+- Use an allowed scope from `commitlint.config.js` (e.g. `app`, `ui`, `api`, `tasks`, `team`,
+  `i18n`, `docs`) or omit the scope if none fits — do not invent scopes.
+- Keep the subject imperative and not ALL-CAPS; header max 100 chars.
+- Reference issue numbers when applicable and keep commits focused and atomic.

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -32,12 +32,13 @@ changes may be requested to be split or closed.
    - Check for typos and formatting
    - Ensure no secrets or credentials
 
-2. **Test thoroughly**
-   - Test manually in browser
-   - Run `pnpm run lint` (must pass with zero warnings)
-   - Run `pnpm run typecheck`
-   - Run `pnpm test` if your change touches executable code
-   - Test in both PvP and PvE modes if relevant
+2. **Run the smallest relevant validation**
+   - `pnpm run lint` (must pass with zero warnings) — for any code change
+   - `pnpm run typecheck` — for TypeScript changes
+   - `pnpm test` — only if your change touches executable code that could break tests
+   - Test manually in browser — for UI changes
+   - Test in both PvP and PvE modes — if the change is mode-specific
+   - Docs-only PRs do not need lint, typecheck, or tests
 
 3. **Update documentation**
    - Update README if adding features
@@ -45,8 +46,8 @@ changes may be requested to be split or closed.
 
 ## PR Requirements
 
-- Title and commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g.
-  `feat(tasks): add objective filter`) — enforced by commitlint
+- Commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g.
+  `feat(tasks): add objective filter`) — enforced by commitlint on commit messages
 - All template sections completed
 - Linked to related issue(s)
 - Passes all CI checks
@@ -75,17 +76,15 @@ asks for the following sections. Complete every section:
 
 ## Review Process
 
-1. Maintainers will review your PR
-2. Address any feedback or requested changes
-3. Once approved, maintainers will merge
-4. Your contribution will be in the next release!
+1. Maintainers and automated review tools review your PR
+2. Address all feedback on the same PR branch — do not open follow-up PRs for in-scope feedback
+3. Every review thread must have an explicit disposition (fixed, rejected with rationale, or
+   deferred to a tracked issue) before merge
+4. Once all threads are resolved and CI is green, a maintainer merges
+5. Your contribution will be in the next release!
 
-## Finding Work
+> The full review gate (including rate-limit handling and out-of-scope deferrals) is in
+> [`../../AGENTS.md`](../../AGENTS.md) under "PR Review Gate".
 
-- Check existing issues before creating new ones
-- Use appropriate issue templates (Bug Report, Feature Request, Enhancement, Data Issue)
-- Comment on an issue to express interest and wait for maintainer assignment to avoid duplicate work
-- Issues labeled `good-first-issue` are great for newcomers
-- See [`../../.github/LABELS.md`](../../.github/LABELS.md) for the complete label reference and
-  [`../../.github/PROJECT_BOARD.md`](../../.github/PROJECT_BOARD.md) for project-board workflow
-  states
+For finding and claiming work, see
+[`../../.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md) ("How to Find and Claim Work").

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -1,0 +1,91 @@
+# Pull Request Process
+
+This guide covers branching strategy, PR requirements, the PR template, the review process, and the
+pre-submit checklist for TarkovTracker. For the contribution workflow overview, see
+[`../../.github/CONTRIBUTING.md`](../../.github/CONTRIBUTING.md). For local development setup and
+coding standards, see [`./development.md`](./development.md).
+
+## Branching Strategy
+
+Create a branch named with a type prefix and a short description:
+
+```bash
+git checkout -b type/short-description
+```
+
+Branch naming convention:
+
+- `fix/issue-description` - Bug fixes
+- `feat/feature-name` - New features
+- `enhance/improvement` - Enhancements
+- `refactor/area-name` - Code refactoring
+- `docs/topic` - Documentation
+- `chore/task` - Maintenance tasks
+
+Each pull request must focus on a single change (fix, update, documentation, or feature). Unrelated
+changes may be requested to be split or closed.
+
+## Before Submitting
+
+1. **Self-review your code**
+   - Remove debug logs and commented code
+   - Check for typos and formatting
+   - Ensure no secrets or credentials
+
+2. **Test thoroughly**
+   - Test manually in browser
+   - Run `pnpm run lint` (must pass with zero warnings)
+   - Run `pnpm run typecheck`
+   - Run `pnpm test` if your change touches executable code
+   - Test in both PvP and PvE modes if relevant
+
+3. **Update documentation**
+   - Update README if adding features
+   - Update [`../../AGENTS.md`](../../AGENTS.md) if changing architecture or repo-wide agent guidance
+
+## PR Requirements
+
+- Title and commits follow [Conventional Commits](https://www.conventionalcommits.org/) (e.g.
+  `feat(tasks): add objective filter`) — enforced by commitlint
+- All template sections completed
+- Linked to related issue(s)
+- Passes all CI checks
+- No merge conflicts
+- Approved by at least one maintainer
+
+## PR Template Fields
+
+The PR template ([`../../.github/pull_request_template.md`](../../.github/pull_request_template.md))
+asks for the following sections. Complete every section:
+
+- **Summary** — a brief description of what the PR does.
+- **Changes** — a list of the key changes made.
+- **Type of Change** — mark the relevant option(s): bug fix, new feature, enhancement, refactoring,
+  documentation update, dependency update, or other.
+- **Area(s) Affected** — mark all that apply: Frontend, Backend, Tasks/Quests, Team Features,
+  Hideout, Maps, Traders, API, i18n/Translations, or Other.
+- **Related Issues** — link related issues using keywords (`Fixes #123`, `Closes #456`,
+  `Related to #789`).
+- **Testing** — mark how you tested (locally, production-like environment, unit tests, manual) and
+  describe your test plan.
+- **Screenshots/Videos** — add screenshots or videos for UI changes.
+- **Checklist** — confirm your code follows conventions, you self-reviewed, documentation is updated,
+  no new warnings/errors, tests pass, and breaking changes are checked.
+- **Additional Notes** — anything reviewers should know.
+
+## Review Process
+
+1. Maintainers will review your PR
+2. Address any feedback or requested changes
+3. Once approved, maintainers will merge
+4. Your contribution will be in the next release!
+
+## Finding Work
+
+- Check existing issues before creating new ones
+- Use appropriate issue templates (Bug Report, Feature Request, Enhancement, Data Issue)
+- Comment on an issue to express interest and wait for maintainer assignment to avoid duplicate work
+- Issues labeled `good-first-issue` are great for newcomers
+- See [`../../.github/LABELS.md`](../../.github/LABELS.md) for the complete label reference and
+  [`../../.github/PROJECT_BOARD.md`](../../.github/PROJECT_BOARD.md) for project-board workflow
+  states

--- a/docs/contributing/pull-requests.md
+++ b/docs/contributing/pull-requests.md
@@ -78,9 +78,9 @@ asks for the following sections. Complete every section:
 
 1. Maintainers and automated review tools review your PR
 2. Address all feedback on the same PR branch — do not open follow-up PRs for in-scope feedback
-3. Every review thread must have an explicit disposition (fixed, rejected with rationale, or
-   deferred to a tracked issue) before merge
-4. Once all threads are resolved and CI is green, a maintainer merges
+3. Every inline review thread and every top-level/review-summary comment must have an explicit
+   disposition (fixed, rejected with rationale, or deferred to a tracked issue) before merge
+4. Once all reviews complete, all threads are resolved, and CI is green, a maintainer merges
 5. Your contribution will be in the next release!
 
 > The full review gate (including rate-limit handling and out-of-scope deferrals) is in


### PR DESCRIPTION
## **User description**
## Summary

- Split `.github/CONTRIBUTING.md` (was 331 lines) into a 75-line entry point plus two focused docs:
  - `docs/contributing/development.md` — detailed dev setup, coding standards, common tasks, debugging, commit conventions
  - `docs/contributing/pull-requests.md` — branching strategy, PR requirements, PR template field explanation, review process
- Removed the duplicated "Issue Types & Label System" and "Project Board" sections from CONTRIBUTING.md (now just links to `.github/LABELS.md` and `.github/PROJECT_BOARD.md`).
- Removed the detailed "Guidelines for AI Coding Agents" section from CONTRIBUTING.md (lives in AGENTS.md only). Kept a one-line agent-use notice pointing to AGENTS.md.
- Updated `docs/README.md` routing table and document map with the two new docs.
- Updated `AGENTS.md` Deeper References to reflect the new ownership model.

#### Test plan
- [x] Prettier passes on all 5 changed markdown files
- [x] All relative links in new/modified files resolve (scripted check)
- [x] Husky pre-commit hook passed
- [ ] CI `link-check` passes
- [ ] CI `format:check` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/579" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Split contributor guidance into focused setup and pull request docs**

### What Changed
- Moved local development setup, coding standards, common tasks, debugging, and commit rules into a dedicated development guide
- Moved branching, PR requirements, template fields, review steps, and submission checklist into a dedicated pull request guide
- Shortened the main contributing page to act as a summary and entry point, with links to the new guides
- Updated the docs index and agent references so contributors can find the right guide quickly

### Impact
`✅ Faster onboarding for new contributors`
`✅ Easier pull request preparation`
`✅ Clearer path to the right contributor guide`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Pure documentation reorganisation with no code changes; all cross-file links were verified to resolve.

Every file touched is documentation only. All relative links across the five changed files resolve to existing paths. Content is consistent across the entry point and the two new focused guides. The nav-link target correction in development.md (DrawerLinks.vue vs NavDrawer.vue) reflects the actual codebase structure.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/CONTRIBUTING.md | Trimmed from 331 to 76 lines; now acts as an entry point with summaries and links to the new focused guides. All relative links verified. |
| docs/contributing/development.md | New file covering setup, coding standards, common tasks, debugging, and commit conventions. Silently corrects the nav-link target to DrawerLinks.vue (correct) from the old NavDrawer.vue reference. All links resolve. |
| docs/contributing/pull-requests.md | New file covering branching strategy, pre-submit checklist, PR template fields, and review process. 'Finding Work' section removed per previous review thread. All links resolve. |
| docs/README.md | Adds two new routing rows and document-map entries for the new contributing guides; no broken links introduced. |
| AGENTS.md | Deeper References section updated to split the single CONTRIBUTING.md entry into three entries reflecting the new ownership model. Minimal, correct change. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[".github/CONTRIBUTING.md\n(entry point, 76 lines)"] --> B["docs/contributing/development.md\nSetup · Standards · Tasks · Debug · Commits"]
    A --> C["docs/contributing/pull-requests.md\nBranching · Checklist · Template · Review"]
    A --> D[".github/LABELS.md"]
    A --> E[".github/PROJECT_BOARD.md"]
    B --> F["AGENTS.md\n(canonical coding standards)"]
    C --> F
    G["docs/README.md\n(routing table)"] --> A
    G --> B
    G --> C
    H["AGENTS.md\nDeeper References"] --> A
    H --> B
    H --> C
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix: address re-review findings on CONTR..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/0cff29bfc3836e8af76360974c70964f356bd0bc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46172219)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->