### PR TITLE
fix(ci): require manual review for action bumps

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -56,7 +56,11 @@ performance/accessibility work instead of treating the current floors as long-te
 ### Dependabot Auto Merge (`dependabot-auto-merge.yml`)
 
 **Trigger:** Dependabot PR opened/updated/reopened/ready for review
-**Jobs:** `Auto-merge safe Dependabot PR` (allowlist gate, wait for CI/security checks, squash merge)
+**Jobs:** `Auto-merge safe Dependabot PR` (npm tooling allowlist gate, wait for check runs and
+legacy status contexts, verify and match the validated head SHA, squash merge). Every GitHub Actions
+workflow-file change requires manual review, including changes to permissions, triggers, or commands.
+Action updates additionally require repository or organization allowlist verification when they
+introduce a new pinned SHA.
 
 ### Stale (`stale.yml`)
 

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,6 +18,7 @@ permissions:
   checks: read
   contents: write
   pull-requests: write
+  statuses: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
@@ -52,12 +53,9 @@ jobs:
           fi
           case "$HEAD_REF" in
             dependabot/npm_and_yarn/lint-and-format-* | \
-            dependabot/npm_and_yarn/nuxt-ecosystem-* | \
             dependabot/npm_and_yarn/testing-tooling-* | \
             dependabot/npm_and_yarn/tailwind-tooling-* | \
-            dependabot/npm_and_yarn/release-tooling-* | \
-            dependabot/github_actions/official-actions-* | \
-            dependabot/github_actions/third-party-actions-*)
+            dependabot/npm_and_yarn/release-tooling-*)
               eligible=true
               ;;
           esac
@@ -76,9 +74,7 @@ jobs:
                   package.json | \
                   pnpm-lock.yaml | \
                   pnpm-workspace.yaml | \
-                  workers/api-gateway/package.json | \
-                  .github/workflows/*.yml | \
-                  .github/workflows/*.yaml)
+                  workers/api-gateway/package.json)
                     ;;
                   *)
                     printf '%s\n' "$file"
@@ -116,17 +112,29 @@ jobs:
                 "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/check-runs?per_page=100" \
                 --jq '.check_runs | map(select(.name != "Auto-merge safe Dependabot PR"))'
             )"
+            status_contexts="$(
+              gh api \
+                "repos/$GITHUB_REPOSITORY/commits/$HEAD_SHA/status" \
+                --jq '.statuses | sort_by(.context, .updated_at) | group_by(.context) | map(last)'
+            )"
             failing_count="$(
               jq '[.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required")] | length' <<< "$check_runs"
             )"
-            if [ "$failing_count" -gt 0 ]; then
+            failing_status_count="$(
+              jq '[.[] | select(.state == "failure" or .state == "error")] | length' <<< "$status_contexts"
+            )"
+            if [ "$failing_count" -gt 0 ] || [ "$failing_status_count" -gt 0 ]; then
               jq -r '.[] | select(.conclusion == "failure" or .conclusion == "cancelled" or .conclusion == "timed_out" or .conclusion == "action_required") | "::error::\(.name) concluded \(.conclusion)"' <<< "$check_runs"
+              jq -r '.[] | select(.state == "failure" or .state == "error") | "::error::\(.context) concluded \(.state)"' <<< "$status_contexts"
               exit 1
             fi
             missing_checks=()
             incomplete_checks=()
             pending_count="$(
               jq '[.[] | select(.status != "completed")] | length' <<< "$check_runs"
+            )"
+            pending_status_count="$(
+              jq '[.[] | select(.state == "pending")] | length' <<< "$status_contexts"
             )"
             for check_name in "${expected_checks[@]}"; do
               matching_check="$(
@@ -143,21 +151,23 @@ jobs:
                 incomplete_checks+=("$check_name")
               fi
             done
-            if [ "${#missing_checks[@]}" -eq 0 ] && [ "${#incomplete_checks[@]}" -eq 0 ] && [ "$pending_count" -eq 0 ]; then
+            if [ "${#missing_checks[@]}" -eq 0 ] && [ "${#incomplete_checks[@]}" -eq 0 ] && [ "$pending_count" -eq 0 ] && [ "$pending_status_count" -eq 0 ]; then
               echo "All checks completed."
               break
             fi
             if [ "$SECONDS" -ge "$deadline" ]; then
-              printf '::error::Timed out waiting for checks. Missing: %s. Incomplete: %s. Pending: %s.\n' \
+              printf '::error::Timed out waiting for checks. Missing: %s. Incomplete: %s. Pending checks: %s. Pending statuses: %s.\n' \
                 "${missing_checks[*]:-none}" \
                 "${incomplete_checks[*]:-none}" \
-                "$pending_count"
+                "$pending_count" \
+                "$pending_status_count"
               exit 1
             fi
-            printf 'Waiting for checks. Missing: %s. Incomplete: %s. Pending: %s.\n' \
+            printf 'Waiting for checks. Missing: %s. Incomplete: %s. Pending checks: %s. Pending statuses: %s.\n' \
               "${missing_checks[*]:-none}" \
               "${incomplete_checks[*]:-none}" \
-              "$pending_count"
+              "$pending_count" \
+              "$pending_status_count"
             sleep 30
           done
       - name: Merge Dependabot PR
@@ -171,12 +181,17 @@ jobs:
           merge_state="UNKNOWN"
           deadline=$((SECONDS + 120))
           while true; do
-            merge_state="$(
+            pr_state="$(
               gh pr view "$PR_NUMBER" \
                 --repo "$GITHUB_REPOSITORY" \
-                --json mergeStateStatus \
-                --jq '.mergeStateStatus'
+                --json headRefOid,mergeStateStatus
             )"
+            current_head_sha="$(jq -r '.headRefOid' <<< "$pr_state")"
+            merge_state="$(jq -r '.mergeStateStatus' <<< "$pr_state")"
+            if [ "$current_head_sha" != "$HEAD_SHA" ]; then
+              echo "::error::PR head changed from $HEAD_SHA to $current_head_sha after validation."
+              exit 1
+            fi
             if [ "$merge_state" != "UNKNOWN" ]; then
               break
             fi
@@ -197,5 +212,6 @@ jobs:
           esac
           gh pr merge "$PR_NUMBER" \
             --repo "$GITHUB_REPOSITORY" \
+            --match-head-commit "$HEAD_SHA" \
             --squash \
             --delete-branch

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,9 @@ Naming:
 - If a review integration cannot complete because of exhausted credits, rate limits, vendor failure, or an equivalent external blocker, document that failure on the PR, perform and report a direct self-review of the diff, and only then decide whether to merge.
 - Treat new comments created by the latest pushed commit as part of the same review cycle. Repeat until checks pass, reviews are complete, and unresolved thread count is zero.
 - After merge, run one fresh review-thread query to verify zero unresolved threads. Post-merge follow-ups are exceptional recovery, not the normal review workflow.
+- Review all Dependabot GitHub Actions PRs manually. Before merging an action SHA change, verify and
+  update repository and organization Actions allowlists when they restrict that action; do not rely
+  on the Dependabot branch checks to prove the new SHA is permitted.
 
 - Prefer a normal branch in the current checkout (with existing `node_modules` and husky hooks) for the first in-flight task.
 - Before edits, run `git status --short --branch`.

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -83,16 +83,20 @@ Merges known low-risk Dependabot PRs after the normal PR checks complete:
 - testing tooling
 - tailwind tooling
 - release tooling
-- official GitHub Actions
-- third-party GitHub Actions minor/patch updates
 
 **Safety rules:**
 
 - Dependabot-only, `main`-targeted PRs only
 - No repository checkout in the privileged `pull_request_target` workflow
-- Only package lockfiles, package manifests, and workflow files are allowed
-- Runtime Nuxt, Cloudflare, TypeScript compiler, and catch-all dependency updates stay manual
-- PR must be mergeable and all standard CI/security checks must finish without failures
+- Only package lockfiles, package manifests, and `pnpm-workspace.yaml` are allowed; any workflow
+  change stays manual
+- Runtime Nuxt, Cloudflare, TypeScript compiler, catch-all dependencies, and all GitHub Actions
+  updates stay manual
+- GitHub Actions updates may require a repository or organization Actions allowlist change for the
+  new pinned SHA, which CI on the Dependabot branch cannot validate reliably
+- PR must stay on the validated head SHA and finish all check runs and the latest result for each
+  legacy status context without failures or pending results; the merge command also matches the
+  validated head commit to close the final race
 
 ### 6. Stale Management (`.github/workflows/stale.yml`)
 
@@ -188,8 +192,9 @@ Automated via Dependabot (`.github/dependabot.yml`):
 **Features:**
 
 - Weekly dependency update batches for the pnpm workspace (root + `workers/api-gateway`)
-- Monthly grouped GitHub Actions updates
-- Official GitHub Actions are allowed to take major updates so runtime migrations do not get stuck behind a minor/patch-only rule
+- Monthly grouped GitHub Actions updates for manual review
+- Official GitHub Actions are allowed to propose major updates so runtime migrations do not get stuck
+  behind a minor/patch-only rule
 - Cooldown windows to avoid immediate churn from fresh releases
 - Patch cooldown is short so safe patch updates do not sit for a full week
 - Grouped minor/patch updates for low-risk tooling families
@@ -212,9 +217,12 @@ Automated via Dependabot (`.github/dependabot.yml`):
 **Review strategy:**
 
 - Let Dependabot batch low-risk tooling updates for scheduled review windows
-- Let the auto-merge workflow clear allowlisted tooling/action PRs after checks pass
+- Let the auto-merge workflow clear allowlisted npm tooling PRs after checks pass
+- Review every GitHub Actions PR manually, including minor and patch updates; update repository and
+  organization Actions allowlists first when the pinned SHA is restricted
 - Keep major upgrades explicit
-- Allow official GitHub-maintained actions to take major updates when GitHub changes required action runtimes
+- Allow official GitHub-maintained actions to propose major updates when GitHub changes required
+  action runtimes, but do not auto-merge them
 - Keep transitive lockfile churn out of version-update PRs unless GitHub raises a security fix
 - Keep Nuxt/runtime, Cloudflare deployment tooling, TypeScript compiler, and catch-all dependency updates manual
 - Review security PRs promptly; they remain separate from the scheduled version-update batches unless GitHub grouped security updates are enabled in repository settings


### PR DESCRIPTION
## **User description**
## Summary

- stop auto-merging every Dependabot GitHub Actions PR and any PR that changes workflow files
- remove the Nuxt runtime group from the low-risk auto-merge allowlist
- fail closed on legacy status-context failures/pending states, changed head SHAs, and non-clean merge states
- document the manual Actions allowlist check at both repository and organization level

## Audit findings

- #621 auto-merged the lychee action SHA before the inherited Actions allowlist was updated; it was repaired afterward and the manual Link Check run passed
- #614, #623, and #624 completed their relevant checks and post-merge deployments cleanly
- #598 and #599 also completed cleanly
- open #626 is clean but remains manual by design; #625 and #622 have failing checks and must not merge

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec prettier --check .github/workflows/dependabot-auto-merge.yml .github/workflows/README.md docs/WORKFLOW_AUTOMATION.md AGENTS.md`
- workflow gate invariant assertions
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/tarkovtracker-org/tarkovtracker/pull/627" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Require manual review for GitHub Actions updates and enforce stricter Dependabot merge checks

### What Changed
- GitHub Actions Dependabot updates and any workflow-file changes now require manual review instead of automatic merging
- Automatic merging is limited to approved npm tooling updates
- Dependabot merges now stop when legacy status checks are failing or pending, the validated commit changes, or the merge state is not clean
- Documentation now explains the manual Actions allowlist review required for new pinned action versions

### Impact
`✅ Manual review for all GitHub Actions updates`
`✅ Fewer unsafe automatic merges`
`✅ Dependabot merges only from fully validated commits`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Automation**
  * Dependabot auto-merges are now limited to approved npm tooling and package files.
  * Workflow, GitHub Actions, Nuxt, and other sensitive updates require manual review.
  * Merges now require validated pull request heads, successful checks, and a clean merge state.
  * Legacy status checks are also monitored before merging.

* **Documentation**
  * Updated workflow guidance to explain review requirements, allowlists, merge validation, and GitHub Actions update handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR tightens the Dependabot auto-merge workflow by restricting the allowlist to npm-only tooling (removing GitHub Actions and Nuxt ecosystem groups), blocking any PR that touches workflow files, and adding two new safety layers: polling for legacy status contexts alongside check runs, and detecting head-SHA drift between check validation and the merge command.

- **Allowlist narrowed**: `github_actions/*` and `nuxt-ecosystem-*` branch patterns removed; `.github/workflows/*.yml/yaml` removed from the permitted file set, so any action-bump PR is now unconditionally manual.
- **Stricter merge gate**: The wait loop now fails fast on failing/error status contexts and blocks progress while any status context is pending; the merge poll loop also aborts if the PR head drifts from the validated SHA, and `--match-head-commit` closes the final window at the `gh pr merge` call.
- **Documentation updated** across `README.md`, `AGENTS.md`, and `docs/WORKFLOW_AUTOMATION.md` to reflect the manual-review requirement for GitHub Actions PRs and the allowlist verification steps.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

Safe to merge. The changes restrict automation surface and add layered merge guards with no widened attack surface.

All changes move in one direction — reducing what auto-merges automatically and adding more verification steps before anything that does qualify gets merged. The logic for status context polling, SHA-drift detection, and --match-head-commit is straightforward bash + jq with no off-by-one risks. Documentation is consistent with the code.

**Files Needing Attention:** No files require special attention. The workflow script changes are self-contained and the documentation updates match the code.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/dependabot-auto-merge.yml | Core changes: removes GitHub Actions and Nuxt ecosystem groups from auto-merge allowlist, removes workflow-file path from the allowed-file set, adds legacy status context polling and failure detection, adds head-SHA drift detection during the merge poll loop, and threads --match-head-commit into the final merge command. Logic is consistent and closes several real TOCTOU windows. |
| AGENTS.md | Adds one new bullet to the PR Review Gate section requiring manual review of all Dependabot GitHub Actions PRs and allowlist verification before merging a new action SHA. Consistent with the workflow changes. |
| .github/workflows/README.md | Documentation update: expands the Dependabot Auto Merge job description to mention npm-only allowlist, legacy status context checks, head SHA validation, and the manual Actions review requirement. |
| docs/WORKFLOW_AUTOMATION.md | Documentation update: removes GitHub Actions and Nuxt ecosystem from the auto-merge safety rules section, adds rationale for Actions allowlist verification, and updates review strategy to reflect the new manual-only approach for action bumps. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Dependabot PR opened/updated] --> B{actor == dependabot-bot?}
    B -- No --> Z[Skip job]
    B -- Yes --> C{base_ref == main?}
    C -- No --> Z
    C -- Yes --> D{Draft PR?}
    D -- Yes --> Z
    D -- No --> E{Branch matches npm allowlist?}
    E -- No --> Z2[Notice: outside allowlist]
    E -- Yes --> F{Files limited to package manifests only?}
    F -- No --> Z3[Notice: extra files - workflow files now blocked]
    F -- Yes --> G[Wait for checks loop]
    G --> H[Fetch check runs via GitHub API]
    G --> I[Fetch legacy status contexts via GitHub API]
    H --> J{Any failing check runs?}
    I --> K{Any failure/error status contexts?}
    J -- Yes --> FAIL1[exit 1]
    K -- Yes --> FAIL1
    J -- No --> L{All expected checks complete AND pending_status_count == 0?}
    K -- No --> L
    L -- No --> G
    L -- Timed out --> FAIL2[exit 1 timeout]
    L -- Yes --> M[Merge poll loop]
    M --> N[Fetch headRefOid + mergeStateStatus]
    N --> O{current_head_sha == HEAD_SHA?}
    O -- No --> FAIL3[exit 1 head drifted]
    O -- Yes --> P{mergeStateStatus != UNKNOWN?}
    P -- No --> M
    P -- Timed out --> FAIL4[exit 1 timeout]
    P -- Yes --> Q{mergeStateStatus == CLEAN or UNSTABLE?}
    Q -- No --> FAIL5[exit 1 not mergeable]
    Q -- Yes --> R[gh pr merge --match-head-commit HEAD_SHA --squash --delete-branch]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(ci): require manual review for actio..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/61f465369feb90fdddd3156f0793fbbc5d706339) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49549091)</sub>

<!-- /greptile_comment -->