### PR TITLE
fix(api): backfill normalized progress for accounts that predate the seasonal deploy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,10 @@ When asked to "review for production readiness", "deep review", "is this safe to
 - **No runtime dependency additions** without explaining why existing deps are insufficient.
 - **Game data comes from `json.tarkov.dev` via the `/api/tarkov/*` server proxy.** Do not add usage of the `api.tarkov.dev` GraphQL API. Task objectives and prestige conditions are discriminated by the upstream `type` field; the synthetic `__typename` discriminator was removed — do not reintroduce it.
 - **Do not add new runtime dependencies on Tarkov task `alternatives`.** Upstream removed the field; branch relationships must be compiled from task-status failure conditions. Existing uses remain until the shared progress engine replaces them.
+- **Never put a bulk data rewrite in a schema migration.** Migrations are transactional, so a
+  timeout rolls the schema back while the frontend from the same merge still deploys. Ship the
+  schema, let the app tolerate missing rows, then backfill in a separate non-transactional, ranged,
+  idempotent migration. See the Database Migrations section of `docs/runbook.md`.
 - **Keep changes scoped** to the requested task. Prefer small, reviewable diffs.
 
 ## Coding Conventions

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -540,7 +540,9 @@ flowchart LR
 ### Flow
 
 1. Startup reads account metadata and legacy PvP/PvE from `user_progress`, then reads normalized
-   rows and prefers the normalized active row for each mode.
+   rows and prefers the normalized active row for each mode. An account with no normalized row falls
+   back to the legacy PvP/PvE JSON, so the normalized table can be populated lazily or backfilled
+   after the schema ships.
 2. Debounced writes call `sync_user_game_mode_progress`, which validates the caller, serializes
    concurrent account-row updates, updates account metadata, mirrors persistent PvP/PvE for older
    clients, and upserts each normalized row. The caller passes the season number its bundle was
@@ -579,7 +581,10 @@ flowchart LR
 ### Files
 
 - `supabase/migrations/20260804043342_normalize_game_mode_progress_and_add_seasonal.sql` — schema,
-  backfill, RLS, compatibility triggers, `team_member_mode_summary`, sync/sharing/prestige RPCs
+  RLS, compatibility triggers, `team_member_mode_summary`, sync/sharing/prestige RPCs
+- `supabase/migrations/20260806120000_add_game_mode_progress_backfill_helper.sql`,
+  `supabase/migrations/20260806120100_backfill_normalized_game_mode_progress.sql` — the persistent
+  PvP/PvE backfill, deliberately separate from the schema and applied one key range per transaction
 - `app/stores/tarkov/progressPersistence.ts`, `app/stores/tarkov/realtimeListener.ts`,
   `app/stores/useTarkov.ts` — load, merge, write, and realtime flow
 - `app/stores/useSystemStore.ts`, `app/stores/useTeamStore.ts` — mode-specific teams and teammate
@@ -597,6 +602,10 @@ flowchart LR
 - App `ACTIVE_SEASON` metadata must match the database's `private.active_season_*()` functions;
   the Worker resolves the active Seasonal number through the database instead of carrying a
   second runtime constant.
+- A missing normalized row is never treated as absent progress: reads fall back to `user_progress`,
+  and the backfill only fills rows whose `progress_data` carries no `level`, so it can never
+  overwrite a write that landed first. The backfill never changes `profile_public` on an existing
+  row, because "never set" and "explicitly set to false" are indistinguishable.
 - Historical Seasonal rows are retained but never merged into the active season. Locally persisted
   Seasonal progress is stamped with its season number and reset to defaults when that stamp does not
   match the active season; absent stamps are treated as the active season. `sync_user_game_mode_progress`

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -246,6 +246,25 @@ These show up in Supabase logs / query performance and are expected. Do not trea
 
 ## Database Migrations
 
+- **Never put a bulk data rewrite in a schema migration.** Migrations run in a transaction, so a
+  statement that exceeds `statement_timeout` rolls the whole file back — schema included — while the
+  Cloudflare Pages deploy from the same merge still succeeds. That is what took production down on
+  2026-08-06: the seasonal backfill timed out, `user_game_mode_progress` and
+  `sync_user_game_mode_progress` never got created, and the new frontend shipped against the old
+  schema, so every signed-in client got `404`s. Ship the schema first, then backfill in a separate
+  migration, and make the app tolerate rows that do not exist yet.
+- **A backfill migration should be non-transactional, ranged, and idempotent.** Use
+  `-- supabase:disable-transaction` with one statement per key range so each range commits on its
+  own, keep the conflict rule a no-op for rows that already hold real data, and re-running must
+  change nothing. See `20260806120000_add_game_mode_progress_backfill_helper.sql` and
+  `20260806120100_backfill_normalized_game_mode_progress.sql` for the shape. A single statement
+  covering every row also holds conflict locks on everything it inserts until it commits, which
+  blocks concurrent user writes to the same rows.
+- **Raise `statement_timeout` explicitly when a migration scans or rewrites whole tables**, and pair
+  the `SET` with a trailing `RESET statement_timeout;`.
+- **Nothing in CI runs a migration against production-sized data.** `supabase:check` resets an empty
+  local database, so per-row cost is invisible. Before merging a migration that touches every row,
+  estimate the row count and the per-row work by hand.
 - **Migrations are the source of truth. Do not change the production schema directly** via the
   Supabase dashboard / SQL editor. Direct edits cause drift: a fresh environment built from
   migrations no longer matches production, and the next `db push` can fail or apply destructive

--- a/supabase/migrations/20260806120000_add_game_mode_progress_backfill_helper.sql
+++ b/supabase/migrations/20260806120000_add_game_mode_progress_backfill_helper.sql
@@ -1,0 +1,65 @@
+-- Helper for the normalized-progress backfill.
+--
+-- Lives in its own transactional migration so the backfill migration can be non-transactional and
+-- call it once per key range, giving each range its own committed transaction. A single statement
+-- covering every account would hold conflict locks on the rows it inserts until it commits, which
+-- would block a concurrent user sync writing the same (user_id, game_mode, season_number).
+--
+-- The conflict rule only fills placeholder rows. A row created by the visibility RPC or the legacy
+-- sharing trigger carries no level, because the BEFORE trigger sanitizes '{}' into the empty shape
+-- rather than leaving it literally empty. Any real write carries a level, so it is never
+-- overwritten. profile_public is deliberately untouched on an existing row: there is no way to
+-- distinguish "never set" from "explicitly set to false", and re-publishing a profile the user just
+-- made private is worse than a profile that stays private until they toggle it again.
+CREATE OR REPLACE FUNCTION private.backfill_game_mode_progress_range(
+  p_from UUID,
+  p_to UUID
+)
+RETURNS BIGINT
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_rows BIGINT;
+BEGIN
+  INSERT INTO public.user_game_mode_progress AS target (
+    user_id,
+    game_mode,
+    season_number,
+    progress_data,
+    profile_public,
+    created_at,
+    updated_at
+  )
+  SELECT
+    progress.user_id,
+    mode.game_mode,
+    0,
+    public.sanitize_user_progress_mode_data(mode.progress_data),
+    CASE mode.game_mode
+      WHEN 'pvp' THEN COALESCE(preferences.profile_share_pvp_public, false)
+      ELSE COALESCE(preferences.profile_share_pve_public, false)
+    END,
+    COALESCE(progress.created_at, now()),
+    COALESCE(progress.updated_at, now())
+  FROM public.user_progress progress
+  CROSS JOIN LATERAL (
+    VALUES
+      ('pvp'::TEXT, COALESCE(progress.pvp_data, '{}'::jsonb)),
+      ('pve'::TEXT, COALESCE(progress.pve_data, '{}'::jsonb))
+  ) AS mode(game_mode, progress_data)
+  LEFT JOIN public.user_preferences preferences ON preferences.user_id = progress.user_id
+  WHERE progress.user_id >= p_from
+    AND (p_to IS NULL OR progress.user_id < p_to)
+  ON CONFLICT (user_id, game_mode, season_number) DO UPDATE
+  SET progress_data = EXCLUDED.progress_data
+  WHERE target.progress_data->'level' IS NULL
+    AND EXCLUDED.progress_data->'level' IS NOT NULL;
+
+  GET DIAGNOSTICS v_rows = ROW_COUNT;
+  RETURN v_rows;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.backfill_game_mode_progress_range(UUID, UUID)
+  FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/20260806120100_backfill_normalized_game_mode_progress.sql
+++ b/supabase/migrations/20260806120100_backfill_normalized_game_mode_progress.sql
@@ -1,0 +1,36 @@
+-- supabase:disable-transaction
+-- Copies existing persistent PvP/PvE progress into user_game_mode_progress.
+--
+-- Runs outside a transaction, one statement per key range, so each range commits on its own. A
+-- failure part-way leaves the completed ranges committed; because the ranges are idempotent, the
+-- next attempt re-runs them as no-ops and continues. The ranges split the uuid keyspace by leading
+-- hex digit, which is uniform for v4 uuids, and each one is an index range scan on the
+-- user_progress primary key.
+--
+-- This is deliberately not part of the schema migration. A backfill that rolls back must never take
+-- the schema with it: on 2026-08-06 that coupling left production with the new frontend and the old
+-- schema. The app tolerates missing rows — reads fall back to user_progress and the sync RPC
+-- creates rows on the next write — so the schema landing is what restores service, and this only
+-- fixes how a dormant account appears to others.
+SET statement_timeout = '15min';
+
+SELECT private.backfill_game_mode_progress_range('00000000-0000-0000-0000-000000000000', '10000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('10000000-0000-0000-0000-000000000000', '20000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('20000000-0000-0000-0000-000000000000', '30000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('30000000-0000-0000-0000-000000000000', '40000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('40000000-0000-0000-0000-000000000000', '50000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('50000000-0000-0000-0000-000000000000', '60000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('60000000-0000-0000-0000-000000000000', '70000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('70000000-0000-0000-0000-000000000000', '80000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('80000000-0000-0000-0000-000000000000', '90000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('90000000-0000-0000-0000-000000000000', 'a0000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('a0000000-0000-0000-0000-000000000000', 'b0000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('b0000000-0000-0000-0000-000000000000', 'c0000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('c0000000-0000-0000-0000-000000000000', 'd0000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('d0000000-0000-0000-0000-000000000000', 'e0000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('e0000000-0000-0000-0000-000000000000', 'f0000000-0000-0000-0000-000000000000');
+SELECT private.backfill_game_mode_progress_range('f0000000-0000-0000-0000-000000000000', NULL);
+
+RESET statement_timeout;
+
+DROP FUNCTION private.backfill_game_mode_progress_range(UUID, UUID);


### PR DESCRIPTION
## **User description**
Closes #650.

## Why

The backfill was pulled out of the schema migration during the 2026-08-06 incident (#649) so that a slow copy could not roll the schema back. That worked, but it left accounts which have not written since the deploy without a normalized row.

That is invisible to the account owner — `useTarkov` falls back to `user_progress` (`modeProgressResult.data.pvp ?? data?.pvp_data`) — but it is visible to everyone else:

- `team_member_mode_summary` has no row, so a dormant teammate shows no level or task count in a team
- a shared profile with sharing enabled reads as private, because a missing row is treated as private

Both self-heal on that account's next sync, so no one will report it.

## How

Two migrations. A transactional one creates a helper that backfills a single uuid key range; a non-transactional one calls it 16 times, once per leading hex digit, and drops the helper.

One statement per range means one transaction per range:

- a failure part-way leaves the completed ranges committed, and because each range is idempotent the retry re-runs them as no-ops and continues
- a single statement over every account would hold conflict locks on every row it inserts until it commits, blocking a concurrent user sync writing the same `(user_id, game_mode, season_number)` — that was the flaw in the first attempt on #649
- v4 uuids distribute uniformly across the 16 ranges, and each range is an index scan on the `user_progress` primary key

The helper needed to be created in a separate transactional migration: the Supabase CLI does not create a dollar-quoted function body before calling it inside a `-- supabase:disable-transaction` file (it failed with `procedure ... does not exist` at the `CALL` when I tried it in #649).

Conflict rule:

```sql
ON CONFLICT (user_id, game_mode, season_number) DO UPDATE
SET progress_data = EXCLUDED.progress_data
WHERE target.progress_data->'level' IS NULL
  AND EXCLUDED.progress_data->'level' IS NOT NULL
```

`level` is the discriminator because a placeholder row is not literally `{}`: the BEFORE trigger sanitizes on insert, so the visibility RPC and the legacy sharing trigger leave the sanitized empty shape, which has no `level`. Every real write carries one (the client defaults to 1 and the sanitizer clamps to >= 1). `profile_public` is deliberately not merged — "never set" and "explicitly set to false" are indistinguishable, and re-publishing a profile the user just made private is worse than one that stays private until they toggle it.

## Verification

Local stack reset to the pre-seasonal schema (`--version 20260729120000`), seeded with legacy rows including an account in the final key range (`ffffffff-…`), then migrated:

- all six expected rows created at season 0, and **zero** mismatches against `sanitize_user_progress_mode_data(user_progress.*)` across every account and both modes
- `user_progress` untouched
- helper dropped afterwards
- incident-window simulation: a visibility-only PvP placeholder (`profile_public = true`, no progress) was filled with the legacy level 42 and kept its visibility; a concurrent PvE write at level 99 was preserved; a Seasonal row was ignored entirely
- resume: a single range produced 2 rows, then a full run added the remaining 4
- idempotence: a full re-run reported 0 rows touched per range and left the table state hash byte-identical

`pnpm run supabase:check` applies all five migrations cleanly and `supabase db lint` is clean.

## Also

Records the rule this incident produced, in `AGENTS.md` and the Database Migrations section of `docs/runbook.md`: a schema migration must not contain a bulk data rewrite, a backfill must be non-transactional, ranged and idempotent, `statement_timeout` raises must be paired with `RESET`, and nothing in CI exercises a migration against production-sized data.

Not included: the post-deploy smoke check discussed in #654. It needs a token per game mode as CI secrets, so it belongs with that issue rather than here.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Restore normalized progress for dormant accounts without disrupting live user data

### What Changed
- Existing PvP and PvE progress is backfilled into normalized records so teammates can see dormant users’ levels and task counts, and shared profiles retain their correct visibility.
- Backfill runs in independent UUID ranges, allowing interrupted runs to resume without repeating completed work or rolling back the schema.
- Existing progress with a level is never overwritten, and existing profile visibility settings are preserved.
- Documentation now defines safe handling for large data backfills and missing normalized rows.

### Impact
`✅ Accurate teammate progress for dormant accounts`
`✅ Shared profiles retain intended visibility`
`✅ Fewer migration rollbacks and blocked user syncs`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR backfills persistent PvP and PvE progress for accounts missing normalized rows while preserving concurrent writes and existing profile visibility.
- Adds a private, range-scoped, idempotent backfill helper.
- Executes the backfill outside a wrapping transaction across sixteen UUID ranges, then removes the helper.
- Documents the normalized-progress fallback and operational rules for safe bulk migrations.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete correctness or security defects identified.

The ranges cover the UUID keyspace without overlap, existing normalized writes containing a level are preserved, visibility-only placeholders are filled without changing their sharing state, and partial execution leaves the helper available for an idempotent retry.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| supabase/migrations/20260806120000_add_game_mode_progress_backfill_helper.sql | Adds a schema-qualified helper that sanitizes legacy mode data, preserves visibility, and avoids replacing normalized rows containing real progress. |
| supabase/migrations/20260806120100_backfill_normalized_game_mode_progress.sql | Runs the idempotent helper over sixteen complete UUID ranges with independent commits, restores the timeout setting, and drops the helper. |
| docs/SYSTEMS.md | Documents fallback behavior, backfill ownership, and the invariant that concurrent normalized progress and existing visibility are preserved. |
| docs/runbook.md | Records operational requirements for separating bulk backfills from transactional schema migrations. |
| AGENTS.md | Adds the repository-level rule requiring non-transactional, ranged, and idempotent backfills. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant M as Migration runner
    participant H as Backfill helper
    participant L as user_progress
    participant N as user_game_mode_progress
    loop Each UUID prefix range
        M->>H: backfill_game_mode_progress_range(from, to)
        H->>L: Read legacy PvP and PvE progress
        H->>N: Insert sanitized season 0 rows
        alt Existing row has no level
            N->>N: Fill progress_data and preserve profile_public
        else Existing row has a level
            N->>N: Keep current normalized progress
        end
        H-->>M: Rows affected
    end
    M->>H: Drop helper function
```
</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): backfill normalized progress f..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/43d893e912ac4536e54f2187739e733344cc984c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50798229)</sub>

<!-- /greptile_comment -->