### PR TITLE
fix(api): revoke anon/authenticated EXECUTE on legacy share trigger

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,12 @@ When asked to "review for production readiness", "deep review", "is this safe to
 - **No runtime dependency additions** without explaining why existing deps are insufficient.
 - **Game data comes from `json.tarkov.dev` via the `/api/tarkov/*` server proxy.** Do not add usage of the `api.tarkov.dev` GraphQL API. Task objectives and prestige conditions are discriminated by the upstream `type` field; the synthetic `__typename` discriminator was removed — do not reintroduce it.
 - **Do not add new runtime dependencies on Tarkov task `alternatives`.** Upstream removed the field; branch relationships must be compiled from task-status failure conditions. Existing uses remain until the shared progress engine replaces them.
+- **Revoke function EXECUTE from `PUBLIC, anon, authenticated`, never `PUBLIC` alone.** Supabase
+  ships `ALTER DEFAULT PRIVILEGES` on schema `public` that grants `EXECUTE` on every new function to
+  `anon`, `authenticated`, and `service_role`. `REVOKE ALL ON FUNCTION ... FROM PUBLIC` only drops
+  the implicit `PUBLIC` grant and leaves those explicit role grants in place, which trips advisor
+  lint 0028 on `SECURITY DEFINER` functions. Trigger functions and service-role-only helpers must
+  name all three roles. Grant back to `service_role` explicitly when the service role needs it.
 - **Never put a bulk data rewrite in a migration.** The deployment runner applies each migration file
   atomically even when `-- supabase:disable-transaction` is present, so a timeout rolls back the file
   while other deploy targets can still succeed. Ship schema separately, make every read tolerate

--- a/supabase/migrations/20260807120000_revoke_legacy_share_trigger_execute.sql
+++ b/supabase/migrations/20260807120000_revoke_legacy_share_trigger_execute.sql
@@ -1,0 +1,19 @@
+-- Address advisor lint 0028 anon_security_definer_function_executable for
+-- public.sync_legacy_profile_share_visibility().
+--
+-- Supabase ships ALTER DEFAULT PRIVILEGES on schema public that grants EXECUTE
+-- on new functions to anon, authenticated, and service_role. The creating
+-- migration (20260804043342) only ran `REVOKE ALL ... FROM PUBLIC`, which drops
+-- the implicit PUBLIC grant but leaves those explicit role grants in place, so
+-- the function stayed callable by anon and authenticated via PostgREST.
+--
+-- Revoking is behavior-neutral: the AFTER UPDATE trigger on user_preferences
+-- fires as the table owner regardless of the caller's EXECUTE privilege, and
+-- nothing invokes this function directly.
+--
+-- The other SECURITY DEFINER functions here are intentional and left alone:
+-- sync_user_game_mode_progress, set_game_mode_profile_visibility, and
+-- archive_prestige_run_and_reset_progress are authenticated RPCs that validate
+-- auth.uid() and pin search_path.
+REVOKE EXECUTE ON FUNCTION public.sync_legacy_profile_share_visibility()
+  FROM PUBLIC, anon, authenticated;


### PR DESCRIPTION
## **User description**
## Summary

Clears Supabase advisor lint [0028 anon_security_definer_function_executable](https://supabase.com/docs/guides/database/database-linter?lint=0028_anon_security_definer_function_executable) for `public.sync_legacy_profile_share_visibility()`.

The creating migration (`20260804043342`) ran only `REVOKE ALL ON FUNCTION ... FROM PUBLIC`. That drops the implicit `PUBLIC` grant but leaves the explicit `anon`/`authenticated` grants that Supabase's `ALTER DEFAULT PRIVILEGES` on schema `public` attaches to every new function, so the `SECURITY DEFINER` trigger function stayed `EXECUTE`-able by both client roles.

Also adds the corresponding Hard Rule to `AGENTS.md` so the one-line `FROM PUBLIC` form does not reappear.

## Scope

Verified against production that this is the **only** affected function. Queried `has_function_privilege` for every `SECURITY DEFINER` function in `public`:

- `sync_legacy_profile_share_visibility` — `anon: true`, `authenticated: true` → fixed here.
- `sync_user_game_mode_progress`, `set_game_mode_profile_visibility`, `archive_prestige_run_and_reset_progress` — intentional authenticated RPCs that validate `auth.uid()` and pin `search_path`. Left alone by design; their advisor warnings are expected.
- Everything else already had both grants revoked.

`sync_legacy_user_progress_modes` was initially suspected but is `SECURITY INVOKER`, so lint 0028 does not apply.

## Testing

`supabase db reset` — all 108 migrations apply cleanly.

Behavior-neutral, verified locally by firing the trigger as the `authenticated` role with `EXECUTE` already revoked:

```
   acting_as   | can_exec_fn
---------------+-------------
 authenticated | f

UPDATE 1

 game_mode | season_number | profile_public
-----------+---------------+----------------
 pve       |             0 | t
 pvp       |             0 | t
```

The trigger fires as the table owner, so revoking the caller's `EXECUTE` does not affect it. Direct invocation was never possible anyway — PostgreSQL rejects it at compile time with `trigger functions can only be called as triggers`.

## Risk

Metadata-only single `REVOKE`. No table is read or rewritten. Reversible with a matching `GRANT`.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
**Revoke client access to the legacy profile-share trigger**

### What Changed
- Anonymous and authenticated users can no longer execute the legacy profile-share trigger function directly
- Profile-share updates continue to work because the database trigger still runs automatically
- Added a migration rule requiring explicit permission removal for public, anonymous, and authenticated roles on protected functions

### Impact
`✅ Prevented unauthorized client execution`
`✅ Preserved automatic profile-share updates`
`✅ Cleared the security advisor warning`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes direct execution of a legacy `SECURITY DEFINER` trigger function from client-facing database roles and documents the required privilege-revocation pattern.

- Adds a migration revoking `EXECUTE` from `PUBLIC`, `anon`, and `authenticated`.
- Adds an `AGENTS.md` hard rule to prevent incomplete function privilege revocations.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because the migration narrows direct function privileges while preserving owner-executed trigger behavior.

The target function is created earlier with the exact referenced signature, remains present through intervening migrations, and the new statement only revokes unintended execution grants.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| supabase/migrations/20260807120000_revoke_legacy_share_trigger_execute.sql | Correctly targets the existing zero-argument trigger function and removes the unintended client-role grants without affecting trigger execution. |
| AGENTS.md | Documents the Supabase default-privilege behavior and the complete role list required for future revocations. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(api): revoke anon and authenticated ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/dd6be8201476374041515cbc11ffc81ae1f66063) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51043978)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Restricted direct execution of the legacy profile-sharing synchronization function to prevent unauthorized access.
  * Preserved automatic synchronization through the existing database trigger.
* **Documentation**
  * Added guidance requiring explicit execution privileges for database functions, including service-level access where appropriate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->