### PR TITLE
fix(api): finish User-Agent rollout safeguards

### DIFF
--- a/docs/decisions/tarkov-data-architecture.md
+++ b/docs/decisions/tarkov-data-architecture.md
@@ -464,7 +464,7 @@ Use a canary before full rollout because current GET progress p95 CPU is already
 
 ### Resume point
 
-When work resumes, start with **Phase 0**, then design the canonical schema and release manifest before changing storage bindings. Do not begin by adding Supabase game tables or by merely increasing the Worker memory TTL; both bypass the root consistency problems.
+When work resumes, verify that the completed **Phase 0** safeguards still hold, then start active implementation with **Phase 1** by designing the canonical schema and release manifest before changing storage bindings. Do not begin by adding Supabase game tables or by merely increasing the Worker memory TTL; both bypass the root consistency problems.
 
 ---
 

--- a/docs/decisions/tarkov-data-architecture.md
+++ b/docs/decisions/tarkov-data-architecture.md
@@ -3,7 +3,7 @@
 ## Document status
 
 - **Purpose:** durable architecture record and resumable implementation plan for the Tarkov data and progress system.
-- **Decision status:** target architecture agreed; Phase 0 local safeguards implemented.
+- **Decision status:** target architecture agreed; Phase 0 deployment safeguards completed.
 - **Interim state:** direct Worker JSON fetching remains an interim compatibility path, not the intended end state.
 
 ## Executive decision
@@ -127,9 +127,9 @@ The remaining limitation is architectural rather than mode correctness: the Work
 
 The upstream `alternatives` field no longer exists. Branch relationships are represented by `taskStatus` failure conditions. Compile explicit branch/failure edges from `failConditions` and remove runtime dependence on `alternatives`.
 
-### P0: active usage migration is not yet deployed
+### Resolved: API usage User-Agent migration deployed and constrained
 
-The local Worker sends `p_user_agent`; the live Supabase RPC does not accept it. Apply the migration before deploying the new Worker.
+Migration `20260718120000_add_user_agent_to_api_usage_daily.sql` is deployed in production. The live seven-argument `record_api_usage` RPC accepts `p_user_agent`, trims it to 200 characters, and stores the latest normalized value per token/day. Follow-up migration `20260723120000_constrain_api_usage_user_agent.sql` constrains the storage column to `VARCHAR(200)` so direct writes cannot bypass the RPC's length bound.
 
 ### P1: Worker has no durable source for patched metadata
 
@@ -401,7 +401,7 @@ Use a canary before full rollout because current GET progress p95 CPU is already
 
 ### Phase 0 — deployment safety
 
-- [ ] Apply `20260718120000_add_user_agent_to_api_usage_daily.sql` before Worker deployment. Production application is explicitly on hold; the corrected migration exists locally only.
+- [x] Deploy `20260718120000_add_user_agent_to_api_usage_daily.sql` before User-Agent-aware usage recording and constrain the storage column with `20260723120000_constrain_api_usage_user_agent.sql`.
 - [x] Do not ship mode-insensitive direct JSON fetching as the final solution. Interim callers and caches are mode-aware; Phase 4 removes runtime upstream fetching.
 - [x] Add tests proving regular and PVE use distinct data.
 - [x] Add a regression test for overlay objective array shape.
@@ -490,6 +490,10 @@ Cloudflare API inspection confirmed overlay objective patches are published as o
 
 The existing scheduled precompute workflow is healthy and appropriately keeps heavy work off the Free-plan Worker. It should be expanded into a validated release publisher rather than replaced by a scheduled Worker.
 
+### 2026-07-23 — User-Agent enforcement rollout accepted
+
+The 5–200 character `User-Agent` requirement shipped directly in API version 2.3.0 without the deprecation window proposed in issue #565. Enforcement is already live, documented in OpenAPI, and verified at the production boundary. The missed advance-warning period cannot be recreated retroactively, so the direct rollout is accepted as the final disposition rather than weakening enforcement after release. The database retains defense in depth through RPC normalization plus a `VARCHAR(200)` column constraint.
+
 ---
 
 ## Primary code references
@@ -533,4 +537,5 @@ The existing scheduled precompute workflow is healthy and appropriately keeps he
 
 - `supabase/migrations/20260708140000_add_merge_progress_rpc.sql`
 - `supabase/migrations/20260718120000_add_user_agent_to_api_usage_daily.sql`
+- `supabase/migrations/20260723120000_constrain_api_usage_user_agent.sql`
 - `supabase/migrations/20260215160000_sanitize_user_progress_payload.sql`

--- a/supabase/migrations/20260723120000_constrain_api_usage_user_agent.sql
+++ b/supabase/migrations/20260723120000_constrain_api_usage_user_agent.sql
@@ -1,0 +1,3 @@
+ALTER TABLE public.api_usage_daily
+  ALTER COLUMN user_agent TYPE VARCHAR(200)
+  USING LEFT(user_agent, 200);


### PR DESCRIPTION
## **User description**
## Summary

Finish the remaining rollout safeguards tracked by #565 after User-Agent enforcement shipped in #572.

## Changes

- Add a follow-up Supabase migration constraining `api_usage_daily.user_agent` to `VARCHAR(200)` while safely truncating any legacy overlength rows.
- Update the architecture decision record to reflect that the User-Agent usage migration is deployed.
- Record the explicit disposition for the missed deprecation window: enforcement is already live, so the rollout is accepted rather than weakened retroactively.

## Related Issues

Closes #565

## Testing

- [x] Tested locally
- [x] Tested in production-like environment
- [ ] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. `pnpm run supabase:check` — full migration reset and public-schema lint pass.
2. `pnpm exec supabase db push --linked --dry-run` — remote reports up to date after deployment.
3. Linked production schema dump confirms `api_usage_daily.user_agent` is `character varying(200)`.
4. `node scripts/check-systems-drift.mjs` and Prettier checks pass.

## Screenshots/Videos

Not applicable.

## Documentation impact

- [ ] No behavior changed — no documentation review needed
- [ ] Behavior changed — existing documentation remains accurate
- [x] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [ ] Contributor documentation
- [x] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [ ] Screenshots or diagrams

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

Migration `20260723120000` has already been applied to the linked production Supabase project. The production table contained no non-null User-Agent rows before alteration, and the final schema was verified after deployment.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/581" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Lock in User-Agent storage limits after rollout**

### What Changed
- User-Agent values in API usage records are now capped at 200 characters, so long values are trimmed instead of being stored unchecked
- The production rollout status is now marked as complete, with the architecture notes updated to match the shipped behavior
- The rollout record now states that the missed advance-warning window was accepted, rather than treated as an open blocker

### Impact
`✅ Consistent User-Agent tracking`
`✅ Fewer storage issues from overlong headers`
`✅ Clearer rollout status for API changes`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced a maximum length of 200 characters for stored User-Agent values.
  * Truncated existing longer values to comply with the new limit.
  * Strengthened API usage tracking safeguards across application and database layers.

* **Documentation**
  * Updated architecture decisions and implementation status to reflect the completed User-Agent enforcement rollout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the migration is a single, already-deployed DDL statement with correct truncation logic, and the doc changes accurately reflect the completed rollout.

The SQL migration is correct: TEXT to VARCHAR(200) with USING LEFT(user_agent, 200) safely handles both NULL values and any legacy overlength rows without data loss risk. The RPC already enforced the 200-char limit, so no existing rows should exceed it — the column constraint is purely defensive. The documentation updates are internally consistent and match the migration content. No logic, security, or correctness issues were found across either changed file.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| supabase/migrations/20260723120000_constrain_api_usage_user_agent.sql | Correct and minimal DDL: alters user_agent from TEXT to VARCHAR(200) with a safe USING clause that truncates existing overlength values. NULL handling is correct (LEFT(NULL, 200) = NULL). No issues found. |
| docs/decisions/tarkov-data-architecture.md | Documentation-only updates: accurately reflects Phase 0 completion, resolves the previously open P0 item, updates the Phase 0 checklist, and adds a journal entry for the accepted rollout disposition. Consistent with the shipped migration. |

</details>

<details><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client as API Client
    participant RPC as record_api_usage (RPC)
    participant Col as api_usage_daily.user_agent
    participant Direct as Direct DB Write

    Client->>RPC: p_user_agent (any length)
    RPC->>RPC: substr(btrim(p_user_agent), 1, 200)
    RPC->>Col: INSERT/UPDATE user_agent ≤200 chars
    Note over Col: VARCHAR(200) constraint

    Direct->>Col: user_agent (any length)
    Col-->>Direct: "ERROR if > 200 chars"
    Note over Col: Column constraint enforces limit<br/>even for direct writes bypassing RPC
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs: advance Tarkov data resume point"](https://github.com/tarkovtracker-org/tarkovtracker/commit/6aa8e0b706953a8353a20b0c5f5298f034af8992) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46559696)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->