### PR TITLE
docs(docs): correct runbook deploy automation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,8 +49,10 @@ can read it and an agent can verify any claim against the code. Each system sect
 - **Stack:** Nuxt 4 SPA (`ssr: false`), Vue 3 Composition API, TypeScript strict, Pinia, Supabase, Tailwind CSS v4, Vitest, Cloudflare Pages/Workers.
 - **Runtime:** Node >=24.12.0, packageManager `pnpm@11.14.0` (engines allow `pnpm >=10.34.5 <12`).
 - **Backend:** Supabase (auth, database, realtime). API proxy via Nitro server routes.
-- **Deployment:** Cloudflare Pages/Workers. The Pages build emits a static SPA shell and routes only
-  `/api/*` plus `/overlay/*` through Pages Functions.
+- **Deployment:** Cloudflare Pages/Workers for the frontend and `api-gateway`; the Supabase GitHub
+  integration applies DB migrations and deploys Edge Functions. All three run automatically on merge
+  to `main` — see the Deployment section of `docs/runbook.md`. The Pages build emits a static SPA
+  shell and routes only `/api/*` plus `/overlay/*` through Pages Functions.
 
 ## Project Map
 

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -251,9 +251,18 @@ Push to `main` triggers:
 1. CI validation in GitHub Actions
 2. Cloudflare Pages deploy for the connected branch
 3. Cloudflare-managed worker deploys for the connected branch
-4. Smoke tests in production
+4. Supabase GitHub integration — applies pending DB migrations and deploys Edge Functions
+   (surfaces as the `Supabase Preview` check on the merge commit)
+5. Smoke tests in production
+
+GitHub Actions itself deploys nothing; items 2-4 are separate Git integrations. See the Deployment
+section of [`runbook.md`](./runbook.md) for what to verify after each merge.
 
 ### Manual Deployment
+
+Fallback only, for when an integration fails. Supabase fallbacks (`supabase db push --linked`,
+`supabase functions deploy --use-api`) are documented in [`runbook.md`](./runbook.md) rather than
+duplicated here:
 
 ```bash
 # Local deployment (run from project root: /home/lab/TarkovTracker or equivalent)

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -94,30 +94,56 @@ product.
 
 ## Deployment
 
+Merging to `main` deploys everything automatically. Three integrations do the work — none of them
+GitHub Actions — and each surfaces as a check on the merge commit:
+
+| What                                 | Mechanism                    | Check on the merge commit     |
+| ------------------------------------ | ---------------------------- | ----------------------------- |
+| Frontend                             | Cloudflare Pages Git build   | `Cloudflare Pages`            |
+| `api-gateway` Worker                 | Cloudflare Workers Git build | `Workers Builds: api-gateway` |
+| DB migrations **and** Edge Functions | Supabase GitHub integration  | `Supabase Preview`            |
+
+The Supabase check keeps the name `Supabase Preview` on `main`, where it targets the **production**
+project rather than a preview branch. Per-PR preview deploys are intentionally disabled to avoid
+per-preview billing, which is why the same check reports `skipping` on pull requests.
+
+The steps below are therefore mostly verification. The manual commands are a fallback for when an
+integration fails or is unavailable, not the normal path.
+
 1. Merge to `main` and verify CI workflow `Validate`, `Supabase DB`, and `Workers` jobs are green.
 2. Confirm the Pages project remains **fail open** so the static SPA shell still serves if the
    Functions daily quota is exhausted.
-3. **Apply DB migrations manually** (CI does not deploy them; Supabase branch/preview deploy is
-   intentionally disabled to avoid per-preview billing). **Before running the commands below:** if
-   this release also changes an Edge Function that validates the same rule a new constraint
-   enforces, complete step 6 first — see _Constraint/validation ordering_ below.
+3. **Verify DB migrations applied.** The Supabase integration applies pending migrations on merge.
+   Confirm rather than assume:
 
    ```bash
-   supabase migration list --linked   # any row with a blank REMOTE column is pending
-   supabase db push --linked          # apply pending migrations to production
+   supabase migration list --linked   # any row with a blank REMOTE column is still pending
    ```
 
-   Skip only if `migration list` shows nothing pending. Verify the change landed afterward.
-   **Ordering caveat:** workers auto-deploy from `main` (step 1) while migrations are manual, so
-   a worker that depends on a new DB object (e.g. the `merge_progress_data` RPC) breaks production
-   for the gap between merge and `db push`. For such changes, apply the pending migration to
-   production **before** merging the worker change; adding a function ahead of its caller is safe.
-   **Constraint/validation ordering:** when a migration adds a CHECK constraint that an Edge
-   Function also enforces in application code (e.g. `api_tokens_token_value_game_mode_match` and
-   the `tokenValue` guards in `token-create`), deploy the function (step 6) **before** `db push`.
-   Otherwise the still-unvalidated function can attempt a write the new constraint rejects, and the
-   resulting Postgres `23514` (`check_violation`) surfaces as whatever that function maps `23514`
-   to — `token-create` reports it as `409 Token limit reached (3 active)`, which is misleading.
+   If a migration is still pending, apply it manually:
+
+   ```bash
+   supabase db push --linked
+   ```
+
+   `db push` is safe to run when nothing is pending — it reports `Remote database is up to date`.
+   Verify the object itself landed, not just the version row; for a constraint, check
+   `pg_constraint` (`convalidated = false` is expected for `NOT VALID`).
+
+   **Ordering caveat:** migrations, Workers and Edge Functions all deploy from the same merge and
+   you cannot control the order between them. Code that depends on a new DB object (e.g. a worker
+   calling the `merge_progress_data` RPC) can briefly run against a database that does not have it
+   yet. When the dependency matters, land the migration in an **earlier release** than the code
+   that uses it; adding a DB object ahead of its caller is safe, the reverse is not.
+
+   **Constraint/validation ordering:** the same applies when a migration adds a CHECK constraint
+   that an Edge Function also enforces in application code (e.g.
+   `api_tokens_token_value_game_mode_match` and the `tokenValue` guards in `token-create`). If the
+   constraint lands first, the still-unvalidated function can attempt a write the constraint
+   rejects, and the resulting Postgres `23514` (`check_violation`) surfaces as whatever that
+   function maps `23514` to — `token-create` reports it as `409 Token limit reached (3 active)`,
+   which sends debugging the wrong way. Ship the function validation in an earlier release than the
+   constraint when that distinction matters.
 
 4. **Pre-deploy secret check (api-gateway Worker):** before merging a change that relies on
    `IP_HASH_SECRET` (e.g. any change to abuse-gate logs that emit `ip_hash`), confirm the secret is
@@ -134,15 +160,21 @@ product.
    merging so the first post-merge request already has a non-null HMAC identifier.
    Do not commit the value.
 
-5. Confirm Cloudflare Pages and Cloudflare Workers Git deployments completed for `main`.
-6. Deploy Supabase Edge Functions after every change under `supabase/functions/`:
+5. Confirm the `Cloudflare Pages`, `Workers Builds: api-gateway` and `Supabase Preview` checks all
+   succeeded on the merge commit.
+6. **Verify Edge Functions deployed.** The Supabase integration deploys every function under
+   `supabase/functions/` on merge; confirm each changed function reports a new version in the
+   Supabase dashboard. Manual fallback:
 
    ```bash
    supabase functions deploy --use-api
    ```
 
-   This deploys all functions using the per-function JWT settings in `supabase/config.toml`. Confirm
-   every changed function reports the expected version in the Supabase dashboard.
+   Deploy **all** functions, not one. A scoped `supabase functions deploy <name>` omits
+   `supabase/functions/deno.json`, so the bare specifiers it maps (`shared/auth`) fail to resolve
+   and the deploy is rejected with a `Relative import path ... not prefixed with / or ./ or ../`
+   bundling error. `--use-api` applies the per-function `verify_jwt` settings from
+   `supabase/config.toml`.
 
 7. Confirm workers are serving the expected revision:
    - `workers/api-gateway`
@@ -197,14 +229,17 @@ These show up in Supabase logs / query performance and are expected. Do not trea
   Supabase dashboard / SQL editor. Direct edits cause drift: a fresh environment built from
   migrations no longer matches production, and the next `db push` can fail or apply destructive
   changes. Always write a migration.
-- **CI does NOT apply migrations to production.** The `Supabase DB` job only validates
-  (`supabase:check` = local reset + lint); no workflow runs `db push`. Supabase branch/preview
-  auto-deploy is intentionally **disabled** (it bills per ephemeral preview DB). Applying to prod
-  is a **manual step** after merge to `main` (see Deployment checklist):
+- **GitHub Actions does not apply migrations — the Supabase integration does.** The `Supabase DB`
+  job only validates (`supabase:check` = local reset + lint) and no workflow runs `db push`.
+  Application to production happens automatically on merge to `main` via the Supabase GitHub
+  integration, which surfaces as the `Supabase Preview` check on the merge commit. Per-PR preview
+  databases are intentionally **disabled** (they bill per ephemeral preview DB), so that same check
+  reports `skipping` on pull requests. Confirm the result after every merge and apply manually only
+  if something is still pending:
 
   ```bash
-  supabase migration list --linked   # confirm the new migration is pending (blank REMOTE column)
-  supabase db push --linked          # applies pending migrations to production
+  supabase migration list --linked   # blank REMOTE column = still pending
+  supabase db push --linked          # fallback if the integration did not apply it
   ```
 
   Then verify the change landed (e.g. catalog query / `has_column_privilege`).


### PR DESCRIPTION
## **User description**
## Summary

The runbook described production deploys as manual when they are automatic. It said applying migrations was "a **manual step** after merge to `main`" and that Edge Functions must be deployed "after every change under `supabase/functions/`". Both are wrong: the **Supabase GitHub integration does both automatically on merge to `main`**, surfacing as the `Supabase Preview` check on the merge commit.

The practical cost of the old text is that an operator concludes production is un-migrated when it is already up to date, and reaches for `db push` unnecessarily.

- Lead the Deployment section with a table of what actually auto-deploys — Cloudflare Pages, `Workers Builds: api-gateway`, and Supabase — and the check on the merge commit that proves each.
- Recast steps 3 and 6 as **verification**, demoting `supabase db push --linked` and `supabase functions deploy --use-api` to fallbacks for when an integration fails.
- Explain that the Supabase check keeps the name `Supabase Preview` on `main` while targeting the **production** project, which is why the same check reports `skipping` on pull requests. That naming is the main reason the automation is easy to miss.
- Fix the same inaccurate claim in the **Database Migrations** section.
- Rewrite both ordering caveats. The old text justified them with "migrations are manual", so it advised hand-sequencing the migration and the function. Since everything ships from one merge and the order between integrations is not controllable, the correct advice is to land an ordering-sensitive dependency in an **earlier release**.
- Record a gotcha that cost a failed deploy: a scoped `supabase functions deploy <name>` does not upload `supabase/functions/deno.json`, so the bare specifiers it maps (`shared/auth`) fail to resolve and the bundle is rejected. Deploy all functions.

## Evidence

Verified against the #608 merge rather than inferred:

- `Supabase Preview` ran **09:27:58 → 09:28:14Z** on `0f657965`, with `details_url` pointing at the production project rather than a preview branch.
- All 13 Edge Functions report `updated_at` **09:28:12Z**, inside that window. The deployed `token-create` body (v361) contains `isTokenValueForGameMode`, so the new validation shipped without a manual deploy.
- Migration `20260729120000` was already applied before any manual `db push`; the push reported `Remote database is up to date`, and `pg_constraint` shows the constraint present with `convalidated = false`.
- The same check also succeeded on the two previous migration-bearing merges (`123d6414`, `edb3e368`), so this is the steady-state behaviour and not a one-off.

## Test plan

- [x] `pnpm run format:check` — clean (prettier covers `docs/**/*.md`)
- [x] `node scripts/check-systems-drift.mjs` — passes
- [x] `npx prettier --check docs/runbook.md` — clean, and no column-0 continuation lines break the numbered list
- [x] Grepped `docs/` and `AGENTS.md` for remaining "manual step" / "CI does not apply" claims — none left
- [x] Docs-only change; no runtime code touched

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/610" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Correct the deployment runbook to reflect automatic production deployments

### What Changed
- Clarifies that merging to `main` automatically deploys the frontend, API Worker, database migrations, and Edge Functions, with checks showing the result.
- Changes migration and Edge Function steps from manual deployment to verification, keeping manual commands as fallbacks when automation fails.
- Explains why `Supabase Preview` appears on the production merge commit but is skipped for pull requests.
- Updates release-order guidance for code that depends on new database objects or constraints.
- Warns that deploying a single Edge Function can fail because shared import mappings are not included; the fallback deploys all functions.

### Impact
`✅ Fewer unnecessary manual production deploys`
`✅ Clearer verification after merging`
`✅ Fewer deployment failures from incorrect release ordering`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR corrects the runbook and related docs to reflect that production deployments — DB migrations, Edge Functions, frontend, and the API Worker — are all automatic on merge to `main` via three separate Git integrations, not manual steps. The practical effect is that operators following the old runbook would reach for `supabase db push` unnecessarily, believing production was un-migrated when it was already up to date.

- Rewrites the Deployment section with an auto-deploy table and demotes `supabase db push --linked` / `supabase functions deploy --use-api` to fallbacks; explains why the `Supabase Preview` check appears on `main` commits but reports `skipping` on PRs.
- Corrects ordering caveats in both the Deployment checklist and the Database Migrations section: old text advised hand-sequencing migration before function deploy, which is no longer actionable when both ship from the same merge; new advice is to land ordering-sensitive dependencies in an earlier release.
- Adds a `deno.json` gotcha: a scoped `supabase functions deploy <name>` omits the import map and causes bare-specifier resolution failures; the fallback must deploy all functions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Documentation-only change; no runtime code is touched.

All three changed files are markdown documentation. The corrections are backed by concrete evidence from the #608 merge (timestamps, migration status, deployed function body), the AGENTS.md maintenance contract is satisfied by updating it in the same PR, and the new ordering guidance is logically sound given that all three integrations now fire from the same merge event.

**Files Needing Attention:** No files require special attention.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/runbook.md | Rewrites the Deployment section to lead with an auto-deploy table, demotes manual commands to fallbacks, corrects ordering caveats now that everything ships from one merge, and adds the scoped-deploy deno.json gotcha to step 6 |
| docs/WORKFLOW_AUTOMATION.md | Adds Supabase integration as step 4 in the push-to-main trigger list, clarifies GitHub Actions deploys nothing, and moves manual fallback commands to runbook.md rather than duplicating them |
| AGENTS.md | Expands the Deployment line in Project Snapshot to mention the Supabase GitHub integration and that all three deploy integrations run automatically on merge to main |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant CF_Pages as Cloudflare Pages
    participant CF_Workers as Cloudflare Workers
    participant SB as Supabase Integration

    Dev->>GH: Merge PR to main
    GH->>GH: Run GitHub Actions (CI only — validate, lint, test)
    GH-->>CF_Pages: Git push event
    GH-->>CF_Workers: Git push event
    GH-->>SB: Git push event

    CF_Pages->>CF_Pages: "Build & deploy frontend SPA"
    CF_Pages-->>GH: Check: Cloudflare Pages ✓

    CF_Workers->>CF_Workers: "Build & deploy api-gateway Worker"
    CF_Workers-->>GH: Check: Workers Builds api-gateway ✓

    SB->>SB: Apply pending DB migrations
    SB->>SB: Deploy all Edge Functions
    SB-->>GH: Check: Supabase Preview ✓ (targets production)

    Dev->>GH: Verify all three checks green on merge commit
    Note over Dev,SB: Manual commands (db push, functions deploy) are fallback only
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(docs): align companion deploy docs ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/9e888511281dde12127d7b690abdc70c6ce0206e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48994849)</sub>

**Context used:**

- Context used - AGENTS.md ([source](https://app.greptile.com/dysektai/github/tarkovtracker-org/tarkovtracker/-/custom-context?memory=635c24fb-71e5-43a4-9979-74405b725e95))

<!-- /greptile_comment -->