### PR TITLE
fix(release): publish patch versions for refactors

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,6 +15,7 @@
           { "type": "feat", "release": "minor" },
           { "type": "fix", "release": "patch" },
           { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
           { "type": "revert", "release": "patch" },
           { "type": "docs", "scope": "README", "release": "patch" },
           { "scope": "no-release", "release": false }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,6 +212,7 @@ Naming:
 - Before every commit: ensure hooks can run (`node_modules` present and `core.hooksPath` / `.husky/_` exist). If they cannot, either run the bootstrap script or manually format/lint staged paths (Prettier for docs/markdown; ESLint for app TS/Vue) so CI `format:check` will pass. Do not commit with known-skipped hooks and unformatted staged files.
 - Commit scopes (from `commitlint.config.js`): `app`, `workers`, `api`, `ui`, `tasks`, `hideout`, `maps`, `team`, `settings`, `admin`, `i18n`, `deps`, `config`, `ci`, `test`, `docs`, `release`. Do not invent new scopes; omit the scope if none fits. Map common cases: `ui` for theme/styling/shell work, `docs` for repository/process documentation such as `AGENTS.md`.
 - Commit types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`, `wip`.
+- Release-producing types: `feat` triggers a minor release; `fix`, `perf`, `refactor`, and `revert` trigger a patch release. Other types do not release unless they contain a breaking change or match an explicit rule in `.releaserc.json`.
 - Header max 100 chars. Subject must not be UPPER_CASE.
 
 ## Environment Variables

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -58,6 +58,7 @@ Semantic versioning with automated releases:
 - `feat:` → minor version bump
 - `fix:` → patch version bump
 - `perf:` → patch version bump
+- `refactor:` → patch version bump
 - `BREAKING CHANGE:` → major version bump
 
 ### 4. PR Checks (`.github/workflows/pr-checks.yml`)

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -59,6 +59,7 @@ Semantic versioning with automated releases:
 - `fix:` → patch version bump
 - `perf:` → patch version bump
 - `refactor:` → patch version bump
+- `revert:` → patch version bump
 - `BREAKING CHANGE:` → major version bump
 
 ### 4. PR Checks (`.github/workflows/pr-checks.yml`)


### PR DESCRIPTION
## Summary

Fix release automation so conventional `refactor:` commits publish patch versions instead of completing the Release workflow without creating a release.

## Changes

- add a `refactor` → patch rule to semantic-release commit analysis
- document all release-producing commit types in `AGENTS.md`
- update `docs/WORKFLOW_AUTOMATION.md` with the `refactor` and pre-existing `revert` patch rules

## Related Issues

No linked issue. This follows up the successful Release run after `v1.61.0` that reported no release-producing commits.

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [ ] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. Run `pnpm run lint`.
2. Run `pnpm exec prettier --check .releaserc.json docs/WORKFLOW_AUTOMATION.md AGENTS.md` and `git diff --check`.
3. Invoke `@semantic-release/commit-analyzer` directly and verify `refactor(i18n): ...` resolves to `patch`.

## Screenshots/Videos

Not applicable; this changes release configuration and documentation only.

## Documentation impact

- [ ] No behavior changed — no documentation review needed
- [ ] Behavior changed — existing documentation remains accurate
- [x] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [x] Contributor documentation
- [ ] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [ ] Screenshots or diagrams

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

The latest Release workflow passed tests, Supabase migration validation, build, and semantic-release execution. It did not publish because the commits since `v1.61.0` were `refactor`, `chore`, and Crowdin updates. Codecov was not blocking the release; its uploads are non-fatal.