### PR TITLE
docs: route community discussions to Discord

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,7 @@ Sign in (via Discord, Twitch, Google, or GitHub) when you want to:
 
 - **Questions or bugs?** See [`SUPPORT.md`](SUPPORT.md) for where to ask.
 - **Found a security issue?** See [`SECURITY.md`](SECURITY.md) for how to report it privately.
-- **Community:** Join us on [Discord](https://discord.gg/M8nBgA2sT6) or
-  [GitHub Discussions](https://github.com/tarkovtracker-org/TarkovTracker/discussions).
+- **Community:** Join us on [Discord](https://discord.gg/M8nBgA2sT6).
 - **Translations:** Help translate at
   [translate.tarkovtracker.org](https://translate.tarkovtracker.org). Supported languages:
   English, German, Spanish, French, Russian, Ukrainian, and Chinese.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,7 +8,7 @@ tracker focused on bugs and features.
 
 | Need                                      | Where                                                                                                                                          |
 | ----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------- |
-| Usage question or general discussion      | [Discord](https://discord.gg/M8nBgA2sT6) or [GitHub Discussions](https://github.com/tarkovtracker-org/TarkovTracker/discussions)               |
+| Usage question or general discussion      | [Discord](https://discord.gg/M8nBgA2sT6)                                                                                                       |
 | Reproducible bug                          | [Bug report form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=bug_report.yml)                                       |
 | Feature idea (something new)              | [Feature request form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=feature_request.yml)                             |
 | Improvement to an existing feature        | [Enhancement form](https://github.com/tarkovtracker-org/TarkovTracker/issues/new?template=enhancement.yml)                                     |


### PR DESCRIPTION
## Summary
- GitHub Discussions is enabled on the repo but unused (0 discussions); the active community channel is Discord.
- Removed stale `github.com/.../discussions` links from `README.md` and `SUPPORT.md`; routed all "general discussion" / "community" references to Discord only.
- Side effect: removes 2 of the 4 `[504]` errors that failed the `Link Check` workflow on PR #435 (the `discussions` URLs were transiently timing out on GitHub's side, but they were also pointing at an unused feature).

The other 2 failures from that run (`.../labels/good_first-issue` and `.../issues/new?template=data_issue.yml`) were transient GitHub 504s on valid URLs and clear with a re-run.

## Changes
- `README.md`: "Community" bullet now links only to Discord; removed the GitHub Discussions link.
- `SUPPORT.md`: "Usage question or general discussion" row in the support routing table now points solely to Discord; removed the GitHub Discussions link.

## Related Issues
Related to #435 (Link Check failures). No direct issue — GitHub Discussions was enabled but unused (0 threads).

## Testing
- [x] Tested locally
- [ ] Tested in production-like environment
- [ ] Added/updated unit tests
- [x] Manual testing performed

### Test Plan
1. `Link Check` workflow passes on this PR (no more `discussions` URLs to hit)
2. `README.md` "Getting help" section reads correctly
3. `SUPPORT.md` routing table renders correctly

## Screenshots/Videos
Not applicable; no UI changes.

## Documentation impact
- [x] No behavior changed — no documentation review needed
- [ ] Behavior changed — existing documentation remains accurate
- [ ] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:
- [x] README or user guidance
- [ ] Contributor documentation
- [ ] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [ ] Screenshots or diagrams

## Checklist
- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes
Docs-only change. The `AGENTS.md` maintenance contract lists `SUPPORT.md` as a trigger, but `AGENTS.md` only contains a pointer reference (`- Support routing: SUPPORT.md`) — it does not embed the routing table content, so a dead-link cleanup requires no matching edit there. The routing policy itself is unchanged.
