### PR TITLE
refactor(api): simplify rate limiter to single daily DO + IP abuse gate

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -393,7 +393,7 @@ A pre-authentication IP-based abuse gate (Cloudflare Workers Rate Limiting bindi
 the token validation step from floods. It is deliberately coarse — infrastructure protection,
 not a customer quota — and is not advertised as a per-IP entitlement.
 
-Every gateway response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix seconds) for the daily quota, plus `Retry-After` on `429` responses. When a free-tier user exhausts a daily quota, the `429` body includes an upgrade link. Admins can inspect the top consumers via `GET /api/admin/api-usage`; usage is bucketed by UTC day, so the report covers the current and previous UTC day (the `since` field gives the exact starting day).
+Authenticated responses include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix seconds) for the daily quota, plus `Retry-After` on `429` responses. Pre-authentication abuse-gate `429` responses include only `Retry-After`, and fail-open responses (daily-quota service temporarily unavailable) omit the `X-RateLimit-*` headers. When a free-tier user exhausts a daily quota, the `429` body includes an upgrade link. Admins can inspect the top consumers via `GET /api/admin/api-usage`; usage is bucketed by UTC day, so the report covers the current and previous UTC day (the `since` field gives the exact starting day).
 
 ### Active Token Cap
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -375,23 +375,25 @@ This section covers **external progress API quotas only** (Worker + Durable Obje
 limits, shared profile limits, Auth limits, and DB hard caps live in a separate ownership map:
 [`RATE_LIMITING.md`](./RATE_LIMITING.md).
 
-Progress API requests (`api.tarkovtracker.org`, `/api/v2/*`) are subject to tiered quotas keyed by user account (not per token). Daily quotas reset at 00:00 UTC; burst limits use a 60-second sliding window so batch updates near a minute boundary are not spuriously throttled.
+Progress API requests (`api.tarkovtracker.org`, `/api/v2/*`) are subject to tiered daily quotas keyed by user account (not per token). Daily quotas reset at 00:00 UTC and count authenticated requests admitted for processing.
 
-| Tier      | Reads/day | Writes/day | Burst/min |
-| --------- | --------- | ---------- | --------- |
-| Free      | 1,000     | 100        | 30        |
-| Supporter | 2,000     | 250        | 60        |
-| Scav      | 2,000     | 250        | 60        |
-| Timmy     | 3,000     | 400        | 90        |
-| Chad      | 5,000     | 600        | 120       |
+| Tier      | Reads/day | Writes/day |
+| --------- | --------- | ---------- |
+| Free      | 1,000     | 100        |
+| Supporter | 2,000     | 250        |
+| Scav      | 2,000     | 250        |
+| Timmy     | 3,000     | 400        |
+| Chad      | 5,000     | 600        |
 
 The gateway resolves the tier from `public.supporters` for the token owner and caches successful
 lookups for up to 60 seconds. Active subscriptions and past-due subscriptions within their recorded
 grace period keep paid limits; expired subscriptions return to Free limits.
 
-A per-IP backstop applies on top of the per-user quotas: 600 reads/hour and 200 writes/hour per IP address (1-hour sliding window). This catches abuse from many accounts sharing one IP while remaining generous enough for shared NAT users. IP-throttled requests do not consume the daily or burst quotas.
+A pre-authentication IP-based abuse gate (Cloudflare Workers Rate Limiting binding) shields
+the token validation step from floods. It is deliberately coarse — infrastructure protection,
+not a customer quota — and is not advertised as a per-IP entitlement.
 
-Every gateway response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix seconds) for the daily quota, plus `Retry-After` on `429` responses. On burst or IP `429`s the `X-RateLimit-*` headers still describe the daily quota (throttled requests do not consume it) while `Retry-After` indicates when capacity frees. When a free-tier user exhausts a daily quota, the `429` body includes an upgrade link. Admins can inspect the top consumers via `GET /api/admin/api-usage`; usage is bucketed by UTC day, so the report covers the current and previous UTC day (the `since` field gives the exact starting day).
+Every gateway response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix seconds) for the daily quota, plus `Retry-After` on `429` responses. When a free-tier user exhausts a daily quota, the `429` body includes an upgrade link. Admins can inspect the top consumers via `GET /api/admin/api-usage`; usage is bucketed by UTC day, so the report covers the current and previous UTC day (the `since` field gives the exact starting day).
 
 ### Active Token Cap
 

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -394,13 +394,13 @@ Treat these deliberately; do not “make everything fail open” without underst
 
 ### Cleanup / retention
 
-| Store                       | Retention guidance                                                                                                             |
-| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
-| `mutation_rate_limits`      | Delete rows with `reset_at` older than 1 day periodically                                                                      |
-| `api_usage_daily`           | Keep finite retention (e.g. 90–180 days) for observability                                                                     |
-| Worker DO state             | Ephemeral keys self-clean via alarms; retained authenticated keys expire by window logic                                       |
-| Legacy burst/IP DO keys     | Removed in the single daily-quota refactor; already-written objects drain via their existing alarms and are never re-addressed |
-| `account_deletion_attempts` | Existing cleanup function / retention policy                                                                                   |
+| Store                       | Retention guidance                                                                                                                                                                                                                                   |
+| --------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `mutation_rate_limits`      | Delete rows with `reset_at` older than 1 day periodically                                                                                                                                                                                            |
+| `api_usage_daily`           | Keep finite retention (e.g. 90–180 days) for observability                                                                                                                                                                                           |
+| Worker DO state             | Ephemeral keys self-clean via alarms; retained authenticated keys expire by window logic                                                                                                                                                             |
+| Legacy burst/IP DO keys     | Removed in the single daily-quota refactor and never re-addressed; expired objects with pending alarms are deleted, but objects whose legacy alarm fired while the window was still active can linger (their alarm was drained without rescheduling) |
+| `account_deletion_attempts` | Existing cleanup function / retention policy                                                                                                                                                                                                         |
 
 ---
 

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -74,14 +74,14 @@ flowchart TB
 
 ### Ownership matrix
 
-| Traffic class               | Examples                                         | Primary enforcer                               | Secondary / hard stop                    | Storage / implementation                   |
-| --------------------------- | ------------------------------------------------ | ---------------------------------------------- | ---------------------------------------- | ------------------------------------------ |
-| External progress API       | `/api/v2/*` on `api.tarkovtracker.org`           | Worker DO quotas (daily + burst + IP backstop) | Supporter tier resolution, token auth    | `ApiGatewayRateLimiter`, `api_usage_daily` |
-| Authenticated app mutations | team create/join/leave/kick, token create/revoke | Edge Function mutation limiter                 | DB token cap (3 active), RLS             | `mutation_rate_limits` + RPC               |
-| Public / shared app reads   | shared profile, team members, tarkov-dev profile | Pages/Nitro shared limiter                     | CDN/cache TTLs, Cloudflare WAF if needed | `sharedEdgeStore` (+ DO if bound)          |
-| Destructive account ops     | account delete                                   | Edge Function (dedicated table for now)        | Deletion jobs queue                      | `account_deletion_attempts`                |
-| Auth platform               | signup, sign-in, refresh, OTP                    | Supabase Auth                                  | Captcha (optional)                       | GoTrue `[auth.rate_limit]`                 |
-| Outbound third parties      | Discord API, Stripe                              | Provider `Retry-After` / SDK rules             | Circuit breakers, job retries            | not user quotas                            |
+| Traffic class               | Examples                                         | Primary enforcer                        | Secondary / hard stop                    | Storage / implementation                   |
+| --------------------------- | ------------------------------------------------ | --------------------------------------- | ---------------------------------------- | ------------------------------------------ |
+| External progress API       | `/api/v2/*` on `api.tarkovtracker.org`           | Worker DO daily quota + IP abuse gate   | Supporter tier resolution, token auth    | `ApiGatewayRateLimiter`, `api_usage_daily` |
+| Authenticated app mutations | team create/join/leave/kick, token create/revoke | Edge Function mutation limiter          | DB token cap (3 active), RLS             | `mutation_rate_limits` + RPC               |
+| Public / shared app reads   | shared profile, team members, tarkov-dev profile | Pages/Nitro shared limiter              | CDN/cache TTLs, Cloudflare WAF if needed | `sharedEdgeStore` (+ DO if bound)          |
+| Destructive account ops     | account delete                                   | Edge Function (dedicated table for now) | Deletion jobs queue                      | `account_deletion_attempts`                |
+| Auth platform               | signup, sign-in, refresh, OTP                    | Supabase Auth                           | Captcha (optional)                       | GoTrue `[auth.rate_limit]`                 |
+| Outbound third parties      | Discord API, Stripe                              | Provider `Retry-After` / SDK rules      | Circuit breakers, job retries            | not user quotas                            |
 
 ---
 
@@ -178,36 +178,39 @@ This is the high-volume system used by token-authenticated progress clients. It 
 ```mermaid
 flowchart LR
   C[External client + API token] --> W[api-gateway Worker]
-  W --> AUTH[Validate token hash]
+  W --> ABUSE[IP abuse gate<br/>Cloudflare Rate Limiting binding]
+  ABUSE --> AUTH[Validate token hash]
   AUTH --> TIER[Resolve supporter tier]
   TIER --> DAILY[DO daily quota<br/>utc-day window]
-  DAILY --> BURST[DO burst/min<br/>sliding]
-  BURST --> IP[DO IP backstop<br/>sliding hour]
-  IP --> HANDLER[Progress / team handlers]
+  DAILY --> HANDLER[Progress / team handlers]
   HANDLER --> DB[(Supabase)]
   W --> USAGE[record_api_usage RPC<br/>api_usage_daily]
 ```
 
-**Primary limits** (from `workers/api-gateway/src/limits.ts`):
+**Daily limits** (from `workers/api-gateway/src/limits.ts`):
 
-| Tier      | Reads/day | Writes/day | Burst/min |
-| --------- | --------: | ---------: | --------: |
-| Free      |     1,000 |        100 |        30 |
-| Supporter |     2,000 |        250 |        60 |
-| Scav      |     2,000 |        250 |        60 |
-| Timmy     |     3,000 |        400 |        90 |
-| Chad      |     5,000 |        600 |       120 |
+| Tier      | Reads/day | Writes/day |
+| --------- | --------: | ---------: |
+| Free      |     1,000 |        100 |
+| Supporter |     2,000 |        250 |
+| Scav      |     2,000 |        250 |
+| Timmy     |     3,000 |        400 |
+| Chad      |     5,000 |        600 |
 
-Plus IP backstop: **600 reads/hour**, **200 writes/hour** per IP.
+**Abuse gate**: a pre-authentication IP-keyed Cloudflare Workers Rate Limiting binding that
+shields the `api_tokens` lookup from floods. Coarse by design (infrastructure protection, not a
+customer quota). Counter is per-Cloudflare-location and eventually consistent.
 
 Details and response headers: [`API.md`](./API.md#rate-limits-api-gateway)
 
 Implementation notes:
 
 - Enforcer class: `ApiGatewayRateLimiter` in `workers/api-gateway/src/index.ts`
-- Keys are namespaced (`daily-read:<userId>`, `burst-write:<userId>`, `ip-...`)
-- Burst uses sliding windows so a TarkovMonitor batch at a minute boundary is not spuriously blocked
-- Throttled requests can refund daily/burst slots when a later check fails
+- Keys are namespaced (`daily-read:<userId>`, `daily-write:<userId>`)
+- Daily quota uses a UTC-day fixed window; a quota unit is consumed when a valid authenticated
+  request is admitted for processing (downstream failures do not trigger refunds)
+- The daily quota DO fails open when unavailable — the abuse gate still protects Supabase,
+  and daily quotas are product entitlements, not database-integrity boundaries
 - Usage observability goes to `public.api_usage_daily` (not a limiter itself)
 
 ---
@@ -371,23 +374,23 @@ Checklist for every new limiter:
 
 ### Fail behavior
 
-| System                          | On limiter failure                                                                                                                                                                                                           |
-| ------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Edge mutation RPC error         | Edge returns **503** “Rate limiter unavailable” (fail closed for that mutation)                                                                                                                                              |
-| Worker DO timeout / error       | Primary daily/burst DOs fail closed with limiter-unavailable **503**. Per-IP backstop DO: **503** fails open (request proceeds after daily/burst pass; no primary refund); genuine **429** rejects and refunds primary slots |
-| Pages shared limiter without DO | Falls back to in-memory best effort                                                                                                                                                                                          |
+| System                          | On limiter failure                                                                                                                                                      |
+| ------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Edge mutation RPC error         | Edge returns **503** “Rate limiter unavailable” (fail closed for that mutation)                                                                                         |
+| Worker DO timeout / error       | Daily quota DO fails open (product entitlement, not DB-integrity boundary). Abuse gate still protects Supabase. Structured `daily_quota_unavailable` warning is logged. |
+| Pages shared limiter without DO | Falls back to in-memory best effort                                                                                                                                     |
 
 Treat these deliberately; do not “make everything fail open” without understanding abuse impact.
 
 ### Observability
 
-| System                   | Where to look                                                               |
-| ------------------------ | --------------------------------------------------------------------------- |
-| External API throttles   | Worker logs (`rate_limit_429`), `api_usage_daily`, admin API usage endpoint |
-| Mutation throttles       | Edge Function logs (`[rate-limit] ...`), `mutation_rate_limits.updated_at`  |
-| Pages endpoint throttles | Pages/Nitro logs from sharedEdgeStore warnings                              |
-| Account delete throttles | `account_deletion_attempts`                                                 |
-| Auth storms              | Supabase Auth logs / dashboard                                              |
+| System                   | Where to look                                                                        |
+| ------------------------ | ------------------------------------------------------------------------------------ |
+| External API throttles   | Worker logs (`daily_quota_unavailable`), `api_usage_daily`, admin API usage endpoint |
+| Mutation throttles       | Edge Function logs (`[rate-limit] ...`), `mutation_rate_limits.updated_at`           |
+| Pages endpoint throttles | Pages/Nitro logs from sharedEdgeStore warnings                                       |
+| Account delete throttles | `account_deletion_attempts`                                                          |
+| Auth storms              | Supabase Auth logs / dashboard                                                       |
 
 ### Cleanup / retention
 
@@ -427,7 +430,7 @@ Browser UI
   └─ auth             → Supabase Auth platform limits
 
 External clients (API tokens)
-  └─ api-gateway Worker → DO quotas (daily / burst / IP) → Supabase data
+  └─ api-gateway Worker → IP abuse gate → DO daily quota → Supabase data
 
 Hard rules always in DB:
   active token cap, RLS, uniqueness, deletion job integrity

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -384,22 +384,23 @@ Treat these deliberately; do not “make everything fail open” without underst
 
 ### Observability
 
-| System                   | Where to look                                                                        |
-| ------------------------ | ------------------------------------------------------------------------------------ |
-| External API throttles   | Worker logs (`daily_quota_unavailable`), `api_usage_daily`, admin API usage endpoint |
-| Mutation throttles       | Edge Function logs (`[rate-limit] ...`), `mutation_rate_limits.updated_at`           |
-| Pages endpoint throttles | Pages/Nitro logs from sharedEdgeStore warnings                                       |
-| Account delete throttles | `account_deletion_attempts`                                                          |
-| Auth storms              | Supabase Auth logs / dashboard                                                       |
+| System                   | Where to look                                                                                  |
+| ------------------------ | ---------------------------------------------------------------------------------------------- |
+| External API throttles   | Worker logs (`daily_quota_429`, `abuse_gate_429`), `api_usage_daily`, admin API usage endpoint |
+| Mutation throttles       | Edge Function logs (`[rate-limit] ...`), `mutation_rate_limits.updated_at`                     |
+| Pages endpoint throttles | Pages/Nitro logs from sharedEdgeStore warnings                                                 |
+| Account delete throttles | `account_deletion_attempts`                                                                    |
+| Auth storms              | Supabase Auth logs / dashboard                                                                 |
 
 ### Cleanup / retention
 
-| Store                       | Retention guidance                                                                       |
-| --------------------------- | ---------------------------------------------------------------------------------------- |
-| `mutation_rate_limits`      | Delete rows with `reset_at` older than 1 day periodically                                |
-| `api_usage_daily`           | Keep finite retention (e.g. 90–180 days) for observability                               |
-| Worker DO state             | Ephemeral keys self-clean via alarms; retained authenticated keys expire by window logic |
-| `account_deletion_attempts` | Existing cleanup function / retention policy                                             |
+| Store                       | Retention guidance                                                                                                             |
+| --------------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `mutation_rate_limits`      | Delete rows with `reset_at` older than 1 day periodically                                                                      |
+| `api_usage_daily`           | Keep finite retention (e.g. 90–180 days) for observability                                                                     |
+| Worker DO state             | Ephemeral keys self-clean via alarms; retained authenticated keys expire by window logic                                       |
+| Legacy burst/IP DO keys     | Removed in the single daily-quota refactor; already-written objects drain via their existing alarms and are never re-addressed |
+| `account_deletion_attempts` | Existing cleanup function / retention policy                                                                                   |
 
 ---
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -121,9 +121,9 @@ product.
    ```
 
    The api-gateway Worker auto-deploys from `main` on merge. If `IP_HASH_SECRET` is absent at
-   deploy time, `abuse_gate_429`, `abuse_gate_unavailable`, and `daily_quota_429` log lines emit
-   `ip_hash: null`, defeating the IP-level abuse observability the change introduced. Provision the
-   secret **before** merging so the first post-merge request already has a non-null HMAC identifier.
+   deploy time, `abuse_gate_429` and `abuse_gate_unavailable` log lines emit `ip_hash: null`,
+   defeating the IP-level abuse observability the change introduced. Provision the secret **before**
+   merging so the first post-merge request already has a non-null HMAC identifier.
    Do not commit the value.
 
 5. Confirm Cloudflare Pages and Cloudflare Workers Git deployments completed for `main`.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -112,7 +112,7 @@ product.
    production **before** merging the worker change; adding a function ahead of its caller is safe.
 
 4. **Pre-deploy secret check (api-gateway Worker):** before merging a change that relies on
-   `IP_HASH_SECRET` (e.g. any change to abuse-gate or throttle logging), confirm the secret is already
+   `IP_HASH_SECRET` (e.g. any change to abuse-gate IP logging), confirm the secret is already
    provisioned on the production `api-gateway` Worker:
 
    ```bash

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -112,7 +112,7 @@ product.
    production **before** merging the worker change; adding a function ahead of its caller is safe.
 
 4. **Pre-deploy secret check (api-gateway Worker):** before merging a change that relies on
-   `IP_HASH_SECRET` (e.g. any change to IP-backstop logging), confirm the secret is already
+   `IP_HASH_SECRET` (e.g. any change to abuse-gate or throttle logging), confirm the secret is already
    provisioned on the production `api-gateway` Worker:
 
    ```bash
@@ -121,9 +121,10 @@ product.
    ```
 
    The api-gateway Worker auto-deploys from `main` on merge. If `IP_HASH_SECRET` is absent at
-   deploy time, every 429 and `ip_backstop_unavailable` log line emits `ip_hash: null`, defeating
-   the IP-level abuse observability the change introduced. Provision the secret **before** merging
-   so the first post-merge request already has a non-null HMAC identifier. Do not commit the value.
+   deploy time, `abuse_gate_429`, `abuse_gate_unavailable`, and `daily_quota_429` log lines emit
+   `ip_hash: null`, defeating the IP-level abuse observability the change introduced. Provision the
+   secret **before** merging so the first post-merge request already has a non-null HMAC identifier.
+   Do not commit the value.
 
 5. Confirm Cloudflare Pages and Cloudflare Workers Git deployments completed for `main`.
 6. Deploy Supabase Edge Functions after every change under `supabase/functions/`:

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -100,6 +100,21 @@ const makeFetchMock = ({
     }
     return new Response('Not Found', { status: 404 });
   });
+const TEST_IP_HASH_SECRET = 'test-ip-hash-secret';
+const expectedIpHash = async (ip: string, secret: string) => {
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(ip));
+  return Array.from(new Uint8Array(sig))
+    .slice(0, 8)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+};
 const buildRequest = (path: string, init?: RequestInit) => {
   const headers = new Headers(init?.headers);
   if (!headers.has('User-Agent')) {
@@ -434,6 +449,7 @@ describe('daily quota and abuse gate', () => {
     expect(calls[0].body).toMatchObject({ limit: TIER_LIMITS.chad.readsPerDay });
   });
   it('returns an upgrade message when a free user exhausts the daily quota', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const calls: LimiterCall[] = [];
     const rpcCalls: Array<Record<string, unknown>> = [];
     const env: Env = {
@@ -461,6 +477,18 @@ describe('daily quota and abuse gate', () => {
     await flushAsync();
     expect(rpcCalls).toHaveLength(1);
     expect(rpcCalls[0]).toMatchObject({ p_user_id: 'user-free', p_throttled: 1, p_reads: 0 });
+    const throttleLog = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('daily_quota_429'));
+    expect(throttleLog).toBeDefined();
+    expect(JSON.parse(throttleLog!)).toMatchObject({
+      event: 'daily_quota_429',
+      action: 'token-info',
+      kind: 'read',
+      user_id: 'user-free',
+      token_id: 'token-1',
+    });
+    warnSpy.mockRestore();
   });
   it('records successful usage through the record_api_usage rpc', async () => {
     const calls: LimiterCall[] = [];
@@ -517,6 +545,7 @@ describe('daily quota and abuse gate', () => {
       SUPABASE_ANON_KEY: 'anon',
       SUPABASE_SERVICE_ROLE_KEY: 'service',
       ALLOWED_ORIGIN: '*',
+      IP_HASH_SECRET: TEST_IP_HASH_SECRET,
     };
     vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
     const res = await worker.fetch(
@@ -534,10 +563,11 @@ describe('daily quota and abuse gate', () => {
       .map((c) => String(c[0]))
       .find((s) => s.includes('abuse_gate_429'));
     expect(warnLog).toBeDefined();
+    expect(warnLog).not.toContain('203.0.113.1');
     expect(JSON.parse(warnLog!)).toMatchObject({
       event: 'abuse_gate_429',
       action: 'token-info',
-      client_ip: '203.0.113.1',
+      ip_hash: await expectedIpHash('203.0.113.1', TEST_IP_HASH_SECRET),
     });
     warnSpy.mockRestore();
   });
@@ -581,6 +611,7 @@ describe('daily quota and abuse gate', () => {
       SUPABASE_ANON_KEY: 'anon',
       SUPABASE_SERVICE_ROLE_KEY: 'service',
       ALLOWED_ORIGIN: '*',
+      IP_HASH_SECRET: TEST_IP_HASH_SECRET,
     };
     vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
     const res = await worker.fetch(
@@ -603,8 +634,55 @@ describe('daily quota and abuse gate', () => {
     expect(parsed).toMatchObject({
       event: 'abuse_gate_unavailable',
       action: 'token-info',
-      client_ip: '203.0.113.1',
+      ip_hash: await expectedIpHash('203.0.113.1', TEST_IP_HASH_SECRET),
       reason: 'binding_error',
+      error_name: 'Error',
+      error_message: 'limiter binding failed',
+    });
+    expect(warnLog).not.toContain('203.0.113.1');
+    warnSpy.mockRestore();
+  });
+  it('treats a malformed daily quota DO payload as unavailable and fails open', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const rpcCalls: Array<Record<string, unknown>> = [];
+    const env: Env = {
+      API_GATEWAY_LIMITER: {
+        idFromName: (name: string) => name,
+        get: () => ({
+          fetch: async () =>
+            new Response(JSON.stringify({ remaining: 5, resetAt: Date.now() + 1000 }), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }),
+        }),
+      } as unknown as Env['API_GATEWAY_LIMITER'],
+      SUPABASE_URL: 'https://supabase.example',
+      SUPABASE_ANON_KEY: 'anon',
+      SUPABASE_SERVICE_ROLE_KEY: 'service',
+      ALLOWED_ORIGIN: '*',
+    };
+    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free', rpcCalls }));
+    const res = await worker.fetch(
+      buildRequest('/token', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer PVP_abc123' },
+      }),
+      env
+    );
+    expect(res.status).toBe(200);
+    await flushAsync();
+    expect(rpcCalls).toHaveLength(1);
+    expect(rpcCalls[0]).toMatchObject({ p_user_id: 'user-free', p_throttled: 0, p_reads: 1 });
+    const warnLog = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('daily_quota_unavailable'));
+    expect(warnLog).toBeDefined();
+    expect(JSON.parse(warnLog!)).toMatchObject({
+      event: 'daily_quota_unavailable',
+      action: 'token-info',
+      user_id: 'user-free',
+      token_id: 'token-1',
+      reason: 'bad_json',
     });
     warnSpy.mockRestore();
   });

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -503,6 +503,7 @@ describe('daily quota and abuse gate', () => {
     expect(isKnownTier('chad')).toBe(true);
   });
   it('returns 429 when the IP abuse gate limit is exceeded', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const calls: LimiterCall[] = [];
     const abuseLimit = vi.fn().mockResolvedValue({ success: false });
     const env: Env = {
@@ -529,6 +530,16 @@ describe('daily quota and abuse gate', () => {
     expect(abuseLimit).toHaveBeenCalledWith({ key: 'api:203.0.113.1' });
     // No DO calls — abuse gate rejects before token validation.
     expect(calls).toHaveLength(0);
+    const warnLog = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('abuse_gate_429'));
+    expect(warnLog).toBeDefined();
+    expect(JSON.parse(warnLog!)).toMatchObject({
+      event: 'abuse_gate_429',
+      action: 'token-info',
+      client_ip: '203.0.113.1',
+    });
+    warnSpy.mockRestore();
   });
   it('skips the abuse gate when the binding is absent', async () => {
     const calls: LimiterCall[] = [];
@@ -554,6 +565,48 @@ describe('daily quota and abuse gate', () => {
     expect(res.status).toBe(200);
     expect(calls).toHaveLength(1);
     expect(calls[0].key).toBe('daily-read:user-free');
+  });
+  it('fails open and logs when the abuse gate binding throws', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    const calls: LimiterCall[] = [];
+    const abuseLimit = vi.fn().mockRejectedValue(new Error('limiter binding failed'));
+    const env: Env = {
+      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
+        allowed: true,
+        remaining: 5,
+        resetAt: Date.now() + 1000,
+      })),
+      API_ABUSE_LIMITER: { limit: abuseLimit } as unknown as RateLimit,
+      SUPABASE_URL: 'https://supabase.example',
+      SUPABASE_ANON_KEY: 'anon',
+      SUPABASE_SERVICE_ROLE_KEY: 'service',
+      ALLOWED_ORIGIN: '*',
+    };
+    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
+    const res = await worker.fetch(
+      buildRequest('/token', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer PVP_abc123', 'CF-Connecting-IP': '203.0.113.1' },
+      }),
+      env
+    );
+    // Fail open: request proceeds to token validation and daily quota.
+    expect(res.status).toBe(200);
+    expect(abuseLimit).toHaveBeenCalledWith({ key: 'api:203.0.113.1' });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].key).toBe('daily-read:user-free');
+    const warnLog = warnSpy.mock.calls
+      .map((c) => String(c[0]))
+      .find((s) => s.includes('abuse_gate_unavailable'));
+    expect(warnLog).toBeDefined();
+    const parsed = JSON.parse(warnLog!);
+    expect(parsed).toMatchObject({
+      event: 'abuse_gate_unavailable',
+      action: 'token-info',
+      client_ip: '203.0.113.1',
+      reason: 'binding_error',
+    });
+    warnSpy.mockRestore();
   });
   it('fails open and logs when the daily quota DO is unavailable', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -659,6 +659,18 @@ describe('daily quota and abuse gate', () => {
       name: 'out-of-range remaining',
       payload: { allowed: true, remaining: Number.MAX_SAFE_INTEGER, resetAt: Date.now() + 1000 },
     },
+    {
+      name: 'fractional remaining',
+      payload: { allowed: true, remaining: 0.5, resetAt: Date.now() + 1000 },
+    },
+    {
+      name: 'contradictory allowed state',
+      payload: { allowed: false, remaining: 3, resetAt: Date.now() + 1000 },
+    },
+    {
+      name: 'far-future resetAt',
+      payload: { allowed: false, remaining: 0, resetAt: Date.now() + 86400000 * 2 },
+    },
   ];
   for (const { name, payload } of malformedQuotaCases) {
     it(`treats a malformed daily quota DO payload (${name}) as unavailable and fails open`, async () => {

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -642,50 +642,70 @@ describe('daily quota and abuse gate', () => {
     expect(warnLog).not.toContain('203.0.113.1');
     warnSpy.mockRestore();
   });
-  it('treats a malformed daily quota DO payload (missing allowed) as unavailable and fails open', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const rpcCalls: Array<Record<string, unknown>> = [];
-    const env: Env = {
-      API_GATEWAY_LIMITER: {
-        idFromName: (name: string) => name,
-        get: () => ({
-          fetch: async () =>
-            new Response(JSON.stringify({ allowed: true, remaining: 5 }), {
-              status: 200,
-              headers: { 'content-type': 'application/json' },
-            }),
+  const malformedQuotaCases: Array<{ name: string; payload: Record<string, unknown> }> = [
+    {
+      name: 'missing allowed',
+      payload: { remaining: 5, resetAt: Date.now() + 1000 },
+    },
+    {
+      name: 'missing resetAt',
+      payload: { allowed: true, remaining: 5 },
+    },
+    {
+      name: 'expired resetAt',
+      payload: { allowed: false, remaining: 0, resetAt: Date.now() - 1000 },
+    },
+    {
+      name: 'out-of-range remaining',
+      payload: { allowed: true, remaining: Number.MAX_SAFE_INTEGER, resetAt: Date.now() + 1000 },
+    },
+  ];
+  for (const { name, payload } of malformedQuotaCases) {
+    it(`treats a malformed daily quota DO payload (${name}) as unavailable and fails open`, async () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const rpcCalls: Array<Record<string, unknown>> = [];
+      const env: Env = {
+        API_GATEWAY_LIMITER: {
+          idFromName: (key: string) => key,
+          get: () => ({
+            fetch: async () =>
+              new Response(JSON.stringify(payload), {
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+              }),
+          }),
+        } as unknown as Env['API_GATEWAY_LIMITER'],
+        SUPABASE_URL: 'https://supabase.example',
+        SUPABASE_ANON_KEY: 'anon',
+        SUPABASE_SERVICE_ROLE_KEY: 'service',
+        ALLOWED_ORIGIN: '*',
+      };
+      vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free', rpcCalls }));
+      const res = await worker.fetch(
+        buildRequest('/token', {
+          method: 'GET',
+          headers: { Authorization: 'Bearer PVP_abc123' },
         }),
-      } as unknown as Env['API_GATEWAY_LIMITER'],
-      SUPABASE_URL: 'https://supabase.example',
-      SUPABASE_ANON_KEY: 'anon',
-      SUPABASE_SERVICE_ROLE_KEY: 'service',
-      ALLOWED_ORIGIN: '*',
-    };
-    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free', rpcCalls }));
-    const res = await worker.fetch(
-      buildRequest('/token', {
-        method: 'GET',
-        headers: { Authorization: 'Bearer PVP_abc123' },
-      }),
-      env
-    );
-    expect(res.status).toBe(200);
-    await flushAsync();
-    expect(rpcCalls).toHaveLength(1);
-    expect(rpcCalls[0]).toMatchObject({ p_user_id: 'user-free', p_throttled: 0, p_reads: 1 });
-    const warnLog = warnSpy.mock.calls
-      .map((c) => String(c[0]))
-      .find((s) => s.includes('daily_quota_unavailable'));
-    expect(warnLog).toBeDefined();
-    expect(JSON.parse(warnLog!)).toMatchObject({
-      event: 'daily_quota_unavailable',
-      action: 'token-info',
-      user_id: 'user-free',
-      token_id: 'token-1',
-      reason: 'bad_json',
+        env
+      );
+      expect(res.status).toBe(200);
+      await flushAsync();
+      expect(rpcCalls).toHaveLength(1);
+      expect(rpcCalls[0]).toMatchObject({ p_user_id: 'user-free', p_throttled: 0, p_reads: 1 });
+      const warnLog = warnSpy.mock.calls
+        .map((c) => String(c[0]))
+        .find((s) => s.includes('daily_quota_unavailable'));
+      expect(warnLog).toBeDefined();
+      expect(JSON.parse(warnLog!)).toMatchObject({
+        event: 'daily_quota_unavailable',
+        action: 'token-info',
+        user_id: 'user-free',
+        token_id: 'token-1',
+        reason: 'bad_json',
+      });
+      warnSpy.mockRestore();
     });
-    warnSpy.mockRestore();
-  });
+  }
   it('fails open and logs when the daily quota DO is unavailable', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const rpcCalls: Array<Record<string, unknown>> = [];

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -642,7 +642,7 @@ describe('daily quota and abuse gate', () => {
     expect(warnLog).not.toContain('203.0.113.1');
     warnSpy.mockRestore();
   });
-  it('treats a malformed daily quota DO payload as unavailable and fails open', async () => {
+  it('treats a malformed daily quota DO payload (missing allowed) as unavailable and fails open', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const rpcCalls: Array<Record<string, unknown>> = [];
     const env: Env = {
@@ -650,7 +650,7 @@ describe('daily quota and abuse gate', () => {
         idFromName: (name: string) => name,
         get: () => ({
           fetch: async () =>
-            new Response(JSON.stringify({ remaining: 5, resetAt: Date.now() + 1000 }), {
+            new Response(JSON.stringify({ allowed: true, remaining: 5 }), {
               status: 200,
               headers: { 'content-type': 'application/json' },
             }),

--- a/workers/api-gateway/src/__tests__/rate-limits.test.ts
+++ b/workers/api-gateway/src/__tests__/rate-limits.test.ts
@@ -150,93 +150,6 @@ describe('ApiGatewayRateLimiter durable object', () => {
     expect(afterMidnight.allowed).toBe(true);
     expect(afterMidnight.resetAt).toBe(Date.parse('2026-07-07T00:00:00Z'));
   });
-  it('sliding mode frees capacity as old requests age out', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-07-05T12:00:00Z'));
-    const limiter = new ApiGatewayRateLimiter(makeState());
-    const payload = { limit: 3, windowSec: 60, mode: 'sliding' };
-    for (let i = 0; i < 3; i++) {
-      const res = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-        allowed: boolean;
-      };
-      expect(res.allowed).toBe(true);
-    }
-    const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-    };
-    expect(blocked.allowed).toBe(false);
-    vi.setSystemTime(new Date('2026-07-05T12:00:30Z'));
-    const stillBlocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-    };
-    expect(stillBlocked.allowed).toBe(false);
-    vi.setSystemTime(new Date('2026-07-05T12:01:01Z'));
-    const allowedAgain = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-      remaining: number;
-    };
-    expect(allowedAgain.allowed).toBe(true);
-  });
-  it('refunds a consumed fixed-window slot on demand', async () => {
-    const limiter = new ApiGatewayRateLimiter(makeState());
-    const payload = { limit: 2, windowSec: 86400, anchor: 'utc-day' };
-    await limiter.fetch(limiterRequest(payload));
-    await limiter.fetch(limiterRequest(payload));
-    const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-    };
-    expect(blocked.allowed).toBe(false);
-    await limiter.fetch(limiterRequest({ refund: true }));
-    const afterRefund = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-      remaining: number;
-    };
-    expect(afterRefund.allowed).toBe(true);
-    expect(afterRefund.remaining).toBe(0);
-  });
-  it('does not refund across a UTC-day rollover when resetAt no longer matches', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-07-05T23:59:58Z'));
-    const limiter = new ApiGatewayRateLimiter(makeState());
-    const payload = { limit: 1, windowSec: 86400, anchor: 'utc-day' };
-    const consumed = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-      resetAt: number;
-    };
-    expect(consumed.allowed).toBe(true);
-    expect(consumed.resetAt).toBe(Date.parse('2026-07-06T00:00:00Z'));
-    // Roll into the next UTC day and consume the new window's only slot.
-    vi.setSystemTime(new Date('2026-07-06T00:00:02Z'));
-    const newDay = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-      resetAt: number;
-    };
-    expect(newDay.allowed).toBe(true);
-    expect(newDay.resetAt).toBe(Date.parse('2026-07-07T00:00:00Z'));
-    // A delayed refund for the previous day must not steal the new day's slot.
-    await limiter.fetch(limiterRequest({ refund: true, resetAt: consumed.resetAt }));
-    const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-    };
-    expect(blocked.allowed).toBe(false);
-    vi.useRealTimers();
-  });
-  it('still refunds when resetAt matches the current window', async () => {
-    const limiter = new ApiGatewayRateLimiter(makeState());
-    const payload = { limit: 1, windowSec: 86400, anchor: 'utc-day' };
-    const consumed = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-      resetAt: number;
-    };
-    expect(consumed.allowed).toBe(true);
-    await limiter.fetch(limiterRequest({ refund: true, resetAt: consumed.resetAt }));
-    const afterRefund = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-      allowed: boolean;
-      remaining: number;
-    };
-    expect(afterRefund.allowed).toBe(true);
-    expect(afterRefund.remaining).toBe(0);
-  });
   it('keeps legacy fixed-window behavior for payloads without mode or anchor', async () => {
     const limiter = new ApiGatewayRateLimiter(makeState());
     const payload = { limit: 2, windowSec: 60 };
@@ -251,65 +164,6 @@ describe('ApiGatewayRateLimiter durable object', () => {
       allowed: boolean;
     };
     expect(blocked.allowed).toBe(false);
-  });
-  it('refunds a sliding-window slot by removing the consumedAt timestamp', async () => {
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(new Date('2026-07-05T12:00:00Z'));
-      const limiter = new ApiGatewayRateLimiter(makeState());
-      const payload = { limit: 2, windowSec: 60, mode: 'sliding' };
-      const first = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-        allowed: boolean;
-        remaining: number;
-        consumedAt: number;
-      };
-      expect(first.allowed).toBe(true);
-      expect(first.consumedAt).toBeDefined();
-      const second = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-        allowed: boolean;
-        remaining: number;
-        consumedAt: number;
-      };
-      expect(second.allowed).toBe(true);
-      const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-        allowed: boolean;
-      };
-      expect(blocked.allowed).toBe(false);
-      // Refund the first slot using its consumedAt timestamp.
-      await limiter.fetch(limiterRequest({ refund: true, consumedAt: first.consumedAt }));
-      const afterRefund = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-        allowed: boolean;
-        remaining: number;
-      };
-      expect(afterRefund.allowed).toBe(true);
-      expect(afterRefund.remaining).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-  it('does not refund a sliding-window slot when consumedAt is missing', async () => {
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(new Date('2026-07-05T12:00:00Z'));
-      const limiter = new ApiGatewayRateLimiter(makeState());
-      const payload = { limit: 1, windowSec: 60, mode: 'sliding' };
-      const consumed = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-        allowed: boolean;
-      };
-      expect(consumed.allowed).toBe(true);
-      const blocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-        allowed: boolean;
-      };
-      expect(blocked.allowed).toBe(false);
-      // Refund without consumedAt should be a no-op for sliding windows.
-      await limiter.fetch(limiterRequest({ refund: true }));
-      const stillBlocked = (await (await limiter.fetch(limiterRequest(payload))).json()) as {
-        allowed: boolean;
-      };
-      expect(stillBlocked.allowed).toBe(false);
-    } finally {
-      vi.useRealTimers();
-    }
   });
   it('treats expired fixed-window persisted state as absent on load', async () => {
     vi.useFakeTimers();
@@ -332,81 +186,7 @@ describe('ApiGatewayRateLimiter durable object', () => {
       vi.useRealTimers();
     }
   });
-  it('treats expired sliding-window persisted state as absent on load', async () => {
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(new Date('2026-07-05T12:00:00Z'));
-      const state = makeState();
-      await state.storage.put('state', {
-        count: 3,
-        resetAt: Date.parse('2026-07-05T11:59:00Z'),
-        windowSec: 60,
-        mode: 'sliding',
-        timestamps: [Date.parse('2026-07-05T11:58:00Z')],
-      });
-      const limiter = new ApiGatewayRateLimiter(state);
-      const res = (await (
-        await limiter.fetch(limiterRequest({ limit: 3, windowSec: 60, mode: 'sliding' }))
-      ).json()) as { allowed: boolean; remaining: number };
-      expect(res.allowed).toBe(true);
-      expect(res.remaining).toBe(2);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-  it('prunes expired timestamps from a sliding window with mixed entries', async () => {
-    vi.useFakeTimers();
-    try {
-      const baseTime = new Date('2026-07-05T12:00:00Z');
-      vi.setSystemTime(baseTime);
-      const state = makeState();
-      const expiredTs = Date.parse('2026-07-05T11:58:30Z');
-      const validTs = Date.parse('2026-07-05T11:59:30Z');
-      await state.storage.put('state', {
-        count: 2,
-        resetAt: validTs + 60_000,
-        windowSec: 60,
-        mode: 'sliding',
-        timestamps: [expiredTs, validTs],
-      });
-      const limiter = new ApiGatewayRateLimiter(state);
-      const res = (await (
-        await limiter.fetch(limiterRequest({ limit: 2, windowSec: 60, mode: 'sliding' }))
-      ).json()) as { allowed: boolean; remaining: number };
-      expect(res.allowed).toBe(true);
-      expect(res.remaining).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-  it('keeps younger sliding hits when stored resetAt has already elapsed', async () => {
-    vi.useFakeTimers();
-    try {
-      // resetAt = oldest + window. At cold load the oldest is past cutoff but
-      // two younger hits remain; discarding whole state would under-enforce.
-      vi.setSystemTime(new Date('2026-07-05T12:00:00.100Z'));
-      const state = makeState();
-      const olderTs = Date.parse('2026-07-05T11:59:00Z');
-      const midTs = Date.parse('2026-07-05T11:59:20Z');
-      const youngerTs = Date.parse('2026-07-05T11:59:40Z');
-      await state.storage.put('state', {
-        count: 3,
-        resetAt: olderTs + 60_000,
-        windowSec: 60,
-        mode: 'sliding',
-        timestamps: [olderTs, midTs, youngerTs],
-      });
-      const limiter = new ApiGatewayRateLimiter(state);
-      const res = (await (
-        await limiter.fetch(limiterRequest({ limit: 2, windowSec: 60, mode: 'sliding' }))
-      ).json()) as { allowed: boolean; remaining: number };
-      expect(res.allowed).toBe(false);
-      expect(res.remaining).toBe(0);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-  it('handles config change from sliding to fixed-window on expired state', async () => {
+  it('treats legacy sliding-window state as a config change and starts a fresh fixed window', async () => {
     vi.useFakeTimers();
     try {
       vi.setSystemTime(new Date('2026-07-05T12:00:00Z'));
@@ -441,17 +221,10 @@ describe('ApiGatewayRateLimiter durable object', () => {
     const state = makeState();
     const setAlarmSpy = vi.spyOn(state.storage, 'setAlarm');
     const limiter = new ApiGatewayRateLimiter(state);
-    await limiter.fetch(limiterRequest({ limit: 5, windowSec: 60, mode: 'sliding', retain: true }));
     await limiter.fetch(
       limiterRequest({ limit: 5, windowSec: 60, anchor: 'utc-day', retain: true })
     );
-    await limiter.fetch(limiterRequest({ limit: 1, windowSec: 60, mode: 'sliding', retain: true }));
-    const throttled = (await (
-      await limiter.fetch(
-        limiterRequest({ limit: 1, windowSec: 60, mode: 'sliding', retain: true })
-      )
-    ).json()) as { allowed: boolean };
-    expect(throttled.allowed).toBe(false);
+    await limiter.fetch(limiterRequest({ limit: 5, windowSec: 60, retain: true }));
     expect(setAlarmSpy).not.toHaveBeenCalled();
   });
   it('schedules cleanup alarm by default when retain is omitted', async () => {
@@ -468,59 +241,6 @@ describe('ApiGatewayRateLimiter durable object', () => {
       expect(setAlarmSpy).toHaveBeenCalledWith(body.resetAt + 1000);
       const stored = await state.storage.get<RateLimitState>('state');
       expect(stored?.ephemeral).toBe(true);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-  it('schedules cleanup alarm for default sliding-window requests', async () => {
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(new Date('2026-07-05T12:00:00Z'));
-      const state = makeState();
-      const setAlarmSpy = vi.spyOn(state.storage, 'setAlarm');
-      const limiter = new ApiGatewayRateLimiter(state);
-      const res = await limiter.fetch(limiterRequest({ limit: 5, windowSec: 60, mode: 'sliding' }));
-      const body = (await res.json()) as { allowed: boolean; resetAt: number };
-      expect(body.allowed).toBe(true);
-      expect(setAlarmSpy).toHaveBeenCalledTimes(1);
-      expect(setAlarmSpy).toHaveBeenCalledWith(body.resetAt + 1000);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-  it('schedules cleanup alarm for default fixed-window requests', async () => {
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(new Date('2026-07-05T12:00:00Z'));
-      const state = makeState();
-      const setAlarmSpy = vi.spyOn(state.storage, 'setAlarm');
-      const limiter = new ApiGatewayRateLimiter(state);
-      const res = await limiter.fetch(limiterRequest({ limit: 5, windowSec: 60 }));
-      const body = (await res.json()) as { allowed: boolean; resetAt: number };
-      expect(body.allowed).toBe(true);
-      expect(setAlarmSpy).toHaveBeenCalledTimes(1);
-      expect(setAlarmSpy).toHaveBeenCalledWith(body.resetAt + 1000);
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-  it('keeps cleanup alarm scheduled on throttled sliding-window deny path', async () => {
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(new Date('2026-07-05T12:00:00Z'));
-      const state = makeState();
-      const limiter = new ApiGatewayRateLimiter(state);
-      const payload = { limit: 1, windowSec: 60, mode: 'sliding' };
-      const first = await limiter.fetch(limiterRequest(payload));
-      const firstBody = (await first.json()) as { allowed: boolean; resetAt: number };
-      expect(firstBody.allowed).toBe(true);
-      const alarmAfterAllow = await state.storage.getAlarm();
-      expect(alarmAfterAllow).toBe(firstBody.resetAt + 1000);
-      const throttled = await limiter.fetch(limiterRequest(payload));
-      const body = (await throttled.json()) as { allowed: boolean; resetAt: number };
-      expect(body.allowed).toBe(false);
-      const alarmAfterDeny = await state.storage.getAlarm();
-      expect(alarmAfterDeny).toBe(body.resetAt + 1000);
     } finally {
       vi.useRealTimers();
     }
@@ -565,37 +285,6 @@ describe('ApiGatewayRateLimiter durable object', () => {
       const limiter = new ApiGatewayRateLimiter(state);
       await limiter.alarm();
       expect(setAlarmSpy).toHaveBeenCalledWith(resetAt + 1000);
-      const stored = await state.storage.get<RateLimitState>('state');
-      expect(stored).toBeDefined();
-    } finally {
-      vi.useRealTimers();
-    }
-  });
-  it('alarm keeps younger sliding hits when stored resetAt has already elapsed', async () => {
-    vi.useFakeTimers();
-    try {
-      vi.setSystemTime(new Date('2026-07-05T12:00:00.100Z'));
-      const state = makeState();
-      const olderTs = Date.parse('2026-07-05T11:59:00Z');
-      const midTs = Date.parse('2026-07-05T11:59:20Z');
-      const youngerTs = Date.parse('2026-07-05T11:59:40Z');
-      const staleResetAt = olderTs + 60_000;
-      await state.storage.put('state', {
-        count: 3,
-        resetAt: staleResetAt,
-        windowSec: 60,
-        mode: 'sliding',
-        timestamps: [olderTs, midTs, youngerTs],
-        ephemeral: true,
-      });
-      const deleteAlarmSpy = vi.spyOn(state.storage, 'deleteAlarm');
-      const deleteAllSpy = vi.spyOn(state.storage, 'deleteAll');
-      const setAlarmSpy = vi.spyOn(state.storage, 'setAlarm');
-      const limiter = new ApiGatewayRateLimiter(state);
-      await limiter.alarm();
-      expect(deleteAlarmSpy).not.toHaveBeenCalled();
-      expect(deleteAllSpy).not.toHaveBeenCalled();
-      expect(setAlarmSpy).toHaveBeenCalledWith(midTs + 60_000 + 1000);
       const stored = await state.storage.get<RateLimitState>('state');
       expect(stored).toBeDefined();
     } finally {
@@ -679,7 +368,7 @@ describe('ApiGatewayRateLimiter durable object', () => {
     }
   });
 });
-describe('tiered quotas in the worker', () => {
+describe('daily quota and abuse gate', () => {
   beforeEach(() => {
     deleteMemoryCache('tier:user-free');
     deleteMemoryCache('tier:user-scav');
@@ -688,7 +377,7 @@ describe('tiered quotas in the worker', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
   });
-  it('applies free-tier daily and burst limits keyed by user id', async () => {
+  it('applies free-tier daily limit keyed by user id (single DO call)', async () => {
     const calls: LimiterCall[] = [];
     const env: Env = {
       API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
@@ -707,19 +396,12 @@ describe('tiered quotas in the worker', () => {
       env
     );
     expect(res.status).toBe(200);
-    expect(calls).toHaveLength(2);
+    expect(calls).toHaveLength(1);
     expect(calls[0].key).toBe('daily-read:user-free');
     expect(calls[0].body).toMatchObject({
       limit: TIER_LIMITS.free.readsPerDay,
       windowSec: 86400,
       anchor: 'utc-day',
-      retain: true,
-    });
-    expect(calls[1].key).toBe('burst-read:user-free');
-    expect(calls[1].body).toMatchObject({
-      limit: TIER_LIMITS.free.burstPerMinute,
-      windowSec: 60,
-      mode: 'sliding',
       retain: true,
     });
   });
@@ -750,14 +432,13 @@ describe('tiered quotas in the worker', () => {
     expect(res.status).toBe(200);
     expect(res.headers.get('X-RateLimit-Limit')).toBe(String(TIER_LIMITS.chad.readsPerDay));
     expect(calls[0].body).toMatchObject({ limit: TIER_LIMITS.chad.readsPerDay });
-    expect(calls[1].body).toMatchObject({ limit: TIER_LIMITS.chad.burstPerMinute });
   });
   it('returns an upgrade message when a free user exhausts the daily quota', async () => {
     const calls: LimiterCall[] = [];
     const rpcCalls: Array<Record<string, unknown>> = [];
     const env: Env = {
-      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, (call) => ({
-        allowed: !String(call.key).startsWith('daily-'),
+      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
+        allowed: false,
         remaining: 0,
         resetAt: Date.now() + 1000,
       })),
@@ -780,46 +461,6 @@ describe('tiered quotas in the worker', () => {
     await flushAsync();
     expect(rpcCalls).toHaveLength(1);
     expect(rpcCalls[0]).toMatchObject({ p_user_id: 'user-free', p_throttled: 1, p_reads: 0 });
-  });
-  it('rejects inherited object keys as tiers', () => {
-    expect(isKnownTier('__proto__')).toBe(false);
-    expect(isKnownTier('constructor')).toBe(false);
-    expect(isKnownTier('chad')).toBe(true);
-  });
-  it('refunds the daily slot and returns daily headers when burst throttles', async () => {
-    const calls: LimiterCall[] = [];
-    const burstResetAt = Date.now() + 30_000;
-    const env: Env = {
-      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, (call) => {
-        if (call.body.refund === true) {
-          return { allowed: true, remaining: 0, resetAt: burstResetAt };
-        }
-        if (String(call.key).startsWith('burst-')) {
-          return { allowed: false, remaining: 0, resetAt: burstResetAt };
-        }
-        return { allowed: true, remaining: 5, resetAt: Date.now() + 1000 };
-      }),
-      SUPABASE_URL: 'https://supabase.example',
-      SUPABASE_ANON_KEY: 'anon',
-      SUPABASE_SERVICE_ROLE_KEY: 'service',
-      ALLOWED_ORIGIN: '*',
-    };
-    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
-    const res = await worker.fetch(
-      buildRequest('/token', { method: 'GET', headers: { Authorization: 'Bearer PVP_abc123' } }),
-      env
-    );
-    expect(res.status).toBe(429);
-    // X-RateLimit-* reflects the daily quota; remaining includes the refunded slot.
-    expect(res.headers.get('X-RateLimit-Limit')).toBe(String(TIER_LIMITS.free.readsPerDay));
-    expect(res.headers.get('X-RateLimit-Remaining')).toBe('6');
-    const retryAfter = Number(res.headers.get('Retry-After'));
-    expect(retryAfter).toBeGreaterThan(0);
-    expect(retryAfter).toBeLessThanOrEqual(31);
-    await flushAsync();
-    const refunds = calls.filter((call) => call.body.refund === true);
-    expect(refunds).toHaveLength(1);
-    expect(refunds[0].key).toBe('daily-read:user-free');
   });
   it('records successful usage through the record_api_usage rpc', async () => {
     const calls: LimiterCall[] = [];
@@ -856,58 +497,27 @@ describe('tiered quotas in the worker', () => {
       p_user_agent: 'TestClient/1.0',
     });
   });
-  it('checks the per-IP backstop when CF-Connecting-IP is present', async () => {
+  it('rejects inherited object keys as tiers', () => {
+    expect(isKnownTier('__proto__')).toBe(false);
+    expect(isKnownTier('constructor')).toBe(false);
+    expect(isKnownTier('chad')).toBe(true);
+  });
+  it('returns 429 when the IP abuse gate limit is exceeded', async () => {
     const calls: LimiterCall[] = [];
+    const abuseLimit = vi.fn().mockResolvedValue({ success: false });
     const env: Env = {
       API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
         allowed: true,
         remaining: 5,
         resetAt: Date.now() + 1000,
       })),
+      API_ABUSE_LIMITER: { limit: abuseLimit } as unknown as RateLimit,
       SUPABASE_URL: 'https://supabase.example',
       SUPABASE_ANON_KEY: 'anon',
       SUPABASE_SERVICE_ROLE_KEY: 'service',
       ALLOWED_ORIGIN: '*',
     };
     vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
-    const res = await worker.fetch(
-      buildRequest('/token', {
-        method: 'GET',
-        headers: { Authorization: 'Bearer PVP_abc123', 'CF-Connecting-IP': '203.0.113.1' },
-      }),
-      env
-    );
-    expect(res.status).toBe(200);
-    const ipCall = calls.find((c) => c.key.startsWith('ip-read:'));
-    expect(ipCall).toBeDefined();
-    expect(ipCall?.body).toMatchObject({ mode: 'sliding', windowSec: 3600 });
-  });
-  it('returns 429 and refunds daily+burst when the per-IP backstop trips', async () => {
-    const calls: LimiterCall[] = [];
-    const rpcCalls: Array<Record<string, unknown>> = [];
-    const ipResetAt = Date.now() + 1800_000;
-    const burstConsumedAt = Date.now();
-    const env: Env = {
-      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, (call) => {
-        if (call.body.refund === true) {
-          return { allowed: true, remaining: 0, resetAt: ipResetAt };
-        }
-        if (String(call.key).startsWith('ip-')) {
-          return { allowed: false, remaining: 0, resetAt: ipResetAt };
-        }
-        return {
-          allowed: true,
-          remaining: 5,
-          resetAt: Date.now() + 1000,
-          consumedAt: burstConsumedAt,
-        };
-      }),
-      SUPABASE_URL: 'https://supabase.example',
-      SUPABASE_ANON_KEY: 'anon',
-      SUPABASE_SERVICE_ROLE_KEY: 'service',
-      ALLOWED_ORIGIN: '*',
-    };
-    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free', rpcCalls }));
     const res = await worker.fetch(
       buildRequest('/token', {
         method: 'GET',
@@ -916,43 +526,43 @@ describe('tiered quotas in the worker', () => {
       env
     );
     expect(res.status).toBe(429);
-    const retryAfter = Number(res.headers.get('Retry-After'));
-    expect(retryAfter).toBeGreaterThan(0);
-    await flushAsync();
-    const refunds = calls.filter((c) => c.body.refund === true);
-    expect(refunds).toHaveLength(2);
-    expect(refunds.some((r) => r.key === 'daily-read:user-free')).toBe(true);
-    const burstRefund = refunds.find((r) => r.key === 'burst-read:user-free');
-    expect(burstRefund).toBeDefined();
-    expect(burstRefund?.body.consumedAt).toBe(burstConsumedAt);
-    expect(rpcCalls).toHaveLength(1);
-    expect(rpcCalls[0]).toMatchObject({ p_user_id: 'user-free', p_throttled: 1, p_reads: 0 });
+    expect(abuseLimit).toHaveBeenCalledWith({ key: 'api:203.0.113.1' });
+    // No DO calls — abuse gate rejects before token validation.
+    expect(calls).toHaveLength(0);
   });
-  it('fails open when the per-IP backstop limiter is unavailable (503)', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  it('skips the abuse gate when the binding is absent', async () => {
     const calls: LimiterCall[] = [];
+    const env: Env = {
+      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
+        allowed: true,
+        remaining: 5,
+        resetAt: Date.now() + 1000,
+      })),
+      SUPABASE_URL: 'https://supabase.example',
+      SUPABASE_ANON_KEY: 'anon',
+      SUPABASE_SERVICE_ROLE_KEY: 'service',
+      ALLOWED_ORIGIN: '*',
+    };
+    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
+    const res = await worker.fetch(
+      buildRequest('/token', {
+        method: 'GET',
+        headers: { Authorization: 'Bearer PVP_abc123', 'CF-Connecting-IP': '203.0.113.1' },
+      }),
+      env
+    );
+    expect(res.status).toBe(200);
+    expect(calls).toHaveLength(1);
+    expect(calls[0].key).toBe('daily-read:user-free');
+  });
+  it('fails open and logs when the daily quota DO is unavailable', async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
     const rpcCalls: Array<Record<string, unknown>> = [];
-    // Custom limiter: IP-keyed DOs return HTTP 500 (non-OK) so rateLimit
-    // produces status 503; all other keys behave normally.
     const env: Env = {
       API_GATEWAY_LIMITER: {
         idFromName: (name: string) => name,
-        get: (id: unknown) => ({
-          fetch: async (_url: string, init?: RequestInit) => {
-            const call: LimiterCall = {
-              key: String(id),
-              body: JSON.parse(String(init?.body || '{}')),
-            };
-            calls.push(call);
-            if (String(id).startsWith('ip-')) {
-              return new Response('Internal Error', { status: 500 });
-            }
-            return new Response(
-              JSON.stringify({ allowed: true, remaining: 5, resetAt: Date.now() + 1000 }),
-              { status: 200, headers: { 'content-type': 'application/json' } }
-            );
-          },
+        get: () => ({
+          fetch: async () => new Response('Internal Error', { status: 500 }),
         }),
       } as unknown as Env['API_GATEWAY_LIMITER'],
       SUPABASE_URL: 'https://supabase.example',
@@ -964,250 +574,26 @@ describe('tiered quotas in the worker', () => {
     const res = await worker.fetch(
       buildRequest('/token', {
         method: 'GET',
-        headers: { Authorization: 'Bearer PVP_abc123', 'CF-Connecting-IP': '203.0.113.1' },
+        headers: { Authorization: 'Bearer PVP_abc123' },
       }),
       env
     );
-    // Request succeeds despite IP limiter being unavailable.
     expect(res.status).toBe(200);
     await flushAsync();
-    // No refund calls — the primary slots stay consumed because the request is served.
-    const refunds = calls.filter((c) => c.body.refund === true);
-    expect(refunds).toHaveLength(0);
-    // Primary daily and burst consumption remains in place (3 calls: daily, burst, ip).
-    expect(calls).toHaveLength(3);
-    expect(calls[0].key).toBe('daily-read:user-free');
-    expect(calls[1].key).toBe('burst-read:user-free');
-    expect(calls[2].key).toBe('ip-read:203.0.113.1');
-    // Usage tracked as non-throttled.
     expect(rpcCalls).toHaveLength(1);
     expect(rpcCalls[0]).toMatchObject({ p_user_id: 'user-free', p_throttled: 0, p_reads: 1 });
-    // No throttle log emitted for the infrastructure failure.
-    const throttleLog = logSpy.mock.calls
-      .map((c) => String(c[0]))
-      .find((s) => s.includes('rate_limit_429'));
-    expect(throttleLog).toBeUndefined();
-    // Availability warning emitted so the failure is observable.
     const warnLog = warnSpy.mock.calls
       .map((c) => String(c[0]))
-      .find((s) => s.includes('ip_backstop_unavailable'));
+      .find((s) => s.includes('daily_quota_unavailable'));
     expect(warnLog).toBeDefined();
     const parsed = JSON.parse(warnLog!);
     expect(parsed).toMatchObject({
-      event: 'ip_backstop_unavailable',
+      event: 'daily_quota_unavailable',
       action: 'token-info',
       user_id: 'user-free',
       token_id: 'token-1',
+      reason: 'http_status',
     });
-    // The warning must never leak the raw client IP or the ip_key (which
-    // embeds the raw IP). Only the HMAC-derived ip_hash is allowed.
-    expect(parsed.ip_key).toBeUndefined();
-    expect(parsed.ip_hash).toBeNull();
-    expect(warnLog).not.toContain('203.0.113.1');
     warnSpy.mockRestore();
-    logSpy.mockRestore();
-  });
-  it('ip_backstop_unavailable warning uses hashed IP when secret is set', async () => {
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const env: Env = {
-      API_GATEWAY_LIMITER: {
-        idFromName: (name: string) => name,
-        get: (id: unknown) => ({
-          fetch: async (_url: string, _init?: RequestInit) => {
-            const key = String(id);
-            if (key.startsWith('ip-')) {
-              return new Response('Internal Error', { status: 500 });
-            }
-            return new Response(
-              JSON.stringify({ allowed: true, remaining: 5, resetAt: Date.now() + 1000 }),
-              { status: 200, headers: { 'content-type': 'application/json' } }
-            );
-          },
-        }),
-      } as unknown as Env['API_GATEWAY_LIMITER'],
-      SUPABASE_URL: 'https://supabase.example',
-      SUPABASE_ANON_KEY: 'anon',
-      SUPABASE_SERVICE_ROLE_KEY: 'service',
-      ALLOWED_ORIGIN: '*',
-      IP_HASH_SECRET: 'test-secret',
-    };
-    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
-    const res = await worker.fetch(
-      buildRequest('/token', {
-        method: 'GET',
-        headers: { Authorization: 'Bearer PVP_abc123', 'CF-Connecting-IP': '203.0.113.1' },
-      }),
-      env
-    );
-    expect(res.status).toBe(200);
-    const warnLog = warnSpy.mock.calls
-      .map((c) => String(c[0]))
-      .find((s) => s.includes('ip_backstop_unavailable'));
-    expect(warnLog).toBeDefined();
-    const parsed = JSON.parse(warnLog!);
-    expect(parsed.ip_key).toBeUndefined();
-    expect(parsed.ip_hash).toMatch(/^[0-9a-f]{16}$/);
-    expect(warnLog).not.toContain('203.0.113.1');
-    warnSpy.mockRestore();
-    logSpy.mockRestore();
-  });
-  it('emits a structured 429 log line with hashed IP on daily throttle', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const calls: LimiterCall[] = [];
-    const env: Env = {
-      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, (call) => ({
-        allowed: !String(call.key).startsWith('daily-'),
-        remaining: 0,
-        resetAt: Date.now() + 1000,
-      })),
-      SUPABASE_URL: 'https://supabase.example',
-      SUPABASE_ANON_KEY: 'anon',
-      SUPABASE_SERVICE_ROLE_KEY: 'service',
-      ALLOWED_ORIGIN: '*',
-      IP_HASH_SECRET: 'test-secret',
-    };
-    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
-    await worker.fetch(
-      buildRequest('/token', {
-        method: 'GET',
-        headers: { Authorization: 'Bearer PVP_abc123', 'CF-Connecting-IP': '203.0.113.1' },
-      }),
-      env
-    );
-    const throttleLog = logSpy.mock.calls
-      .map((c) => String(c[0]))
-      .find((s) => s.includes('rate_limit_429'));
-    expect(throttleLog).toBeDefined();
-    const parsed = JSON.parse(throttleLog!);
-    expect(parsed).toMatchObject({
-      event: 'rate_limit_429',
-      action: 'token-info',
-      bucket: 'daily',
-      user_id: 'user-free',
-    });
-    expect(parsed.ip_hash).toMatch(/^[0-9a-f]{16}$/);
-    expect(parsed.token_id).toBe('token-1');
-    expect(parsed.token_suffix).toBeUndefined();
-    logSpy.mockRestore();
-  });
-  it('logs ip_hash as null when IP_HASH_SECRET is not set', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const calls: LimiterCall[] = [];
-    const env: Env = {
-      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, (call) => ({
-        allowed: !String(call.key).startsWith('daily-'),
-        remaining: 0,
-        resetAt: Date.now() + 1000,
-      })),
-      SUPABASE_URL: 'https://supabase.example',
-      SUPABASE_ANON_KEY: 'anon',
-      SUPABASE_SERVICE_ROLE_KEY: 'service',
-      ALLOWED_ORIGIN: '*',
-    };
-    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
-    await worker.fetch(
-      buildRequest('/token', {
-        method: 'GET',
-        headers: { Authorization: 'Bearer PVP_abc123', 'CF-Connecting-IP': '203.0.113.1' },
-      }),
-      env
-    );
-    const throttleLog = logSpy.mock.calls
-      .map((c) => String(c[0]))
-      .find((s) => s.includes('rate_limit_429'));
-    expect(throttleLog).toBeDefined();
-    const parsed = JSON.parse(throttleLog!);
-    expect(parsed.ip_hash).toBeNull();
-    logSpy.mockRestore();
-  });
-  it('emits a structured 429 log line with bucket=ip on IP backstop throttle', async () => {
-    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const calls: LimiterCall[] = [];
-    const ipResetAt = Date.now() + 1800_000;
-    const env: Env = {
-      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, (call) => {
-        if (call.body.refund === true) {
-          return { allowed: true, remaining: 0, resetAt: ipResetAt };
-        }
-        if (String(call.key).startsWith('ip-')) {
-          return { allowed: false, remaining: 0, resetAt: ipResetAt };
-        }
-        return { allowed: true, remaining: 5, resetAt: Date.now() + 1000 };
-      }),
-      SUPABASE_URL: 'https://supabase.example',
-      SUPABASE_ANON_KEY: 'anon',
-      SUPABASE_SERVICE_ROLE_KEY: 'service',
-      ALLOWED_ORIGIN: '*',
-      IP_HASH_SECRET: 'test-secret',
-    };
-    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
-    await worker.fetch(
-      buildRequest('/token', {
-        method: 'GET',
-        headers: { Authorization: 'Bearer PVP_abc123', 'CF-Connecting-IP': '203.0.113.1' },
-      }),
-      env
-    );
-    const throttleLog = logSpy.mock.calls
-      .map((c) => String(c[0]))
-      .find((s) => s.includes('rate_limit_429'));
-    expect(throttleLog).toBeDefined();
-    const parsed = JSON.parse(throttleLog!);
-    expect(parsed).toMatchObject({
-      event: 'rate_limit_429',
-      action: 'token-info',
-      bucket: 'ip',
-      user_id: 'user-free',
-    });
-    expect(parsed.ip_hash).toMatch(/^[0-9a-f]{16}$/);
-    expect(parsed.token_id).toBe('token-1');
-    expect(parsed.token_suffix).toBeUndefined();
-    logSpy.mockRestore();
-  });
-  it('does not check the per-IP backstop when no IP header is present', async () => {
-    const calls: LimiterCall[] = [];
-    const env: Env = {
-      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
-        allowed: true,
-        remaining: 5,
-        resetAt: Date.now() + 1000,
-      })),
-      SUPABASE_URL: 'https://supabase.example',
-      SUPABASE_ANON_KEY: 'anon',
-      SUPABASE_SERVICE_ROLE_KEY: 'service',
-      ALLOWED_ORIGIN: '*',
-    };
-    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
-    const res = await worker.fetch(
-      buildRequest('/token', { method: 'GET', headers: { Authorization: 'Bearer PVP_abc123' } }),
-      env
-    );
-    expect(res.status).toBe(200);
-    expect(calls.filter((c) => c.key.startsWith('ip-'))).toHaveLength(0);
-  });
-  it('does not check the per-IP backstop when only X-Forwarded-For is present', async () => {
-    const calls: LimiterCall[] = [];
-    const env: Env = {
-      API_GATEWAY_LIMITER: makeCapturingLimiter(calls, () => ({
-        allowed: true,
-        remaining: 5,
-        resetAt: Date.now() + 1000,
-      })),
-      SUPABASE_URL: 'https://supabase.example',
-      SUPABASE_ANON_KEY: 'anon',
-      SUPABASE_SERVICE_ROLE_KEY: 'service',
-      ALLOWED_ORIGIN: '*',
-    };
-    vi.stubGlobal('fetch', makeFetchMock({ userId: 'user-free' }));
-    const res = await worker.fetch(
-      buildRequest('/token', {
-        method: 'GET',
-        headers: { Authorization: 'Bearer PVP_abc123', 'X-Forwarded-For': '203.0.113.1' },
-      }),
-      env
-    );
-    expect(res.status).toBe(200);
-    expect(calls.filter((c) => c.key.startsWith('ip-'))).toHaveLength(0);
   });
 });

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -8,14 +8,7 @@ import {
 } from './handlers/progress';
 import { handleGetTeamProgress } from './handlers/team';
 import { handleGetToken } from './handlers/token';
-import {
-  BURST_WINDOW_SEC,
-  DAILY_WINDOW_SEC,
-  IP_BACKSTOP_LIMITS,
-  IP_BACKSTOP_WINDOW_SEC,
-  TIER_LIMITS,
-  upgradeMessage,
-} from './limits';
+import { ABUSE_GATE_PERIOD_SEC, DAILY_WINDOW_SEC, TIER_LIMITS, upgradeMessage } from './limits';
 import { OPENAPI_JSON } from './openapi';
 import { resolveTier } from './services/supporter';
 import { recordUsage } from './services/usage';
@@ -60,34 +53,33 @@ function normalizeTaskUpdates(body: unknown): BatchTaskUpdate[] | null {
 type Action = 'progress-read' | 'progress-write' | 'token-info';
 type UsageKind = 'read' | 'write';
 type RateLimitAnchor = 'utc-day';
-type RateLimitMode = 'sliding';
 type RateLimitOptions = {
   anchor?: RateLimitAnchor;
-  mode?: RateLimitMode;
 };
 export type RateLimitState = {
   count: number;
   resetAt: number;
   windowSec: number;
   anchor?: RateLimitAnchor;
-  mode?: RateLimitMode;
-  timestamps?: number[];
   ephemeral?: boolean;
 };
 type RateLimitResponse = {
   allowed: boolean;
   remaining: number;
   resetAt: number;
-  consumedAt?: number;
 };
+type LimiterUnavailableReason = 'http_status' | 'bad_json' | 'timeout' | 'fetch_error';
 type RateLimitResult = {
   allowed: boolean;
-  status?: number;
+  // Set when the limiter could not answer. Callers treat this as fail-open:
+  // the quota is a product entitlement, not a database-integrity boundary, and
+  // the pre-auth abuse gate still protects Supabase.
+  unavailable?: boolean;
+  reason?: LimiterUnavailableReason;
   message?: string;
   limit?: number;
   remaining?: number;
   resetAt?: number;
-  consumedAt?: number;
 };
 const RATE_LIMIT_TIMEOUT_MS = 3000;
 const RATE_LIMIT_SLOW_MS = 200;
@@ -113,19 +105,7 @@ export class ApiGatewayRateLimiter {
     try {
       const stored = await this.state.storage.get<RateLimitState>('state');
       this.loaded = true;
-      // Sliding-window resetAt is oldestTimestamp + windowMs, so it can elapse
-      // while younger timestamps are still inside the window. Keep sliding
-      // state for the fetch path to prune; only fixed windows may discard by
-      // resetAt alone.
-      if (stored) {
-        if (stored.mode === 'sliding' || Date.now() < stored.resetAt) {
-          this.data = stored;
-        } else {
-          this.data = undefined;
-        }
-      } else {
-        this.data = undefined;
-      }
+      this.data = stored && Date.now() < stored.resetAt ? stored : undefined;
     } catch (error) {
       logger.error('rate limiter storage load failed', { id: this.state.id.toString(), error });
       throw error;
@@ -139,10 +119,6 @@ export class ApiGatewayRateLimiter {
       limit?: number;
       windowSec?: number;
       anchor?: string;
-      mode?: string;
-      refund?: boolean;
-      resetAt?: number;
-      consumedAt?: number;
       retain?: boolean;
     };
     try {
@@ -150,55 +126,10 @@ export class ApiGatewayRateLimiter {
         limit?: number;
         windowSec?: number;
         anchor?: string;
-        mode?: string;
-        refund?: boolean;
-        resetAt?: number;
-        consumedAt?: number;
         retain?: boolean;
       };
     } catch {
       return new Response('Bad Request', { status: 400 });
-    }
-    if (payload.refund === true) {
-      // Return one previously consumed slot. For fixed-window buckets the
-      // caller passes the resetAt of the window it consumed from so a refund
-      // delayed past a UTC-day rollover cannot decrement the new day. For
-      // sliding-window buckets the caller passes the consumedAt timestamp so
-      // the exact entry can be removed from the log.
-      await this.load();
-      const now = Date.now();
-      if (
-        this.data &&
-        this.data.mode === 'sliding' &&
-        typeof payload.consumedAt === 'number' &&
-        Array.isArray(this.data.timestamps)
-      ) {
-        const idx = this.data.timestamps.indexOf(payload.consumedAt);
-        if (idx >= 0) {
-          this.data.timestamps.splice(idx, 1);
-          this.data.count = this.data.timestamps.length;
-          if (this.data.timestamps.length > 0) {
-            this.data.resetAt = this.data.timestamps[0] + this.data.windowSec * 1000;
-          } else {
-            this.data.resetAt = now + this.data.windowSec * 1000;
-          }
-          await this.state.storage.put('state', this.data);
-          await this.scheduleCleanup(this.data.resetAt);
-        }
-        return this.json({ allowed: true, remaining: 0, resetAt: this.data.resetAt });
-      }
-      const expectedResetAt = payload.resetAt;
-      if (
-        this.data &&
-        !this.data.mode &&
-        now < this.data.resetAt &&
-        this.data.count > 0 &&
-        (typeof expectedResetAt !== 'number' || this.data.resetAt === expectedResetAt)
-      ) {
-        this.data.count -= 1;
-        await this.state.storage.put('state', this.data);
-      }
-      return this.json({ allowed: true, remaining: 0, resetAt: this.data?.resetAt ?? now });
     }
     const limit = Number(payload.limit);
     const windowSec = Number(payload.windowSec);
@@ -207,7 +138,6 @@ export class ApiGatewayRateLimiter {
     }
     const anchor: RateLimitAnchor | undefined =
       payload.anchor === 'utc-day' ? 'utc-day' : undefined;
-    const mode: RateLimitMode | undefined = payload.mode === 'sliding' ? 'sliding' : undefined;
     // Cleanup is the default for high-cardinality callers (Pages, legacy, unknown).
     // Authenticated gateway quotas opt in to long retention via retain: true so a
     // Worker-first deploy never drops cleanup for keys that omit the flag.
@@ -215,51 +145,14 @@ export class ApiGatewayRateLimiter {
     await this.load();
     const now = Date.now();
     const windowMs = windowSec * 1000;
-    if (mode === 'sliding') {
-      // Sliding-window log: bounded by `limit` entries, so short bursts across
-      // a fixed-window boundary are not spuriously throttled.
-      const cutoff = now - windowMs;
-      const timestamps = (this.data?.timestamps ?? []).filter((ts) => ts > cutoff);
-      const resetAt = timestamps.length ? timestamps[0] + windowMs : now + windowMs;
-      if (timestamps.length >= limit) {
-        // Deny path: refresh in-memory state but skip the storage write. The
-        // pruned timestamps/resetAt are recomputed from storage on the next
-        // load, so persisting on every throttled hit would only add Durable
-        // Object write amplification under sustained bursts.
-        this.data = {
-          count: timestamps.length,
-          resetAt,
-          windowSec,
-          mode,
-          timestamps,
-          ...(ephemeral && { ephemeral: true }),
-        };
-        if (ephemeral) await this.scheduleCleanup(resetAt);
-        return this.json({ allowed: false, remaining: 0, resetAt });
-      }
-      timestamps.push(now);
-      this.data = {
-        count: timestamps.length,
-        resetAt: timestamps[0] + windowMs,
-        windowSec,
-        mode,
-        timestamps,
-        ...(ephemeral && { ephemeral: true }),
-      };
-      await this.state.storage.put('state', this.data);
-      if (ephemeral) await this.scheduleCleanup(this.data.resetAt);
-      return this.json({
-        allowed: true,
-        remaining: Math.max(limit - timestamps.length, 0),
-        resetAt: this.data.resetAt,
-        consumedAt: now,
-      });
-    }
+    // Sliding-window state written by earlier deployments carries `mode` and
+    // `timestamps`. It is treated as a config change and replaced with a fresh
+    // fixed window rather than migrated.
     const configChanged =
       !this.data ||
       this.data.windowSec !== windowSec ||
       this.data.anchor !== anchor ||
-      this.data.mode !== undefined;
+      'timestamps' in this.data;
     if (configChanged || now >= this.data!.resetAt) {
       const resetAt = anchor === 'utc-day' ? nextUtcMidnight(now) : now + windowMs;
       this.data = { count: 0, resetAt, windowSec, anchor, ...(ephemeral && { ephemeral: true }) };
@@ -300,33 +193,18 @@ export class ApiGatewayRateLimiter {
       await this.state.storage.setAlarm(cleanupAt);
     }
   }
-  private isStateActive(stored: RateLimitState, now: number): { active: boolean; resetAt: number } {
-    if (stored.mode === 'sliding') {
-      const windowMs = (stored.windowSec || 0) * 1000;
-      const cutoff = now - windowMs;
-      const timestamps = (stored.timestamps ?? []).filter((ts) => ts > cutoff);
-      if (!timestamps.length) {
-        return { active: false, resetAt: stored.resetAt };
-      }
-      return { active: true, resetAt: timestamps[0] + windowMs };
-    }
-    return { active: now < stored.resetAt, resetAt: stored.resetAt };
-  }
   async alarm(): Promise<void> {
     try {
       const stored = await this.state.storage.get<RateLimitState>('state');
       const now = Date.now();
-      if (stored) {
-        const { active, resetAt } = this.isStateActive(stored, now);
-        if (active) {
-          if (stored.ephemeral === true) {
-            await this.state.storage.setAlarm(resetAt + 1000);
-            return;
-          }
-          this.data = undefined;
-          this.loaded = false;
+      if (stored && now < stored.resetAt) {
+        if (stored.ephemeral === true) {
+          await this.state.storage.setAlarm(stored.resetAt + 1000);
           return;
         }
+        this.data = undefined;
+        this.loaded = false;
+        return;
       }
       this.data = undefined;
       this.loaded = false;
@@ -359,7 +237,6 @@ async function rateLimit(
         limit,
         windowSec,
         anchor: options?.anchor,
-        mode: options?.mode,
         retain: true,
       }),
       signal: controller.signal,
@@ -371,83 +248,56 @@ async function rateLimit(
     if (!res.ok) {
       return {
         allowed: false,
-        status: 503,
+        unavailable: true,
+        reason: 'http_status',
         message: 'Rate limiter unavailable',
       };
     }
-    let data: { allowed?: boolean; remaining?: number; resetAt?: number; consumedAt?: number } = {};
+    let data: { allowed?: boolean; remaining?: number; resetAt?: number } = {};
     try {
       data = (await res.json()) as {
         allowed?: boolean;
         remaining?: number;
         resetAt?: number;
-        consumedAt?: number;
       };
     } catch {
       return {
         allowed: false,
-        status: 503,
+        unavailable: true,
+        reason: 'bad_json',
         message: 'Rate limiter unavailable',
       };
     }
     const remaining = typeof data.remaining === 'number' ? data.remaining : undefined;
     const resetAt = typeof data.resetAt === 'number' ? data.resetAt : undefined;
-    const consumedAt = typeof data.consumedAt === 'number' ? data.consumedAt : undefined;
     if (data.allowed === false) {
       return {
         allowed: false,
-        status: 429,
         message: 'Rate limit exceeded',
         limit,
         remaining: remaining ?? 0,
         resetAt,
       };
     }
-    return { allowed: true, limit, remaining, resetAt, consumedAt };
+    return { allowed: true, limit, remaining, resetAt };
   } catch (error) {
     const durationMs = Date.now() - startedAt;
     if (error instanceof Error && error.name === 'AbortError') {
       console.warn('rateLimit timeout', { action, durationMs, timeoutMs: RATE_LIMIT_TIMEOUT_MS });
-    } else {
-      console.error('rateLimit error', { action, durationMs, error });
+      return {
+        allowed: false,
+        unavailable: true,
+        reason: 'timeout',
+        message: 'Rate limiter unavailable',
+      };
     }
+    console.error('rateLimit error', { action, durationMs, error });
     return {
       allowed: false,
-      status: 503,
+      unavailable: true,
+      reason: 'fetch_error',
       message: 'Rate limiter unavailable',
     };
-  } finally {
-    clearTimeout(timeout);
-  }
-}
-/**
- * Best-effort refund of one previously consumed slot. For fixed-window buckets
- * `consumedResetAt` is the resetAt of the window the slot was taken from; the
- * Durable Object only decrements when its current window still matches, so a
- * refund delayed past a UTC-day rollover cannot steal a slot from the new day.
- * For sliding-window buckets `consumedAt` is the timestamp of the entry to
- * remove from the log.
- */
-async function refundRateLimit(
-  env: Env,
-  key: string,
-  action: string,
-  consumedResetAt?: number,
-  consumedAt?: number
-): Promise<void> {
-  const id = env.API_GATEWAY_LIMITER.idFromName(key);
-  const stub = env.API_GATEWAY_LIMITER.get(id);
-  const controller = new AbortController();
-  const timeout = setTimeout(() => controller.abort(), RATE_LIMIT_TIMEOUT_MS);
-  try {
-    await stub.fetch('https://rate-limit', {
-      method: 'POST',
-      headers: { 'content-type': 'application/json' },
-      body: JSON.stringify({ refund: true, resetAt: consumedResetAt, consumedAt }),
-      signal: controller.signal,
-    });
-  } catch (error) {
-    console.warn('rateLimit refund failed', { action, error });
   } finally {
     clearTimeout(timeout);
   }
@@ -490,10 +340,6 @@ function rateLimitHeaders(rl: RateLimitResult): Record<string, string> {
     }
   }
   return headers;
-}
-function retryAfterS(rl: RateLimitResult): number | undefined {
-  if (typeof rl.resetAt !== 'number') return undefined;
-  return retryAfterSeconds(rl.resetAt);
 }
 function docsResponse(envOrigin?: string, requestOrigin?: string): Response {
   const html = `<!doctype html>
@@ -611,47 +457,6 @@ type AuthSuccess = {
   validation: { valid: true; token: ApiToken };
   rlHeaders: Record<string, string>;
 };
-type ThrottleBucket = 'daily' | 'burst' | 'ip';
-function resolveClientIp(request: Request): string | null {
-  const cfIp = request.headers.get('CF-Connecting-IP');
-  if (cfIp && cfIp.trim()) return cfIp.trim();
-  return null;
-}
-async function hashIp(ip: string, secret?: string): Promise<string | null> {
-  if (!secret) return null;
-  const key = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign']
-  );
-  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(ip));
-  return Array.from(new Uint8Array(sig))
-    .slice(0, 8)
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-}
-function logThrottle(
-  action: Action,
-  bucket: ThrottleBucket,
-  userId: string,
-  tokenId: string,
-  ipHash: string | null,
-  retryAfterS: number | undefined
-): void {
-  console.log(
-    JSON.stringify({
-      event: 'rate_limit_429',
-      action,
-      bucket,
-      user_id: userId,
-      token_id: tokenId,
-      ip_hash: ipHash,
-      retry_after_s: retryAfterS ?? null,
-    })
-  );
-}
 async function authenticateAndRateLimit(
   env: Env,
   request: Request,
@@ -663,6 +468,19 @@ async function authenticateAndRateLimit(
   ctx?: ExecutionContext,
   userAgent?: string | null
 ): Promise<AuthSuccess | Response> {
+  // Pre-authentication abuse gate: keyed on CF-Connecting-IP to shield
+  // the api_tokens lookup (and therefore Supabase) from token-rotation floods.
+  // Counters are per-Cloudflare-location and eventually consistent — this is
+  // infrastructure protection, not a customer quota.
+  const clientIp = request.headers.get('CF-Connecting-IP')?.trim() || null;
+  if (clientIp && env.API_ABUSE_LIMITER) {
+    const { success } = await env.API_ABUSE_LIMITER.limit({ key: `api:${clientIp}` });
+    if (!success) {
+      return errorResponse('Too many requests', 429, envOrigin, requestOrigin, {
+        'Retry-After': String(ABUSE_GATE_PERIOD_SEC),
+      });
+    }
+  }
   const validation = await validateToken(env, rawToken, permission);
   if (!validation.valid) {
     return errorResponse(validation.error, validation.status, envOrigin, requestOrigin);
@@ -672,7 +490,6 @@ async function authenticateAndRateLimit(
   const tier = await resolveTier(env, token.user_id);
   const limits = TIER_LIMITS[tier];
   const dailyLimit = kind === 'write' ? limits.writesPerDay : limits.readsPerDay;
-  const clientIp = resolveClientIp(request);
   const track = (throttled: boolean) => {
     const promise = recordUsage(env, {
       userId: token.user_id,
@@ -686,138 +503,34 @@ async function authenticateAndRateLimit(
       ctx.waitUntil(promise);
     }
   };
-  // Daily quota first, so a request rejected by the daily quota does not
-  // consume a burst slot. Both counters key on user_id so extra tokens do not
-  // multiply a user's quota.
+  // Daily quota: a single fixed-window DO call keyed by user_id so extra
+  // tokens do not multiply a user's quota. The quota counts authenticated
+  // requests admitted for processing — downstream Supabase failures do not
+  // trigger refunds (see docs/RATE_LIMITING.md).
   const dailyKey = `daily-${kind}:${token.user_id}`;
   const daily = await rateLimit(env, dailyKey, dailyLimit, DAILY_WINDOW_SEC, {
     anchor: 'utc-day',
   });
   const dailyHeaders = rateLimitHeaders(daily);
   if (!daily.allowed) {
-    track(true);
-    const ipHash = clientIp ? await hashIp(clientIp, env.IP_HASH_SECRET) : null;
-    logThrottle(action, 'daily', token.user_id, token.token_id, ipHash, retryAfterS(daily));
-    const message =
-      daily.status === 429 && tier === 'free'
-        ? upgradeMessage(kind)
-        : daily.message || 'Rate limit exceeded';
-    return errorResponse(message, daily.status || 429, envOrigin, requestOrigin, dailyHeaders);
-  }
-  const burst = await rateLimit(
-    env,
-    `burst-${kind}:${token.user_id}`,
-    limits.burstPerMinute,
-    BURST_WINDOW_SEC,
-    { mode: 'sliding' }
-  );
-  if (!burst.allowed) {
-    // Give back the daily slot consumed above so burst-throttled attempts do
-    // not drain the daily quota.
-    const refund = refundRateLimit(
-      env,
-      dailyKey,
-      `daily-${kind}`,
-      typeof daily.resetAt === 'number' ? daily.resetAt : undefined
-    );
-    if (ctx) ctx.waitUntil(refund);
-    track(true);
-    const ipHash = clientIp ? await hashIp(clientIp, env.IP_HASH_SECRET) : null;
-    logThrottle(action, 'burst', token.user_id, token.token_id, ipHash, retryAfterS(burst));
-    // X-RateLimit-* always describes the daily quota (see docs/API.md); adjust
-    // remaining for the refund. Retry-After reflects when burst capacity frees.
-    const headers = rateLimitHeaders({
-      ...daily,
-      remaining: typeof daily.remaining === 'number' ? daily.remaining + 1 : undefined,
-    });
-    if (typeof burst.resetAt === 'number') {
-      headers['Retry-After'] = String(retryAfterSeconds(burst.resetAt));
-    }
-    return errorResponse(
-      burst.message || 'Rate limit exceeded',
-      burst.status || 429,
-      envOrigin,
-      requestOrigin,
-      headers
-    );
-  }
-  // Per-IP backstop: catches "many accounts from one IP" abuse. Tuned
-  // generously (600 reads/hour, 200 writes/hour) so shared NAT users are not
-  // impacted. Uses a 1-hour sliding window. Only checked when CF-Connecting-IP
-  // is present (Cloudflare overwrites any inbound spoof).
-  //
-  // Availability policy: the daily and burst limiters are the primary rate
-  // limiting mechanism and remain fail-closed — if they are unavailable the
-  // request is rejected because there is no other protection. The IP backstop
-  // is a secondary abuse signal; when its Durable Object is unavailable
-  // (status 503) it fails open so a transient infrastructure issue does not
-  // take down the API for everyone behind a given IP. A genuine 429 from the
-  // IP backstop still rejects the request and refunds the primary slots.
-  if (clientIp) {
-    const ipLimit =
-      kind === 'write' ? IP_BACKSTOP_LIMITS.writesPerHour : IP_BACKSTOP_LIMITS.readsPerHour;
-    const ipKey = `ip-${kind}:${clientIp}`;
-    const ipResult = await rateLimit(env, ipKey, ipLimit, IP_BACKSTOP_WINDOW_SEC, {
-      mode: 'sliding',
-    });
-    if (!ipResult.allowed && ipResult.status !== 503) {
-      // Genuine IP throttle (429): refund both the daily (fixed-window) and
-      // burst (sliding-window) slots so IP-throttled requests do not drain
-      // per-user quotas.
-      const refundBurst = refundRateLimit(
-        env,
-        `burst-${kind}:${token.user_id}`,
-        `burst-${kind}`,
-        undefined,
-        burst.consumedAt
-      );
-      const refundDaily = refundRateLimit(
-        env,
-        dailyKey,
-        `daily-${kind}`,
-        typeof daily.resetAt === 'number' ? daily.resetAt : undefined
-      );
-      if (ctx) {
-        ctx.waitUntil(refundBurst);
-        ctx.waitUntil(refundDaily);
-      }
-      track(true);
-      const ipHash = await hashIp(clientIp, env.IP_HASH_SECRET);
-      logThrottle(action, 'ip', token.user_id, token.token_id, ipHash, retryAfterS(ipResult));
-      const headers = rateLimitHeaders({
-        ...daily,
-        remaining: typeof daily.remaining === 'number' ? daily.remaining + 1 : undefined,
-      });
-      if (typeof ipResult.resetAt === 'number') {
-        headers['Retry-After'] = String(retryAfterSeconds(ipResult.resetAt));
-      }
-      return errorResponse(
-        ipResult.message || 'Rate limit exceeded',
-        ipResult.status || 429,
-        envOrigin,
-        requestOrigin,
-        headers
-      );
-    }
-    if (!ipResult.allowed && ipResult.status === 503) {
-      // IP backstop limiter unavailable: fail open. The primary daily and
-      // burst checks already passed, so the request proceeds. Do not refund
-      // the primary slots (the request is being served) and do not surface
-      // the 503 to the client. Log a warning so the infrastructure failure
-      // remains observable and is not counted as a throttle. Log the hashed
-      // IP (never the raw CF-Connecting-IP) so the privacy control is
-      // consistent with the 429 path.
-      const ipHash = await hashIp(clientIp, env.IP_HASH_SECRET);
+    if (daily.unavailable) {
       console.warn(
         JSON.stringify({
-          event: 'ip_backstop_unavailable',
+          event: 'daily_quota_unavailable',
           action,
           user_id: token.user_id,
           token_id: token.token_id,
-          ip_hash: ipHash,
+          reason: daily.reason,
         })
       );
+      // Fail open: the daily quota is a product entitlement, not a
+      // database-integrity boundary. The abuse gate still protects Supabase.
+      track(false);
+      return { validation, rlHeaders: {} };
     }
+    track(true);
+    const message = tier === 'free' ? upgradeMessage(kind) : daily.message || 'Rate limit exceeded';
+    return errorResponse(message, 429, envOrigin, requestOrigin, dailyHeaders);
   }
   track(false);
   return { validation, rlHeaders: dailyHeaders };

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -270,6 +270,14 @@ async function rateLimit(
     }
     const remaining = typeof data.remaining === 'number' ? data.remaining : undefined;
     const resetAt = typeof data.resetAt === 'number' ? data.resetAt : undefined;
+    if (data.allowed !== true && data.allowed !== false) {
+      return {
+        allowed: false,
+        unavailable: true,
+        reason: 'bad_json',
+        message: 'Rate limiter unavailable',
+      };
+    }
     if (data.allowed === false) {
       return {
         allowed: false,
@@ -457,6 +465,27 @@ type AuthSuccess = {
   validation: { valid: true; token: ApiToken };
   rlHeaders: Record<string, string>;
 };
+async function hashIp(ip: string, secret?: string): Promise<string | null> {
+  if (!secret) return null;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign']
+  );
+  const sig = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(ip));
+  return Array.from(new Uint8Array(sig))
+    .slice(0, 8)
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+}
+function errorInfo(error: unknown): { error_name: string; error_message: string } {
+  if (error instanceof Error) {
+    return { error_name: error.name, error_message: error.message.slice(0, 200) };
+  }
+  return { error_name: typeof error, error_message: String(error).slice(0, 200) };
+}
 async function authenticateAndRateLimit(
   env: Env,
   request: Request,
@@ -477,17 +506,20 @@ async function authenticateAndRateLimit(
     // Fail open: the abuse gate is infrastructure protection for Supabase,
     // not a customer quota. A binding/runtime failure must not turn into a
     // 500 outage for valid requests — the daily quota still enforces the
-    // customer entitlement downstream.
+    // customer entitlement downstream. Log the HMAC-hashed IP only: raw IPs
+    // must never reach Worker logs (see docs/RATE_LIMITING.md).
+    const ipHash = await hashIp(clientIp, env.IP_HASH_SECRET);
     let abuseResult: { success: boolean } | null = null;
     try {
       abuseResult = await env.API_ABUSE_LIMITER.limit({ key: `api:${clientIp}` });
-    } catch {
+    } catch (error) {
       console.warn(
         JSON.stringify({
           event: 'abuse_gate_unavailable',
           action,
-          client_ip: clientIp,
+          ip_hash: ipHash,
           reason: 'binding_error',
+          ...errorInfo(error),
         })
       );
     }
@@ -496,7 +528,7 @@ async function authenticateAndRateLimit(
         JSON.stringify({
           event: 'abuse_gate_429',
           action,
-          client_ip: clientIp,
+          ip_hash: ipHash,
         })
       );
       return errorResponse('Too many requests', 429, envOrigin, requestOrigin, {
@@ -552,6 +584,16 @@ async function authenticateAndRateLimit(
       return { validation, rlHeaders: {} };
     }
     track(true);
+    console.warn(
+      JSON.stringify({
+        event: 'daily_quota_429',
+        action,
+        kind,
+        user_id: token.user_id,
+        token_id: token.token_id,
+        retry_after_s: typeof daily.resetAt === 'number' ? retryAfterSeconds(daily.resetAt) : null,
+      })
+    );
     const message = tier === 'free' ? upgradeMessage(kind) : daily.message || 'Rate limit exceeded';
     return errorResponse(message, 429, envOrigin, requestOrigin, dailyHeaders);
   }

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -270,7 +270,11 @@ async function rateLimit(
     }
     const remaining = typeof data.remaining === 'number' ? data.remaining : undefined;
     const resetAt = typeof data.resetAt === 'number' ? data.resetAt : undefined;
-    if (data.allowed !== true && data.allowed !== false) {
+    if (
+      (data.allowed !== true && data.allowed !== false) ||
+      !Number.isFinite(remaining) ||
+      !Number.isFinite(resetAt)
+    ) {
       return {
         allowed: false,
         unavailable: true,
@@ -508,7 +512,15 @@ async function authenticateAndRateLimit(
     // 500 outage for valid requests — the daily quota still enforces the
     // customer entitlement downstream. Log the HMAC-hashed IP only: raw IPs
     // must never reach Worker logs (see docs/RATE_LIMITING.md).
-    const ipHash = await hashIp(clientIp, env.IP_HASH_SECRET);
+    const getIpHash = (() => {
+      let cached: Promise<string | null> | null = null;
+      return () => {
+        if (!cached) {
+          cached = hashIp(clientIp, env.IP_HASH_SECRET).catch(() => null);
+        }
+        return cached;
+      };
+    })();
     let abuseResult: { success: boolean } | null = null;
     try {
       abuseResult = await env.API_ABUSE_LIMITER.limit({ key: `api:${clientIp}` });
@@ -517,7 +529,7 @@ async function authenticateAndRateLimit(
         JSON.stringify({
           event: 'abuse_gate_unavailable',
           action,
-          ip_hash: ipHash,
+          ip_hash: await getIpHash(),
           reason: 'binding_error',
           ...errorInfo(error),
         })
@@ -528,7 +540,7 @@ async function authenticateAndRateLimit(
         JSON.stringify({
           event: 'abuse_gate_429',
           action,
-          ip_hash: ipHash,
+          ip_hash: await getIpHash(),
         })
       );
       return errorResponse('Too many requests', 429, envOrigin, requestOrigin, {

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -270,15 +270,18 @@ async function rateLimit(
     }
     const remaining = typeof data.remaining === 'number' ? data.remaining : undefined;
     const resetAt = typeof data.resetAt === 'number' ? data.resetAt : undefined;
+    const now = Date.now();
     if (
       (data.allowed !== true && data.allowed !== false) ||
       remaining === undefined ||
-      !Number.isFinite(remaining) ||
+      !Number.isInteger(remaining) ||
       remaining < 0 ||
       remaining > limit ||
+      (data.allowed === false ? remaining !== 0 : remaining >= limit) ||
       resetAt === undefined ||
       !Number.isFinite(resetAt) ||
-      resetAt <= Date.now()
+      resetAt <= now ||
+      resetAt > now + windowSec * 1000
     ) {
       return {
         allowed: false,

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -272,8 +272,13 @@ async function rateLimit(
     const resetAt = typeof data.resetAt === 'number' ? data.resetAt : undefined;
     if (
       (data.allowed !== true && data.allowed !== false) ||
+      remaining === undefined ||
       !Number.isFinite(remaining) ||
-      !Number.isFinite(resetAt)
+      remaining < 0 ||
+      remaining > limit ||
+      resetAt === undefined ||
+      !Number.isFinite(resetAt) ||
+      resetAt <= Date.now()
     ) {
       return {
         allowed: false,

--- a/workers/api-gateway/src/index.ts
+++ b/workers/api-gateway/src/index.ts
@@ -474,8 +474,31 @@ async function authenticateAndRateLimit(
   // infrastructure protection, not a customer quota.
   const clientIp = request.headers.get('CF-Connecting-IP')?.trim() || null;
   if (clientIp && env.API_ABUSE_LIMITER) {
-    const { success } = await env.API_ABUSE_LIMITER.limit({ key: `api:${clientIp}` });
-    if (!success) {
+    // Fail open: the abuse gate is infrastructure protection for Supabase,
+    // not a customer quota. A binding/runtime failure must not turn into a
+    // 500 outage for valid requests — the daily quota still enforces the
+    // customer entitlement downstream.
+    let abuseResult: { success: boolean } | null = null;
+    try {
+      abuseResult = await env.API_ABUSE_LIMITER.limit({ key: `api:${clientIp}` });
+    } catch {
+      console.warn(
+        JSON.stringify({
+          event: 'abuse_gate_unavailable',
+          action,
+          client_ip: clientIp,
+          reason: 'binding_error',
+        })
+      );
+    }
+    if (abuseResult && !abuseResult.success) {
+      console.warn(
+        JSON.stringify({
+          event: 'abuse_gate_429',
+          action,
+          client_ip: clientIp,
+        })
+      );
       return errorResponse('Too many requests', 429, envOrigin, requestOrigin, {
         'Retry-After': String(ABUSE_GATE_PERIOD_SEC),
       });

--- a/workers/api-gateway/src/limits.ts
+++ b/workers/api-gateway/src/limits.ts
@@ -1,11 +1,8 @@
 export type ApiTier = 'free' | 'supporter' | 'scav' | 'timmy' | 'chad';
-
 export interface TierLimits {
   readsPerDay: number;
   writesPerDay: number;
-  burstPerMinute: number;
 }
-
 /**
  * Tiered API quotas (decision log):
  * Observed free-tier consumers reached ~1.4k requests/day, far above what a
@@ -14,34 +11,36 @@ export interface TierLimits {
  * wipe-to-Kappa run is ~400 task writes spread over weeks, so 100/day covers
  * normal play with batch updates counting as one write). Paid tiers scale
  * roughly 2x/3x/5x so upgrades map to the existing supporter tiers
- * (scav/timmy/chad in public.supporters). Burst limits keep the previous
- * per-minute ceilings but scale by tier and use a sliding window so a
- * TarkovMonitor batch right at a minute boundary is not spuriously throttled.
- * The legacy generic 'supporter' tier maps to scav-level limits.
+ * (scav/timmy/chad in public.supporters). The legacy generic 'supporter' tier
+ * maps to scav-level limits.
+ *
+ * Per-tier burst ceilings were removed: burst is now a flat infrastructure
+ * abuse gate (see ABUSE_GATE_*), not a per-tier entitlement. Supporter
+ * differentiation lives entirely in the daily read/write quotas.
  */
 export const TIER_LIMITS: Record<ApiTier, TierLimits> = {
-  free: { readsPerDay: 1000, writesPerDay: 100, burstPerMinute: 30 },
-  supporter: { readsPerDay: 2000, writesPerDay: 250, burstPerMinute: 60 },
-  scav: { readsPerDay: 2000, writesPerDay: 250, burstPerMinute: 60 },
-  timmy: { readsPerDay: 3000, writesPerDay: 400, burstPerMinute: 90 },
-  chad: { readsPerDay: 5000, writesPerDay: 600, burstPerMinute: 120 },
+  free: { readsPerDay: 1000, writesPerDay: 100 },
+  supporter: { readsPerDay: 2000, writesPerDay: 250 },
+  scav: { readsPerDay: 2000, writesPerDay: 250 },
+  timmy: { readsPerDay: 3000, writesPerDay: 400 },
+  chad: { readsPerDay: 5000, writesPerDay: 600 },
 };
-
 export const UPGRADE_URL = 'https://tarkovtracker.org/supporter';
-
 export const DAILY_WINDOW_SEC = 86400;
-export const BURST_WINDOW_SEC = 60;
-
-export const IP_BACKSTOP_WINDOW_SEC = 3600;
-export const IP_BACKSTOP_LIMITS = {
-  readsPerHour: 600,
-  writesPerHour: 200,
-} as const;
-
+/**
+ * Pre-authentication abuse gate, enforced by the native Workers rate limiting
+ * binding keyed on CF-Connecting-IP. Deliberately coarse: it exists to shield
+ * the api_tokens lookup (and therefore Supabase) from floods, not to meter
+ * legitimate users. Counters are per-Cloudflare-location and eventually
+ * consistent, so this is never advertised as a customer quota.
+ *
+ * ABUSE_GATE_PERIOD_SEC must match `period` in the [[ratelimits]] block of
+ * wrangler.toml; it is only used here to derive Retry-After.
+ */
+export const ABUSE_GATE_PERIOD_SEC = 60;
 export function upgradeMessage(kind: 'read' | 'write'): string {
   return `Daily ${kind} quota exceeded for the free tier. Quotas reset at 00:00 UTC. Upgrade your account for higher limits: ${UPGRADE_URL}`;
 }
-
 export function isKnownTier(value: string): value is ApiTier {
   return Object.hasOwn(TIER_LIMITS, value);
 }

--- a/workers/api-gateway/src/openapi.ts
+++ b/workers/api-gateway/src/openapi.ts
@@ -8,13 +8,15 @@ export const OPENAPI_SPEC = {
       'Authentication: Send API tokens in the Authorization header as `Bearer <token>`.\n' +
       'Tokens use prefixes `PVP_` or `PVE_`.\n\n' +
       'Rate limits: tiered daily quotas keyed by user account (free: 1,000 reads/day and ' +
-      '100 writes/day; supporter tiers scale up), resetting at 00:00 UTC, plus a per-minute ' +
-      'burst limit using a 60-second sliding window. A per-IP backstop (600 reads/hour, ' +
-      '200 writes/hour) catches abuse from many accounts sharing one IP. ' +
-      'Every response includes `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` ' +
-      '(unix seconds) describing the daily quota. On `429` responses a `Retry-After` header (seconds) ' +
-      'is also returned, so clients should queue and retry after that delay rather than busy-looping. ' +
-      'Burst-throttled and IP-throttled requests do not consume the daily quota.\n\n' +
+      '100 writes/day; supporter tiers scale up), resetting at 00:00 UTC. A pre-authentication ' +
+      'IP abuse gate (Cloudflare Workers Rate Limiting binding) shields token validation from ' +
+      'floods and returns its own `429` with only `Retry-After`. ' +
+      'Authenticated responses that reach the daily quota include `X-RateLimit-Limit`, ' +
+      '`X-RateLimit-Remaining`, and `X-RateLimit-Reset` (unix seconds); daily-quota `429` ' +
+      'responses add `Retry-After` (seconds), so clients should queue and retry after that ' +
+      'delay rather than busy-looping. Throttled requests do not consume the daily quota. ' +
+      'If the daily-quota service is temporarily unavailable the gateway fails open and ' +
+      'serves the request without rate-limit headers.\n\n' +
       'Token cap: each account may have at most 3 active API tokens. Revoke an existing ' +
       'token before creating a new one if the cap is reached. Token creation is only ' +
       'allowed through the token-create Edge Function and is rate-limited to 3/hour.\n\n' +
@@ -118,11 +120,13 @@ export const OPENAPI_SPEC = {
       },
       RateLimited: {
         description:
-          'Rate limit exceeded (daily quota, per-minute burst limit, or per-IP backstop)',
+          'Rate limit exceeded (tiered daily quota, or the pre-authentication IP abuse gate). ' +
+          'Daily-quota `429` responses include the `X-RateLimit-*` headers below; abuse-gate ' +
+          '`429` responses are pre-authentication and include only `Retry-After`.',
         headers: {
           'Retry-After': {
             description:
-              'Seconds the client should wait before retrying (daily reset, or when burst capacity frees).',
+              'Seconds the client should wait before retrying (until the daily quota resets at 00:00 UTC, or the abuse-gate period elapses).',
             schema: { type: 'integer', minimum: 1 },
           },
           'X-RateLimit-Limit': {
@@ -573,7 +577,7 @@ export const OPENAPI_SPEC = {
         tags: ['tokens'],
         summary: 'Get token info',
         description:
-          'Requires GP permission. Counts against the tiered daily read quota (keyed by user) and the per-minute burst limit.',
+          'Requires GP permission. Counts against the tiered daily read quota (keyed by user).',
         operationId: 'getTokenInfo',
         security: [{ bearerAuth: [] }],
         parameters: [{ $ref: '#/components/parameters/UserAgentHeader' }],
@@ -599,7 +603,7 @@ export const OPENAPI_SPEC = {
         tags: ['progress'],
         summary: 'Get user progress',
         description:
-          'Requires GP permission. Counts against the tiered daily read quota (keyed by user) and the per-minute burst limit.',
+          'Requires GP permission. Counts against the tiered daily read quota (keyed by user).',
         operationId: 'getProgress',
         security: [{ bearerAuth: [] }],
         parameters: [{ $ref: '#/components/parameters/UserAgentHeader' }],
@@ -625,7 +629,7 @@ export const OPENAPI_SPEC = {
         tags: ['team'],
         summary: 'Get team progress',
         description:
-          'Requires TP permission. Counts against the tiered daily read quota (keyed by user) and the per-minute burst limit.',
+          'Requires TP permission. Counts against the tiered daily read quota (keyed by user).',
         operationId: 'getTeamProgress',
         security: [{ bearerAuth: [] }],
         parameters: [{ $ref: '#/components/parameters/UserAgentHeader' }],
@@ -651,7 +655,7 @@ export const OPENAPI_SPEC = {
         tags: ['progress'],
         summary: 'Update player level',
         description:
-          'Requires WP permission. Counts against the tiered daily write quota (keyed by user) and the per-minute burst limit.',
+          'Requires WP permission. Counts against the tiered daily write quota (keyed by user).',
         operationId: 'updatePlayerLevel',
         security: [{ bearerAuth: [] }],
         parameters: [
@@ -687,7 +691,7 @@ export const OPENAPI_SPEC = {
         tags: ['progress'],
         summary: 'Update single task state',
         description:
-          'Requires WP permission. Counts against the tiered daily write quota (keyed by user) and the per-minute burst limit.',
+          'Requires WP permission. Counts against the tiered daily write quota (keyed by user).',
         operationId: 'updateTask',
         security: [{ bearerAuth: [] }],
         parameters: [
@@ -735,7 +739,7 @@ export const OPENAPI_SPEC = {
         tags: ['progress'],
         summary: 'Update a task objective',
         description:
-          'Requires WP permission. Counts against the tiered daily write quota (keyed by user) and the per-minute burst limit.',
+          'Requires WP permission. Counts against the tiered daily write quota (keyed by user).',
         operationId: 'updateTaskObjective',
         security: [{ bearerAuth: [] }],
         parameters: [
@@ -783,7 +787,7 @@ export const OPENAPI_SPEC = {
         tags: ['progress'],
         summary: 'Batch update tasks',
         description:
-          'Requires WP permission. Counts against the tiered daily write quota (keyed by user) and the per-minute burst limit.',
+          'Requires WP permission. Counts against the tiered daily write quota (keyed by user).',
         operationId: 'updateTasksBatch',
         security: [{ bearerAuth: [] }],
         parameters: [{ $ref: '#/components/parameters/UserAgentHeader' }],

--- a/workers/api-gateway/src/types.ts
+++ b/workers/api-gateway/src/types.ts
@@ -1,6 +1,9 @@
 // Environment bindings
 export interface Env {
   API_GATEWAY_LIMITER: DurableObjectNamespace;
+  // Native Workers rate limiting binding used as the pre-auth abuse gate.
+  // Optional so local dev and tests without the binding simply skip the gate.
+  API_ABUSE_LIMITER?: RateLimit;
   SUPABASE_URL: string;
   SUPABASE_ANON_KEY: string;
   SUPABASE_SERVICE_ROLE_KEY: string;

--- a/workers/api-gateway/wrangler.toml
+++ b/workers/api-gateway/wrangler.toml
@@ -38,6 +38,18 @@ bindings = [
   { name = "API_GATEWAY_LIMITER", class_name = "ApiGatewayRateLimiter" },
 ]
 
+# Pre-authentication abuse gate keyed on CF-Connecting-IP. Coarse by design:
+# it shields the api_tokens lookup from floods and is not a customer quota.
+# Counters are per-location and eventually consistent. `period` must be 10 or
+# 60 and must stay in sync with ABUSE_GATE_PERIOD_SEC in src/limits.ts.
+[[ratelimits]]
+name = "API_ABUSE_LIMITER"
+namespace_id = "1001"
+
+  [ratelimits.simple]
+  limit = 300
+  period = 60
+
 [[migrations]]
 tag = "v1"
 new_sqlite_classes = ["ApiGatewayRateLimiter"]


### PR DESCRIPTION
## **User description**
## Summary

Replaces the three-bucket rate-limit design (daily + burst + IP, with parallel DO calls and refund reconciliation) with a single daily-quota Durable Object call preceded by a native Workers Rate Limiting binding as an IP-keyed pre-authentication abuse gate.

## What changed

### Architecture

```
Request
  → native Workers IP abuse gate (Cloudflare [[ratelimits]] binding)
  → validate token
  → resolve tier
  → one daily-quota DO call (fixed UTC-day window)
  → serve
  → async record_api_usage
```

**Before:** 3 parallel DO calls per auth'd request, distributed refund reconciliation, sliding-window timestamps, IP-key DO alarms, primary/secondary fail-policy matrix (~400 lines of limiter logic in index.ts)

**After:** 1 DO call per auth'd request, no refunds, no sliding windows, no IP bucket, no fail-policy matrix. The pre-auth abuse gate is a Cloudflare-native binding (no network hop, no stored state).

### Files

| File | Change |
|------|--------|
| `workers/api-gateway/src/index.ts` | Delete sliding-window mode, refund system, IP backstop, $\sim$70 lines of dead code. Daily-quota fails open on DO unavailability (logs `daily_quota_unavailable`). |
| `workers/api-gateway/src/limits.ts` | Remove `burstPerMinute`, `BURST_WINDOW_SEC`, `IP_BACKSTOP_*`; add `ABUSE_GATE_PERIOD_SEC` |
| `workers/api-gateway/src/types.ts` | Add optional `API_ABUSE_LIMITER?: RateLimit` to `Env` |
| `workers/api-gateway/wrangler.toml` | Add `[[ratelimits]]` block for abuse gate |
| `workers/api-gateway/src/__tests__/rate-limits.test.ts` | Rewritten: 21 tests from $\sim$30, covering single-bucket + abuse gate |
| `docs/API.md` | Remove Burst/min column, IP backstop paragraph |
| `docs/RATE_LIMITING.md` | Update diagrams, tables, fail-behavior, target state |

### Key design decisions

- **Daily quota counts admitted requests**, not successful responses. A Supabase 500 after admission consumes one slot — no refund system needed.
- **Abuse gate keys on IP** (CF-Connecting-IP), not token hash. An IP-keyed gate protects the `api_tokens` lookup from token-rotation floods; a token-hash gate would not.
- **Fail-open on DO unavailability.** The abuse gate still protects Supabase; daily quotas are product entitlements, not database-integrity boundaries.
- **No tier-specific burst.** The abuse gate is infrastructure protection, not a customer quota. Supporter differentiation remains through daily read/write quotas.

## Validation

- `tsc -p workers/api-gateway/tsconfig.json` — clean
- ESLint on changed files — clean
- `pnpm run test:api-gateway` — 98/98 pass
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/591" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Simplify API throttling to daily quotas with a pre-login abuse gate**

### What Changed
- API requests now use one daily quota per user instead of daily, burst, and IP backstop limits
- A new IP-based abuse gate blocks request floods before token validation, and returns 429 when it trips
- If the daily quota service is unavailable, requests now continue and a warning is logged instead of failing users
- Rate-limit responses now reflect only the daily quota, and old burst/IP refund behavior has been removed

### Impact
`✅ Fewer false throttles for normal API use`
`✅ Faster API requests under load`
`✅ Less downtime from limiter failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Updated external API rate limits to tiered **daily quotas** by authenticated account, resetting at **00:00 UTC**.
  * Removed tier **burst** and per-IP customer quota limits.
  * Added a **pre-authentication IP abuse gate** to block excessive traffic before token validation.
  * When limits are exceeded, **429** responses now use refreshed **rate-limit headers** and **`Retry-After`** behavior, including fail-open handling (daily quota unavailable returns empty headers).
* **Documentation**
  * Updated public rate-limiting guidance, OpenAPI text, and runbook notes to match the new quota model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces the previous three-bucket rate-limit design (parallel daily + burst + IP Durable Object calls with refund reconciliation) with a single UTC-day quota DO call preceded by a Cloudflare-native IP abuse gate binding. The result is a significantly simpler request path with one fewer network hop per authenticated request and no refund or sliding-window logic.

- **`index.ts`**: The `rateLimit` helper now makes a single DO call with `anchor: 'utc-day'` and `retain: true`; the response is validated strictly (bounds-checked `remaining`, `resetAt` within `windowSec`, consistency between `allowed` and `remaining`). Fail-open for DO unavailability emits a structured `daily_quota_unavailable` warn; genuine 429s emit `daily_quota_429`; abuse gate blocks emit `abuse_gate_429` with an HMAC-hashed IP.
- **`wrangler.toml`**: Adds a `[[ratelimits]]` binding (`API_ABUSE_LIMITER`, 300 req/60 s) as the pre-auth IP gate. `ABUSE_GATE_PERIOD_SEC` in `limits.ts` is kept in sync with this `period` value.
- **Docs + OpenAPI**: `API.md`, `RATE_LIMITING.md`, `runbook.md`, and `openapi.ts` all updated to remove burst/IP references and document the narrowed `X-RateLimit-*` header guarantee (absent on fail-open and pre-auth abuse-gate responses).
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge — the refactor cleanly reduces complexity with no correctness regressions and well-tested fail-open paths.

The new single-bucket design is correctly implemented. DO response validation is thorough (bounds-checks remaining, resetAt, and allowed/remaining consistency). Privacy concerns for the abuse gate are handled via HMAC-hashed IPs. All structured log events raised in previous review threads are present in the code and asserted in the 100-test suite. Documentation is fully updated across API.md, RATE_LIMITING.md, runbook.md, and openapi.ts.

No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workers/api-gateway/src/index.ts | Core refactor: removes sliding-window, burst, IP backstop, and refund logic; adds single UTC-day DO call + native CF abuse gate. Fail-open paths log structured events (daily_quota_unavailable, abuse_gate_429). DO response validation is thorough. All paths well-tested. |
| workers/api-gateway/src/__tests__/rate-limits.test.ts | Tests rewritten for single-bucket design; covers utc-day anchor, clock advancement, legacy sliding-window migration, ephemeral cleanup, abuse gate success/fail/missing, malformed DO payloads, and structured log event assertions. |
| workers/api-gateway/wrangler.toml | Adds [[ratelimits]] block for API_ABUSE_LIMITER binding (limit=300/60s). namespace_id="1001" is a user-defined identifier per CF docs, not a dashboard-provisioned value. |
| workers/api-gateway/src/limits.ts | Removes burstPerMinute, BURST_WINDOW_SEC, IP_BACKSTOP_*; adds ABUSE_GATE_PERIOD_SEC=60 with a note that it must match the [[ratelimits]] period in wrangler.toml. |
| docs/API.md | Removes Burst/min column from rate limit table, adds IP abuse gate description, narrows X-RateLimit-* header guarantee to authenticated requests with an available limiter. |
| docs/RATE_LIMITING.md | Updated diagrams, tables, and observability section to match the new single-bucket design; abuse_gate_429 and daily_quota_429 log events correctly documented. |
| docs/runbook.md | Updated to reflect new architecture, replacing old burst/IP backstop runbook steps with abuse gate and daily quota guidance. |
| workers/api-gateway/src/openapi.ts | OpenAPI spec updated to remove burst limit references and reflect that X-RateLimit-* headers are absent on fail-open and abuse-gate responses. |
| workers/api-gateway/src/types.ts | Adds optional API_ABUSE_LIMITER?: RateLimit to Env, keeping it optional so local dev and tests without the binding skip the gate. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant W as Worker
    participant AG as Abuse Gate<br/>(CF Native RateLimit)
    participant S as Supabase<br/>(api_tokens)
    participant DO as Daily Quota DO<br/>(ApiGatewayRateLimiter)
    participant DB as Supabase<br/>(record_api_usage)

    C->>W: API Request + Bearer token
    W->>W: Validate User-Agent

    alt CF-Connecting-IP present AND binding configured
        W->>AG: "limit({ key: "api:{ip}" })"
        AG-->>W: "{ success: false }"
        W-->>C: 429 + Retry-After (abuse_gate_429 logged)
    end

    W->>S: Validate token + resolve tier
    S-->>W: ApiToken + tier (cached 60s)

    W->>DO: "POST daily-{kind}:{user_id} { limit, windowSec:86400, anchor:"utc-day", retain:true }"

    alt DO available
        DO-->>W: "{ allowed, remaining, resetAt }"
        alt "allowed === false"
            W-->>C: "429 + X-RateLimit-* headers (daily_quota_429 logged)"
        else "allowed === true"
            W-->>C: "200 + X-RateLimit-* headers"
        end
    else DO unavailable (timeout/error)
        W->>W: Fail open (daily_quota_unavailable logged)
        W-->>C: "200 (no X-RateLimit-* headers)"
    end

    W-)DB: waitUntil record_api_usage (async)
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(api): enforce integer/state/window i..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/0bbf9c2803d644d3c8dd4d782121bf7ed0e199bb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46880644)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->