### PR TITLE
style: migrate max-w-[Npx] to Tailwind v4 idiomatic spacing scale

### DIFF
--- a/app/features/profile/ProfileProgression.vue
+++ b/app/features/profile/ProfileProgression.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[calc(100vh-250px)] px-3 py-6 sm:px-6">
-    <div class="mx-auto max-w-[1400px] space-y-4 sm:space-y-6">
+    <div class="mx-auto max-w-350 space-y-4 sm:space-y-6">
       <section
         class="bg-surface-900 relative overflow-hidden rounded-xl border border-white/10 p-4 shadow-md sm:p-6"
       >

--- a/app/pages/admin.vue
+++ b/app/pages/admin.vue
@@ -52,7 +52,7 @@
     />
   </div>
   <div v-else-if="systemStore.isAdmin" class="px-3 py-6 sm:px-6">
-    <div class="mx-auto max-w-[1400px] space-y-6">
+    <div class="mx-auto max-w-350 space-y-6">
       <UAlert
         icon="i-mdi-alert"
         color="warning"

--- a/app/pages/hideout.vue
+++ b/app/pages/hideout.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="min-h-full overflow-x-hidden">
     <div class="px-3 py-5 sm:px-5 sm:py-6">
-      <div class="mx-auto max-w-[1400px] space-y-3 sm:space-y-4">
+      <div class="mx-auto max-w-350 space-y-3 sm:space-y-4">
         <div class="flex flex-col gap-4">
           <div class="flex justify-center">
             <div

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex min-h-[calc(100vh-250px)] overflow-x-hidden">
     <div class="min-w-0 flex-1 px-3 py-6 sm:px-6">
-      <div class="mx-auto max-w-[1400px] xl:max-w-[1600px] 2xl:max-w-[1800px]">
+      <div class="mx-auto max-w-350 xl:max-w-400 2xl:max-w-450">
         <h1 class="sr-only">Tarkov Tracker - Escape from Tarkov Progress Tracker</h1>
         <DashboardNextActions />
         <DashboardChangelog />

--- a/app/pages/needed-items.vue
+++ b/app/pages/needed-items.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex min-h-full overflow-x-hidden">
     <div class="min-w-0 flex-1 px-3 py-6 sm:px-6">
-      <div class="mx-auto max-w-[1400px]">
+      <div class="mx-auto max-w-350">
         <NeededItemsFilterBar
           v-model="activeFilter"
           v-model:search="search"

--- a/app/pages/settings.vue
+++ b/app/pages/settings.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="px-3 py-6 sm:px-6">
-    <div class="mx-auto max-w-[1400px]">
-      <div class="mx-auto max-w-[1160px] space-y-4 lg:space-y-0">
+    <div class="mx-auto max-w-350">
+      <div class="mx-auto max-w-290 space-y-4 lg:space-y-0">
         <UTabs
           :items="settingsTabItems"
           :model-value="activeTab"

--- a/app/pages/storyline.vue
+++ b/app/pages/storyline.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[calc(100vh-250px)] px-3 py-6 sm:px-6">
-    <div class="mx-auto max-w-[1400px] space-y-4">
+    <div class="mx-auto max-w-350 space-y-4">
       <div class="flex items-center justify-between">
         <div>
           <h1 class="text-xl font-bold text-white sm:text-2xl">

--- a/app/pages/supporter.vue
+++ b/app/pages/supporter.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="min-h-[calc(100vh-250px)] px-3 py-6 sm:px-6">
-    <div class="mx-auto max-w-[1100px] space-y-8">
+    <div class="mx-auto max-w-275 space-y-8">
       <header class="text-center">
         <h1 class="text-2xl font-bold text-white sm:text-3xl">
           {{ t('page.supporter.title') }}

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="flex min-h-full overflow-x-hidden">
     <div class="min-w-0 flex-1 px-3 py-6 sm:px-6">
-      <div class="mx-auto max-w-[1400px]">
+      <div class="mx-auto max-w-350">
         <TaskLoadingState v-if="isLoading" />
         <div v-else>
           <TaskFilterBar

--- a/app/pages/team.vue
+++ b/app/pages/team.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="px-3 py-6 sm:px-6">
-    <div class="mx-auto max-w-[1400px] space-y-6">
+    <div class="mx-auto max-w-350 space-y-6">
       <div v-if="route?.query?.team && route?.query?.code" class="mx-auto max-w-6xl">
         <TeamInvite />
       </div>


### PR DESCRIPTION
## **User description**
## Summary

- Converts all `max-w-[Npx]` arbitrary-value utilities to Tailwind v4's idiomatic numeric spacing scale (`max-w-<n>` where `n × 0.25rem` = original px value)
- Render-equivalent: identical output, modern idiomatic syntax
- Completes a partial migration that had left 2 files converted in a feature worktree

### Conversions

| Before | After | Files |
|---|---|---|
| `max-w-[1400px]` | `max-w-350` | 10 files |
| `max-w-[1600px]` | `max-w-400` | `index.vue` (`xl:` breakpoint) |
| `max-w-[1800px]` | `max-w-450` | `index.vue` (`2xl:` breakpoint) |
| `max-w-[1160px]` | `max-w-290` | `settings.vue` (inner container) |
| `max-w-[1100px]` | `max-w-275` | `supporter.vue` |

### Left as-is

`max-w-[90vw]` in `app/app.config.ts` and `app/components/SelectMenuFixed.vue` — viewport units have no idiomatic numeric-scale equivalent in Tailwind v4.

### Why no formatter?

`prettier-plugin-tailwindcss` (installed) only sorts class names — it does not convert arbitrary-value syntax to scale utilities. No automatic tool exists for this conversion, so it was done manually with verified math (all values were clean multiples of 4px).

#### Test plan

- [x] Pre-commit hook passed (prettier + eslint --fix on all 10 staged files)
- [ ] CI `format:check` passes
- [ ] CI lint passes
- [ ] Visual spot-check: page widths unchanged on hideout, tasks, needed-items, index, settings, supporter, admin, storyline, team, profile
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/606" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Standardize page width styling across the application

### What Changed
- Updated dashboard and page containers to use Tailwind v4 spacing-scale widths
- Preserved the existing responsive maximum widths across admin, settings, supporter, hideout, tasks, storyline, team, and profile views

### Impact
`✅ Consistent page widths across major views`
`✅ Preserved responsive layouts`
`✅ Tailwind v4-compatible styling`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR migrates all `max-w-[Npx]` arbitrary-value utilities in 10 Vue files to Tailwind v4's open-ended numeric spacing scale (`max-w-N` where `N × 0.25rem` equals the original pixel value). All conversions are mathematically correct and consistent with the project's Tailwind v4 configuration, which does not override `--spacing`.

- **10 files updated** replacing `max-w-[1400px]` → `max-w-350` (and the unique breakpoint variants `max-w-[1600px]`/`max-w-400`, `max-w-[1800px]`/`max-w-450` on `index.vue`, plus `max-w-[1160px]`/`max-w-290` and `max-w-[1100px]`/`max-w-275`).
- **Two `max-w-[90vw]` uses** in `app.config.ts` and `SelectMenuFixed.vue` are correctly left unconverted since viewport units have no spacing-scale equivalent.
- One minor note: `max-w-[1400px]` is pixel-absolute, while `max-w-350` resolves to `87.5rem` — a value that scales with the browser's root font size. This is intentional Tailwind v4 behaviour and an accessibility improvement, but the PR description's claim of \"identical output\" is not strictly accurate at non-default font sizes.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

All 10 files receive a pure class-name substitution with no logic, template structure, or runtime behaviour changed.

Every conversion divides the original pixel value by 4 to get the spacing-scale integer (1400→350, 1600→400, 1800→450, 1160→290, 1100→275), which is arithmetically correct for Tailwind v4's default --spacing: 0.25rem. The CSS config does not override --spacing, so generated values are equivalent at the browser's default font size. The two remaining max-w-[90vw] viewport-unit usages are correctly left unconverted. No logic, state, or API surfaces are touched.

**Files Needing Attention:** No files require special attention; all changes are single-line class-name replacements.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/pages/index.vue | Three responsive max-width values migrated (max-w-350, xl:max-w-400, 2xl:max-w-450); all math correct. |
| app/pages/settings.vue | Two nested containers migrated (max-w-350 outer, max-w-290 inner); values correctly correspond to 1400px and 1160px. |
| app/pages/supporter.vue | Single max-w-[1100px] → max-w-275 migration; 1100/4=275 is correct. |
| app/pages/hideout.vue | Single max-w-[1400px] → max-w-350 migration; correct. |
| app/pages/admin.vue | Single max-w-[1400px] → max-w-350 migration; correct. |
| app/pages/tasks.vue | Single max-w-[1400px] → max-w-350 migration; correct. |
| app/pages/team.vue | Single max-w-[1400px] → max-w-350 migration; correct. |
| app/pages/storyline.vue | Single max-w-[1400px] → max-w-350 migration; correct. |
| app/pages/needed-items.vue | Single max-w-[1400px] → max-w-350 migration; correct. |
| app/features/profile/ProfileProgression.vue | Single max-w-[1400px] → max-w-350 migration; correct. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["max-w-[Npx] arbitrary values\n(10 files)"] --> B{Value}
    B --> C["max-w-[1400px]\n→ max-w-350\n(9 files)"]
    B --> D["max-w-[1600px]\n→ xl:max-w-400\n(index.vue)"]
    B --> E["max-w-[1800px]\n→ 2xl:max-w-450\n(index.vue)"]
    B --> F["max-w-[1160px]\n→ max-w-290\n(settings.vue)"]
    B --> G["max-w-[1100px]\n→ max-w-275\n(supporter.vue)"]
    C & D & E & F & G --> H["Tailwind v4 spacing scale\nN × var(--spacing, 0.25rem)"]
    H --> I["CSS output\nmax-width: calc(var(--spacing) * N)"]
    J["max-w-[90vw]\n(app.config.ts, SelectMenuFixed.vue)"] --> K["Left as-is\n(viewport units have no scale equivalent)"]
```
</details>

<sub>Reviews (1): Last reviewed commit: ["style: migrate max-w-\[Npx\] to Tailwind v..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/46d990e5dbfbd3d3bf25b8a88d591edce29e0399) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48290273)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated maximum content widths across the dashboard, profile, admin, hideout, needed items, settings, storyline, supporter, tasks, and team pages.
  * Introduced a more consistent responsive sizing scale, with narrower layouts on standard and larger screens.
  * Preserved existing page structure, content, and interactions while improving overall visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->