### PR TITLE
fix(api): bind token prefix to stored game mode, drop tt_ tokens

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -399,6 +399,22 @@ Responses for which the daily-quota service returns a quota decision include `X-
 
 Each account may have at most **3 active API tokens**. This is enforced by a database trigger, so token rotation cannot bypass it. The `token-create` Edge Function returns `409` with `error: "Token limit reached (3 active)"` when the cap is reached. Revoke an existing token before creating a new one. Token creation is only allowed through the `token-create` Edge Function (authenticated clients cannot insert into `api_tokens` directly) and is rate-limited to 3 creates per hour per account.
 
+### Token Prefixes
+
+Progress API tokens are prefixed `PVP_` or `PVE_`. The prefix is cosmetic: the token's stored
+`game_mode` decides which progress blob every read and write touches, never the game mode the owner
+is currently viewing on the site. The two are kept from diverging at three layers:
+
+- `token-create` rejects a `gameMode` outside `pvp`/`pve` with `400`, and rejects a supplied
+  `tokenValue` whose prefix contradicts `gameMode` with `400 tokenValue prefix must match gameMode`.
+- A `NOT VALID` check constraint on `api_tokens` requires `token_value` to carry the prefix matching
+  `game_mode`.
+- The gateway rejects a token whose prefix disagrees with its stored `game_mode` with
+  `401 Token game mode mismatch` instead of silently serving the stored mode.
+
+Legacy `tt_` tokens are no longer accepted; they fail with `401 Invalid token format`. Create a
+`PVP_`/`PVE_` token in Settings → API Tokens instead.
+
 ---
 
 ## Error Responses

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -110,6 +110,12 @@ product.
    a worker that depends on a new DB object (e.g. the `merge_progress_data` RPC) breaks production
    for the gap between merge and `db push`. For such changes, apply the pending migration to
    production **before** merging the worker change; adding a function ahead of its caller is safe.
+   **Constraint/validation ordering:** when a migration adds a CHECK constraint that an Edge
+   Function also enforces in application code (e.g. `api_tokens_token_value_game_mode_match` and
+   the `tokenValue` guards in `token-create`), deploy the function (step 6) **before** `db push`.
+   Otherwise the still-unvalidated function can attempt a write the new constraint rejects, and the
+   resulting Postgres `23514` (`check_violation`) surfaces as whatever that function maps `23514`
+   to — `token-create` reports it as `409 Token limit reached (3 active)`, which is misleading.
 
 4. **Pre-deploy secret check (api-gateway Worker):** before merging a change that relies on
    `IP_HASH_SECRET` (e.g. any change to abuse-gate logs that emit `ip_hash`), confirm the secret is

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -98,7 +98,9 @@ product.
 2. Confirm the Pages project remains **fail open** so the static SPA shell still serves if the
    Functions daily quota is exhausted.
 3. **Apply DB migrations manually** (CI does not deploy them; Supabase branch/preview deploy is
-   intentionally disabled to avoid per-preview billing):
+   intentionally disabled to avoid per-preview billing). **Before running the commands below:** if
+   this release also changes an Edge Function that validates the same rule a new constraint
+   enforces, complete step 6 first — see _Constraint/validation ordering_ below.
 
    ```bash
    supabase migration list --linked   # any row with a blank REMOTE column is pending

--- a/supabase/functions/token-create/index.ts
+++ b/supabase/functions/token-create/index.ts
@@ -7,13 +7,7 @@ import {
   type AuthSuccess,
 } from 'shared/auth';
 import { enforceUserMutationRateLimit } from "../_shared/rate-limit.ts"
-
-const generateToken = (gameMode: string) => {
-  const bytes = crypto.getRandomValues(new Uint8Array(9))
-  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, "0")).join("")
-  const prefix = gameMode === "pve" ? "PVE" : "PVP"
-  return `${prefix}_${hex}`
-}
+import { generateToken, isTokenGameMode, isTokenValueForGameMode } from "./tokenValue.ts"
 
 const hashToken = async (token: string) => {
   const buffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token))
@@ -53,6 +47,14 @@ Deno.serve(async (req) => {
 
     if (!permissions.length || !gameMode) {
       return createErrorResponse("gameMode and permissions are required", 400, req)
+    }
+
+    if (!isTokenGameMode(gameMode)) {
+      return createErrorResponse("gameMode must be 'pvp' or 'pve'", 400, req)
+    }
+
+    if (tokenValue && !isTokenValueForGameMode(tokenValue, gameMode)) {
+      return createErrorResponse("tokenValue prefix must match gameMode", 400, req)
     }
 
     if (!tokenValue) tokenValue = generateToken(gameMode)

--- a/supabase/functions/token-create/index.ts
+++ b/supabase/functions/token-create/index.ts
@@ -53,6 +53,10 @@ Deno.serve(async (req) => {
       return createErrorResponse("gameMode must be 'pvp' or 'pve'", 400, req)
     }
 
+    if (body.tokenValue !== undefined && typeof body.tokenValue !== "string") {
+      return createErrorResponse("tokenValue must be a string", 400, req)
+    }
+
     if (tokenValue && !isTokenValueForGameMode(tokenValue, gameMode)) {
       return createErrorResponse("tokenValue prefix must match gameMode", 400, req)
     }

--- a/supabase/functions/token-create/index.ts
+++ b/supabase/functions/token-create/index.ts
@@ -7,7 +7,7 @@ import {
   type AuthSuccess,
 } from 'shared/auth';
 import { enforceUserMutationRateLimit } from "../_shared/rate-limit.ts"
-import { generateToken, isTokenGameMode, isTokenValueForGameMode } from "./tokenValue.ts"
+import { generateToken, isTokenGameMode, isTokenValueForGameMode } from './tokenValue.ts';
 
 const hashToken = async (token: string) => {
   const buffer = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(token))

--- a/supabase/functions/token-create/tokenValue.test.ts
+++ b/supabase/functions/token-create/tokenValue.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateToken,
+  isTokenGameMode,
+  isTokenValueForGameMode,
+  tokenPrefix,
+} from './tokenValue.ts';
+
+describe('isTokenGameMode', () => {
+  it('accepts only the supported game modes', () => {
+    expect(isTokenGameMode('pvp')).toBe(true);
+    expect(isTokenGameMode('pve')).toBe(true);
+  });
+
+  it('rejects unknown, legacy, and non-string values', () => {
+    expect(isTokenGameMode('dual')).toBe(false);
+    expect(isTokenGameMode('PVP')).toBe(false);
+    expect(isTokenGameMode('')).toBe(false);
+    expect(isTokenGameMode(undefined)).toBe(false);
+    expect(isTokenGameMode(null)).toBe(false);
+  });
+});
+
+describe('generateToken', () => {
+  it('prefixes generated tokens with the requested game mode', () => {
+    expect(generateToken('pvp')).toMatch(/^PVP_[0-9a-f]{18}$/);
+    expect(generateToken('pve')).toMatch(/^PVE_[0-9a-f]{18}$/);
+  });
+
+  it('produces values that pass its own consistency check', () => {
+    expect(isTokenValueForGameMode(generateToken('pvp'), 'pvp')).toBe(true);
+    expect(isTokenValueForGameMode(generateToken('pve'), 'pve')).toBe(true);
+  });
+});
+
+describe('isTokenValueForGameMode', () => {
+  const pvp = `${tokenPrefix('pvp')}0123456789abcdef01`;
+  const pve = `${tokenPrefix('pve')}0123456789abcdef01`;
+
+  it('accepts a token value whose prefix matches the game mode', () => {
+    expect(isTokenValueForGameMode(pvp, 'pvp')).toBe(true);
+    expect(isTokenValueForGameMode(pve, 'pve')).toBe(true);
+  });
+
+  it('rejects a token value whose prefix contradicts the game mode', () => {
+    expect(isTokenValueForGameMode(pve, 'pvp')).toBe(false);
+    expect(isTokenValueForGameMode(pvp, 'pve')).toBe(false);
+  });
+
+  it('rejects legacy tt_ and otherwise malformed token values', () => {
+    expect(isTokenValueForGameMode('tt_0123456789abcdef01', 'pvp')).toBe(false);
+    expect(isTokenValueForGameMode('PVP_notHex0123456789', 'pvp')).toBe(false);
+    expect(isTokenValueForGameMode('PVP_0123', 'pvp')).toBe(false);
+    expect(isTokenValueForGameMode('PVP_0123456789ABCDEF01', 'pvp')).toBe(false);
+    expect(isTokenValueForGameMode('pvp_0123456789abcdef01', 'pvp')).toBe(false);
+  });
+});

--- a/supabase/functions/token-create/tokenValue.ts
+++ b/supabase/functions/token-create/tokenValue.ts
@@ -3,8 +3,11 @@ export type TokenGameMode = (typeof TOKEN_GAME_MODES)[number];
 const TOKEN_VALUE_PATTERN = /^(PVP|PVE)_[0-9a-f]{18}$/;
 export const isTokenGameMode = (value: unknown): value is TokenGameMode =>
   typeof value === 'string' && (TOKEN_GAME_MODES as readonly string[]).includes(value);
-export const tokenPrefix = (gameMode: TokenGameMode): string =>
-  gameMode === 'pve' ? 'PVE_' : 'PVP_';
+const TOKEN_PREFIXES: Record<TokenGameMode, string> = {
+  pvp: 'PVP_',
+  pve: 'PVE_',
+};
+export const tokenPrefix = (gameMode: TokenGameMode): string => TOKEN_PREFIXES[gameMode];
 export const generateToken = (gameMode: TokenGameMode): string => {
   const bytes = crypto.getRandomValues(new Uint8Array(9));
   const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');

--- a/supabase/functions/token-create/tokenValue.ts
+++ b/supabase/functions/token-create/tokenValue.ts
@@ -1,0 +1,14 @@
+export const TOKEN_GAME_MODES = ['pvp', 'pve'] as const;
+export type TokenGameMode = (typeof TOKEN_GAME_MODES)[number];
+const TOKEN_VALUE_PATTERN = /^(PVP|PVE)_[0-9a-f]{18}$/;
+export const isTokenGameMode = (value: unknown): value is TokenGameMode =>
+  typeof value === 'string' && (TOKEN_GAME_MODES as readonly string[]).includes(value);
+export const tokenPrefix = (gameMode: TokenGameMode): string =>
+  gameMode === 'pve' ? 'PVE_' : 'PVP_';
+export const generateToken = (gameMode: TokenGameMode): string => {
+  const bytes = crypto.getRandomValues(new Uint8Array(9));
+  const hex = Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+  return `${tokenPrefix(gameMode)}${hex}`;
+};
+export const isTokenValueForGameMode = (tokenValue: string, gameMode: TokenGameMode): boolean =>
+  TOKEN_VALUE_PATTERN.test(tokenValue) && tokenValue.startsWith(tokenPrefix(gameMode));

--- a/supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql
+++ b/supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql
@@ -1,0 +1,14 @@
+-- Keep the cosmetic PVP_/PVE_ prefix in api_tokens.token_value aligned with the
+-- authoritative api_tokens.game_mode, so a token can never display a mode it does
+-- not authorize. NOT VALID: new and updated rows are checked, historical rows are
+-- left as-is (legacy tt_ tokens predate the prefix scheme).
+ALTER TABLE public.api_tokens
+  DROP CONSTRAINT IF EXISTS api_tokens_token_value_game_mode_match;
+
+ALTER TABLE public.api_tokens
+  ADD CONSTRAINT api_tokens_token_value_game_mode_match
+  CHECK (token_value IS NULL OR left(token_value, 4) = upper(game_mode) || '_')
+  NOT VALID;
+
+COMMENT ON CONSTRAINT api_tokens_token_value_game_mode_match ON public.api_tokens IS
+  'token_value must carry the PVP_/PVE_ prefix matching game_mode; the API gateway rejects tokens whose prefix and stored game mode disagree.';

--- a/supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql
+++ b/supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql
@@ -9,7 +9,7 @@ ALTER TABLE public.api_tokens
 
 ALTER TABLE public.api_tokens
   ADD CONSTRAINT api_tokens_token_value_game_mode_match
-  CHECK (token_value IS NULL OR token_value LIKE 'tt_%' OR left(token_value, 4) = upper(game_mode) || '_')
+  CHECK (token_value IS NULL OR left(token_value, 3) = 'tt_' OR left(token_value, 4) = upper(game_mode) || '_')
   NOT VALID;
 
 COMMENT ON CONSTRAINT api_tokens_token_value_game_mode_match ON public.api_tokens IS

--- a/supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql
+++ b/supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql
@@ -1,13 +1,15 @@
 -- Keep the cosmetic PVP_/PVE_ prefix in api_tokens.token_value aligned with the
 -- authoritative api_tokens.game_mode, so a token can never display a mode it does
--- not authorize. NOT VALID: new and updated rows are checked, historical rows are
--- left as-is (legacy tt_ tokens predate the prefix scheme).
+-- not authorize. NOT VALID: new and updated rows are checked. Legacy tt_ tokens
+-- (which predate the prefix scheme) are grandfathered via the LIKE clause so that
+-- UPDATEs to those rows (e.g. usage stats) do not violate the constraint; the API
+-- gateway still rejects them at the prefix check before any DB lookup.
 ALTER TABLE public.api_tokens
   DROP CONSTRAINT IF EXISTS api_tokens_token_value_game_mode_match;
 
 ALTER TABLE public.api_tokens
   ADD CONSTRAINT api_tokens_token_value_game_mode_match
-  CHECK (token_value IS NULL OR left(token_value, 4) = upper(game_mode) || '_')
+  CHECK (token_value IS NULL OR token_value LIKE 'tt_%' OR left(token_value, 4) = upper(game_mode) || '_')
   NOT VALID;
 
 COMMENT ON CONSTRAINT api_tokens_token_value_game_mode_match ON public.api_tokens IS

--- a/supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql
+++ b/supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql
@@ -1,9 +1,9 @@
 -- Keep the cosmetic PVP_/PVE_ prefix in api_tokens.token_value aligned with the
 -- authoritative api_tokens.game_mode, so a token can never display a mode it does
 -- not authorize. NOT VALID: new and updated rows are checked. Legacy tt_ tokens
--- (which predate the prefix scheme) are grandfathered via the LIKE clause so that
--- UPDATEs to those rows (e.g. usage stats) do not violate the constraint; the API
--- gateway still rejects them at the prefix check before any DB lookup.
+-- (which predate the prefix scheme) are grandfathered by the literal left(token_value, 3)
+-- comparison so that UPDATEs to those rows (e.g. usage stats) do not violate the
+-- constraint; the API gateway still rejects them at the prefix check before any DB lookup.
 ALTER TABLE public.api_tokens
   DROP CONSTRAINT IF EXISTS api_tokens_token_value_game_mode_match;
 

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -256,6 +256,30 @@ describe('api-gateway', () => {
     const res = await worker.fetch(buildRequest('/token', { method: 'GET' }), BASE_ENV);
     await expectErrorResponse(res, 401, 'Unauthorized');
   });
+  it('rejects legacy tt_ prefixed tokens without a token lookup', async () => {
+    const fetchMock = createBaseFetchMock({ permissions: ['GP'] });
+    vi.stubGlobal('fetch', fetchMock);
+    const res = await worker.fetch(
+      buildRequest('/token', { method: 'GET', headers: { Authorization: 'Bearer tt_abc123' } }),
+      BASE_ENV
+    );
+    await expectErrorResponse(res, 401, 'Invalid token format');
+    expect(
+      fetchMock.mock.calls.some((call) => String(call[0]).includes('/rest/v1/api_tokens'))
+    ).toBe(false);
+  });
+  it('rejects a token whose prefix contradicts its stored game mode', async () => {
+    const fetchMock = createBaseFetchMock({ permissions: ['GP'], gameMode: 'pve' });
+    vi.stubGlobal('fetch', fetchMock);
+    const res = await worker.fetch(
+      buildRequest('/progress', { method: 'GET', headers: { Authorization: 'Bearer PVP_abc123' } }),
+      BASE_ENV
+    );
+    await expectErrorResponse(res, 401, 'Token game mode mismatch');
+    expect(
+      fetchMock.mock.calls.some((call) => String(call[0]).includes('/rest/v1/user_progress'))
+    ).toBe(false);
+  });
   it('rejects requests with a missing User-Agent header', async () => {
     const res = await worker.fetch(
       new Request('https://api.tarkovtracker.org/token', {
@@ -913,10 +937,12 @@ describe('api-gateway', () => {
     expect(objectives?.['obj-1']?.count).toBe(5);
     expect('complete' in (objectives?.['obj-1'] ?? {})).toBe(false);
   });
-  const progressRequest = (headers: Record<string, string> = {}) =>
+  const bearerForMode = (mode: 'pvp' | 'pve') =>
+    `Bearer ${mode === 'pve' ? 'PVE' : 'PVP'}_abc123`;
+  const progressRequest = (mode: 'pvp' | 'pve' = 'pvp', headers: Record<string, string> = {}) =>
     buildRequest('/progress', {
       method: 'GET',
-      headers: { Authorization: 'Bearer PVP_abc123', ...headers },
+      headers: { Authorization: bearerForMode(mode), ...headers },
     });
   const findProgressSelect = (fetchMock: ReturnType<typeof vi.fn>): string | undefined =>
     fetchMock.mock.calls
@@ -932,17 +958,20 @@ describe('api-gateway', () => {
     async (mode, expected) => {
       const fetchMock = createBaseFetchMock({ permissions: ['GP'], gameMode: mode });
       vi.stubGlobal('fetch', fetchMock);
-      const res = await worker.fetch(progressRequest(), BASE_ENV);
+      const res = await worker.fetch(progressRequest(mode), BASE_ENV);
       expect(res.status).toBe(200);
       const select = findProgressSelect(fetchMock as unknown as ReturnType<typeof vi.fn>);
       expect(select).toBe(expected);
       expect(select).not.toContain('*');
     }
   );
-  const teamProgressRequest = (headers: Record<string, string> = {}) =>
+  const teamProgressRequest = (
+    mode: 'pvp' | 'pve' = 'pvp',
+    headers: Record<string, string> = {}
+  ) =>
     buildRequest('/team/progress', {
       method: 'GET',
-      headers: { Authorization: 'Bearer PVP_abc123', ...headers },
+      headers: { Authorization: bearerForMode(mode), ...headers },
     });
   it.each([
     ['pvp', 'user_id,game_edition,pvp_data'],
@@ -957,7 +986,7 @@ describe('api-gateway', () => {
         teamMembers: ['user-1', 'user-2'],
       });
       vi.stubGlobal('fetch', fetchMock);
-      const res = await worker.fetch(teamProgressRequest(), BASE_ENV);
+      const res = await worker.fetch(teamProgressRequest(mode), BASE_ENV);
       expect(res.status).toBe(200);
       const select = findProgressSelect(fetchMock as unknown as ReturnType<typeof vi.fn>);
       expect(select).toBe(expected);
@@ -983,7 +1012,7 @@ describe('api-gateway', () => {
         teamId: null,
       });
       vi.stubGlobal('fetch', fetchMock);
-      const res = await worker.fetch(teamProgressRequest(), BASE_ENV);
+      const res = await worker.fetch(teamProgressRequest(mode), BASE_ENV);
       expect(res.status).toBe(200);
       const select = findProgressSelect(fetchMock as unknown as ReturnType<typeof vi.fn>);
       expect(select).toBe(expected);

--- a/workers/api-gateway/src/auth.ts
+++ b/workers/api-gateway/src/auth.ts
@@ -1,11 +1,15 @@
+import { logger } from './utils/logger';
 import type { Env, ApiToken, Permission } from './types';
-// Valid token prefixes: tt_ (legacy), PVE_, PVP_ (game mode specific)
-const VALID_TOKEN_PREFIXES = ['tt_', 'PVE_', 'PVP_'];
+const TOKEN_PREFIX_GAME_MODES: ReadonlyArray<readonly [string, ApiToken['game_mode']]> = [
+  ['PVP_', 'pvp'],
+  ['PVE_', 'pve'],
+];
 /**
- * Check if token has a valid prefix format
+ * Resolve the game mode a token's prefix claims, or null for unsupported prefixes.
+ * The prefix is cosmetic; `api_tokens.game_mode` stays authoritative for behaviour.
  */
-export function isValidTokenFormat(token: string): boolean {
-  return VALID_TOKEN_PREFIXES.some((prefix) => token.startsWith(prefix));
+export function getTokenPrefixGameMode(token: string): ApiToken['game_mode'] | null {
+  return TOKEN_PREFIX_GAME_MODES.find(([prefix]) => token.startsWith(prefix))?.[1] ?? null;
 }
 /**
  * SHA-256 hash a string and return hex
@@ -36,7 +40,8 @@ export async function validateToken(
 ): Promise<{ valid: true; token: ApiToken } | { valid: false; error: string; status: number }> {
   try {
     // Validate token format (must have valid prefix)
-    if (!isValidTokenFormat(token)) {
+    const prefixGameMode = getTokenPrefixGameMode(token);
+    if (!prefixGameMode) {
       return { valid: false, error: 'Invalid token format', status: 401 };
     }
     // Hash the token for lookup
@@ -58,6 +63,14 @@ export async function validateToken(
       return { valid: false, error: 'Invalid token', status: 401 };
     }
     const row = tokens[0];
+    if (row.game_mode !== prefixGameMode) {
+      logger.error('token game mode mismatch', {
+        tokenId: row.token_id,
+        prefixGameMode,
+        storedGameMode: row.game_mode,
+      });
+      return { valid: false, error: 'Token game mode mismatch', status: 401 };
+    }
     // Check if token is active
     if (!row.is_active) {
       return { valid: false, error: 'Token is inactive', status: 401 };

--- a/workers/api-gateway/src/auth.ts
+++ b/workers/api-gateway/src/auth.ts
@@ -6,7 +6,6 @@ const TOKEN_PREFIX_GAME_MODES: ReadonlyArray<readonly [string, ApiToken['game_mo
 ];
 /**
  * Resolve the game mode a token's prefix claims, or null for unsupported prefixes.
- * The prefix is cosmetic; `api_tokens.game_mode` stays authoritative for behaviour.
  */
 export function getTokenPrefixGameMode(token: string): ApiToken['game_mode'] | null {
   return TOKEN_PREFIX_GAME_MODES.find(([prefix]) => token.startsWith(prefix))?.[1] ?? null;

--- a/workers/api-gateway/src/openapi.ts
+++ b/workers/api-gateway/src/openapi.ts
@@ -2,11 +2,13 @@ export const OPENAPI_SPEC = {
   openapi: '3.1.0',
   info: {
     title: 'TarkovTracker API Gateway',
-    version: '2.3.0',
+    version: '2.4.0',
     description:
       'Public API gateway for TarkovTracker progress, team progress, and token info.\n\n' +
       'Authentication: Send API tokens in the Authorization header as `Bearer <token>`.\n' +
-      'Tokens use prefixes `PVP_` or `PVE_`.\n\n' +
+      'Tokens use prefixes `PVP_` or `PVE_`, which must match the token\'s game mode; ' +
+      'a mismatched token is rejected with 401. The token game mode alone decides which ' +
+      'progress data is read or written. Legacy `tt_` tokens are no longer accepted.\n\n' +
       'Rate limits: tiered daily quotas keyed by user account (free: 1,000 reads/day and ' +
       '100 writes/day; supporter tiers scale up), resetting at 00:00 UTC. A pre-authentication ' +
       'IP abuse gate (Cloudflare Workers Rate Limiting binding) shields token validation from ' +


### PR DESCRIPTION
## **User description**
## What

The `PVP_`/`PVE_` prefix on an API token was cosmetic: `api_tokens.game_mode` alone drives which progress blob is read and written (see `validateToken` → `validation.token.game_mode` on every `/progress` and `/team/progress` route). Nothing stopped the two from disagreeing, so a token could *display* one mode and *authorize* another — a silent, hard-to-debug inconsistency in bug reports.

This closes the gap at three layers and removes the legacy `tt_` prefix.

- `supabase/functions/token-create/tokenValue.ts` (new) — `isTokenGameMode`, `tokenPrefix`, `generateToken`, `isTokenValueForGameMode`, extracted so the rules are unit-testable outside `Deno.serve`.
- `supabase/functions/token-create/index.ts` — `400` when `gameMode` is not `pvp`/`pve`, and `400 tokenValue prefix must match gameMode` when a caller-supplied `tokenValue` contradicts the requested mode (or is not `(PVP|PVE)_<18 hex>`).
- `supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql` — `NOT VALID` check constraint: `token_value IS NULL OR left(token_value, 4) = upper(game_mode) || '_'`. `NOT VALID` so historical rows (including legacy `tt_` values) are untouched while every new/updated row is checked.
- `workers/api-gateway/src/auth.ts` — `VALID_TOKEN_PREFIXES` (which included `tt_`) replaced by a prefix→game-mode map. `getTokenPrefixGameMode` resolves the claimed mode; an unknown prefix still yields `401 Invalid token format`, and a prefix that disagrees with the stored `game_mode` now yields `401 Token game mode mismatch` with a structured `logger.error`, instead of quietly serving the stored mode.
- `openapi.ts` (2.3.0 → 2.4.0) and `docs/API.md` — document the invariant and the `tt_` removal.

Behaviour is unchanged for every consistent token, which is all the create path has ever produced (the prefix and the stored mode both come from the same `gameMode` input).

## Why

Follow-up to the game-mode discussion on #590. `game_mode` was already authoritative on both reads and writes, so this is not a data-correctness fix — it removes the cosmetic ambiguity that would make such a bug report unreadable, and drops a legacy prefix that no longer maps to any game mode.

## Breaking

- Legacy `tt_` tokens now fail with `401 Invalid token format`. The *prefix* carried no game mode, but the row always did: `api_tokens.game_mode` has been `NOT NULL CHECK (game_mode IN ('pvp', 'pve'))` with no default since the table was created in `20251121210000`, so a `tt_` token may have been serving either PvP or PvE progress — production bears this out: 4 of the 5 surviving rows are `pvp` and 1 is `pve`. Measured blast radius: **5 active `tt_` tokens held by 5 distinct users, 0.05% of the 9,633 active tokens, none used since 2026-01-02 and 3 never used at all**. Every active row has a non-null `token_value`, so that figure is exact rather than a lower bound, and no affected holder is at the 3-active-token cap.
- A token whose prefix and stored `game_mode` disagree now fails with `401 Token game mode mismatch`. **Production currently has zero such tokens**, so this rule guards against future drift rather than changing live behaviour.

## Validation

- `pnpm run test:api-gateway` — 118/118 pass (adds: `tt_` rejected before any `api_tokens` lookup; PvP-prefixed token with a stored `pve` mode rejected before any `user_progress` read; the three mode-parameterized suites from #590 now send a prefix matching the token mode)
- `npx vitest run supabase/functions/token-create` — 7/7 pass
- `pnpm run supabase:check` — `supabase db reset` applies the migration cleanly, `db lint --schema public` reports no errors
- Constraint behaviour verified against the local Postgres: inserting `token_value='PVE_…'` with `game_mode='pvp'` raises `violates check constraint "api_tokens_token_value_game_mode_match"`; the matching `PVP_…`/`pvp` insert succeeds
- `npx tsc -p workers/api-gateway/tsconfig.json --noEmit`, `npx tsc -p supabase/functions/tsconfig.json --noEmit` — clean
- `pnpm run validate:openapi` — spec 2.4.0 valid; `pnpm run format:check` — clean; `npx eslint` on changed worker files — clean (`supabase/functions/**` is eslint-ignored)
- `node scripts/check-systems-drift.mjs` — passes

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/608" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Enforce matching API token prefixes and game modes

### What Changed
- API tokens now require `PVP_` or `PVE_` prefixes that match their stored game mode; mismatches return `401` before progress data is accessed.
- Legacy `tt_` tokens are rejected as invalid.
- Token creation rejects unsupported game modes, non-string token values, and supplied token values with the wrong or malformed prefix.
- Database validation and API documentation now describe the prefix and game-mode requirement.
- Added coverage for legacy tokens, mismatched modes, token generation, and invalid token values.

### Impact
`✅ Prevents tokens from accessing the wrong game-mode progress`
`✅ Clearer token validation errors`
`✅ Legacy token rejection without database lookups`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added game-mode-specific API tokens using `PVP_` and `PVE_` prefixes.
  * Token creation now validates token format and matching game mode.
  * Progress access now reflects the token’s game mode.

* **Bug Fixes**
  * Requests with mismatched or legacy token prefixes are rejected.
  * Database validation prevents inconsistent token and game-mode pairings.

* **Documentation**
  * Updated API documentation with token requirements and authentication errors.
  * Added deployment guidance for applying token validation safely.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR closes the gap between the cosmetic `PVP_`/`PVE_` token prefix and the authoritative `api_tokens.game_mode`, enforcing the invariant at three independent layers: Edge Function validation, a `NOT VALID` DB constraint (with `tt_` grandfathering), and a pre-progress-read mismatch check in the gateway. Legacy `tt_` tokens are now rejected before any DB lookup, and 5 surviving rows are documented to be the full blast radius.

- `tokenValue.ts` extracts prefix/format helpers into a testable module with an exhaustive `Record<TokenGameMode, string>` map (previous review concern addressed), and `isTokenValueForGameMode` correctly combines the full-format regex with the per-mode `startsWith` check.
- `auth.ts` replaces the prefix array with a `TOKEN_PREFIX_GAME_MODES` map and adds a structured `logger.error` for mismatches before the `is_active` / expiry checks, so a mismatch is detected without reaching any progress data.
- The `NOT VALID` constraint uses `left(token_value, 3) = 'tt_'` to grandfather legacy rows, preventing UPDATE failures on those rows (previous review concern addressed); the `DROP CONSTRAINT IF EXISTS` makes the migration idempotent.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. All consistent tokens (the entire live token population) are unaffected; the 5 legacy tt_ tokens have been unused since 2026-01-02 and are deliberately rejected.

The three enforcement layers are independently correct and tested. Previous review concerns about NOT VALID UPDATE semantics and the ternary prefix fallback were both addressed in this iteration. The one observation worth noting — the 23514 error handler now has two constraint sources and could misreport the prefix mismatch as a token-limit error during a wrong-order deployment — is mitigated by the runbook guidance and cannot occur in steady-state operation where the function validates before inserting.

**Files Needing Attention:** No files require special attention. index.ts error handling for 23514 is the one area where a future improvement (checking error.constraint to distinguish the two check violations) would add clarity, but it does not affect correct deployments.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workers/api-gateway/src/auth.ts | Replaces prefix array with prefix→game_mode map; mismatch check is placed correctly before active/expiry checks and logs structured context |
| supabase/functions/token-create/index.ts | Adds three ordered guards (game mode, tokenValue type, prefix/mode match) before insert; ordering is correct after narrowing via isTokenGameMode |
| supabase/functions/token-create/tokenValue.ts | Extracts token-format helpers into a testable module; exhaustive PREFIX map, regex, and guard functions are correct |
| supabase/migrations/20260729120000_enforce_api_token_prefix_game_mode.sql | NOT VALID constraint with tt_ grandfathering is correct; DROP CONSTRAINT IF EXISTS makes it idempotent; previous review concerns addressed |
| workers/api-gateway/src/__tests__/gateway.test.ts | New tests cover tt_ pre-lookup rejection and prefix/stored-mode mismatch; bearerForMode helper correctly aligns token prefix with the stubbed game mode in parameterized suites |
| supabase/functions/token-create/tokenValue.test.ts | Good coverage of isTokenGameMode, generateToken, and isTokenValueForGameMode including legacy tt_ and uppercase-hex rejection |
| docs/runbook.md | Adds correct constraint/validation ordering guidance; calls out the misleading 409 surface if wrong order is used |
| docs/API.md | Documents the three enforcement layers and legacy tt_ removal clearly |
| workers/api-gateway/src/openapi.ts | Version bumped to 2.4.0; description updated to mention prefix/game_mode invariant and tt_ deprecation |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant C as Client
    participant GW as API Gateway (auth.ts)
    participant DB as Supabase (api_tokens)
    participant FN as token-create (index.ts)

    Note over C,FN: Token validation path (GET /progress)
    C->>GW: "Authorization: Bearer PVP_<hex>"
    GW->>GW: getTokenPrefixGameMode() → 'pvp'
    alt unknown prefix (e.g. tt_)
        GW-->>C: 401 Invalid token format
    end
    GW->>DB: "SELECT … WHERE token_hash = sha256(token)"
    DB-->>GW: "row (game_mode='pve')"
    alt prefix game mode ≠ stored game_mode
        GW->>GW: logger.error(tokenId, prefixGameMode, storedGameMode)
        GW-->>C: 401 Token game mode mismatch
    end
    GW->>DB: updateTokenUsage() [non-blocking]
    GW-->>C: 200 progress data

    Note over C,FN: Token creation path (POST /token-create)
    C->>FN: "{gameMode, permissions, tokenValue?}"
    FN->>FN: isTokenGameMode() guard
    alt invalid gameMode
        FN-->>C: 400 gameMode must be pvp or pve
    end
    FN->>FN: typeof tokenValue check
    FN->>FN: isTokenValueForGameMode() prefix check
    alt prefix mismatch
        FN-->>C: 400 tokenValue prefix must match gameMode
    end
    FN->>FN: generateToken(gameMode) if no tokenValue
    FN->>DB: INSERT api_tokens (DB constraint: NOT VALID)
    DB-->>FN: token_id
    FN-->>C: "200 {tokenId, tokenValue}"
```
</details>

<sub>Reviews (6): Last reviewed commit: ["docs(docs): surface migration ordering p..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/2c921edb00cec961b99e26f5182ff7210552537b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48416284)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->