### PR TITLE
ci: add focused drift checks for SYSTEMS.md

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,6 +218,21 @@ jobs:
       - name: Validate Supabase migrations
         run: pnpm run supabase:check
 
+  systems-drift:
+    name: Systems drift check
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e
+        with:
+          node-version-file: .nvmrc
+
+      - name: Systems drift check
+        run: node scripts/check-systems-drift.mjs
+
   workers:
     name: Workers
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "setup": "bash scripts/setup-dev-environment.sh",
     "supabase:check": "bash scripts/check-supabase-db.sh",
     "supabase:types": "supabase gen types typescript --linked > supabase/functions/_shared/database.types.ts",
+    "systems:check": "node scripts/check-systems-drift.mjs",
     "test": "vitest run --maxWorkers=2",
     "test:coverage": "vitest run --coverage --maxWorkers=2",
     "test:watch": "vitest --watch",

--- a/scripts/check-systems-drift.mjs
+++ b/scripts/check-systems-drift.mjs
@@ -167,29 +167,12 @@ function checkKvBinding(md) {
     return;
   }
   const wrangler = readText(WRANGLER_TOML);
-  const bindingLines = wrangler
-    .split('\n')
-    .filter((l) => /^\s*binding\s*=/.test(l) && !l.trim().startsWith('#'));
-  if (bindingLines.length === 0) {
+  const wranglerBindingRe = new RegExp(`binding\\s*=\\s*"${documentedBinding}"`);
+  if (!wranglerBindingRe.test(wrangler)) {
     fail(
-      `SYSTEMS.md documents KV binding "${documentedBinding}" but wrangler.toml has no binding declarations.`
+      `SYSTEMS.md documents KV binding "${documentedBinding}" but wrangler.toml does not ` +
+        `contain a binding with that name.`
     );
-  } else {
-    for (const line of bindingLines) {
-      const match = line.match(/binding\s*=\s*"([^"]+)"/);
-      if (match && match[1] !== documentedBinding) {
-        fail(
-          `wrangler.toml contains KV binding "${match[1]}" which does not match the documented binding "${documentedBinding}".`
-        );
-      }
-    }
-    const wranglerBindingRe = new RegExp(`binding\\s*=\\s*"${documentedBinding}"`);
-    if (!wranglerBindingRe.test(wrangler)) {
-      fail(
-        `SYSTEMS.md documents KV binding "${documentedBinding}" but wrangler.toml does not ` +
-          `contain a binding with that name.`
-      );
-    }
   }
 
   // Check PRECOMPUTED_KV_BINDING constant in precomputedTarkov.ts.

--- a/scripts/check-systems-drift.mjs
+++ b/scripts/check-systems-drift.mjs
@@ -41,6 +41,10 @@ function readText(filePath) {
 }
 
 function listTarkovHandlers() {
+  if (!existsSync(TARKOV_API_DIR)) {
+    fail(`Cannot list Tarkov handlers: ${TARKOV_API_DIR} does not exist.`);
+    return [];
+  }
   return readdirSync(TARKOV_API_DIR)
     .filter((f) => f.endsWith('.get.ts'))
     .map((f) => f.replace(/\.get\.ts$/, ''));
@@ -212,6 +216,10 @@ function checkSupportedLanguages(md) {
   // SYSTEMS.md does not currently enumerate supported languages. When it does
   // (as a backtick-quoted, comma/space-separated list on a line containing
   // "supported languages" or similar), verify it against app/locales/.
+  if (!existsSync(LOCALES_DIR)) {
+    fail(`Cannot verify supported languages: ${LOCALES_DIR} does not exist.`);
+    return;
+  }
   const localeFiles = readdirSync(LOCALES_DIR)
     .filter((f) => f.endsWith('.json'))
     .map((f) => f.replace(/\.json$/, ''));

--- a/scripts/check-systems-drift.mjs
+++ b/scripts/check-systems-drift.mjs
@@ -20,7 +20,7 @@
  * Uses only Node.js built-in modules so it runs without installing deps.
  */
 import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
-import { join, dirname, basename, extname } from 'path';
+import { join, dirname, basename } from 'path';
 
 const ROOT = process.cwd();
 const SYSTEMS_MD = join(ROOT, 'docs', 'SYSTEMS.md');
@@ -94,7 +94,9 @@ function pathExists(relativePath) {
     // Glob: check that the directory exists and at least one file matches.
     const dir = dirname(absolute);
     if (!existsSync(dir)) return false;
-    const pattern = basename(absolute).replace(/\./g, '\\.').replace(/\*/g, '.*');
+    const pattern = basename(absolute)
+      .replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      .replace(/\\\*/g, '.*');
     const re = new RegExp(`^${pattern}$`);
     try {
       return readdirSync(dir).some((f) => re.test(f));
@@ -102,13 +104,16 @@ function pathExists(relativePath) {
       return false;
     }
   }
-  return existsSync(absolute);
+  if (!existsSync(absolute)) return false;
+  return statSync(absolute).isFile();
 }
 
 function checkEndpoints(md) {
   const documented = extractDocumentedEndpoints(md);
   if (documented.length === 0) {
-    warnings.push('No /api/tarkov/* endpoints found in SYSTEMS.md endpoint table.');
+    fail(
+      'No /api/tarkov/* endpoints found in SYSTEMS.md endpoint table. The endpoint section is required.'
+    );
     return;
   }
   const handlers = new Set(listTarkovHandlers());
@@ -133,7 +138,9 @@ function checkEndpoints(md) {
 function checkDocumentedPaths(md) {
   const paths = extractDocumentedPaths(md);
   if (paths.length === 0) {
-    warnings.push('No implementation file paths found in SYSTEMS.md.');
+    fail(
+      'No implementation file paths found in SYSTEMS.md. The implementation paths section is required.'
+    );
     return;
   }
   for (const p of paths) {
@@ -148,18 +155,41 @@ function checkKvBinding(md) {
   const bindingMatch = md.match(/KV binding name is `([A-Z_]+)`/);
   const documentedBinding = bindingMatch ? bindingMatch[1] : null;
   if (!documentedBinding) {
-    warnings.push('Could not find a KV binding name declaration in SYSTEMS.md.');
+    fail(
+      'Could not find a KV binding name declaration in SYSTEMS.md. The KV binding section is required.'
+    );
     return;
   }
 
   // Check wrangler.toml binding.
+  if (!existsSync(WRANGLER_TOML)) {
+    fail(`Cannot verify KV binding: ${WRANGLER_TOML} does not exist.`);
+    return;
+  }
   const wrangler = readText(WRANGLER_TOML);
-  const wranglerBindingRe = new RegExp(`binding\\s*=\\s*"${documentedBinding}"`);
-  if (!wranglerBindingRe.test(wrangler)) {
+  const bindingLines = wrangler
+    .split('\n')
+    .filter((l) => /^\s*binding\s*=/.test(l) && !l.trim().startsWith('#'));
+  if (bindingLines.length === 0) {
     fail(
-      `SYSTEMS.md documents KV binding "${documentedBinding}" but wrangler.toml does not ` +
-        `contain a binding with that name.`
+      `SYSTEMS.md documents KV binding "${documentedBinding}" but wrangler.toml has no binding declarations.`
     );
+  } else {
+    for (const line of bindingLines) {
+      const match = line.match(/binding\s*=\s*"([^"]+)"/);
+      if (match && match[1] !== documentedBinding) {
+        fail(
+          `wrangler.toml contains KV binding "${match[1]}" which does not match the documented binding "${documentedBinding}".`
+        );
+      }
+    }
+    const wranglerBindingRe = new RegExp(`binding\\s*=\\s*"${documentedBinding}"`);
+    if (!wranglerBindingRe.test(wrangler)) {
+      fail(
+        `SYSTEMS.md documents KV binding "${documentedBinding}" but wrangler.toml does not ` +
+          `contain a binding with that name.`
+      );
+    }
   }
 
   // Check PRECOMPUTED_KV_BINDING constant in precomputedTarkov.ts.
@@ -181,15 +211,15 @@ function checkSupportedLanguages(md) {
   // SYSTEMS.md does not currently enumerate supported languages. When it does
   // (as a backtick-quoted, comma/space-separated list on a line containing
   // "supported languages" or similar), verify it against app/locales/.
-  const localeDirs = readdirSync(LOCALES_DIR)
+  const localeFiles = readdirSync(LOCALES_DIR)
     .filter((f) => f.endsWith('.json'))
     .map((f) => f.replace(/\.json$/, ''));
-  const localeSet = new Set(localeDirs);
+  const localeSet = new Set(localeFiles);
 
-  // Look for an explicit language list in the doc, e.g. a line like:
-  //   Supported languages: `en`, `de`, `fr`, ...
-  const listRe = /[Ss]upported languages?[:\s]+(.+)/;
-  const match = md.match(listRe);
+  // Look for an explicit language list in the doc. Capture the full section
+  // after the "Supported languages" heading to handle multiline lists.
+  const sectionRe = /[Ss]upported languages?[:\s]+([\s\S]*?)(?:\n#|\n##|\n$|$)/;
+  const match = md.match(sectionRe);
   if (!match) {
     // No language list in the doc — nothing to verify yet.
     return;
@@ -206,10 +236,11 @@ function checkSupportedLanguages(md) {
       );
     }
   }
-  const undocumentedLocales = localeDirs.filter((c) => !langCodes.includes(c));
+  const undocumentedLocales = localeFiles.filter((c) => !langCodes.includes(c));
   if (undocumentedLocales.length > 0) {
-    warnings.push(
-      `Locale directories exist without a SYSTEMS.md language entry: ${undocumentedLocales.join(', ')}.`
+    fail(
+      `Locale files exist without a SYSTEMS.md language entry: ${undocumentedLocales.join(', ')}. ` +
+        `Add them to the supported languages list or remove them from app/locales/.`
     );
   }
 }

--- a/scripts/check-systems-drift.mjs
+++ b/scripts/check-systems-drift.mjs
@@ -1,0 +1,246 @@
+#!/usr/bin/env node
+/**
+ * Focused drift checks for docs/SYSTEMS.md.
+ *
+ * Verifies the most volatile, easily-checkable facts the doc records against
+ * the actual codebase so drift is caught automatically in CI. Checks:
+ *
+ *   1. Every /api/tarkov/* endpoint listed in the doc's endpoint table has a
+ *      matching app/server/api/tarkov/*.get.ts handler file.
+ *   2. Every implementation file path mentioned in the doc exists on disk
+ *      (glob patterns like `*.get.ts` are expanded against their directory).
+ *   3. The KV namespace binding name documented (`TARKOV_DATA`) matches the
+ *      binding in wrangler.toml and the PRECOMPUTED_KV_BINDING constant in
+ *      precomputedTarkov.ts.
+ *   4. The supported languages listed in the doc (if any) match the locale
+ *      directories in app/locales/. The doc does not currently enumerate
+ *      languages, so this check is a no-op until it does.
+ *
+ * Exits 0 when all checks pass, 1 with a per-mismatch report otherwise.
+ * Uses only Node.js built-in modules so it runs without installing deps.
+ */
+import { readFileSync, readdirSync, statSync, existsSync } from 'fs';
+import { join, dirname, basename, extname } from 'path';
+
+const ROOT = process.cwd();
+const SYSTEMS_MD = join(ROOT, 'docs', 'SYSTEMS.md');
+const TARKOV_API_DIR = join(ROOT, 'app', 'server', 'api', 'tarkov');
+const LOCALES_DIR = join(ROOT, 'app', 'locales');
+const WRANGLER_TOML = join(ROOT, 'wrangler.toml');
+const PRECOMPUTED_TARKOV_TS = join(ROOT, 'app', 'server', 'utils', 'precomputedTarkov.ts');
+
+const errors = [];
+const warnings = [];
+
+function fail(message) {
+  errors.push(message);
+}
+
+function readText(filePath) {
+  return readFileSync(filePath, 'utf-8');
+}
+
+function listTarkovHandlers() {
+  return readdirSync(TARKOV_API_DIR)
+    .filter((f) => f.endsWith('.get.ts'))
+    .map((f) => f.replace(/\.get\.ts$/, ''));
+}
+
+/**
+ * Extract the /api/tarkov/* endpoints from the endpoint table in SYSTEMS.md.
+ * The table rows look like `| `/api/tarkov/bootstrap` | ... |`.
+ */
+function extractDocumentedEndpoints(md) {
+  const endpoints = [];
+  const endpointRe = /`\s*\/api\/tarkov\/([a-z0-9-]+)\s*`/g;
+  let match;
+  while ((match = endpointRe.exec(md)) !== null) {
+    endpoints.push(match[1]);
+  }
+  return [...new Set(endpoints)];
+}
+
+/**
+ * Extract backtick-quoted file paths from the doc. Handles plain paths
+ * (`app/server/utils/edgeCache.ts`) and glob patterns (`app/server/api/tarkov/*.get.ts`).
+ * Only paths that look like repo-relative files (contain a slash and a known
+ * extension) are considered.
+ */
+function extractDocumentedPaths(md) {
+  // Strip fenced code blocks (```...```) so they don't interfere with inline
+  // backtick extraction. File paths in mermaid diagrams are inside fenced
+  // blocks; the "Files" sections use inline backticks we want to capture.
+  const stripped = md.replace(/```[\s\S]*?```/g, '');
+  const paths = new Set();
+  const codeSpanRe = /`([^`]+)`/g;
+  let match;
+  while ((match = codeSpanRe.exec(stripped)) !== null) {
+    const span = match[1];
+    // Skip URLs, env vars, header names, cache keys, and prose fragments.
+    if (span.includes('://')) continue;
+    if (!span.includes('/')) continue;
+    // Must end with a file-like extension or a glob + extension.
+    if (!/\.[a-z0-9]+$/i.test(span)) continue;
+    // Skip things that are clearly not file paths (e.g. "tasks[*].name").
+    if (/\s/.test(span)) continue;
+    paths.add(span);
+  }
+  return [...paths];
+}
+
+function pathExists(relativePath) {
+  const absolute = join(ROOT, relativePath);
+  if (relativePath.includes('*')) {
+    // Glob: check that the directory exists and at least one file matches.
+    const dir = dirname(absolute);
+    if (!existsSync(dir)) return false;
+    const pattern = basename(absolute).replace(/\./g, '\\.').replace(/\*/g, '.*');
+    const re = new RegExp(`^${pattern}$`);
+    try {
+      return readdirSync(dir).some((f) => re.test(f));
+    } catch {
+      return false;
+    }
+  }
+  return existsSync(absolute);
+}
+
+function checkEndpoints(md) {
+  const documented = extractDocumentedEndpoints(md);
+  if (documented.length === 0) {
+    warnings.push('No /api/tarkov/* endpoints found in SYSTEMS.md endpoint table.');
+    return;
+  }
+  const handlers = new Set(listTarkovHandlers());
+  for (const endpoint of documented) {
+    if (!handlers.has(endpoint)) {
+      fail(
+        `SYSTEMS.md documents endpoint "/api/tarkov/${endpoint}" but no handler file ` +
+          `app/server/api/tarkov/${endpoint}.get.ts exists.`
+      );
+    }
+  }
+  // Report handlers that exist in code but are not documented (informational).
+  const undocumented = [...handlers].filter((h) => !documented.includes(h));
+  if (undocumented.length > 0) {
+    warnings.push(
+      `Handler(s) exist without a SYSTEMS.md endpoint entry: ${undocumented.join(', ')}. ` +
+        `Add them to the endpoint table if they are part of the Tarkov.dev data integration.`
+    );
+  }
+}
+
+function checkDocumentedPaths(md) {
+  const paths = extractDocumentedPaths(md);
+  if (paths.length === 0) {
+    warnings.push('No implementation file paths found in SYSTEMS.md.');
+    return;
+  }
+  for (const p of paths) {
+    if (!pathExists(p)) {
+      fail(`SYSTEMS.md references path "${p}" but it does not exist on disk.`);
+    }
+  }
+}
+
+function checkKvBinding(md) {
+  // The doc states the binding name is `TARKOV_DATA` (PRECOMPUTED_KV_BINDING).
+  const bindingMatch = md.match(/KV binding name is `([A-Z_]+)`/);
+  const documentedBinding = bindingMatch ? bindingMatch[1] : null;
+  if (!documentedBinding) {
+    warnings.push('Could not find a KV binding name declaration in SYSTEMS.md.');
+    return;
+  }
+
+  // Check wrangler.toml binding.
+  const wrangler = readText(WRANGLER_TOML);
+  const wranglerBindingRe = new RegExp(`binding\\s*=\\s*"${documentedBinding}"`);
+  if (!wranglerBindingRe.test(wrangler)) {
+    fail(
+      `SYSTEMS.md documents KV binding "${documentedBinding}" but wrangler.toml does not ` +
+        `contain a binding with that name.`
+    );
+  }
+
+  // Check PRECOMPUTED_KV_BINDING constant in precomputedTarkov.ts.
+  if (existsSync(PRECOMPUTED_TARKOV_TS)) {
+    const source = readText(PRECOMPUTED_TARKOV_TS);
+    const constRe = new RegExp(`PRECOMPUTED_KV_BINDING\\s*=\\s*['"]${documentedBinding}['"]`);
+    if (!constRe.test(source)) {
+      fail(
+        `SYSTEMS.md documents KV binding "${documentedBinding}" but ` +
+          `precomputedTarkov.ts does not set PRECOMPUTED_KV_BINDING to that value.`
+      );
+    }
+  } else {
+    fail(`Cannot verify KV binding: ${PRECOMPUTED_TARKOV_TS} does not exist.`);
+  }
+}
+
+function checkSupportedLanguages(md) {
+  // SYSTEMS.md does not currently enumerate supported languages. When it does
+  // (as a backtick-quoted, comma/space-separated list on a line containing
+  // "supported languages" or similar), verify it against app/locales/.
+  const localeDirs = readdirSync(LOCALES_DIR)
+    .filter((f) => f.endsWith('.json'))
+    .map((f) => f.replace(/\.json$/, ''));
+  const localeSet = new Set(localeDirs);
+
+  // Look for an explicit language list in the doc, e.g. a line like:
+  //   Supported languages: `en`, `de`, `fr`, ...
+  const listRe = /[Ss]upported languages?[:\s]+(.+)/;
+  const match = md.match(listRe);
+  if (!match) {
+    // No language list in the doc — nothing to verify yet.
+    return;
+  }
+  const raw = match[1];
+  const langCodes = [...raw.matchAll(/`([a-z]{2})`/g)].map((m) => m[1]);
+  if (langCodes.length === 0) return;
+
+  for (const code of langCodes) {
+    if (!localeSet.has(code)) {
+      fail(
+        `SYSTEMS.md lists supported language "${code}" but no locale file ` +
+          `app/locales/${code}.json exists.`
+      );
+    }
+  }
+  const undocumentedLocales = localeDirs.filter((c) => !langCodes.includes(c));
+  if (undocumentedLocales.length > 0) {
+    warnings.push(
+      `Locale directories exist without a SYSTEMS.md language entry: ${undocumentedLocales.join(', ')}.`
+    );
+  }
+}
+
+function main() {
+  if (!existsSync(SYSTEMS_MD)) {
+    console.error(`SYSTEMS.md not found at ${SYSTEMS_MD}`);
+    process.exit(1);
+  }
+  const md = readText(SYSTEMS_MD);
+
+  checkEndpoints(md);
+  checkDocumentedPaths(md);
+  checkKvBinding(md);
+  checkSupportedLanguages(md);
+
+  if (warnings.length > 0) {
+    console.warn('Warnings (non-fatal):');
+    for (const w of warnings) console.warn(`  - ${w}`);
+    console.warn();
+  }
+
+  if (errors.length > 0) {
+    console.error('SYSTEMS.md drift detected:');
+    for (const e of errors) console.error(`  - ${e}`);
+    console.error(`\n${errors.length} error(s). Fix the doc or the code in the same PR.`);
+    process.exit(1);
+  }
+
+  console.log('systems:check — all drift checks passed.');
+  process.exit(0);
+}
+
+main();

--- a/scripts/check-systems-drift.mjs
+++ b/scripts/check-systems-drift.mjs
@@ -179,7 +179,7 @@ function checkKvBinding(md) {
       inKvBlock = true;
       continue;
     }
-    if (/^\s*\[\[/.test(line) && inKvBlock) {
+    if (/^\s*\[/.test(line) && inKvBlock) {
       inKvBlock = false;
     }
     if (inKvBlock) kvBlocks.push(line);

--- a/scripts/check-systems-drift.mjs
+++ b/scripts/check-systems-drift.mjs
@@ -41,7 +41,11 @@ function readText(filePath) {
 }
 
 function listTarkovHandlers() {
-  if (!existsSync(TARKOV_API_DIR) || !statSync(TARKOV_API_DIR).isDirectory()) {
+  if (!existsSync(TARKOV_API_DIR)) {
+    fail(`Cannot list Tarkov handlers: ${TARKOV_API_DIR} does not exist.`);
+    return [];
+  }
+  if (!statSync(TARKOV_API_DIR).isDirectory()) {
     fail(`Cannot list Tarkov handlers: ${TARKOV_API_DIR} is not a directory.`);
     return [];
   }
@@ -216,7 +220,11 @@ function checkSupportedLanguages(md) {
   // SYSTEMS.md does not currently enumerate supported languages. When it does
   // (as a backtick-quoted, comma/space-separated list on a line containing
   // "supported languages" or similar), verify it against app/locales/.
-  if (!existsSync(LOCALES_DIR) || !statSync(LOCALES_DIR).isDirectory()) {
+  if (!existsSync(LOCALES_DIR)) {
+    fail(`Cannot verify supported languages: ${LOCALES_DIR} does not exist.`);
+    return;
+  }
+  if (!statSync(LOCALES_DIR).isDirectory()) {
     fail(`Cannot verify supported languages: ${LOCALES_DIR} is not a directory.`);
     return;
   }

--- a/scripts/check-systems-drift.mjs
+++ b/scripts/check-systems-drift.mjs
@@ -41,8 +41,8 @@ function readText(filePath) {
 }
 
 function listTarkovHandlers() {
-  if (!existsSync(TARKOV_API_DIR)) {
-    fail(`Cannot list Tarkov handlers: ${TARKOV_API_DIR} does not exist.`);
+  if (!existsSync(TARKOV_API_DIR) || !statSync(TARKOV_API_DIR).isDirectory()) {
+    fail(`Cannot list Tarkov handlers: ${TARKOV_API_DIR} is not a directory.`);
     return [];
   }
   return readdirSync(TARKOV_API_DIR)
@@ -216,8 +216,8 @@ function checkSupportedLanguages(md) {
   // SYSTEMS.md does not currently enumerate supported languages. When it does
   // (as a backtick-quoted, comma/space-separated list on a line containing
   // "supported languages" or similar), verify it against app/locales/.
-  if (!existsSync(LOCALES_DIR)) {
-    fail(`Cannot verify supported languages: ${LOCALES_DIR} does not exist.`);
+  if (!existsSync(LOCALES_DIR) || !statSync(LOCALES_DIR).isDirectory()) {
+    fail(`Cannot verify supported languages: ${LOCALES_DIR} is not a directory.`);
     return;
   }
   const localeFiles = readdirSync(LOCALES_DIR)

--- a/scripts/check-systems-drift.mjs
+++ b/scripts/check-systems-drift.mjs
@@ -167,11 +167,29 @@ function checkKvBinding(md) {
     return;
   }
   const wrangler = readText(WRANGLER_TOML);
+  // Scope the binding search to [[kv_namespaces]] / [[env.*.kv_namespaces]] blocks so
+  // a binding name in a non-KV resource (Durable Objects, R2, etc.) cannot satisfy the check.
+  // Only active (non-commented) binding lines are considered.
+  const kvBlocks = [];
+  const blockRe = /^\s*\[\[(env\.\w+\.)?kv_namespaces\]\]/;
+  const lines = wrangler.split('\n');
+  let inKvBlock = false;
+  for (const line of lines) {
+    if (blockRe.test(line)) {
+      inKvBlock = true;
+      continue;
+    }
+    if (/^\s*\[\[/.test(line) && inKvBlock) {
+      inKvBlock = false;
+    }
+    if (inKvBlock) kvBlocks.push(line);
+  }
+  const kvText = kvBlocks.filter((l) => !l.trim().startsWith('#')).join('\n');
   const wranglerBindingRe = new RegExp(`binding\\s*=\\s*"${documentedBinding}"`);
-  if (!wranglerBindingRe.test(wrangler)) {
+  if (!wranglerBindingRe.test(kvText)) {
     fail(
       `SYSTEMS.md documents KV binding "${documentedBinding}" but wrangler.toml does not ` +
-        `contain a binding with that name.`
+        `declare it inside a [[kv_namespaces]] block.`
     );
   }
 


### PR DESCRIPTION
## **User description**
## Summary

- Added `scripts/check-systems-drift.mjs` — a focused drift-check script using only Node.js built-in modules. It verifies four categories of facts from `docs/SYSTEMS.md` against the codebase:
  - **API endpoints**: `/api/tarkov/*` endpoints documented in SYSTEMS.md have matching handler files in `app/server/api/tarkov/`
  - **Implementation file paths**: Every backtick-quoted file path in SYSTEMS.md exists on disk
  - **KV binding name**: Documented `TARKOV_DATA` binding matches `wrangler.toml` and `precomputedTarkov.ts`
  - **Supported languages**: Activates automatically if a language list is added to the doc (currently a no-op)
- Added a `systems-drift` CI job in `.github/workflows/ci.yml` that runs the script (lightweight, no deps needed, 5-min timeout).
- Added `"systems:check": "node scripts/check-systems-drift.mjs"` to `package.json` scripts.
- No drift was found — all documented endpoints, file paths, and the KV binding name match the codebase.

#### Test plan
- [x] `node scripts/check-systems-drift.mjs` passes locally
- [x] Prettier passes on all 3 changed files
- [x] Husky pre-commit hook passed
- [ ] CI `systems-drift` job passes
- [ ] CI `format:check` passes
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/580" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Add automatic drift checks for `SYSTEMS.md`**

### What Changed
- CI now checks that the `SYSTEMS.md` docs still match the code for Tarkov API endpoints, referenced file paths, and the `TARKOV_DATA` KV binding.
- The new check also verifies supported languages against locale files when a language list is present in the doc.
- A reusable `systems:check` command was added for running the same validation locally.

### Impact
`✅ Fewer broken docs after API or file moves`
`✅ Earlier detection of mismatched KV binding names`
`✅ Safer CI checks for SYSTEMS.md`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the script is read-only, uses only built-in modules, and all previously identified guard omissions have been fixed.

The change is additive and read-only: the drift script cannot mutate the repo and the CI job only runs it. All three issues flagged in earlier review rounds have been addressed in the current HEAD. The one remaining note — AGENTS.md not updated to document the new command — is a process gap with no runtime impact.

No files require special attention; all changed files are straightforward additions.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/check-systems-drift.mjs | New drift-check script using only Node.js built-ins; existsSync guards for missing directories/files in place after previous fixes; logic is correct for all four check categories. |
| .github/workflows/ci.yml | New lightweight systems-drift job correctly skips pnpm install, uses pinned action SHAs, and applies a 5-min timeout. |
| package.json | Adds systems:check script; alphabetically ordered correctly. AGENTS.md not updated to document the new command. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CI: systems-drift job] --> B[node scripts/check-systems-drift.mjs]
    B --> C{docs/SYSTEMS.md exists?}
    C -- No --> Z[exit 1]
    C -- Yes --> D[checkEndpoints]
    D --> D1{TARKOV_API_DIR exists?}
    D1 -- No --> E1[fail + continue]
    D1 -- Yes --> D2[match doc endpoints vs *.get.ts handlers]
    B --> F[checkDocumentedPaths]
    F --> F1[match inline backtick paths vs disk]
    B --> G[checkKvBinding]
    G --> G1{wrangler.toml exists?}
    G1 -- No --> E2[fail + return]
    G1 -- Yes --> G2[match KV binding in kv_namespaces block]
    G2 --> G3{precomputedTarkov.ts exists?}
    G3 -- No --> E3[fail]
    G3 -- Yes --> G4[match PRECOMPUTED_KV_BINDING const]
    B --> H[checkSupportedLanguages]
    H --> H1{LOCALES_DIR exists?}
    H1 -- No --> E4[fail + return]
    H1 -- Yes --> H2{lang list in doc?}
    H2 -- No --> H3[no-op]
    H2 -- Yes --> H4[match doc codes vs locale files]
    D2 & F1 & G4 & H4 --> I{errors.length > 0?}
    I -- Yes --> Z
    I -- No --> Y[exit 0]
```
</details>

<sub>Reviews (8): Last reviewed commit: ["fix: split directory guards into distinc..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/cb9a006d0e3687ef4db0d0509c8504afc780d0d1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46172250)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->