### PR TITLE
refactor(settings): fix Fallow complexity gate on Turnstile profile fetch

### DIFF
--- a/app/features/settings/DataManagementCard.vue
+++ b/app/features/settings/DataManagementCard.vue
@@ -1212,20 +1212,32 @@
     tarkovDevRefetchMode.value = mode;
     tarkovDevTargetMode.value = mode;
   }
+  type TurnstileVerification = { status: 'failed' } | { status: 'ok'; token: string | null };
+  function turnstileVerificationPending(): boolean {
+    return isTurnstileEnabled && !isTurnstileSolved.value;
+  }
+  function turnstileTokenMissing(token: string | null): boolean {
+    return isTurnstileEnabled && token === null;
+  }
+  async function verifyTurnstileToken(): Promise<TurnstileVerification> {
+    if (turnstileVerificationPending()) return { status: 'failed' };
+    const token = await getTurnstileToken();
+    if (turnstileTokenMissing(token)) return { status: 'failed' };
+    return { status: 'ok', token };
+  }
   async function fetchTarkovDevProfile(profileUrl: string, fresh = false) {
     const requestGeneration = ++tarkovDevRequestGeneration.value;
     try {
-      if (isTurnstileEnabled && !isTurnstileSolved.value) {
+      const verification = await verifyTurnstileToken();
+      if (verification.status === 'failed') {
         setTarkovDevImportError(t('settings.tarkov_dev_import.errors.verification_failed'));
         return null;
       }
-      const turnstileToken = await getTurnstileToken();
       if (requestGeneration !== tarkovDevRequestGeneration.value) return null;
-      if (isTurnstileEnabled && !turnstileToken) {
-        setTarkovDevImportError(t('settings.tarkov_dev_import.errors.verification_failed'));
-        return null;
-      }
-      return await parseTarkovDevProfileUrl(profileUrl, { fresh, turnstileToken });
+      return await parseTarkovDevProfileUrl(profileUrl, {
+        fresh,
+        turnstileToken: verification.token,
+      });
     } finally {
       resetTurnstile();
     }


### PR DESCRIPTION
## **User description**
## Summary

The `Fallow audit` CI job (integrated in #632) is failing on `main` ([run 30812876457](https://github.com/tarkovtracker-org/TarkovTracker/actions/runs/30812876457)) and on every PR via GitHub's merge ref, because commit `32ea5316` ("fix(ui): gate profile fetch buttons on Turnstile completion") introduced `fetchTarkovDevProfile` in `app/features/settings/DataManagementCard.vue` at cyclomatic 6 → estimated CRAP 42, above the gate's threshold. Because the gate runs with `--gate new-only`, the failure is attributed to that one introduced function — the other 16 complexity findings are pre-existing and excluded.

This PR fixes it properly by refactoring (no `fallow-ignore` suppressions).

## What changed

Extracted the Turnstile verification flow from `fetchTarkovDevProfile` into a small helper flow:

- `verifyTurnstileToken()` — checks the challenge is solved, acquires the token, and returns a discriminated result (`{ status: 'failed' }` | `{ status: 'ok'; token }`)
- `turnstileVerificationPending()` / `turnstileTokenMissing()` — pure boolean helpers

`fetchTarkovDevProfile` drops from cyclomatic 6 (CRAP 42) to **cyclomatic 3**, and the duplicated error handling collapses to a single site.

Behavior is preserved exactly:
- Fast-fail with the same `verification_failed` error when the challenge is unsolved (no 8s token wait)
- Same error when the token is missing after solving
- `null` token still passed through to `parseTarkovDevProfileUrl` when Turnstile is disabled
- Request-generation staleness check unchanged

## Validation

- `fallow audit --base origin/main --gate new-only` → **verdict: pass** (0 introduced findings)
- `DataManagementCard.test.ts` → 34/34 pass
- `pnpm run typecheck` → pass
- `eslint` → clean
- `prettier --check` / `lint-blank-lines` → clean

## Test plan

- [x] Fallow audit passes locally with the same base/gate flags CI uses
- [x] Component tests, typecheck, lint, format all green
- [x] CI run on this PR confirms the Fallow job is green


___

## **CodeAnt-AI Description**
Simplify Turnstile verification during Tarkov profile imports

### What Changed
- Profile imports now use a single verification flow for unsolved challenges and missing tokens
- Failed verification still stops the import with the existing error message
- Turnstile-disabled imports continue without a token, while stale requests are still ignored

### Impact
`✅ Clearer profile import verification`
`✅ Fewer duplicate verification failures`
`✅ Preserved protection against stale profile results`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>
