### PR TITLE
docs+refactor: Tarkov.dev API source docs and GraphQL artifact cleanup

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -24,14 +24,14 @@ GitHub's native **Issue Types** feature replaces type labels. Each issue must ha
 
 All area labels use `#c2e0c6` (light green) for visual grouping.
 
-| Label           | Description                                 | Examples                                                              |
-| --------------- | ------------------------------------------- | --------------------------------------------------------------------- |
-| `area:ui`       | Vue components, pages, styling              | Component bugs, layout issues, Tailwind CSS, responsive design        |
-| `area:api`      | Nitro server routes, workers, API endpoints | Server routes in `app/server/api/`, Cloudflare Workers, GraphQL proxy |
-| `area:database` | Supabase schema, migrations, queries        | Database schema, Postgres queries, migrations, RLS policies           |
-| `area:auth`     | Authentication and authorization            | Login/logout, Supabase Auth, permissions, session management          |
-| `area:realtime` | Team sync, Supabase broadcasts              | Team features, real-time sync, Supabase Realtime, broadcasts          |
-| `area:i18n`     | Translations and localization               | Language files, translation keys, i18n system, locale switching       |
+| Label           | Description                                 | Examples                                                               |
+| --------------- | ------------------------------------------- | ---------------------------------------------------------------------- |
+| `area:ui`       | Vue components, pages, styling              | Component bugs, layout issues, Tailwind CSS, responsive design         |
+| `area:api`      | Nitro server routes, workers, API endpoints | Server routes in `app/server/api/`, Cloudflare Workers, JSON API proxy |
+| `area:database` | Supabase schema, migrations, queries        | Database schema, Postgres queries, migrations, RLS policies            |
+| `area:auth`     | Authentication and authorization            | Login/logout, Supabase Auth, permissions, session management           |
+| `area:realtime` | Team sync, Supabase broadcasts              | Team features, real-time sync, Supabase Realtime, broadcasts           |
+| `area:i18n`     | Translations and localization               | Language files, translation keys, i18n system, locale switching        |
 
 **Note:** Issues can have multiple area labels if they affect multiple systems (e.g., `area:ui` + `area:realtime` for team page display issues).
 

--- a/.gitignore
+++ b/.gitignore
@@ -23,8 +23,6 @@ node_modules
 .env.*
 !.env.example
 .dev.vars
-graphql.config.js
-schema.graphql
 .lighthouseci*
 
 # Local EFT log archives (can contain sensitive data)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -109,6 +109,7 @@ When asked to "review for production readiness", "deep review", "is this safe to
 - **Keep secrets out of the repo.** Use `useRuntimeConfig()` for env-driven values.
 - **No destructive git commands** (`git restore`, `git checkout --`, `git reset`, `git clean`, force-push) without explicit user approval in the current conversation.
 - **No runtime dependency additions** without explaining why existing deps are insufficient.
+- **Game data comes from `json.tarkov.dev` via the `/api/tarkov/*` server proxy.** Do not add usage of the `api.tarkov.dev` GraphQL API. Task objectives and prestige conditions are discriminated by the upstream `type` field; the synthetic `__typename` discriminator was removed — do not reintroduce it.
 - **Do not add new runtime dependencies on Tarkov task `alternatives`.** Upstream removed the field; branch relationships must be compiled from task-status failure conditions. Existing uses remain until the shared progress engine replaces them.
 - **Keep changes scoped** to the requested task. Prefer small, reviewable diffs.
 

--- a/app/composables/__tests__/useSkillCalculation.test.ts
+++ b/app/composables/__tests__/useSkillCalculation.test.ts
@@ -156,4 +156,77 @@ describe('useSkillCalculation', () => {
     const { allGameSkills } = useSkillCalculation();
     expect(allGameSkills.value).toEqual([]);
   });
+  it('backfills missing skill id and image link from later objectives', () => {
+    const metadataStore = useMetadataStore();
+    metadataStore.tasks = [
+      {
+        id: 'task-vitality',
+        name: 'Vitality Task',
+        objectives: [
+          {
+            id: 'objective-vitality-no-meta',
+            type: 'skill',
+            skillLevel: {
+              id: 'req-1',
+              name: 'Vitality',
+              level: 3,
+            },
+          },
+          {
+            id: 'objective-vitality-with-meta',
+            type: 'skill',
+            skillLevel: {
+              id: 'req-2',
+              name: 'Vitality',
+              level: 5,
+              skill: {
+                id: 'Vitality',
+                name: 'Vitality',
+                imageLink: 'https://example.com/vitality.webp',
+              },
+            },
+          },
+        ],
+      },
+    ] as Task[];
+    const { allGameSkills } = useSkillCalculation();
+    const vitality = allGameSkills.value.find((skill) => skill.key === 'Vitality');
+    expect(vitality).toMatchObject({
+      id: 'Vitality',
+      imageLink: 'https://example.com/vitality.webp',
+      name: 'Vitality',
+      requiredByTasks: ['Vitality Task', 'Vitality Task'],
+      requiredLevels: [3, 5],
+    });
+  });
+  it('deduplicates repeated required levels for the same skill', () => {
+    const metadataStore = useMetadataStore();
+    metadataStore.tasks = [
+      {
+        id: 'task-a',
+        name: 'Task A',
+        objectives: [
+          {
+            id: 'objective-1',
+            type: 'skill',
+            skillLevel: { id: 'req-1', name: 'Strength', level: 5, skill: { id: 'Strength' } },
+          },
+        ],
+      },
+      {
+        id: 'task-b',
+        name: 'Task B',
+        objectives: [
+          {
+            id: 'objective-2',
+            type: 'skill',
+            skillLevel: { id: 'req-2', name: 'Strength', level: 5, skill: { id: 'Strength' } },
+          },
+        ],
+      },
+    ] as Task[];
+    const { allGameSkills } = useSkillCalculation();
+    const strength = allGameSkills.value.find((skill) => skill.key === 'Strength');
+    expect(strength?.requiredLevels).toEqual([5]);
+  });
 });

--- a/app/composables/__tests__/useSkillCalculation.test.ts
+++ b/app/composables/__tests__/useSkillCalculation.test.ts
@@ -81,4 +81,79 @@ describe('useSkillCalculation', () => {
     expect(totalSkills.value.Perception).toBe(16);
     expect(getSkillOffset('Perception')).toBe(14.5);
   });
+  it('collects skills required by task objectives', () => {
+    const metadataStore = useMetadataStore();
+    metadataStore.tasks = [
+      {
+        id: 'task-vitality',
+        name: 'Shootout Picnic',
+        objectives: [
+          {
+            id: 'objective-vitality',
+            type: 'skill',
+            skillLevel: {
+              id: 'req-vitality',
+              name: 'Vitality',
+              level: 5,
+              skill: {
+                id: 'Vitality',
+                name: 'Vitality',
+                imageLink: 'https://example.com/vitality.webp',
+              },
+            },
+          },
+          { id: 'objective-item', type: 'giveItem', items: [{ id: 'item-1', name: 'Salewa' }] },
+        ],
+      },
+    ] as Task[];
+    const { allGameSkills } = useSkillCalculation();
+    const vitality = allGameSkills.value.find((skill) => skill.key === 'Vitality');
+    expect(vitality).toMatchObject({
+      id: 'Vitality',
+      imageLink: 'https://example.com/vitality.webp',
+      name: 'Vitality',
+      requiredByTasks: ['Shootout Picnic'],
+      requiredLevels: [5],
+    });
+    expect(allGameSkills.value.some((skill) => skill.key === 'Salewa')).toBe(false);
+  });
+  it('merges required levels for a skill demanded by several tasks', () => {
+    const metadataStore = useMetadataStore();
+    const objective = (id: string, level: number) => ({
+      id,
+      type: 'skill',
+      skillLevel: {
+        id: `req-${id}`,
+        name: 'Endurance',
+        level,
+        skill: { id: 'Endurance', name: 'Endurance' },
+      },
+    });
+    metadataStore.tasks = [
+      { id: 'task-a', name: 'Task A', objectives: [objective('a', 6)] },
+      { id: 'task-b', name: 'Task B', objectives: [objective('b', 2)] },
+      { id: 'task-c', name: 'Task C', objectives: [objective('c', 6)] },
+    ] as Task[];
+    const { allGameSkills } = useSkillCalculation();
+    const endurance = allGameSkills.value.find((skill) => skill.key === 'Endurance');
+    expect(endurance?.requiredByTasks).toEqual(['Task A', 'Task B', 'Task C']);
+    expect(endurance?.requiredLevels).toEqual([2, 6]);
+  });
+  it('ignores tasks with no name when collecting objective skills', () => {
+    const metadataStore = useMetadataStore();
+    metadataStore.tasks = [
+      {
+        id: 'task-unnamed',
+        objectives: [
+          {
+            id: 'objective-vitality',
+            type: 'skill',
+            skillLevel: { id: 'req', name: 'Vitality', level: 5 },
+          },
+        ],
+      },
+    ] as Task[];
+    const { allGameSkills } = useSkillCalculation();
+    expect(allGameSkills.value).toEqual([]);
+  });
 });

--- a/app/composables/useSkillCalculation.ts
+++ b/app/composables/useSkillCalculation.ts
@@ -20,30 +20,6 @@ import {
   getCanonicalSkillKey,
   resolveSkillKey as resolveSkillAliasKey,
 } from '@/utils/skillHelpers';
-import type { Skill, SkillRequirement, TaskObjective } from '@/types/tarkov';
-/**
- * Extended TaskObjective with GraphQL __typename discriminator
- */
-interface TaskObjectiveWithTypename extends TaskObjective {
-  __typename?: string;
-}
-/**
- * TaskObjectiveSkill - objective type that requires a skill level
- */
-interface TaskObjectiveSkill extends TaskObjectiveWithTypename {
-  __typename: 'TaskObjectiveSkill';
-  skillLevel?: SkillRequirement & {
-    skill?: Skill;
-  };
-}
-/**
- * Type guard to check if an objective is a TaskObjectiveSkill
- */
-function isTaskObjectiveSkill(
-  objective: TaskObjectiveWithTypename
-): objective is TaskObjectiveSkill {
-  return objective.__typename === 'TaskObjectiveSkill';
-}
 export interface SkillMetadata {
   key: string;
   id?: string;
@@ -66,14 +42,15 @@ export function useSkillCalculation() {
       const taskName = task.name;
       if (!taskName) return;
       task.objectives?.forEach((objective) => {
-        const objectiveWithType = objective as TaskObjectiveWithTypename;
-        if (!isTaskObjectiveSkill(objectiveWithType) || !objectiveWithType.skillLevel?.name) return;
-        const skillName = objectiveWithType.skillLevel.name;
-        const skillId = objectiveWithType.skillLevel.skill?.id;
+        if (objective.type !== 'skill') return;
+        const skillLevel = objective.skillLevel;
+        const skillName = skillLevel?.name;
+        if (!skillName || !skillLevel) return;
+        const skillId = skillLevel.skill?.id;
         const skillKey = getCanonicalSkillKey(skillName, skillId);
         if (!skillKey) return;
-        const requiredLevel = objectiveWithType.skillLevel.level || 0;
-        const imageLink = objectiveWithType.skillLevel?.skill?.imageLink;
+        const requiredLevel = skillLevel.level || 0;
+        const imageLink = skillLevel.skill?.imageLink;
         if (!skillsMap.has(skillKey)) {
           skillsMap.set(skillKey, {
             key: skillKey,

--- a/app/composables/useSkillCalculation.ts
+++ b/app/composables/useSkillCalculation.ts
@@ -18,6 +18,7 @@ import {
   buildSkillKeyAliases,
   collapseSkillOffsets,
   getCanonicalSkillKey,
+  readSkillObjective,
   resolveSkillKey as resolveSkillAliasKey,
 } from '@/utils/skillHelpers';
 export interface SkillMetadata {
@@ -42,15 +43,9 @@ export function useSkillCalculation() {
       const taskName = task.name;
       if (!taskName) return;
       task.objectives?.forEach((objective) => {
-        if (objective.type !== 'skill') return;
-        const skillLevel = objective.skillLevel;
-        const skillName = skillLevel?.name;
-        if (!skillName || !skillLevel) return;
-        const skillId = skillLevel.skill?.id;
-        const skillKey = getCanonicalSkillKey(skillName, skillId);
-        if (!skillKey) return;
-        const requiredLevel = skillLevel.level || 0;
-        const imageLink = skillLevel.skill?.imageLink;
+        const skill = readSkillObjective(objective);
+        if (!skill) return;
+        const { imageLink, requiredLevel, skillId, skillKey, skillName } = skill;
         if (!skillsMap.has(skillKey)) {
           skillsMap.set(skillKey, {
             key: skillKey,

--- a/app/features/resources/__tests__/ResourceCard.test.ts
+++ b/app/features/resources/__tests__/ResourceCard.test.ts
@@ -68,7 +68,7 @@ describe('ResourceCard', () => {
         primaryAction: 'api',
         keywords: ['api'],
         links: [
-          { type: 'api', url: 'https://api.tarkov.dev/' },
+          { type: 'api', url: 'https://json.tarkov.dev/endpoints' },
           { type: 'website', url: 'https://tarkov.dev/' },
           { type: 'github', url: 'https://github.com/the-hideout' },
         ],
@@ -76,7 +76,9 @@ describe('ResourceCard', () => {
       true
     );
     expect(wrapper.text()).toContain('Data Platform');
-    expect(wrapper.get('a[href="https://api.tarkov.dev/"]').text()).toBe('API documentation');
+    expect(wrapper.get('a[href="https://json.tarkov.dev/endpoints"]').text()).toBe(
+      'API documentation'
+    );
     expect(wrapper.get('a[href="/resources/tarkovdev"]').text()).toBe('Read guide');
     expect(wrapper.get('[data-testid="more-menu"]').text()).toContain('Open website');
     expect(wrapper.get('[data-testid="more-menu"]').text()).toContain('View source');

--- a/app/features/resources/resourceData.ts
+++ b/app/features/resources/resourceData.ts
@@ -81,9 +81,9 @@ export const RESOURCES: Resource[] = [
     hasGuide: true,
     guide: { steps: 3, tips: 2, faq: 2 },
     primaryAction: 'api',
-    keywords: ['api', 'graphql', 'data', 'developer', 'items', 'quests', 'market', 'traders'],
+    keywords: ['api', 'json', 'data', 'developer', 'items', 'quests', 'market', 'traders'],
     links: [
-      { type: 'api', url: 'https://api.tarkov.dev/' },
+      { type: 'api', url: 'https://json.tarkov.dev/endpoints' },
       { type: 'website', url: 'https://tarkov.dev/' },
       { type: 'github', url: 'https://github.com/the-hideout' },
       { type: 'discord', url: 'https://discord.gg/bgpejCuFDf' },

--- a/app/features/settings/__tests__/PrestigeCard.test.ts
+++ b/app/features/settings/__tests__/PrestigeCard.test.ts
@@ -81,7 +81,7 @@ vi.mock('@/stores/useMetadata', () => ({
         prestigeLevel: 5,
         conditions: [
           {
-            __typename: 'TaskObjectivePlayerLevel',
+            type: 'playerLevel',
             id: 'player-level',
             playerLevel: 47,
           },

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1573,7 +1573,7 @@
           "step_2_desc": "If you are a developer, point your HTTP client at json.tarkov.dev. The endpoint catalog is at json.tarkov.dev/endpoints. The API is free, requires no authentication for read queries, and returns static JSON files you can cache locally.",
           "step_3_title": "Join the community",
           "step_3_desc": "The Hideout Discord is the hub for data contributors, tool developers, and bug reports. If you spot outdated data or want to contribute, this is where it happens.",
-          "tip_1": "The JSON endpoints are rate-limited but generous. For production apps, cache responses client-side to avoid redundant requests.",
+          "tip_1": "The JSON endpoints have no rate limit. For production apps, cache responses client-side to avoid redundant requests.",
           "tip_2": "Tarkov.dev data updates frequently during wipe seasons. If something looks wrong, it may already be fixed in the latest dataset.",
           "faq_1_q": "Is the Tarkov.dev API free to use?",
           "faq_1_a": "Yes, the JSON endpoints are completely free for read queries. No API key or authentication is required for standard usage.",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1566,17 +1566,17 @@
       },
       "guides": {
         "tarkovdev": {
-          "overview": "Tarkov.dev is the backbone of the community data ecosystem. It maintains an open-source dataset of items, quests, traders, hideout stations, and more, all accessible through a free GraphQL API. TarkovTracker itself uses this API to stay up to date with the latest game data. If you build tools, write guides, or just want to look up item stats, Tarkov.dev is the authoritative source.",
+          "overview": "Tarkov.dev is the backbone of the community data ecosystem. It maintains an open-source dataset of items, quests, traders, hideout stations, and more, all accessible through free static JSON endpoints at json.tarkov.dev. TarkovTracker itself uses these endpoints to stay up to date with the latest game data. If you build tools, write guides, or just want to look up item stats, Tarkov.dev is the authoritative source.",
           "step_1_title": "Browse the website",
           "step_1_desc": "Visit tarkov.dev to search items, check quest requirements, view trader inventories, and explore hideout station data in a clean, ad-free interface.",
-          "step_2_title": "Use the GraphQL API",
-          "step_2_desc": "If you are a developer, point your GraphQL client at api.tarkov.dev. The API is free, requires no authentication for read queries, and has full schema documentation available at the endpoint.",
+          "step_2_title": "Use the JSON API",
+          "step_2_desc": "If you are a developer, point your HTTP client at json.tarkov.dev. The endpoint catalog is at json.tarkov.dev/endpoints. The API is free, requires no authentication for read queries, and returns static JSON files you can cache locally.",
           "step_3_title": "Join the community",
           "step_3_desc": "The Hideout Discord is the hub for data contributors, tool developers, and bug reports. If you spot outdated data or want to contribute, this is where it happens.",
-          "tip_1": "The GraphQL API is rate-limited but generous. For production apps, cache responses client-side to avoid redundant queries.",
+          "tip_1": "The JSON endpoints are rate-limited but generous. For production apps, cache responses client-side to avoid redundant requests.",
           "tip_2": "Tarkov.dev data updates frequently during wipe seasons. If something looks wrong, it may already be fixed in the latest dataset.",
           "faq_1_q": "Is the Tarkov.dev API free to use?",
-          "faq_1_a": "Yes, the GraphQL API is completely free for read queries. No API key or authentication is required for standard usage.",
+          "faq_1_a": "Yes, the JSON endpoints are completely free for read queries. No API key or authentication is required for standard usage.",
           "faq_2_q": "How often is the data updated?",
           "faq_2_a": "Data is maintained by community contributors and updated as changes are discovered in-game. During active wipe periods, updates can happen multiple times per day."
         },

--- a/app/server/utils/__tests__/edgeCacheSanitizers.test.ts
+++ b/app/server/utils/__tests__/edgeCacheSanitizers.test.ts
@@ -1,9 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import {
-  sanitizeErrorMessage,
-  sanitizeGraphQLErrors,
-  sanitizeVariables,
-} from '@/server/utils/edgeCacheSanitizers';
+import { sanitizeErrorMessage, sanitizeVariables } from '@/server/utils/edgeCacheSanitizers';
 describe('edge cache sanitizers', () => {
   it('sanitizes host and path details from error messages', () => {
     const urlMessage = 'query failed at https://api.example.com/private/file.sql';
@@ -34,11 +30,5 @@ describe('edge cache sanitizers', () => {
       },
       userId: '[redacted]',
     });
-  });
-  it('handles graphql error arrays and unknown shapes', () => {
-    const arrayResult = sanitizeGraphQLErrors([{ message: 'boom', extensions: { code: 'BAD' } }]);
-    const objectResult = sanitizeGraphQLErrors({ message: 'boom' });
-    expect(arrayResult).toContain('BAD');
-    expect(objectResult).toContain('Non-array error object');
   });
 });

--- a/app/server/utils/__tests__/tarkov-json.test.ts
+++ b/app/server/utils/__tests__/tarkov-json.test.ts
@@ -469,12 +469,12 @@ describe('tarkov JSON adapters', () => {
       [{ id: 'item1' }],
       [{ id: 'item2' }, { id: 'missing-item' }],
     ]);
-    expect(objectives?.objectives?.[0]?.__typename).toBe('TaskObjectiveItem');
+    expect(objectives?.objectives?.[0]?.type).toBe('giveItem');
     expect(objectives?.objectives?.[0]?.items?.[0]).toEqual({ id: 'item1' });
     expect(objectives?.objectives?.[0]?.items?.[24]).toEqual({ id: 'bulk-item-23' });
     expect(objectives?.objectives?.[0]?.items?.[25]).toEqual({ id: 'bulk-item-24' });
     expect(objectives?.objectives?.[1]).toMatchObject({
-      __typename: 'TaskObjectiveQuestItem',
+      type: 'findQuestItem',
       questItem: { id: 'questItem1', name: 'Bronze pocket watch' },
     });
     const rewards = adaptTaskRewardsResponse(tasksPayload, { tradersPayload }).data.tasks[0];
@@ -489,7 +489,7 @@ describe('tarkov JSON adapters', () => {
       tradersPayload,
     }).data.tasks[0];
     expect(objectives?.objectives?.[2]).toMatchObject({
-      __typename: 'TaskObjectiveSkill',
+      type: 'skill',
       skillLevel: {
         name: 'Vitality',
         level: 5,
@@ -515,7 +515,7 @@ describe('tarkov JSON adapters', () => {
       tradersPayload,
     }).data.tasks[0];
     expect(objectives?.objectives?.[0]).toMatchObject({
-      __typename: 'TaskObjectiveItem',
+      type: 'giveItem',
       maps: [{ id: 'map1', name: 'Customs' }],
       items: expect.arrayContaining([expect.objectContaining({ id: 'item1', name: 'Salewa' })]),
     });
@@ -543,11 +543,11 @@ describe('tarkov JSON adapters', () => {
       hideoutPayload,
       tradersPayload,
     }).data.prestige[0];
-    expect(prestige?.conditions?.map((condition) => condition.__typename)).toEqual([
-      'TaskObjectivePlayerLevel',
-      'TaskObjectiveTaskStatus',
-      'TaskObjectiveHideoutStation',
-      'TaskObjectiveItem',
+    expect(prestige?.conditions?.map((condition) => condition.type)).toEqual([
+      'playerLevel',
+      'taskStatus',
+      'hideoutStation',
+      'haveItem',
     ]);
     expect(prestige?.conditions?.[1]?.task).toMatchObject({ id: 'task1', name: 'Debut' });
   });

--- a/app/server/utils/edgeCacheSanitizers.ts
+++ b/app/server/utils/edgeCacheSanitizers.ts
@@ -54,32 +54,6 @@ export const sanitizeErrorMessage = (message: string): string => {
   }
   return sanitized;
 };
-export const sanitizeGraphQLErrors = (errors: unknown): string => {
-  try {
-    if (Array.isArray(errors)) {
-      const sanitized = errors.map((err) => {
-        if (typeof err === 'object' && err !== null) {
-          const e = err as Record<string, unknown>;
-          return {
-            code:
-              e.extensions && typeof e.extensions === 'object'
-                ? (e.extensions as Record<string, unknown>).code
-                : undefined,
-            type: typeof e.message === 'string' ? e.message.slice(0, 100) : 'Unknown error',
-          };
-        }
-        return { type: 'Unknown error' };
-      });
-      return JSON.stringify(sanitized);
-    }
-    if (typeof errors === 'object' && errors !== null) {
-      return JSON.stringify({ type: 'Non-array error object' });
-    }
-    return 'Unknown error format';
-  } catch {
-    return 'Error sanitization failed';
-  }
-};
 export function sanitizeVariables(variables: Record<string, unknown>): Record<string, unknown> {
   const sanitizeValue = (value: unknown): unknown => {
     if (Array.isArray(value)) {

--- a/app/server/utils/tarkov-json.ts
+++ b/app/server/utils/tarkov-json.ts
@@ -661,35 +661,6 @@ function adaptHideoutRef(value: unknown, context: AdapterContext) {
     name: typeof raw.name === 'string' ? raw.name : undefined,
   });
 }
-function inferObjectiveTypename(type: unknown): string | undefined {
-  if (typeof type !== 'string') return undefined;
-  const typenameByType: Record<string, string> = {
-    buildItem: 'TaskObjectiveBuildItem',
-    buildWeapon: 'TaskObjectiveBuildItem',
-    experience: 'TaskObjectiveExperience',
-    extract: 'TaskObjectiveExtract',
-    findItem: 'TaskObjectiveItem',
-    findQuestItem: 'TaskObjectiveQuestItem',
-    giveItem: 'TaskObjectiveItem',
-    giveQuestItem: 'TaskObjectiveQuestItem',
-    haveItem: 'TaskObjectiveItem',
-    hideoutStation: 'TaskObjectiveHideoutStation',
-    mark: 'TaskObjectiveMark',
-    playerLevel: 'TaskObjectivePlayerLevel',
-    plantItem: 'TaskObjectiveItem',
-    plantQuestItem: 'TaskObjectiveQuestItem',
-    questItem: 'TaskObjectiveQuestItem',
-    sellItem: 'TaskObjectiveItem',
-    shoot: 'TaskObjectiveShoot',
-    skill: 'TaskObjectiveSkill',
-    taskStatus: 'TaskObjectiveTaskStatus',
-    traderLevel: 'TaskObjectiveTraderLevel',
-    traderStanding: 'TaskObjectiveTraderStanding',
-    useItem: 'TaskObjectiveUseItem',
-    visit: 'TaskObjectiveBasic',
-  };
-  return typenameByType[type];
-}
 function adaptRequiredKeys(value: unknown, context: AdapterContext): TarkovItem[][] | undefined {
   if (!Array.isArray(value)) return undefined;
   return value
@@ -720,8 +691,6 @@ function adaptObjective(raw: JsonRecord, context: AdapterContext): TaskObjective
   return compactObject({
     ...raw,
     id: stringId(raw) ?? '',
-    __typename:
-      typeof raw.__typename === 'string' ? raw.__typename : inferObjectiveTypename(raw.type),
     maps: Array.isArray(raw.maps)
       ? raw.maps.map((map) => adaptMapRef(map, context)).filter(Boolean)
       : undefined,
@@ -787,8 +756,8 @@ function adaptTraderRequirement(raw: unknown, context: AdapterContext) {
     trader: adaptTraderRef(raw.trader, context),
   });
 }
-// json.tarkov.dev serializes requiredPrestige as a bare Prestige id string, while
-// the GraphQL API returns an object ref. Accept both.
+// json.tarkov.dev may serialize requiredPrestige as a bare id string or as an object ref.
+// Accept both shapes.
 function adaptRequiredPrestigeRef(value: unknown): { id: string } | undefined {
   if (typeof value === 'string' && value) return { id: value };
   if (isRecord(value) && value.id != null) return { id: String(value.id) };

--- a/app/stores/__tests__/prestigeRequirements.test.ts
+++ b/app/stores/__tests__/prestigeRequirements.test.ts
@@ -271,4 +271,33 @@ describe('buildPrestigeRequirementRows', () => {
       tracked: false,
     });
   });
+  it.each(['findItem', 'giveItem', 'haveItem', 'plantItem', 'sellItem'])(
+    'renders an item requirement row for the %s condition type',
+    (conditionType) => {
+      const rows = buildPrestigeRequirementRows({
+        currentPrestigeLevel: 0,
+        edition,
+        hideoutStations,
+        prestigeLevels: [
+          createPrestigeLevel(1, [
+            {
+              type: conditionType,
+              count: 2,
+              id: 'item-objective',
+              items: [{ id: 'bitcoin', name: 'Physical bitcoin' }],
+            },
+          ]),
+        ],
+        pvpProgress: createProgressData(),
+        storyChapters: [],
+        tasks: [],
+      });
+      expect(rows.find((row) => row.id === 'item:Physical bitcoin:2')).toMatchObject({
+        kind: 'item',
+        name: '2 Physical bitcoin',
+        requiredValue: 2,
+        source: 'tarkov.dev',
+      });
+    }
+  );
 });

--- a/app/stores/__tests__/prestigeRequirements.test.ts
+++ b/app/stores/__tests__/prestigeRequirements.test.ts
@@ -271,6 +271,109 @@ describe('buildPrestigeRequirementRows', () => {
       tracked: false,
     });
   });
+  it('renders skill and hideout station requirement rows when configured', () => {
+    const pvpProgress = createProgressData();
+    pvpProgress.skillOffsets = { Vitality: 3 };
+    const stations: HideoutStation[] = [
+      {
+        id: 'station1',
+        name: 'Test Station',
+        levels: [
+          {
+            id: 'station1-1',
+            level: 1,
+            constructionTime: 0,
+            itemRequirements: [],
+            stationLevelRequirements: [],
+            skillRequirements: [],
+            traderRequirements: [],
+            crafts: [],
+          },
+        ],
+      },
+    ];
+    pvpProgress.hideoutModules = { 'station1-1': { complete: true } };
+    const rows = buildPrestigeRequirementRows({
+      currentPrestigeLevel: 0,
+      edition,
+      hideoutStations: stations,
+      prestigeLevels: [
+        createPrestigeLevel(1, [
+          {
+            type: 'skill',
+            id: 'skill-condition',
+            skillLevel: {
+              id: 'skill-1',
+              name: 'Vitality',
+              level: 5,
+              skill: { id: 'Vitality', name: 'Vitality' },
+            },
+          },
+          {
+            type: 'hideoutStation',
+            id: 'hideout-condition',
+            hideoutStation: { id: 'station1', name: 'Test Station' },
+            stationLevel: 2,
+          },
+        ]),
+      ],
+      pvpProgress,
+      storyChapters: [],
+      tasks: [],
+    });
+    expect(rows.find((row) => row.kind === 'skill')).toMatchObject({
+      currentValue: 3,
+      id: 'skill:Vitality:5',
+      kind: 'skill',
+      name: 'Vitality',
+      requiredValue: 5,
+      source: 'tarkov.dev',
+      status: 'unmet',
+    });
+    expect(rows.find((row) => row.kind === 'hideoutStation')).toMatchObject({
+      currentValue: 1,
+      id: 'hideout:station1:2',
+      kind: 'hideoutStation',
+      name: 'Test Station',
+      requiredValue: 2,
+      source: 'tarkov.dev',
+      status: 'unmet',
+    });
+  });
+  it('skips taskStatus, skill, and hideout conditions when required references are missing', () => {
+    const rows = buildPrestigeRequirementRows({
+      currentPrestigeLevel: 0,
+      edition,
+      hideoutStations,
+      prestigeLevels: [
+        createPrestigeLevel(1, [
+          {
+            type: 'taskStatus',
+            id: 'no-task-id',
+            task: { name: 'Missing id' },
+          } as TaskObjective,
+          {
+            type: 'skill',
+            id: 'no-skill-name',
+            skillLevel: { id: 'skill-1', level: 5 },
+          } as TaskObjective,
+          {
+            type: 'hideoutStation',
+            id: 'no-station-id',
+            hideoutStation: { name: 'Missing id' },
+            stationLevel: 1,
+          } as TaskObjective,
+        ]),
+      ],
+      pvpProgress: createProgressData(),
+      storyChapters: [],
+      tasks: [],
+    });
+    expect(rows.some((row) => row.kind === 'task')).toBe(false);
+    expect(rows.some((row) => row.kind === 'skill')).toBe(false);
+    expect(rows.some((row) => row.kind === 'hideoutStation')).toBe(false);
+    expect(rows.find((row) => row.kind === 'playerLevel')).toBeTruthy();
+  });
   it.each(['findItem', 'giveItem', 'haveItem', 'plantItem', 'sellItem'])(
     'renders an item requirement row for the %s condition type',
     (conditionType) => {

--- a/app/stores/__tests__/prestigeRequirements.test.ts
+++ b/app/stores/__tests__/prestigeRequirements.test.ts
@@ -52,7 +52,7 @@ describe('buildPrestigeRequirementRows', () => {
       prestigeLevels: [
         createPrestigeLevel(1, [
           {
-            __typename: 'TaskObjectivePlayerLevel',
+            type: 'playerLevel',
             id: 'player-level',
           },
         ]),
@@ -113,12 +113,12 @@ describe('buildPrestigeRequirementRows', () => {
     const prestigeLevels = [
       createPrestigeLevel(5, [
         {
-          __typename: 'TaskObjectivePlayerLevel',
+          type: 'playerLevel',
           id: 'player-level',
           playerLevel: 47,
         },
         {
-          __typename: 'TaskObjectiveTaskStatus',
+          type: 'taskStatus',
           id: 'collector',
           task: {
             id: 'collector',
@@ -126,7 +126,7 @@ describe('buildPrestigeRequirementRows', () => {
           },
         },
         {
-          __typename: 'TaskObjectiveItem',
+          type: 'haveItem',
           count: 20000000,
           id: 'roubles',
           items: [
@@ -206,7 +206,7 @@ describe('buildPrestigeRequirementRows', () => {
     const prestigeLevels = [
       createPrestigeLevel(6, [
         {
-          __typename: 'TaskObjectivePlayerLevel',
+          type: 'playerLevel',
           id: 'player-level',
           playerLevel: 47,
         },
@@ -239,12 +239,12 @@ describe('buildPrestigeRequirementRows', () => {
       prestigeLevels: [
         createPrestigeLevel(1, [
           {
-            __typename: 'TaskObjectivePlayerLevel',
+            type: 'playerLevel',
             id: 'player-level',
             playerLevel: 47,
           },
           {
-            __typename: 'TaskObjectiveItem',
+            type: 'haveItem',
             count: 3,
             id: 'item-objective',
             items: [

--- a/app/stores/__tests__/useMetadata.fetchPrestigeData.test.ts
+++ b/app/stores/__tests__/useMetadata.fetchPrestigeData.test.ts
@@ -47,7 +47,7 @@ describe('useMetadataStore fetchPrestigeData', () => {
           prestigeLevel: 1,
           conditions: [
             {
-              __typename: 'TaskObjectiveItem',
+              type: 'haveItem',
               id: 'objective1',
               items: [{ id: 'item1' }],
             },

--- a/app/stores/tarkov/prestige.ts
+++ b/app/stores/tarkov/prestige.ts
@@ -364,7 +364,7 @@ export const buildPrestigeRequirementRows = (
     rows.push(row);
   };
   for (const condition of prestige?.conditions || []) {
-    if (condition.__typename === 'TaskObjectivePlayerLevel') {
+    if (condition.type === 'playerLevel') {
       const apiRequiredLevel = toSafeInteger(condition.playerLevel, 0);
       const requiredLevel =
         apiRequiredLevel > 0 ? apiRequiredLevel : PRESTIGE_PLAYER_LEVEL_REQUIREMENT;
@@ -391,7 +391,7 @@ export const buildPrestigeRequirementRows = (
       });
       continue;
     }
-    if (condition.__typename === 'TaskObjectiveTaskStatus' && condition.task?.id) {
+    if (condition.type === 'taskStatus' && condition.task?.id) {
       const taskName = condition.task.name || 'Task';
       const taskRole: PrestigeRequirementTaskRole =
         taskName === 'Collector'
@@ -422,7 +422,7 @@ export const buildPrestigeRequirementRows = (
       });
       continue;
     }
-    if (condition.__typename === 'TaskObjectiveSkill' && condition.skillLevel?.name) {
+    if (condition.type === 'skill' && condition.skillLevel?.name) {
       const skillName = condition.skillLevel.name;
       const requiredLevel = Math.max(0, condition.skillLevel.level || 0);
       const skillKey = getCanonicalSkillKey(skillName, condition.skillLevel.skill?.id) || skillName;
@@ -440,7 +440,7 @@ export const buildPrestigeRequirementRows = (
       });
       continue;
     }
-    if (condition.__typename === 'TaskObjectiveHideoutStation' && condition.hideoutStation?.id) {
+    if (condition.type === 'hideoutStation' && condition.hideoutStation?.id) {
       const stationId = condition.hideoutStation.id;
       const requiredLevel = Math.max(0, toSafeInteger(condition.stationLevel, 0));
       const currentLevel = stationLevels.get(stationId) ?? 0;
@@ -457,7 +457,7 @@ export const buildPrestigeRequirementRows = (
       });
       continue;
     }
-    if (condition.__typename === 'TaskObjectiveItem') {
+    if (condition.type === 'haveItem') {
       const itemName = condition.items?.[0]?.name || 'Item';
       pushRow({
         currentValue: null,

--- a/app/stores/tarkov/prestige.ts
+++ b/app/stores/tarkov/prestige.ts
@@ -33,6 +33,16 @@ const PRESTIGE_MANUAL_ITEM_RULES: Partial<Record<number, string[]>> = {
   4: ['Ticket from Tarkov'],
   5: ['Ticket from Tarkov'],
 };
+// Upstream currently only emits `haveItem` for prestige item conditions, but the objective schema
+// shares one item shape across these types. Matching all of them keeps a requirement row rendering
+// if upstream ever switches the condition type.
+const PRESTIGE_ITEM_CONDITION_TYPES = new Set([
+  'findItem',
+  'giveItem',
+  'haveItem',
+  'plantItem',
+  'sellItem',
+]);
 export type PrestigeRunSummary = {
   completedHideoutModules: number;
   completedHideoutParts: number;
@@ -457,7 +467,7 @@ export const buildPrestigeRequirementRows = (
       });
       continue;
     }
-    if (condition.type === 'haveItem') {
+    if (condition.type && PRESTIGE_ITEM_CONDITION_TYPES.has(condition.type)) {
       const itemName = condition.items?.[0]?.name || 'Item';
       pushRow({
         currentValue: null,

--- a/app/types/tarkov.ts
+++ b/app/types/tarkov.ts
@@ -133,7 +133,6 @@ export interface HideoutModule extends HideoutLevel {
 }
 export interface TaskObjective {
   id: string;
-  __typename?: string;
   description?: string;
   location?: { id: string; name?: string };
   maps?: { id: string; name?: string }[];

--- a/app/utils/__tests__/skillHelpers.test.ts
+++ b/app/utils/__tests__/skillHelpers.test.ts
@@ -94,6 +94,16 @@ describe('readSkillObjective', () => {
     objective.skillLevel = { id: 'req', name: '   ', level: 5 };
     expect(readSkillObjective(objective)).toBeNull();
   });
+  it('ignores a whitespace-only skill name even when a nested skill id exists', () => {
+    const objective = skillObjective();
+    objective.skillLevel = {
+      id: 'req',
+      name: '   ',
+      level: 5,
+      skill: { id: 'endurance', name: 'Endurance' },
+    };
+    expect(readSkillObjective(objective)).toBeNull();
+  });
   it('falls back to the skill name when the nested skill ref is absent', () => {
     const objective = skillObjective();
     objective.skillLevel = { id: 'req', name: 'Endurance', level: 3 };

--- a/app/utils/__tests__/skillHelpers.test.ts
+++ b/app/utils/__tests__/skillHelpers.test.ts
@@ -1,9 +1,23 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildSkillKeyAliases,
   collapseSkillOffsets,
   getCanonicalSkillKey,
   normalizeSkillToken,
+  readSkillObjective,
 } from '@/utils/skillHelpers';
+import type { Task, TaskObjective } from '@/types/tarkov';
+const skillObjective = (overrides: Partial<TaskObjective> = {}): TaskObjective => ({
+  id: 'objective-1',
+  type: 'skill',
+  skillLevel: {
+    id: 'skill-requirement-1',
+    name: 'Vitality',
+    level: 5,
+    skill: { id: 'Vitality', name: 'Vitality', imageLink: 'https://example.com/vitality.webp' },
+  },
+  ...overrides,
+});
 describe('normalizeSkillToken', () => {
   it('returns null for null', () => {
     expect(normalizeSkillToken(null)).toBeNull();
@@ -45,6 +59,165 @@ describe('getCanonicalSkillKey', () => {
   });
   it('returns null when both are empty', () => {
     expect(getCanonicalSkillKey('', '')).toBeNull();
+  });
+});
+describe('readSkillObjective', () => {
+  it('reads name, id, level and image from a skill objective', () => {
+    expect(readSkillObjective(skillObjective())).toEqual({
+      skillKey: 'Vitality',
+      skillName: 'Vitality',
+      skillId: 'Vitality',
+      requiredLevel: 5,
+      imageLink: 'https://example.com/vitality.webp',
+    });
+  });
+  it.each(['giveItem', 'findQuestItem', 'shoot', 'visit', 'taskStatus', 'playerLevel'])(
+    'ignores the %s objective type',
+    (type) => {
+      expect(readSkillObjective(skillObjective({ type }))).toBeNull();
+    }
+  );
+  it('ignores an objective with no type', () => {
+    expect(readSkillObjective(skillObjective({ type: undefined }))).toBeNull();
+  });
+  it('ignores a skill objective with no skillLevel', () => {
+    expect(readSkillObjective(skillObjective({ skillLevel: undefined }))).toBeNull();
+  });
+  it('ignores a skill objective with a blank skill name', () => {
+    const objective = skillObjective();
+    objective.skillLevel = { id: 'req', name: '', level: 5 };
+    expect(readSkillObjective(objective)).toBeNull();
+  });
+  it('ignores a whitespace-only skill name that has no usable id', () => {
+    const objective = skillObjective();
+    objective.skillLevel = { id: 'req', name: '   ', level: 5 };
+    expect(readSkillObjective(objective)).toBeNull();
+  });
+  it('falls back to the skill name when the nested skill ref is absent', () => {
+    const objective = skillObjective();
+    objective.skillLevel = { id: 'req', name: 'Endurance', level: 3 };
+    expect(readSkillObjective(objective)).toMatchObject({
+      skillKey: 'Endurance',
+      skillName: 'Endurance',
+      skillId: undefined,
+      requiredLevel: 3,
+      imageLink: undefined,
+    });
+  });
+  it('prefers the nested skill id over the name as the canonical key', () => {
+    const objective = skillObjective();
+    objective.skillLevel = {
+      id: 'req',
+      name: 'Vitalität',
+      level: 2,
+      skill: { id: 'Vitality', name: 'Vitality' },
+    };
+    expect(readSkillObjective(objective)).toMatchObject({
+      skillKey: 'Vitality',
+      skillName: 'Vitalität',
+    });
+  });
+  it('defaults a missing level to 0', () => {
+    const objective = skillObjective();
+    objective.skillLevel = { id: 'req', name: 'Strength', level: 0 };
+    expect(readSkillObjective(objective)?.requiredLevel).toBe(0);
+  });
+});
+describe('buildSkillKeyAliases', () => {
+  it('returns an empty map for tasks with no objectives or rewards', () => {
+    expect(buildSkillKeyAliases([{ id: 'task-1', name: 'Debut' }] as Task[]).size).toBe(0);
+  });
+  it('aliases the localized name and the id onto the canonical key', () => {
+    const tasks = [
+      {
+        id: 'task-1',
+        name: 'Debut',
+        objectives: [
+          {
+            id: 'objective-1',
+            type: 'skill',
+            skillLevel: {
+              id: 'req',
+              name: 'Vitalität',
+              level: 5,
+              skill: { id: 'Vitality', name: 'Vitality' },
+            },
+          },
+        ],
+      },
+    ] as Task[];
+    const aliases = buildSkillKeyAliases(tasks);
+    expect(aliases.get('Vitalität')).toBe('Vitality');
+    expect(aliases.get('Vitality')).toBe('Vitality');
+  });
+  it('skips non-skill objectives', () => {
+    const tasks = [
+      {
+        id: 'task-1',
+        name: 'Debut',
+        objectives: [
+          { id: 'objective-1', type: 'giveItem', items: [{ id: 'item-1', name: 'Salewa' }] },
+        ],
+      },
+    ] as Task[];
+    expect(buildSkillKeyAliases(tasks).size).toBe(0);
+  });
+  it('aliases skill level rewards as well as objectives', () => {
+    const tasks = [
+      {
+        id: 'task-1',
+        name: 'Debut',
+        objectives: [],
+        finishRewards: {
+          skillLevelReward: [
+            { name: 'Stärke', level: 1, skill: { id: 'Strength', name: 'Strength' } },
+          ],
+        },
+      },
+    ] as Task[];
+    const aliases = buildSkillKeyAliases(tasks);
+    expect(aliases.get('Stärke')).toBe('Strength');
+    expect(aliases.get('Strength')).toBe('Strength');
+  });
+  it('ignores rewards with no name', () => {
+    const tasks = [
+      {
+        id: 'task-1',
+        name: 'Debut',
+        objectives: [],
+        finishRewards: { skillLevelReward: [{ name: '', level: 1 }] },
+      },
+    ] as unknown as Task[];
+    expect(buildSkillKeyAliases(tasks).size).toBe(0);
+  });
+  it('merges aliases across multiple tasks', () => {
+    const tasks = [
+      {
+        id: 'task-1',
+        name: 'Debut',
+        objectives: [
+          {
+            id: 'objective-1',
+            type: 'skill',
+            skillLevel: { id: 'req', name: 'Vitality', level: 5 },
+          },
+        ],
+      },
+      {
+        id: 'task-2',
+        name: 'Shootout Picnic',
+        objectives: [
+          {
+            id: 'objective-2',
+            type: 'skill',
+            skillLevel: { id: 'req', name: 'Endurance', level: 2 },
+          },
+        ],
+      },
+    ] as Task[];
+    const aliases = buildSkillKeyAliases(tasks);
+    expect(aliases.get('Vitality')).toBe('Vitality');
+    expect(aliases.get('Endurance')).toBe('Endurance');
   });
 });
 describe('collapseSkillOffsets', () => {

--- a/app/utils/__tests__/skillHelpers.test.ts
+++ b/app/utils/__tests__/skillHelpers.test.ts
@@ -5,6 +5,7 @@ import {
   getCanonicalSkillKey,
   normalizeSkillToken,
   readSkillObjective,
+  resolveSkillKey,
 } from '@/utils/skillHelpers';
 import type { Task, TaskObjective } from '@/types/tarkov';
 const skillObjective = (overrides: Partial<TaskObjective> = {}): TaskObjective => ({
@@ -190,6 +191,17 @@ describe('buildSkillKeyAliases', () => {
     ] as unknown as Task[];
     expect(buildSkillKeyAliases(tasks).size).toBe(0);
   });
+  it('ignores rewards with a whitespace-only name and no skill id', () => {
+    const tasks = [
+      {
+        id: 'task-1',
+        name: 'Debut',
+        objectives: [],
+        finishRewards: { skillLevelReward: [{ name: '   ', level: 1 }] },
+      },
+    ] as unknown as Task[];
+    expect(buildSkillKeyAliases(tasks).size).toBe(0);
+  });
   it('merges aliases across multiple tasks', () => {
     const tasks = [
       {
@@ -218,6 +230,21 @@ describe('buildSkillKeyAliases', () => {
     const aliases = buildSkillKeyAliases(tasks);
     expect(aliases.get('Vitality')).toBe('Vitality');
     expect(aliases.get('Endurance')).toBe('Endurance');
+  });
+});
+describe('resolveSkillKey', () => {
+  it('returns the original name when it is empty or whitespace-only', () => {
+    const aliases = new Map<string, string>([['Strength', 'Strength']]);
+    expect(resolveSkillKey('', aliases)).toBe('');
+    expect(resolveSkillKey('   ', aliases)).toBe('   ');
+  });
+  it('falls back to the normalized name when no alias exists', () => {
+    const aliases = new Map<string, string>();
+    expect(resolveSkillKey('Endurance', aliases)).toBe('Endurance');
+  });
+  it('returns an alias when present', () => {
+    const aliases = new Map<string, string>([['Starke', 'Strength']]);
+    expect(resolveSkillKey('Starke', aliases)).toBe('Strength');
   });
 });
 describe('collapseSkillOffsets', () => {

--- a/app/utils/__tests__/tarkovUrls.test.ts
+++ b/app/utils/__tests__/tarkovUrls.test.ts
@@ -42,7 +42,7 @@ describe('buildSkillImageUrl', () => {
       'https://assets.tarkov.dev/skill-Vitality-icon.webp'
     );
   });
-  it('builds URLs for known skill ids from the tarkov.dev GraphQL API', () => {
+  it('builds URLs for known skill ids from the tarkov.dev dataset', () => {
     const knownSkillIds = [
       'Health',
       'Sniper',

--- a/app/utils/skillHelpers.ts
+++ b/app/utils/skillHelpers.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/utils/logger';
-import type { SkillRequirement, Task, TaskObjective } from '@/types/tarkov';
+import type { Task } from '@/types/tarkov';
 export const normalizeSkillToken = (value: string | null | undefined): string | null => {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
@@ -15,15 +15,11 @@ export const buildSkillKeyAliases = (tasks: Task[]): Map<string, string> => {
   const aliases = new Map<string, string>();
   tasks.forEach((task) => {
     task.objectives?.forEach((objective) => {
-      const objectiveData = objective as TaskObjective & {
-        __typename?: string;
-        skillLevel?: SkillRequirement & { skill?: { id?: string | null } };
-      };
-      if (objectiveData.__typename !== 'TaskObjectiveSkill' || !objectiveData.skillLevel?.name) {
-        return;
-      }
-      const skillName = objectiveData.skillLevel.name;
-      const skillId = objectiveData.skillLevel.skill?.id;
+      if (objective.type !== 'skill') return;
+      const skillLevel = objective.skillLevel;
+      const skillName = skillLevel?.name;
+      if (!skillName || !skillLevel) return;
+      const skillId = skillLevel.skill?.id;
       const skillKey = getCanonicalSkillKey(skillName, skillId);
       if (!skillKey) return;
       aliases.set(skillKey, skillKey);

--- a/app/utils/skillHelpers.ts
+++ b/app/utils/skillHelpers.ts
@@ -20,8 +20,8 @@ export type SkillObjectiveDetails = {
 };
 export const readSkillObjective = (objective: TaskObjective): SkillObjectiveDetails | null => {
   const { skillLevel } = objective;
-  if (objective.type !== 'skill' || !skillLevel?.name) return null;
-  const skillName = skillLevel.name;
+  const skillName = normalizeSkillToken(skillLevel?.name);
+  if (objective.type !== 'skill' || !skillLevel || !skillName) return null;
   const skillId = skillLevel.skill?.id;
   const skillKey = getCanonicalSkillKey(skillName, skillId);
   if (!skillKey) return null;

--- a/app/utils/skillHelpers.ts
+++ b/app/utils/skillHelpers.ts
@@ -1,5 +1,5 @@
 import { logger } from '@/utils/logger';
-import type { Task } from '@/types/tarkov';
+import type { Task, TaskObjective } from '@/types/tarkov';
 export const normalizeSkillToken = (value: string | null | undefined): string | null => {
   if (typeof value !== 'string') return null;
   const trimmed = value.trim();
@@ -11,21 +11,38 @@ export const getCanonicalSkillKey = (
 ): string | null => {
   return normalizeSkillToken(skillId) ?? normalizeSkillToken(skillName);
 };
+export type SkillObjectiveDetails = {
+  skillKey: string;
+  skillName: string;
+  skillId?: string;
+  requiredLevel: number;
+  imageLink?: string;
+};
+export const readSkillObjective = (objective: TaskObjective): SkillObjectiveDetails | null => {
+  const { skillLevel } = objective;
+  if (objective.type !== 'skill' || !skillLevel?.name) return null;
+  const skillName = skillLevel.name;
+  const skillId = skillLevel.skill?.id;
+  const skillKey = getCanonicalSkillKey(skillName, skillId);
+  if (!skillKey) return null;
+  return {
+    skillKey,
+    skillName,
+    skillId,
+    requiredLevel: skillLevel.level || 0,
+    imageLink: skillLevel.skill?.imageLink,
+  };
+};
 export const buildSkillKeyAliases = (tasks: Task[]): Map<string, string> => {
   const aliases = new Map<string, string>();
   tasks.forEach((task) => {
     task.objectives?.forEach((objective) => {
-      if (objective.type !== 'skill') return;
-      const skillLevel = objective.skillLevel;
-      const skillName = skillLevel?.name;
-      if (!skillName || !skillLevel) return;
-      const skillId = skillLevel.skill?.id;
-      const skillKey = getCanonicalSkillKey(skillName, skillId);
-      if (!skillKey) return;
-      aliases.set(skillKey, skillKey);
-      aliases.set(skillName, skillKey);
-      if (skillId) {
-        aliases.set(skillId, skillKey);
+      const skill = readSkillObjective(objective);
+      if (!skill) return;
+      aliases.set(skill.skillKey, skill.skillKey);
+      aliases.set(skill.skillName, skill.skillKey);
+      if (skill.skillId) {
+        aliases.set(skill.skillId, skill.skillKey);
       }
     });
     task.finishRewards?.skillLevelReward?.forEach((reward) => {

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,12 +47,14 @@ Authorization: Bearer <supabase_jwt_token>
 > data from `json.tarkov.dev` directly, or use the progress API at `https://api.tarkovtracker.org`
 > (see [Progress API Host Migration](#progress-api-host-migration-apitarkovtrackerorg)).
 >
-> These routes skip auth (`defaultPublicRoutes` in `app/server/middleware/api-protection.ts`) and are
-> gated only by a `Host` header allowlist (`tarkovtracker.org`, `www.tarkovtracker.org`, plus
-> `NUXT_PUBLIC_APP_URL`) and a CORS `Origin` allowlist. The CORS allowlist stops cross-site browser
-> JavaScript from reading responses; it does not stop non-browser clients, which send no `Origin` and
-> reach the route with a matching `Host`. There is no rate limit on these routes today — see
-> `docs/RATE_LIMITING.md`.
+> These routes skip auth (`defaultPublicRoutes` in `app/server/middleware/api-protection.ts`) but are
+> subject to `Host` header validation. When `API_ALLOWED_HOSTS` is unset, the production defaults are
+> `tarkovtracker.org` and `www.tarkovtracker.org`; setting `API_ALLOWED_HOSTS` replaces those
+> defaults, and the host derived from `NUXT_PUBLIC_APP_URL` is always allowed. If
+> `API_TRUSTED_IP_RANGES` is configured, its client-IP allowlist applies to these routes as well. The
+> CORS `Origin` allowlist stops cross-site browser JavaScript from reading responses; it does not
+> stop non-browser clients, which send no `Origin` and reach the route with a matching `Host`. There
+> is no route-specific rate limit today — see `docs/RATE_LIMITING.md`.
 
 ### GET /api/tarkov/bootstrap
 
@@ -470,7 +472,7 @@ The `lang` query parameter is validated against `API_SUPPORTED_LANGUAGES` (`app/
 | `tr` | Turkish    |
 | `zh` | Chinese    |
 
-This allowlist is a subset of what upstream serves. `json.tarkov.dev` additionally supports `id`, `th`, and `vn`; add them to `API_SUPPORTED_LANGUAGES` if a UI locale ever needs them. The authoritative upstream list is the `languages` array at `https://json.tarkov.dev/endpoints`.
+This allowlist is a subset of what upstream serves. `json.tarkov.dev` additionally supports `id`, `th`, and `vn`; add them to `API_SUPPORTED_LANGUAGES` when the API should accept those languages on `/api/tarkov/*` requests. Enabling a UI locale is a separate step (`SUPPORTED_LOCALES` below). The authoritative upstream list is the `languages` array at `https://json.tarkov.dev/endpoints`.
 
 **Enabled UI locales** (`SUPPORTED_LOCALES` in `app/utils/locales.ts`):
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -47,14 +47,9 @@ Authorization: Bearer <supabase_jwt_token>
 > data from `json.tarkov.dev` directly, or use the progress API at `https://api.tarkovtracker.org`
 > (see [Progress API Host Migration](#progress-api-host-migration-apitarkovtrackerorg)).
 >
-> These routes skip auth (`defaultPublicRoutes` in `app/server/middleware/api-protection.ts`) but are
-> subject to `Host` header validation. When `API_ALLOWED_HOSTS` is unset, the production defaults are
-> `tarkovtracker.org` and `www.tarkovtracker.org`; setting `API_ALLOWED_HOSTS` replaces those
-> defaults, and the host derived from `NUXT_PUBLIC_APP_URL` is always allowed. If
-> `API_TRUSTED_IP_RANGES` is configured, its client-IP allowlist applies to these routes as well. The
-> CORS `Origin` allowlist stops cross-site browser JavaScript from reading responses; it does not
-> stop non-browser clients, which send no `Origin` and reach the route with a matching `Host`. There
-> is no route-specific rate limit today — see `docs/RATE_LIMITING.md`.
+> These routes are public and pass through the API protection middleware; see
+> `docs/ARCHITECTURE.md#api-protection` for access-control configuration and
+> `docs/RATE_LIMITING.md` for rate-limit ownership.
 
 ### GET /api/tarkov/bootstrap
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -48,8 +48,8 @@ Authorization: Bearer <supabase_jwt_token>
 > (see [Progress API Host Migration](#progress-api-host-migration-apitarkovtrackerorg)).
 >
 > These routes are public and pass through the API protection middleware; see
-> `docs/ARCHITECTURE.md#api-protection` for access-control configuration and
-> `docs/RATE_LIMITING.md` for rate-limit ownership.
+> [`ARCHITECTURE.md#api-protection`](./ARCHITECTURE.md#api-protection) for access-control configuration and
+> [`RATE_LIMITING.md`](./RATE_LIMITING.md) for rate-limit ownership.
 
 ### GET /api/tarkov/bootstrap
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -33,13 +33,26 @@ Migration example:
 
 ## Authentication
 
-Most tarkov data endpoints are public. Team endpoints require Supabase authentication.
+Tarkov data endpoints (`/api/tarkov/*`) are unauthenticated. Team endpoints require Supabase authentication.
 
 ```http
 Authorization: Bearer <supabase_jwt_token>
 ```
 
 ## Tarkov Data Endpoints
+
+> **First-party routes, not a third-party API.** `/api/tarkov/*` exists to serve game data to the
+> TarkovTracker site itself. It is not a supported integration surface, carries no compatibility
+> guarantee, and its response shape can change in any release. Third-party clients should read game
+> data from `json.tarkov.dev` directly, or use the progress API at `https://api.tarkovtracker.org`
+> (see [Progress API Host Migration](#progress-api-host-migration-apitarkovtrackerorg)).
+>
+> These routes skip auth (`defaultPublicRoutes` in `app/server/middleware/api-protection.ts`) and are
+> gated only by a `Host` header allowlist (`tarkovtracker.org`, `www.tarkovtracker.org`, plus
+> `NUXT_PUBLIC_APP_URL`) and a CORS `Origin` allowlist. The CORS allowlist stops cross-site browser
+> JavaScript from reading responses; it does not stop non-browser clients, which send no `Origin` and
+> reach the route with a matching `Host`. There is no rate limit on these routes today — see
+> `docs/RATE_LIMITING.md`.
 
 ### GET /api/tarkov/bootstrap
 
@@ -432,9 +445,9 @@ Pass `cacheBust=1` query parameter to bypass cache.
 
 ## Supported Languages
 
-The `lang` query parameter is passed through to `json.tarkov.dev`. It must be a code supported by the upstream static JSON API (`API_SUPPORTED_LANGUAGES` in `app/utils/constants.ts`). Unsupported codes fall back to `en`. The current upstream language list is available at `https://json.tarkov.dev/endpoints`.
+The `lang` query parameter is validated against `API_SUPPORTED_LANGUAGES` (`app/utils/constants.ts`) and then passed through to `json.tarkov.dev`. Codes outside that allowlist fall back to `en` (`getValidatedLanguage` in `app/server/utils/language-helpers.ts`).
 
-**Upstream languages currently supported** by `json.tarkov.dev`:
+**Language codes accepted by `/api/tarkov/*`:**
 
 | Code | Language   |
 | ---- | ---------- |
@@ -455,11 +468,17 @@ The `lang` query parameter is passed through to `json.tarkov.dev`. It must be a 
 | `tr` | Turkish    |
 | `zh` | Chinese    |
 
-**UI locale with upstream fallback.** `uk` (Ukrainian) is an enabled UI locale (`SUPPORTED_LOCALES` in `app/utils/locales.ts`) but is **not supported by `json.tarkov.dev`**. It is mapped to `en` via `LOCALE_TO_API_MAPPING` in `app/utils/constants.ts`, so Ukrainian users see English game data while the rest of the UI remains in Ukrainian.
+This allowlist is a subset of what upstream serves. `json.tarkov.dev` additionally supports `id`, `th`, and `vn`; add them to `API_SUPPORTED_LANGUAGES` if a UI locale ever needs them. The authoritative upstream list is the `languages` array at `https://json.tarkov.dev/endpoints`.
+
+**Enabled UI locales** (`SUPPORTED_LOCALES` in `app/utils/locales.ts`):
+
+`en` (English), `de` (German), `es` (Spanish), `fr` (French), `ko` (Korean), `ru` (Russian), `uk` (Ukrainian), `zh` (Chinese)
+
+**UI locale with upstream fallback.** `uk` (Ukrainian) is an enabled UI locale but is **not supported by `json.tarkov.dev`**. It is mapped to `en` via `LOCALE_TO_API_MAPPING` in `app/utils/constants.ts`, so Ukrainian users see English game data while the rest of the UI remains in Ukrainian.
 
 **Locale JSON files that exist but are not currently enabled** (may be enabled in the future; Crowdin may still sync translations for these):
 
-`cs` (Czech), `it` (Italian), `ko` (Korean), `pl` (Polish), `pt` (Portuguese)
+`cs` (Czech), `it` (Italian), `pl` (Polish), `pt` (Portuguese)
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -445,7 +445,9 @@ Pass `cacheBust=1` query parameter to bypass cache.
 
 ## Supported Languages
 
-The `lang` query parameter is validated against `API_SUPPORTED_LANGUAGES` (`app/utils/constants.ts`) and then passed through to `json.tarkov.dev`. Codes outside that allowlist fall back to `en` (`getValidatedLanguage` in `app/server/utils/language-helpers.ts`).
+The `lang` query parameter is validated against `API_SUPPORTED_LANGUAGES` (`app/utils/constants.ts`); codes outside that allowlist fall back to `en` (`getValidatedLanguage` in `app/server/utils/language-helpers.ts`).
+
+`lang` is not forwarded to upstream as a query parameter. `json.tarkov.dev` serves an English base document containing translation keys plus a separate per-language document at `{gameMode}/{endpoint}_{lang}`; the proxy fetches both (plus `_en` as a per-key fallback) and merges them via the base document's `translations` JSONPath list. See [Data fetching pipeline](SYSTEMS.md#2-data-fetching-pipeline).
 
 **Language codes accepted by `/api/tarkov/*`:**
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -5,6 +5,10 @@
 TarkovTracker provides internal API routes for fetching game data and team information. Game data is proxied through Nuxt server routes to `json.tarkov.dev` with caching and overlay corrections applied.
 Set `NUXT_TARKOV_JSON_BASE_URL` to point static game-data requests at a compatible `json.tarkov.dev` mirror.
 
+> **Upstream data source.** TarkovTracker consumes the static JSON endpoints at `json.tarkov.dev`.
+> The endpoint catalog lives at `https://json.tarkov.dev/endpoints`. The older `api.tarkov.dev`
+> GraphQL playground is deprecated and unstable; do not use it for game data or external tooling.
+
 ## Base URL
 
 - **Development:** `http://localhost:3000/api`
@@ -428,23 +432,34 @@ Pass `cacheBust=1` query parameter to bypass cache.
 
 ## Supported Languages
 
-**Enabled UI locales** (from `SUPPORTED_LOCALES` in `app/utils/locales.ts`):
+The `lang` query parameter is passed through to `json.tarkov.dev`. It must be a code supported by the upstream static JSON API (`API_SUPPORTED_LANGUAGES` in `app/utils/constants.ts`). Unsupported codes fall back to `en`. The current upstream language list is available at `https://json.tarkov.dev/endpoints`.
 
-| Code | Language  |
-| ---- | --------- |
-| `en` | English   |
-| `de` | German    |
-| `es` | Spanish   |
-| `fr` | French    |
-| `ru` | Russian   |
-| `uk` | Ukrainian |
-| `zh` | Chinese   |
+**Upstream languages currently supported** by `json.tarkov.dev`:
+
+| Code | Language   |
+| ---- | ---------- |
+| `cs` | Czech      |
+| `de` | German     |
+| `en` | English    |
+| `es` | Spanish    |
+| `fr` | French     |
+| `hu` | Hungarian  |
+| `it` | Italian    |
+| `ja` | Japanese   |
+| `ko` | Korean     |
+| `pl` | Polish     |
+| `pt` | Portuguese |
+| `ro` | Romanian   |
+| `ru` | Russian    |
+| `sk` | Slovak     |
+| `tr` | Turkish    |
+| `zh` | Chinese    |
+
+**UI locale with upstream fallback.** `uk` (Ukrainian) is an enabled UI locale (`SUPPORTED_LOCALES` in `app/utils/locales.ts`) but is **not supported by `json.tarkov.dev`**. It is mapped to `en` via `LOCALE_TO_API_MAPPING` in `app/utils/constants.ts`, so Ukrainian users see English game data while the rest of the UI remains in Ukrainian.
 
 **Locale JSON files that exist but are not currently enabled** (may be enabled in the future; Crowdin may still sync translations for these):
 
 `cs` (Czech), `it` (Italian), `ko` (Korean), `pl` (Polish), `pt` (Portuguese)
-
-The API accepts any language code that `json.tarkov.dev` supports; unsupported codes fall back to English.
 
 ---
 

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -239,8 +239,10 @@ Important:
 - When the DO binding is present, enforcement is shared across isolates.
 - Without it, fallback is best-effort in-memory and can under-enforce under concurrency or restarts.
 - These limits protect **app endpoints**, not the external progress API.
-- Static game-data routes (`/api/tarkov/*`) are not enrolled in this limiter. They are served through
-  `edgeCache` with CDN/WAF abuse protection and have no route-specific rate limit.
+- Most static game-data routes (`/api/tarkov/*`) are not enrolled in this limiter. They are served
+  through `edgeCache` with CDN/WAF abuse protection and have no route-specific rate limit. The
+  `/api/tarkov/cache-meta` endpoint is an exception — it queries Supabase directly and relies on its
+  own `Cache-Control` headers.
 
 ---
 

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -239,6 +239,8 @@ Important:
 - When the DO binding is present, enforcement is shared across isolates.
 - Without it, fallback is best-effort in-memory and can under-enforce under concurrency or restarts.
 - These limits protect **app endpoints**, not the external progress API.
+- Static game-data routes (`/api/tarkov/*`) are not enrolled in this limiter. They are served through
+  `edgeCache` with CDN/WAF abuse protection and have no route-specific rate limit.
 
 ---
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -32,6 +32,11 @@ from the community-maintained `json.tarkov.dev` static JSON API. The browser nev
 client expects, and (for most endpoints) applies corrections (see [Overlay](#4-overlay-corrections))
 before returning it.
 
+> **Note on upstream endpoints.** `json.tarkov.dev` is the canonical static JSON API for all
+> Tarkov.dev game data. The older `api.tarkov.dev` GraphQL playground is deprecated and unstable;
+> do not use it for new TarkovTracker functionality or external tooling. The current endpoint list
+> is available at `https://json.tarkov.dev/endpoints`.
+
 **Why a proxy instead of calling upstream from the browser?**
 
 - We control caching headers and can serve stale-while-revalidate from the Cloudflare edge.
@@ -89,6 +94,8 @@ flowchart LR
   `/api/tarkov/*`.
 - Every endpoint handler returns its payload through `edgeCache()`; no handler fetches upstream
   outside the cache wrapper.
+- Only `json.tarkov.dev` static endpoints are used for upstream game data. The `api.tarkov.dev`
+  GraphQL playground is deprecated and must not be called by TarkovTracker code.
 - Overlay is applied only by endpoints that call `applyOverlay()` in their handler. Adding a new
   endpoint does not imply adding overlay — only add it when the upstream data needs corrections.
 - Game mode is validated with `validateGameMode()` and defaults to `regular` on any invalid input.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -32,10 +32,10 @@ from the community-maintained `json.tarkov.dev` static JSON API. The browser nev
 client expects, and (for most endpoints) applies corrections (see [Overlay](#4-overlay-corrections))
 before returning it.
 
-> **Note on upstream endpoints.** `json.tarkov.dev` is the canonical static JSON API for all
-> Tarkov.dev game data. The older `api.tarkov.dev` GraphQL playground is deprecated and unstable;
-> do not use it for new TarkovTracker functionality or external tooling. The current endpoint list
-> is available at `https://json.tarkov.dev/endpoints`.
+> **Note on upstream endpoints.** `json.tarkov.dev` is the static JSON API TarkovTracker uses for
+> all Tarkov.dev game data. TarkovTracker no longer uses the older `api.tarkov.dev` GraphQL API;
+> do not use it for new TarkovTracker functionality. The current static endpoint list is available
+> at `https://json.tarkov.dev/endpoints`.
 
 **Why a proxy instead of calling upstream from the browser?**
 

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -20,7 +20,7 @@ Crawl and discovery directives live at `/robots.txt` and `/sitemap.xml`; see tho
 - [Needed Items](https://tarkovtracker.org/needed-items): Consolidated item requirements.
 - [Storyline](https://tarkovtracker.org/storyline): Storyline quest view.
 - [Resources](https://tarkovtracker.org/resources): Community tools hub and setup guides.
-- [Tarkov.dev Guide](https://tarkovtracker.org/resources/tarkovdev): Using Tarkov.dev data and JSON API.
+- [Tarkov.dev Guide](https://tarkovtracker.org/resources/tarkovdev): Using Tarkov.dev data via the json.tarkov.dev JSON API.
 - [TarkovMonitor Guide](https://tarkovtracker.org/resources/tarkovmonitor): Install and link TarkovMonitor to TarkovTracker.
 - [RatScanner Guide](https://tarkovtracker.org/resources/ratscanner): Install and use RatScanner overlays.
 - [CultistCircle Guide](https://tarkovtracker.org/resources/cultistcircle): Cultist Circle recipe calculator reference.

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -20,7 +20,7 @@ Crawl and discovery directives live at `/robots.txt` and `/sitemap.xml`; see tho
 - [Needed Items](https://tarkovtracker.org/needed-items): Consolidated item requirements.
 - [Storyline](https://tarkovtracker.org/storyline): Storyline quest view.
 - [Resources](https://tarkovtracker.org/resources): Community tools hub and setup guides.
-- [Tarkov.dev Guide](https://tarkovtracker.org/resources/tarkovdev): Using Tarkov.dev data and GraphQL API.
+- [Tarkov.dev Guide](https://tarkovtracker.org/resources/tarkovdev): Using Tarkov.dev data and JSON API.
 - [TarkovMonitor Guide](https://tarkovtracker.org/resources/tarkovmonitor): Install and link TarkovMonitor to TarkovTracker.
 - [RatScanner Guide](https://tarkovtracker.org/resources/ratscanner): Install and use RatScanner overlays.
 - [CultistCircle Guide](https://tarkovtracker.org/resources/cultistcircle): Cultist Circle recipe calculator reference.


### PR DESCRIPTION
## **User description**
## Summary

- Updates `docs/SYSTEMS.md` and `docs/API.md` to document `json.tarkov.dev` as the canonical upstream source, point to `https://json.tarkov.dev/endpoints`, and note that `api.tarkov.dev` GraphQL is deprecated/unstable.
- Updates the Tarkov.dev resource card (`app/features/resources/resourceData.ts`) and its guide copy (`app/locales/en.json`) to reference the JSON endpoints instead of the GraphQL API.
- Removes the synthetic `__typename` discriminator from `TaskObjective` and migrates consumers (`useSkillCalculation`, `skillHelpers`, `prestige`) to the upstream `type` field.
- Removes the dead `sanitizeGraphQLErrors` helper and its tests.
- Cleans stale GraphQL references from `.gitignore`, `.github/LABELS.md`, and `public/llms.txt`.

## Review follow-ups (added after the initial push)

- **`fix(app)`** — `buildPrestigeRequirementRows` matched `__typename === 'TaskObjectiveItem'`, which the adapter inferred from five objective types (`findItem`, `giveItem`, `haveItem`, `plantItem`, `sellItem`). The migration narrowed it to `type === 'haveItem'`, so any other item condition would silently drop its requirement row. Restored the full set behind `PRESTIGE_ITEM_CONDITION_TYPES` and covered each type with a test. Live upstream only emits `haveItem` today, so this is a latent fix rather than a user-visible one.
- **`refactor(app)`** — `useSkillCalculation` and `buildSkillKeyAliases` ended up with an identical extraction block, both guarding on `!skillLevel`, which is unreachable once `skillLevel?.name` is known truthy. Extracted `readSkillObjective()` into `skillHelpers`.
- **`docs(api)`** — three accuracy fixes:
  - `/api/tarkov/*` is a first-party site route, not a supported third-party API. Documented the actual gates (no auth, `Host` allowlist, CORS `Origin` allowlist, no rate limit) instead of calling the routes "public".
  - The language table is `API_SUPPORTED_LANGUAGES` (our allowlist, 16 codes), not upstream's list — upstream now serves 19 (`id`, `th`, `vn` are new). Relabelled and documented the gap. See #585.
  - `ko` is in `SUPPORTED_LOCALES` and is enabled, not pending. Restored the enabled UI locale list. See #584.
  - `lang` is **not** forwarded upstream as a query parameter — upstream ignores `?lang=` entirely. It selects a separate `{endpoint}_{lang}` translation document merged over the English base, as `SYSTEMS.md` already described.
- **`test(app)`** — `readSkillObjective` and `buildSkillKeyAliases` had no tests, and `allGameSkills`' objective branch was uncovered, so the `__typename` → `type` migration in those paths landed untested. Patch coverage 37.5% → 100%; `skillHelpers.ts` line coverage 77.2% → 100%.

## Verification

- [x] `pnpm run typecheck` passed
- [x] `pnpm run lint` passed (zero warnings)
- [x] `pnpm run i18n:check` passed
- [x] `pnpm run test` — 218 files, 2151 tests passing
- [x] `prettier --check` clean on all changed paths
- [x] Patch coverage 100% (23/23 changed executable lines), verified locally by intersecting the diff's changed lines with `coverage/lcov.info`
- [x] No runtime code references `https://api.tarkov.dev`
- [x] No `__typename` usage remains in `app` code (non-English locale files are Crowdin-owned and untouched)
- [x] Migration verified against live upstream data: task objective types and prestige condition types fetched from `json.tarkov.dev` and checked against every migrated branch

## Notes for reviewers

- This is intentionally split from #582 (dead-locale-keys cleanup) to keep that PR scoped.
- Non-English locale files still contain the old `api.tarkov.dev`/`GraphQL` copy; those are Crowdin exports and should update on next sync after `en.json` changes propagate.
- Removing `__typename` changes the response shape of `/api/tarkov/*`. The field was synthetic and nothing reads it, so stale KV/edge entries carrying it are harmless and no cache bust is needed.
- Broader project coverage (~59%) is tracked separately, not in this PR.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/583?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Prestige requirement rows now recognize a broader set of item/condition types using the updated objective format.
  * Skill requirement aggregation now more reliably derives and merges skill requirements across tasks.
* **Updates**
  * Requirement rendering is now aligned with the non-GraphQL objective data shape for more consistent results.
* **Bug Fixes**
  * Improved robustness when objectives vary in structure, preventing missing/incorrect requirement rows.
* **Documentation**
  * Tarkov.dev guide, resource links, and API/system docs now consistently direct to `json.tarkov.dev` static JSON endpoints and updated language guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

___

## **CodeAnt-AI Description**
**Switch Tarkov.dev references to the JSON API and keep skill/prestige requirements working**

### What Changed
- Tarkov.dev docs, guide text, and resource links now point to `json.tarkov.dev/endpoints` instead of the older GraphQL API
- The Tarkov.dev resource card now shows the JSON endpoint as the API documentation link
- Skill-related task requirements and prestige requirement rows now read the upstream `type` field, so required skills, player levels, hideout stations, tasks, and item conditions still appear correctly
- Removed stale GraphQL-specific cleanup and updated tests to match the JSON API data shape

### Impact
`✅ Clearer Tarkov.dev setup instructions`
`✅ Fewer missing skill and prestige requirements`
`✅ Less confusion about the supported upstream API`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the migration is complete, all consumers updated, and 100% patch coverage (218 files, 2151 tests) is reported passing.

Every __typename consumer in app code has been migrated to the upstream type field. The prestige item-condition set is now explicitly enumerated rather than inferred by the adapter, which is strictly more robust. The extracted readSkillObjective helper is fully tested, as are the new prestige condition branches. Dead code (sanitizeGraphQLErrors, inferObjectiveTypename) is cleanly removed with its tests. Documentation accurately reflects the real API surface, language allowlist, and routing constraints. The AGENTS.md maintenance contract is fulfilled in the same PR.

No files require special attention.
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/stores/tarkov/prestige.ts | Migrates all four prestige condition branches from __typename === 'TaskObjective*' to condition.type literals; expands item-condition matching to PRESTIGE_ITEM_CONDITION_TYPES set covering the five item shapes previously collapsed under TaskObjectiveItem. |
| app/utils/skillHelpers.ts | Extracts readSkillObjective() from duplicated logic in useSkillCalculation and buildSkillKeyAliases; migrates the skill-objective guard from __typename to type === 'skill'; removes SkillRequirement import now unused here. |
| app/composables/useSkillCalculation.ts | Removes local TaskObjectiveWithTypename / TaskObjectiveSkill interfaces and isTaskObjectiveSkill guard; delegates to readSkillObjective() from skillHelpers — clean DRY improvement. |
| app/server/utils/tarkov-json.ts | Removes inferObjectiveTypename() and the __typename assignment in adaptObjective(); objectives now carry only the upstream type string; minor comment updated to reflect both accepted shapes for requiredPrestige. |
| app/types/tarkov.ts | Removes the optional __typename field from TaskObjective; type field (already present) is now the sole discriminator. |
| app/server/utils/edgeCacheSanitizers.ts | Removes dead sanitizeGraphQLErrors export and its test; sanitizeErrorMessage and sanitizeVariables are unaffected. |
| docs/API.md | Accurate documentation of the API_SUPPORTED_LANGUAGES allowlist (16 codes), upstream gap (id/th/vn), lang parameter behaviour, enabled UI locales including ko, and the first-party-route disclaimer for /api/tarkov/*. |
| AGENTS.md | Adds Hard Rule prohibiting api.tarkov.dev GraphQL and the removed __typename discriminator, fulfilling the AGENTS.md maintenance contract triggered by SYSTEMS.md changes in this PR. |

</details>

<details><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[TaskObjective from json.tarkov.dev] --> B{condition.type}
    B -->|'playerLevel'| C[pushRow: playerLevel kind]
    B -->|'taskStatus' + task.id| D[pushRow: task kind]
    B -->|'skill' + skillLevel.name| E[readSkillObjective]
    E --> F[pushRow: skill kind]
    B -->|'hideoutStation' + hideoutStation.id| G[pushRow: hideoutStation kind]
    B -->|PRESTIGE_ITEM_CONDITION_TYPES| H["findItem / giveItem / haveItem / plantItem / sellItem"]
    H --> I[pushRow: item kind]
    B -->|other / unknown| J[skipped]

    subgraph skillHelpers.ts
        E
    end

    subgraph prestige.ts
        B
        C
        D
        F
        G
        H
        I
        J
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["docs: fix sibling-relative links and cac..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/61a7b8e7789da4e1ccb44f3f9d35b2ef345013c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46605878)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->