### PR TITLE
fix(workers): use a redirect mode workerd accepts for the active-season lookup

### DIFF
--- a/workers/api-gateway/src/__tests__/gameMode.test.ts
+++ b/workers/api-gateway/src/__tests__/gameMode.test.ts
@@ -24,6 +24,23 @@ describe('getGameModeSeasonNumber', () => {
     await expect(getGameModeSeasonNumber(env, 'seasonal')).resolves.toBe(2);
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
+  it('requests the active season with a redirect mode workerd accepts', async () => {
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify(1)));
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(getGameModeSeasonNumber(env, 'seasonal')).resolves.toBe(1);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    expect(init.redirect).toBe('manual');
+    expect(init.redirect).not.toBe('error');
+  });
+  it('rejects a redirected active-season response', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 301, headers: { location: '/elsewhere' } }));
+    vi.stubGlobal('fetch', fetchMock);
+    await expect(getGameModeSeasonNumber(env, 'seasonal')).rejects.toThrow(
+      'Failed to fetch active season'
+    );
+  });
   it('resolves non-seasonal modes to 0 without a network call', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);

--- a/workers/api-gateway/src/utils/gameMode.ts
+++ b/workers/api-gateway/src/utils/gameMode.ts
@@ -20,7 +20,10 @@ const getActiveSeasonNumber = async (env: Env): Promise<number> => {
   rpcUrl.hash = '';
   const response = await fetch(rpcUrl, {
     method: 'POST',
-    redirect: 'error',
+    // workerd only accepts 'follow' or 'manual'; 'error' throws at the fetch call. 'manual'
+    // surfaces a redirect as a non-ok status, which the check below rejects, so service
+    // credentials are still never replayed to another host.
+    redirect: 'manual',
     headers: { ...getServiceHeaders(env), 'Content-Type': 'application/json' },
     body: '{}',
     signal: AbortSignal.timeout(ACTIVE_SEASON_FETCH_TIMEOUT_MS),


### PR DESCRIPTION
## **User description**
Reported by a user hitting HTTP 500 with a freshly generated `SZN_` token, reproduced against production.

## Symptom

Any public API call authenticated with a seasonal token:

```
GET https://api.tarkovtracker.org/progress      -> 500
GET https://api.tarkovtracker.org/team/progress -> 500
{"success":false,"error":"Invalid redirect value, must be one of \"follow\" or \"manual\" (\"error\" won't be implemented since it does not make sense at the edge; use \"manual\" and check the response status code)."}
```

`GET /token` returns 200 for the same token, so authentication, the `SZN_` prefix mapping and the token record are all fine — only the progress paths fail.

## Cause

`getActiveSeasonNumber` passed `redirect: 'error'` to `fetch`. workerd rejects that value at the call rather than at redirect time, so the request throws before it is ever sent. `getGameModeSeasonNumber` only reaches that code for `seasonal`; `pvp` and `pve` return season 0 without a request, which is why PvP and PvE tokens were unaffected and why this was invisible until a seasonal token existed.

## Fix

`redirect: 'manual'`. A redirect then arrives as a non-ok status and the existing `if (!response.ok) throw` rejects it, so the original intent — never replay service-role credentials to another host — is preserved.

## Why CI missed it

`workers/api-gateway/vitest.config.ts` runs in the `node` environment and the tests stub global `fetch`. Node undici accepts `redirect: 'error'`, so the runtime restriction never appeared. Added two tests: one asserting the option is a value workerd accepts, one asserting a 3xx active-season response is rejected.

The deeper gap is that these tests do not execute in workerd at all, so no workerd-specific restriction can be caught. Worth a follow-up to run this suite under `@cloudflare/vitest-pool-workers`; filed separately rather than expanded here.

## Verification

`pnpm run test:api-gateway` — 151 tests pass. Confirmed no other `redirect: 'error'` usage anywhere in `app/`, `workers/`, `scripts/` or `supabase/`. I will re-run the live seasonal token check against production after this deploys.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Restore seasonal-token API access in edge workers

### What Changed
- Seasonal-token API requests no longer fail because of an unsupported redirect setting
- Redirected active-season responses are rejected instead of following another host
- Added coverage for the supported redirect behavior and redirect failures

### Impact
`✅ Seasonal tokens no longer cause HTTP 500 errors`
`✅ Service credentials are not sent to redirected hosts`
`✅ Clearer handling of active-season lookup failures`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of redirected seasonal data requests.
  * Requests now fail safely when redirected instead of following redirects, helping prevent unintended credential exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR replaces workerd’s unsupported `redirect: 'error'` mode with `redirect: 'manual'` for the active-season lookup while preserving redirect rejection.

- Restores seasonal-token progress requests in the Cloudflare Worker runtime.
- Adds regression coverage for the accepted redirect mode and non-successful redirect responses.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because it restores workerd compatibility without weakening the service-role credential boundary.

Manual mode does not follow redirects, and the existing non-ok response check rejects redirected responses before their body can affect season resolution.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workers/api-gateway/src/utils/gameMode.ts | Uses workerd-compatible manual redirect handling while the existing non-ok check continues to reject redirects before parsing. |
| workers/api-gateway/src/__tests__/gameMode.test.ts | Adds focused tests for the redirect option and rejection of redirected active-season responses. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(workers): use a redirect mode worker..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/91707dd62c1a03bf6a7b75e29c2a299c349928ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50791534)</sub>

**Context used:**

- Knowledge Base — [API Gateway (Cloudflare Worker)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/api-gateway.md)

<!-- /greptile_comment -->