### PR TITLE
perf(api): select only the active game mode blob on progress reads

### DIFF
--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -142,7 +142,39 @@ const createBaseFetchMock = ({
       return jsonResponse(teamMembers.map((id) => ({ user_id: id })));
     }
     if (url.includes('/rest/v1/user_progress')) {
-      return jsonResponse([userProgress]);
+      const parsedUrl = new URL(url);
+      const selectParam = parsedUrl.searchParams.get('select') ?? '*';
+      const selectedColumns = selectParam === '*' ? null : selectParam.split(',');
+      const userIdParam = parsedUrl.searchParams.get('user_id') ?? '';
+      let requestedUserIds: string[];
+      if (userIdParam.startsWith('eq.')) {
+        requestedUserIds = [userIdParam.slice(3)];
+      } else if (userIdParam.startsWith('in.(') && userIdParam.endsWith(')')) {
+        requestedUserIds = userIdParam
+          .slice(4, -1)
+          .split(',')
+          .map((s) => s.trim());
+      } else {
+        requestedUserIds = [String(userProgress.user_id)];
+      }
+      const activeModeField = selectedColumns?.includes('pve_data') ? 'pve_data' : 'pvp_data';
+      const buildRow = (userId: string): Record<string, unknown> => {
+        const base: Record<string, unknown> = { ...userProgress, user_id: userId };
+        // Give each member a distinct displayName in the active mode's data so
+        // per-member mapping regressions are detectable in team tests.
+        const modeData = base[activeModeField];
+        base[activeModeField] = {
+          ...(typeof modeData === 'object' && modeData !== null ? modeData : {}),
+          displayName: `Member-${userId}`,
+        };
+        if (!selectedColumns) return base;
+        const row: Record<string, unknown> = {};
+        for (const col of selectedColumns) {
+          if (col in base) row[col] = base[col];
+        }
+        return row;
+      };
+      return jsonResponse(requestedUserIds.map(buildRow));
     }
     const apiGameMode = gameMode === 'pve' ? 'pve' : 'regular';
     if (url === `https://json.tarkov.dev/${apiGameMode}/tasks`) {
@@ -930,6 +962,13 @@ describe('api-gateway', () => {
       const select = findProgressSelect(fetchMock as unknown as ReturnType<typeof vi.fn>);
       expect(select).toBe(expected);
       expect(select).not.toContain('*');
+      // Verify per-member mapping: each member gets their own row's displayName.
+      const body = (await res.json()) as {
+        data: Array<{ userId: string; displayName: string }>;
+      };
+      const byUser = new Map(body.data.map((d) => [d.userId, d.displayName]));
+      expect(byUser.get('user-1')).toBe('Member-user-1');
+      expect(byUser.get('user-2')).toBe('Member-user-2');
     }
   );
   it.each([

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -871,6 +871,28 @@ describe('api-gateway', () => {
     expect(objectives?.['obj-1']?.count).toBe(5);
     expect('complete' in (objectives?.['obj-1'] ?? {})).toBe(false);
   });
+  const progressRequest = (headers: Record<string, string> = {}) =>
+    buildRequest('/progress', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer PVP_abc123', ...headers },
+    });
+  it.each([
+    ['pvp', 'select=user_id,game_edition,pvp_data'],
+    ['pve', 'select=user_id,game_edition,pve_data'],
+  ] as const)(
+    'narrows the user_progress select to the %s token game mode',
+    async (mode, expected) => {
+      const fetchMock = createBaseFetchMock({ permissions: ['GP'], gameMode: mode });
+      vi.stubGlobal('fetch', fetchMock);
+      const res = await worker.fetch(progressRequest(), BASE_ENV);
+      expect(res.status).toBe(200);
+      const progressUrl = fetchMock.mock.calls
+        .map((call) => String(call[0]))
+        .find((url) => url.includes('/rest/v1/user_progress'));
+      expect(progressUrl).toContain(expected);
+      expect(progressUrl).not.toContain('select=*');
+    }
+  );
 });
 describe('ApiGatewayRateLimiter storage cleanup', () => {
   afterEach(() => {

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -86,6 +86,8 @@ type BaseFetchMockOptions = {
   userProgress?: Record<string, unknown>;
   permissions?: string[];
   gameMode?: 'pvp' | 'pve';
+  teamId?: string | null;
+  teamMembers?: string[];
 };
 const createBaseFetchMock = ({
   onMerge,
@@ -100,6 +102,8 @@ const createBaseFetchMock = ({
   },
   permissions = ['WP'],
   gameMode = 'pvp',
+  teamId = null,
+  teamMembers = ['user-1', 'user-2'],
 }: BaseFetchMockOptions = {}) =>
   vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
     const url =
@@ -130,6 +134,12 @@ const createBaseFetchMock = ({
         mergeStore.data = applyMergeRpc(mergeStore.data, payload);
       }
       return new Response(result, { status: 200 });
+    }
+    if (url.includes('/rest/v1/user_system')) {
+      return jsonResponse([{ user_id: 'user-1', pvp_team_id: teamId, pve_team_id: teamId }]);
+    }
+    if (url.includes('/rest/v1/team_memberships')) {
+      return jsonResponse(teamMembers.map((id) => ({ user_id: id })));
     }
     if (url.includes('/rest/v1/user_progress')) {
       return jsonResponse([userProgress]);
@@ -876,9 +886,15 @@ describe('api-gateway', () => {
       method: 'GET',
       headers: { Authorization: 'Bearer PVP_abc123', ...headers },
     });
+  const findProgressSelect = (fetchMock: ReturnType<typeof vi.fn>): string | undefined =>
+    fetchMock.mock.calls
+      .map((call) => String(call[0]))
+      .filter((url) => url.includes('/rest/v1/user_progress'))
+      .map((url) => new URL(url).searchParams.get('select') ?? undefined)
+      .find((select) => select !== undefined);
   it.each([
-    ['pvp', 'select=user_id,game_edition,pvp_data'],
-    ['pve', 'select=user_id,game_edition,pve_data'],
+    ['pvp', 'user_id,game_edition,pvp_data'],
+    ['pve', 'user_id,game_edition,pve_data'],
   ] as const)(
     'narrows the user_progress select to the %s token game mode',
     async (mode, expected) => {
@@ -886,11 +902,53 @@ describe('api-gateway', () => {
       vi.stubGlobal('fetch', fetchMock);
       const res = await worker.fetch(progressRequest(), BASE_ENV);
       expect(res.status).toBe(200);
-      const progressUrl = fetchMock.mock.calls
-        .map((call) => String(call[0]))
-        .find((url) => url.includes('/rest/v1/user_progress'));
-      expect(progressUrl).toContain(expected);
-      expect(progressUrl).not.toContain('select=*');
+      const select = findProgressSelect(fetchMock as unknown as ReturnType<typeof vi.fn>);
+      expect(select).toBe(expected);
+      expect(select).not.toContain('*');
+    }
+  );
+  const teamProgressRequest = (headers: Record<string, string> = {}) =>
+    buildRequest('/team/progress', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer PVP_abc123', ...headers },
+    });
+  it.each([
+    ['pvp', 'user_id,game_edition,pvp_data'],
+    ['pve', 'user_id,game_edition,pve_data'],
+  ] as const)(
+    'narrows the team batch user_progress select to the %s token game mode',
+    async (mode, expected) => {
+      const fetchMock = createBaseFetchMock({
+        permissions: ['TP'],
+        gameMode: mode,
+        teamId: 'team-1',
+        teamMembers: ['user-1', 'user-2'],
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const res = await worker.fetch(teamProgressRequest(), BASE_ENV);
+      expect(res.status).toBe(200);
+      const select = findProgressSelect(fetchMock as unknown as ReturnType<typeof vi.fn>);
+      expect(select).toBe(expected);
+      expect(select).not.toContain('*');
+    }
+  );
+  it.each([
+    ['pvp', 'user_id,game_edition,pvp_data'],
+    ['pve', 'user_id,game_edition,pve_data'],
+  ] as const)(
+    'narrows the solo-fallback user_progress select to the %s token game mode',
+    async (mode, expected) => {
+      const fetchMock = createBaseFetchMock({
+        permissions: ['TP'],
+        gameMode: mode,
+        teamId: null,
+      });
+      vi.stubGlobal('fetch', fetchMock);
+      const res = await worker.fetch(teamProgressRequest(), BASE_ENV);
+      expect(res.status).toBe(200);
+      const select = findProgressSelect(fetchMock as unknown as ReturnType<typeof vi.fn>);
+      expect(select).toBe(expected);
+      expect(select).not.toContain('*');
     }
   );
 });

--- a/workers/api-gateway/src/handlers/progress.ts
+++ b/workers/api-gateway/src/handlers/progress.ts
@@ -5,7 +5,7 @@ import { extractGameModeData, transformProgress } from '../utils/transform';
 import type {
   Env,
   ApiToken,
-  UserProgressRow,
+  UserProgressModeRow,
   ProgressResponse,
   TaskState,
   BatchTaskUpdate,
@@ -285,8 +285,10 @@ export async function handleGetProgress(
   token: ApiToken,
   gameMode: 'pvp' | 'pve'
 ): Promise<ProgressResponse> {
-  // Fetch user progress from Supabase
-  const url = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=eq.${token.user_id}&select=*&limit=1`;
+  // Select only the requested game mode's JSONB blob — fetching both pvp_data
+  // and pve_data doubles Supabase egress and Worker memory for no benefit.
+  const dataField = gameMode === 'pve' ? 'pve_data' : 'pvp_data';
+  const url = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=eq.${token.user_id}&select=user_id,game_edition,${dataField}&limit=1`;
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
@@ -296,7 +298,7 @@ export async function handleGetProgress(
   if (!response.ok) {
     throw new Error('Failed to fetch user progress');
   }
-  const rows = (await response.json()) as UserProgressRow[];
+  const rows = (await response.json()) as UserProgressModeRow[];
   const row = rows[0] || null;
   const gameEdition = row?.game_edition ?? 1;
   // Extract game mode specific data

--- a/workers/api-gateway/src/handlers/progress.ts
+++ b/workers/api-gateway/src/handlers/progress.ts
@@ -285,8 +285,8 @@ export async function handleGetProgress(
   token: ApiToken,
   gameMode: 'pvp' | 'pve'
 ): Promise<ProgressResponse> {
-  // Select only the requested game mode's JSONB blob — fetching both pvp_data
-  // and pve_data doubles Supabase egress and Worker memory for no benefit.
+  // Select only the requested game mode's JSONB blob to reduce Supabase egress
+  // and Worker memory; the other mode's column is not needed for this response.
   const dataField = gameMode === 'pve' ? 'pve_data' : 'pvp_data';
   const url = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=eq.${token.user_id}&select=user_id,game_edition,${dataField}&limit=1`;
   const response = await fetch(url, {

--- a/workers/api-gateway/src/handlers/team.ts
+++ b/workers/api-gateway/src/handlers/team.ts
@@ -112,7 +112,8 @@ export async function handleGetTeamProgress(
   if (memberIds.length === 0) {
     return await getSoloProgress(env, token, gameMode);
   }
-  // Step 3: Fetch progress for all team members (only the active mode's blob)
+  // Step 3: Fetch progress for all team members (only the active mode's blob,
+  // to reduce Supabase egress and Worker memory; the other mode is not needed).
   const dataField = gameMode === 'pve' ? 'pve_data' : 'pvp_data';
   const progressUrl = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=in.(${memberIds.join(',')})&select=user_id,game_edition,${dataField}`;
   const progressRes = await fetch(progressUrl, {

--- a/workers/api-gateway/src/handlers/team.ts
+++ b/workers/api-gateway/src/handlers/team.ts
@@ -1,7 +1,7 @@
 import { getTasks, getHideoutStations } from '../services/tarkov';
 import { getMemoryCache, setMemoryCache } from '../utils/memory-cache';
 import { extractGameModeData, transformProgress } from '../utils/transform';
-import type { Env, ApiToken, UserProgressRow, ProgressResponseData } from '../types';
+import type { Env, ApiToken, UserProgressModeRow, ProgressResponseData } from '../types';
 // Team member from database
 interface TeamMember {
   user_id: string;
@@ -112,8 +112,9 @@ export async function handleGetTeamProgress(
   if (memberIds.length === 0) {
     return await getSoloProgress(env, token, gameMode);
   }
-  // Step 3: Fetch progress for all team members
-  const progressUrl = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=in.(${memberIds.join(',')})&select=*`;
+  // Step 3: Fetch progress for all team members (only the active mode's blob)
+  const dataField = gameMode === 'pve' ? 'pve_data' : 'pvp_data';
+  const progressUrl = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=in.(${memberIds.join(',')})&select=user_id,game_edition,${dataField}`;
   const progressRes = await fetch(progressUrl, {
     headers: {
       Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
@@ -123,7 +124,7 @@ export async function handleGetTeamProgress(
   if (!progressRes.ok) {
     throw new Error('Failed to fetch team progress');
   }
-  const progressRows = (await progressRes.json()) as UserProgressRow[];
+  const progressRows = (await progressRes.json()) as UserProgressModeRow[];
   // Step 4: Fetch task and hideout data (cached)
   const [tasks, hideoutStations] = await Promise.all([
     getTasks(gameMode),
@@ -163,8 +164,8 @@ async function getSoloProgress(
   token: ApiToken,
   gameMode: 'pvp' | 'pve'
 ): Promise<TeamProgressResponse> {
-  // Fetch user progress
-  const url = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=eq.${token.user_id}&select=*&limit=1`;
+  const dataField = gameMode === 'pve' ? 'pve_data' : 'pvp_data';
+  const url = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=eq.${token.user_id}&select=user_id,game_edition,${dataField}&limit=1`;
   const response = await fetch(url, {
     headers: {
       Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
@@ -174,7 +175,7 @@ async function getSoloProgress(
   if (!response.ok) {
     throw new Error('Failed to fetch user progress');
   }
-  const rows = (await response.json()) as UserProgressRow[];
+  const rows = (await response.json()) as UserProgressModeRow[];
   const row = rows[0] || null;
   const gameEdition = row?.game_edition ?? 1;
   const progressData = extractGameModeData(row, gameMode);

--- a/workers/api-gateway/src/types.ts
+++ b/workers/api-gateway/src/types.ts
@@ -90,6 +90,14 @@ export interface UserProgressRow {
   created_at?: string | null;
   updated_at?: string | null;
 }
+/**
+ * Read-path projection of `user_progress`. Reads select only the requested
+ * game mode's blob, so the other mode's column and every unselected field are
+ * genuinely absent. Typing the projection separately keeps the compiler from
+ * treating unselected columns as present.
+ */
+export type UserProgressModeRow = Pick<UserProgressRow, 'user_id' | 'game_edition'> &
+  Partial<Pick<UserProgressRow, 'pvp_data' | 'pve_data'>>;
 // Legacy token response format (matching old API)
 export interface LegacyTokenResponse {
   permissions: string[];

--- a/workers/api-gateway/src/utils/transform.ts
+++ b/workers/api-gateway/src/utils/transform.ts
@@ -1,7 +1,7 @@
 import { computeInvalidProgress } from './invalidation';
 import type {
   UserProgressData,
-  UserProgressRow,
+  UserProgressModeRow,
   TarkovTask,
   TarkovHideoutStation,
   ProgressResponseData,
@@ -16,11 +16,11 @@ const CULTIST_CIRCLE_STATION_ID = '667298e75ea6b4493c08f266';
  * Extract game mode specific data from user progress row
  */
 export function extractGameModeData(
-  row: UserProgressRow | null,
+  row: UserProgressModeRow | null,
   gameMode: 'pvp' | 'pve'
 ): UserProgressData | null {
   if (!row) return null;
-  return gameMode === 'pve' ? row.pve_data : row.pvp_data;
+  return (gameMode === 'pve' ? row.pve_data : row.pvp_data) ?? null;
 }
 /**
  * Apply hideout auto-complete based on game edition


### PR DESCRIPTION
## **User description**
Extracted from #589 so the database-read improvement can land independently of the rate-limiter redesign.

## What

`GET /progress` and `GET /team/progress` selected `*` from `user_progress`, fetching **both** `pvp_data` and `pve_data` when only one is ever used. This narrows the select to the requested mode.

- `handlers/progress.ts`, `handlers/team.ts` — select `user_id,game_edition,<mode>_data` instead of `*` (all three read paths, including the solo-team fallback)
- `types.ts` — new `UserProgressModeRow` projection type so the compiler stops treating unselected columns as present
- `utils/transform.ts` — `extractGameModeData` takes the projection and normalises the absent column to `null`
- `__tests__/gateway.test.ts` — parameterized test asserting the narrowed select for **both** pvp and pve tokens

## Why

Directly reduces Supabase egress and Worker memory on the hottest read path, with no behavioural or architectural commitment.

## Not included

This PR deliberately excludes the rest of #589 — the parallel three-bucket rate-limiter, refund reconciliation, ETag/304, and manual gzip. Those are being reworked separately.

## Validation

- `pnpm run test:api-gateway` — 120/120 pass
- `npx tsc -p workers/api-gateway/tsconfig.json --noEmit` — clean
- `npx eslint` on all changed files — clean

Prettier was intentionally not run: `workers/**` is in neither `lint-staged` nor `format:check`, so reformatting would add churn unrelated to this change.
<!-- devin-review-badge-begin -->

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/590" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Progress requests now retrieve only the data needed for the selected game mode, reducing unnecessary data transfer.
* **Bug Fixes**
  * Improved handling of player and team progress for PvE and PvP modes.
  * Missing mode-specific progress is now returned consistently as `null`.
* **Tests**
  * Added coverage verifying that progress requests use mode-specific data fields.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

___

## **CodeAnt-AI Description**
Reduce progress-read data without changing API responses

### What Changed
- Progress and team-progress requests now fetch only the selected game mode’s data instead of both PvP and PvE data.
- Solo team-progress fallbacks use the same focused read.
- Missing mode data continues to be handled as empty progress, preserving existing responses.
- Tests verify the exact data selected for PvP, PvE, team, and solo-fallback requests.

### Impact
`✅ Lower memory during progress reads`
`✅ Lower database data transfer`
`✅ Fewer regressions in game-mode selection`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR narrows the `user_progress` Supabase select from `*` to `user_id,game_edition,<mode>_data` across all three progress read paths (`handleGetProgress`, `handleGetTeamProgress`, and the `getSoloProgress` fallback), reducing egress and Worker memory on the hottest read path.

- **`types.ts`** introduces `UserProgressModeRow`, a `Pick`+`Partial` projection so TypeScript correctly models the absent column without widening to `UserProgressRow`.
- **`utils/transform.ts`** adds `?? null` to `extractGameModeData` to normalise `undefined` (absent column) to `null`, preserving the existing null-data code path.
- **`__tests__/gateway.test.ts`** adds six parameterized tests verifying the narrowed `select` for all three paths × both game modes, including per-member mapping assertions on the team batch path.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — all three read paths correctly narrow the Supabase select and the absent-column edge case is handled throughout.

The change is mechanically straightforward: the URL string changes, the type cast narrows, and ?? null covers the undefined-column case. All downstream consumers of extractGameModeData already handle null progress data. The six new parameterized tests exercise every changed code path for both game modes, including the per-member row-mapping assertion on the batch path.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workers/api-gateway/src/types.ts | Adds UserProgressModeRow projection type (Pick + Partial) so the compiler correctly models the narrowed select without treating unselected columns as present. |
| workers/api-gateway/src/utils/transform.ts | Updates extractGameModeData to accept UserProgressModeRow and adds ?? null to normalise undefined (absent column) to null — correctly handles the new projection. |
| workers/api-gateway/src/handlers/progress.ts | Narrows handleGetProgress select from * to user_id,game_edition,{mode}_data; updates type cast to UserProgressModeRow[]. |
| workers/api-gateway/src/handlers/team.ts | Narrows the batch team query and getSoloProgress fallback to the same three-column projection; type casts updated consistently. |
| workers/api-gateway/src/__tests__/gateway.test.ts | Adds six parameterized tests covering all three read paths x both game modes; includes per-member mapping assertions on the team batch path and a findProgressSelect helper to inspect fetch calls. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant Worker as API Gateway Worker
    participant SB as Supabase user_progress

    Client->>Worker: "GET /progress (token: pvp|pve)"
    Worker->>SB: "SELECT user_id,game_edition,pvp_data|pve_data WHERE user_id=eq.{id}&limit=1"
    SB-->>Worker: UserProgressModeRow (one mode blob only)
    Worker->>Worker: extractGameModeData(row, gameMode) → data ?? null
    Worker-->>Client: ProgressResponse

    Client->>Worker: "GET /team/progress (token: pvp|pve)"
    Worker->>SB: SELECT user_id FROM user_system
    SB-->>Worker: teamId
    alt teamId present
        Worker->>SB: SELECT user_id FROM team_memberships
        SB-->>Worker: memberIds[]
        Worker->>SB: "SELECT user_id,game_edition,pvp_data|pve_data WHERE user_id=in.(...)"
        SB-->>Worker: UserProgressModeRow[] (one mode blob each)
    else no team (solo fallback)
        Worker->>SB: "SELECT user_id,game_edition,pvp_data|pve_data WHERE user_id=eq.{id}&limit=1"
        SB-->>Worker: UserProgressModeRow (one mode blob)
    end
    Worker-->>Client: TeamProgressResponse
```
</details>

<sub>Reviews (3): Last reviewed commit: ["test(api): make user\_progress mock proje..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/f84a22e166841fabb3d3161184f6146f6a0e45da) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46807062)</sub>

<!-- /greptile_comment -->