### PR TITLE
chore(i18n): remove 89 orphaned locale keys from en.json

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -119,16 +119,12 @@
   "promoted_stream": {
     "close": "Close stream",
     "expand": "Open stream",
-    "mute": "Mute stream",
     "open_channel": "Go to Twitch channel",
-    "pause": "Pause stream",
     "player_title": "{streamer} Twitch stream",
-    "play": "Play stream",
     "region_label": "Promoted Twitch stream for {streamer}",
     "reopen": "Reopen stream",
     "shrink": "Shrink stream",
-    "title": "{streamer} live",
-    "unmute": "Unmute stream"
+    "title": "{streamer} live"
   },
   "buttons": {
     "retry": "Retry"
@@ -231,8 +227,6 @@
   },
   "page_help": {
     "button": "Help",
-    "hint_title": "New here?",
-    "dismiss": "Dismiss",
     "launcher": {
       "title": "Help and onboarding",
       "summary": "Pick a quick guide for this page or the full setup path.",
@@ -506,7 +500,6 @@
         },
         "stat": {
           "why": "Why it won",
-          "progress": "Progress this adds",
           "status": "Status",
           "secondary": "Other good options",
           "secondary_actionable": "Use these if the primary plan is not a fit.",
@@ -548,17 +541,6 @@
           "filters_one": "No visible options: 1 available task is hidden by your filters.",
           "filters_other": "No visible options: {count} available tasks are hidden by your filters.",
           "complete": "No visible work remains in this dashboard scope."
-        },
-        "contribution": {
-          "unlock_trader": "Unlocks the {trader} task line.",
-          "impact_one": "Creates 1 new follow-up task.",
-          "impact_other": "Creates {count} new follow-up tasks.",
-          "kappa": "Counts toward your Kappa chain.",
-          "lightkeeper": "Counts toward your Lightkeeper chain.",
-          "trader": "Moves the {trader} task line forward.",
-          "filters": "Shows tasks that are already actionable.",
-          "complete": "The rest of the dashboard is now supporting context.",
-          "default": "Keeps your visible dashboard progress moving."
         },
         "status": {
           "ready_one": "Ready now. 1 objective left.",
@@ -696,10 +678,6 @@
         "lightkeeper": "Lightkeeper"
       },
       "stats": {
-        "total": "Kappa Tasks",
-        "completed": "Kappa Done",
-        "lightkeeper_total": "Lightkeeper Tasks",
-        "lightkeeper_completed": "Lightkeeper Done",
         "available": "Available",
         "locked": "Locked",
         "failed": "Failed"
@@ -720,8 +698,6 @@
         "action_reset_failed": "Reset failed",
         "locked_by": "Requires: {task}"
       },
-      "progress_label": "complete",
-      "all_complete": "All tasks complete! Well done, PMC.",
       "empty": "No tasks for this list yet.",
       "summary": {
         "progress": "Progress",
@@ -743,10 +719,8 @@
       "billing_6month": "6 Months",
       "billing_yearly": "Yearly",
       "most_popular": "Most Popular",
-      "fee_note": "Price shown includes Stripe fees.",
       "tier_cta": "Subscribe",
       "tier_login_cta": "Log in to subscribe",
-      "tier_current_cta": "Current tier",
       "tier_change_cta": "Change plan in billing portal",
       "current_tier_badge": "Current tier",
       "tier_scav_name": "Scav",
@@ -818,7 +792,6 @@
     "tasks": {
       "title": "Tasks",
       "primary_views": {
-        "all": "List",
         "list": "List",
         "maps": "Maps",
         "traders": "Traders",
@@ -877,17 +850,6 @@
       },
       "filters": {
         "close": "Close"
-      },
-      "api_update_log": {
-        "title": "Recent Sync History",
-        "subtitle": "Track when your progress was automatically synced from external sources.",
-        "empty": "No syncs recorded yet. Your progress will appear here when synced.",
-        "entry_count": "{count} tasks",
-        "no_task_details": "Progress synced successfully.",
-        "more_tasks": "+{count} more",
-        "unknown_time": "Unknown time",
-        "collapse": "Collapse sync history",
-        "expand": "Expand sync history"
       },
       "settings": {
         "title": "Task Settings",
@@ -976,7 +938,6 @@
         "trader_level_badge": "{trader} LL{level}",
         "wiki": "Wiki page",
         "locked_before": "Tasks Before: {count}",
-        "locked_behind": "Tasks Locked Behind: {count}",
         "requires": "Requires",
         "unlocks_next": "Unlocks next",
         "impact": "Impact",
@@ -1018,7 +979,6 @@
         "undo_uncomplete": "Undid uncompleting of {name}",
         "undo_failed": "Undid failing {name}",
         "undo_reset_failed": "Restored failed status for {name}",
-        "undo_unknown": "Unable to undo action for {name}",
         "mark_failed_confirm": "Mark this task as failed? This is only for data issues, isn't recommended, and may block task chains.",
         "reset_item_counts_confirm": "Reset all item counts for this task?",
         "failed_because": "Failed because",
@@ -1029,11 +989,8 @@
         "blocked_because_was": "was {status}",
         "blocked_because_status_tooltip": "Permanently blocked — \"{name}\" was {status}",
         "blocked_because_unknown": "Blocked by prerequisites",
-        "keys_header": "Required Keys",
         "keys_disclaimer_tooltip": "Based on API data and not always 100% required. Doors may already be unlocked. Verify in-game or on the wiki before buying keys.",
         "keys_disclaimer_aria": "Required keys disclaimer",
-        "keys_needed": "{keys} on {map} | One of {keys} on {map}",
-        "keys_optional_badge": "Optional",
         "keys_or": "or",
         "equipment_disclaimer_tooltip": "Special equipment that must be brought into raid to complete this objective.",
         "equipment_disclaimer_aria": "Required equipment disclaimer",
@@ -1056,9 +1013,6 @@
         "objective_optional_badge": "Optional",
         "ready_to_hand_over": "Ready to hand over",
         "objectives_hidden": "{count} objectives not on this map ({uncompleted} uncompleted)",
-        "alternatives": "Alternative tasks",
-        "alternative_failed": "Alternative tasks will also be reset",
-        "different_faction": "This task is not available to your faction",
         "needed_by": "Needed by: {names}",
         "unlocks_next_tooltip": "Number of tasks that become available after completing this task",
         "impact_tooltip": "Number of incomplete tasks that depend on this task being completed",
@@ -1079,12 +1033,10 @@
         "find_fir": "Find in raid",
         "items_count": "{count} items",
         "kappa_tooltip": "This quest is required to obtain the Kappa Secure Container",
-        "kappa_required": "KAPPA REQUIRED",
         "level_badge_tooltip": "Minimum player level {level} required to unlock this quest",
         "lightkeeper_tooltip": "This quest is required to unlock the Lightkeeper trader",
         "alternatives_tooltip": "This quest has {count} alternative choice(s) — you only need to complete one",
         "alternatives_badge": "{count} alt",
-        "lightkeeper_required": "LIGHTKEEPER REQUIRED",
         "location_tooltip": "Quest objectives are on {map}",
         "next_tasks": "Next Task(s):",
         "objective": "Objective",
@@ -1103,7 +1055,6 @@
       "loading": "Loading hideout data",
       "station_link_label": "Go to {name}",
       "no_stations_found": "No stations found. Try changing your filters.",
-      "load_more_stations": "Load more stations",
       "collapse_completed": "Collapse completed stations",
       "sort": {
         "ready_first": "Sort ready to build first"
@@ -1166,26 +1117,17 @@
       "filters": {
         "all": "All",
         "label": "Filters",
-        "sections": {
-          "items": "ITEMS",
-          "team": "TEAM"
-        },
         "fir": "FIR",
         "non_fir": "NON-FIR",
-        "show_owned": "SHOW OWNED",
         "hide_owned": "HIDE OWNED",
         "hide_non_fir_special_equipment_title": "Hide non-FIR special equipment (e.g., MS2000 Markers, Wi-Fi Cameras)",
-        "no_special": "NO-SPECIAL",
-        "special": "SPECIAL",
         "kappa_only": "KAPPA",
         "kappa_only_tooltip": "Show only items required for Kappa tasks",
         "kappa_only_disabled_tooltip": "Kappa filter applies to tasks only.",
-        "hide_team_needs": "HIDE TEAM NEEDS",
-        "show_team_needs": "SHOW TEAM NEEDS"
+        "hide_team_needs": "HIDE TEAM NEEDS"
       },
       "sort": {
         "label": "Sort",
-        "by": "SORT BY",
         "priority": "Priority",
         "name": "Name",
         "category": "Category",
@@ -1399,25 +1341,17 @@
       "achievement_mainline": "Mainline Task Progress",
       "achievement_objectives": "Objective Completion",
       "no_storyline": "No storyline data available for this profile.",
-      "storyline_chapter": "Chapter",
       "storyline_auto_start": "Auto-start",
       "storyline_discovered": "Discovered",
       "storyline_requires": "Requires",
-      "storyline_unlocks_maps": "Unlocks maps",
-      "storyline_unlocks_traders": "Unlocks traders",
-      "storyline_wiki": "Wiki",
       "storyline_objectives_main": "Main Objectives",
       "storyline_objectives_optional": "Optional Objectives",
-      "storyline_description": "Description",
-      "storyline_notes": "Notes",
-      "storyline_rewards": "Rewards",
       "view_tarkov_dev": "View on Tarkov.dev",
       "no_hideout": "No hideout data available for this profile.",
       "hideout_level": "Level",
       "hideout_fallback": "Hideout",
       "hideout_item_fallback": "Hideout item",
       "hideout_module_fallback": "Hideout upgrade",
-      "unknown_trader": "Unknown Trader",
       "level_prefix": "Lv.",
       "no_tasks": "No tasks available for this profile.",
       "task_fallback": "Task",
@@ -1512,7 +1446,6 @@
         "open_tool": "Open tool",
         "download_release": "Download latest release"
       },
-      "view_guide": "Setup guide",
       "back_to_hub": "Back to Resources",
       "breadcrumb": "Breadcrumb",
       "guide_label": "Guide",
@@ -1656,7 +1589,6 @@
       "github": "GitHub"
     },
     "support_button": "Support",
-    "support_tagline": "Help keep TarkovTracker free & updated",
     "terms_of_service": "Terms of Service",
     "privacy_policy": "Privacy Policy",
     "credits": "Credits",
@@ -1833,13 +1765,10 @@
     "title": "Settings",
     "locale": "Language",
     "tabs": {
-      "gameplay": "Gameplay",
-      "interface": "Interface",
       "account": "Account",
       "progression": "Progression",
       "prestige": "Prestige",
       "preferences": "Preferences",
-      "data_management": "Data Management",
       "imports": "Imports",
       "backup_restore": "Backup & Restore",
       "api": "API",
@@ -1887,10 +1816,6 @@
       "compact": "Compact",
       "comfortable": "Comfortable"
     },
-    "account_moved": {
-      "message": "Looking for API tokens or account settings?",
-      "link": "Go to Account"
-    },
     "account": {
       "begin_deletion": "Begin Account Deletion"
     },
@@ -1905,7 +1830,6 @@
       "admin_panel": "Admin Panel"
     },
     "interface": {
-      "title": "Interface Customization",
       "tasks": {
         "title": "Task Cards",
         "show_required": "Show Required Labels",
@@ -1914,9 +1838,6 @@
         "show_prev": "Show Previous Quests",
         "density": "Card Density",
         "require_trader_levels": "Require Trader Loyalty Level and Reputation for Task Availability"
-      },
-      "defaults": {
-        "title": "Default Views"
       },
       "maps": {
         "title": "Maps",
@@ -1942,9 +1863,6 @@
         "title": "Wiki Links",
         "antifandom": "Use antifandom.com",
         "antifandom_hint": "Open wiki links on antifandom.com, a community-run, ad-light mirror of Fandom, instead of fandom.com."
-      },
-      "misc": {
-        "title": "Miscellaneous"
       }
     },
     "game_profile": {
@@ -1960,7 +1878,6 @@
       "mode_pve": "PvE",
       "toggle_pvp_label": "Toggle PvP profile sharing",
       "toggle_pve_label": "Toggle PvE profile sharing",
-      "copy_link": "Copy profile link",
       "copy_pvp_link": "Copy PvP profile link",
       "copy_pve_link": "Copy PvE profile link",
       "login_required": "Log in to manage profile sharing visibility."
@@ -1971,9 +1888,6 @@
       "pve": "PvE",
       "switch_mode_failed": "Failed to switch game mode, please retry",
       "switch_mode_fetch_failed": "Game mode switched but failed to refresh data, please retry"
-    },
-    "data_management_card": {
-      "title": "Data Management"
     },
     "data_management": {
       "reset_pvp_title": "Reset PvP Data",
@@ -1988,20 +1902,14 @@
       "reset_all_data": "Reset All Data",
       "reset_all_confirmation": "Are you sure you want to reset ALL your progress?",
       "reset_all_warning": "This will permanently delete ALL your progress for PvP and PvE modes. This action cannot be undone!",
-      "prestige_pvp_title": "Prestige PvP Profile",
-      "prestige_pvp_data": "Prestige PvP",
-      "prestige_pvp_confirmation": "Are you sure you want to prestige your PvP profile?",
       "prestige_pvp_warning": "Your current PvP run will be archived, then PvP progression will reset for the next prestige level. PvE data is not affected.",
       "reset_cancel": "Cancel",
       "reset_confirm": "Reset Data",
-      "export_title": "Export & Backup",
       "export_description": "Download a backup of your progress data for both PvP and PvE modes.",
       "export_button": "Export Progress Backup",
       "debug_export_button": "Export Debug Snapshot",
       "debug_export_description": "Download a sanitized account snapshot for debugging signed-in issues. This excludes auth tokens, email, and profile images.",
-      "import_title": "Import",
       "import_backup_button": "Import TarkovTracker Backup",
-      "import_tarkovdev_button": "Import Tarkov.dev Profile",
       "import_eft_logs_folder_button": "Import EFT Logs Folder",
       "recommended_badge": "Recommended",
       "active_flow_blocked_title": "Finish the current data flow first",
@@ -2016,7 +1924,6 @@
       "backup_restore_section_title": "Backup & Restore",
       "backup_restore_section_description": "Export a backup or restore from a previously exported file",
       "debug_section_title": "Debug Snapshot",
-      "debug_section_description": "Download a sanitized snapshot for support and debugging",
       "import_backup_title": "Restore from Backup",
       "import_backup_description": "Restore progress from a TarkovTracker backup file",
       "import_preview_exported_at": "Exported",
@@ -2038,7 +1945,6 @@
       "debug_export_error_title": "Debug Export Failed",
       "reset_title": "Reset Progress",
       "prestige_history_title": "Prestige History",
-      "prestige_history_description": "Archived PvP runs are kept after each prestige so you can compare progression.",
       "prestige_history_loading": "Loading prestige history...",
       "prestige_history_empty": "No archived prestige runs yet.",
       "prestige_history_load_error": "Failed to load prestige history.",
@@ -2061,10 +1967,6 @@
       "success_title": "PvP Prestige Complete",
       "success_description": "Your PvP profile has been prestiged to level {level}.",
       "error_description": "Failed to prestige PvP profile. Please try again."
-    },
-    "data_migration": {
-      "title": "Local Data Migration",
-      "description": "Migrate your local progress data to your cloud account. This happens automatically when you sign in."
     },
     "reset": {
       "error_title": "Reset Failed"
@@ -2094,7 +1996,6 @@
       "member_since_label": "Member since",
       "account_id_label": "Account ID",
       "unknown_label": "Unknown",
-      "data_reset_title": "Data Reset",
       "account_deletion_title": "Account Deletion",
       "login_required_delete": "Log in to delete your account",
       "action_show": "Show",
@@ -2208,9 +2109,7 @@
       "summary_description_manual": "{count} requirement(s) still need manual in-game verification."
     },
     "display_name": {
-      "title": "Display Name",
       "explanation": "Your display name is shown to teammates and in the navigation. Each game mode (PVP/PVE) has a separate display name.",
-      "mode_hint": "You are editing the display name for {mode} mode. Switch game modes in the navigation drawer to edit the other display name.",
       "label": "Display Name",
       "placeholder": "Enter your display name...",
       "save": "Save",
@@ -2272,7 +2171,6 @@
       "reset_offset": "Reset XP Offset"
     },
     "danger_zone": {
-      "confirm_delete_instruction": "Type {word} to confirm:",
       "confirm_word": "DELETE"
     },
     "log_import": {
@@ -2313,7 +2211,6 @@
       "unknown_mode_event_details": "Unknown Mode Event Details",
       "unknown_completion_events": "Completed Tasks (Unknown Mode)",
       "unknown_started_events": "Started Tasks (Unknown Mode)",
-      "import_to_mode": "Import to Mode",
       "import_unknown_to_mode": "Import Unknown Mode Events To",
       "import_unknown_to_mode_hint": "Known PvP/PvE events are auto-routed. This only applies to unresolved events.",
       "auto_mode_hint": "Mode routing was detected from backend logs and will be applied automatically.",
@@ -2350,9 +2247,7 @@
       "profile_url_label": "Tarkov.dev profile URL",
       "profile_url_placeholder": "https://tarkov.dev/players/regular/8560316",
       "profile_url_hint": "Find your profile at {link}, open the matching PvP or PvE profile, then paste that page URL here.",
-      "profile_url_hint_before_link": "Find your profile at",
       "profile_url_hint_link": "tarkov.dev/players",
-      "profile_url_hint_after_link": ", open the matching PvP or PvE profile, then paste that page URL here.",
       "profile_url_refresh_hint": "Tarkov.dev refreshes the profile JSON after you open your profile page there.",
       "fetch_profile": "Fetch Profile",
       "nickname": "Nickname",


### PR DESCRIPTION
## **User description**
# Pull Request

## Summary

Dead-code sweep of `app/locales/en.json`. Removes 89 locale keys that have no reference anywhere in the codebase — strings left behind when the UI that used them was replaced. Key count drops 2014 → 1925.

Locale-only change. No source files touched, no behavior change.

## Changes

- `page.tasks.api_update_log.*` (9 keys) — the "Recent Sync History" panel, superseded by the Activity Log in #443. The underlying `apiUpdateHistory` pipeline is still live (it feeds `useActivityLogStore` → `ActivityLogPanel`); only the retired UI's copy was orphaned.
- `page.dashboard.focus.contribution.*` (9 keys) — removed in #553.
- `settings.tabs.{gameplay,interface,data_management}` — leftovers from an older tab layout. Live tabs are `progression, prestige, preferences, account, imports, backup_restore, api, streamer_tools`.
- `promoted_stream.{mute,unmute,play,pause}` — `PromotedTwitchEmbed.vue` has no playback controls; the iframe autoplays muted via URL params.
- Assorted singles across `page.tasks.questcard.*`, `page.needed_items.filters.*`, `page.profile.storyline_*`, `page.kappa.stats.*`, and `settings.*`.

## Related Issues

<!-- none -->

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [ ] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. `pnpm run test` — 218 files / 2124 tests pass.
2. `pnpm run lint:unused` (knip) — clean, exit 0.
3. `pnpm run i18n:check` — non-fatal, no snake_case violations.
4. `npx prettier --check app/locales/en.json` — clean.

**How the keys were confirmed dead.** A literal grep alone is not sufficient here, because this codebase builds i18n keys dynamically. I enumerated every dynamic key construction in the app — patterns like ``t(`page.resources.items.${slug}.name`)``, ``t(`page.tasks.sort.${mode}`)``, and ``t(`page.${routeName}.title`)`` — and matched every candidate against them. That separated 168 legitimately dynamic keys from the 89 dead ones. Each removed key also has zero whole-repo references including tests, so nothing asserts on them.

## Screenshots/Videos

N/A — no rendered output changes.

## Documentation impact

Select one:

- [x] No behavior changed — no documentation review needed

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

**Crowdin interaction — expected, no action needed.** Only `en.json` is modified, per the locale ownership rule. The 11 Crowdin-owned non-English files still contain these keys, so `i18n:check` now reports ~971 "extra" keys. That is informational and non-fatal, and Crowdin reconciles it on the next sync.

**Audit findings deliberately left out of this PR**, to keep the diff scoped:

- ~37 symbols are exported but only consumed inside their own module (`hideoutPrereqs.ts`, `progressMerge.ts`, `prestige.ts`, `app/types/*`). These are over-exported, not dead — knip's `ignoreExportsUsedInFile: true` masks them. Dropping the `export` keyword would be zero-behavior churn across 14 files, and type barrels in `app/types/` export by design.
- `knip --production` flags `csp.ts`, `stripBareNodeImports`, `resolveTrustProxySetting`, and the `tarkov-json.ts` fetchers. All false positives: the first three are used by `nuxt.config.ts` and the fetchers by auto-discovered Nitro routes, neither of which production mode traces.
- No unused Vue components. `NeededItemRow.vue` / `NeededItemSmallCard.vue` initially looked unreferenced but are used via Nuxt's `Lazy` prefix.

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/582" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Remove unused English locale strings**

### What Changed
- Removed English translation keys that are no longer used anywhere in the app
- Cleaned up retired labels from pages, settings, task views, support screens, imports, profile sharing, and overlays
- Kept the current user-facing text unchanged for active features

### Impact
`✅ Smaller locale file`
`✅ Fewer outdated translation strings`
`✅ No visible change in active screens`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated interface text across onboarding, dashboard, trackers, tasks, resource guides, settings, imports, and account management.
  * Clarified labels, instructions, warnings, empty states, filters, and subscription prompts.
  * Added copy for streamer and overlay features, data management actions, and import/export workflows.
  * Refined footer and branding text for improved consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — locale-only change with no source file modifications and no behavioral impact.

Every removed key was verified absent from source via direct search and dynamic-pattern analysis. The live settings tabs, needed-items filters, and questcard keys that remain in use are untouched. The Crowdin extra-keys side-effect is expected and handled automatically on next sync.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/locales/en.json | Removes 89 orphaned locale keys across 9 namespaces; spot-checks confirm none of the removed keys are referenced in source code, including via dynamic key-construction patterns. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["app/locales/en.json\n(2014 keys → 1925 keys)"] --> B["Removed Namespaces"]
    B --> C["page.tasks.api_update_log.*\n9 keys — retired sync panel UI"]
    B --> D["page.dashboard.focus.contribution.*\n9 keys — removed in #553"]
    B --> E["settings.tabs.gameplay / interface / data_management\n3 keys — old tab layout"]
    B --> F["promoted_stream.mute / unmute / play / pause\n4 keys — iframe handles playback via URL params"]
    B --> G["Assorted singles\n64 keys — questcard, needed_items, profile,\nkappa.stats, settings.*"]
    A --> H["Live Keys Preserved"]
    H --> I["settings.tabs: progression, prestige,\npreferences, account, imports,\nbackup_restore, api, streamer_tools"]
    H --> J["page.needed_items.filters.hide_team_needs\n(show_team_needs removed — checkbox uses hide label only)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["chore(i18n): remove 89 orphaned keys fro..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/07ca99645e267f39280a7abc53f02729cd4e0ae9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46572067)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->