### PR TITLE
chore(api): schedule api_usage_daily and mutation_rate_limits retention

### DIFF
--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -161,7 +161,9 @@ RPC + table: migration `supabase/migrations/20260404120000_add_mutation_rate_lim
 
 **Hygiene**
 
-Expired rows are harmless but accumulate. Safe cleanup:
+Expired rows are harmless but accumulate. The `mutation-rate-limits-cleanup` pg_cron job
+(`supabase/migrations/20260807130000_add_usage_and_rate_limit_retention.sql`) runs this nightly at
+03:30 UTC; run it manually only when investigating an incident:
 
 ```sql
 DELETE FROM public.mutation_rate_limits
@@ -408,8 +410,8 @@ Treat these deliberately; do not “make everything fail open” without underst
 
 | Store                       | Retention guidance                                                                                                                                                                                                                                                          |
 | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `mutation_rate_limits`      | Delete rows with `reset_at` older than 1 day periodically                                                                                                                                                                                                                   |
-| `api_usage_daily`           | Keep finite retention (e.g. 90–180 days) for observability                                                                                                                                                                                                                  |
+| `mutation_rate_limits`      | 1 day past `reset_at`, enforced nightly at 03:30 UTC by the `mutation-rate-limits-cleanup` pg_cron job                                                                                                                                                                      |
+| `api_usage_daily`           | 180 days, enforced nightly at 03:15 UTC by the `api-usage-daily-cleanup` pg_cron job                                                                                                                                                                                        |
 | Worker DO state             | Ephemeral keys self-clean via alarms; retained authenticated keys expire by window logic                                                                                                                                                                                    |
 | Legacy burst/IP DO keys     | Removed in the single daily-quota refactor and never re-addressed; gateway-created retained keys did not schedule cleanup alarms, so their finite orphaned state persists until the staged cleanup in [#594](https://github.com/tarkovtracker-org/TarkovTracker/issues/594) |
 | `account_deletion_attempts` | Existing cleanup function / retention policy                                                                                                                                                                                                                                |

--- a/supabase/migrations/20260807130000_add_usage_and_rate_limit_retention.sql
+++ b/supabase/migrations/20260807130000_add_usage_and_rate_limit_retention.sql
@@ -1,0 +1,40 @@
+-- Implement the retention policies documented in docs/RATE_LIMITING.md, which
+-- were specified but never scheduled.
+--
+-- api_usage_daily: 180 days, the top of the documented 90-180 day range. The
+-- admin usage endpoint only reads the last two UTC days, so the longer window is
+-- purely for trend/abuse analysis. idx_api_usage_daily_day backs the range scan.
+--
+-- mutation_rate_limits: rows are dead once reset_at has passed; 1 day of slack
+-- keeps them available for incident triage. The table holds ~140 live rows, so
+-- the sequential scan is irrelevant.
+--
+-- Mirrors 20260523130000_stripe_events_retention.sql, including the idempotent
+-- unschedule-then-schedule guard (cron.schedule throws on a duplicate jobname
+-- and cron.unschedule raises when the job is missing). Times are staggered so
+-- the nightly jobs do not overlap stripe-events-cleanup at 03:00.
+CREATE EXTENSION IF NOT EXISTS pg_cron SCHEMA extensions;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'api-usage-daily-cleanup') THEN
+    PERFORM cron.unschedule('api-usage-daily-cleanup');
+  END IF;
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'mutation-rate-limits-cleanup') THEN
+    PERFORM cron.unschedule('mutation-rate-limits-cleanup');
+  END IF;
+END;
+$$;
+
+SELECT cron.schedule(
+  'api-usage-daily-cleanup',
+  '15 3 * * *',
+  $$DELETE FROM public.api_usage_daily
+    WHERE day < ((NOW() AT TIME ZONE 'utc')::date - 180)$$
+);
+
+SELECT cron.schedule(
+  'mutation-rate-limits-cleanup',
+  '30 3 * * *',
+  $$DELETE FROM public.mutation_rate_limits WHERE reset_at < NOW() - INTERVAL '1 day'$$
+);


### PR DESCRIPTION
## Summary

`docs/RATE_LIMITING.md` has specified retention for `api_usage_daily` (90–180 days) and `mutation_rate_limits` (1 day past `reset_at`) for a while, but no job ever enforced either. `api_usage_daily` had grown to ~29k rows with no cleanup path.

Adds two `pg_cron` jobs, mirroring `20260523130000_stripe_events_retention.sql` including its idempotent unschedule-then-schedule guard:

| Job | Schedule (UTC) | Policy |
| --- | --- | --- |
| `api-usage-daily-cleanup` | `15 3 * * *` | delete rows older than 180 days |
| `mutation-rate-limits-cleanup` | `30 3 * * *` | delete rows with `reset_at` older than 1 day |

Staggered so neither overlaps the existing `stripe-events-cleanup` at 03:00.

180 days is the top of the documented range. The admin usage endpoint (`app/server/api/admin/api-usage.get.ts`) only reads the last two UTC days, so the longer window exists purely for trend and abuse analysis. `idx_api_usage_daily_day` backs the range scan, and the predicate uses integer date arithmetic (`::date - 180`) so it stays a `date` comparison against the indexed column.

Docs updated to state the enforced policy rather than guidance.

## Risk

Effectively zero on the first run. Production `api_usage_daily` currently spans `2026-07-08` to `2026-08-07`, so the 180-day job deletes **0 rows** for roughly the next five months — there is no large first-run delete. `mutation_rate_limits` holds ~140 live rows.

## Testing

`supabase db reset` — all 108 migrations apply cleanly, and both jobs register:

```
           jobname            |  schedule  |                    command
------------------------------+------------+------------------------------------------------
 api-usage-daily-cleanup      | 15 3 * * * | DELETE FROM public.api_usage_daily            +
                              |            |     WHERE day < ((NOW() AT TIME ZONE 'utc')::date - 180)
 mutation-rate-limits-cleanup | 30 3 * * * | DELETE FROM public.mutation_rate_limits WHERE reset_at < NOW() - INTERVAL '1 day'
 stripe-events-cleanup        | 0 3 * * *  | DELETE FROM public.stripe_events WHERE received_at < NOW() - INTERVAL '30 days'
```

Both `DELETE` bodies were then executed inside a transaction and rolled back, confirming they parse and plan rather than failing silently at 03:15 every night.

`CREATE EXTENSION IF NOT EXISTS pg_cron` is a no-op: production already has pg_cron 1.6.4 installed.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds nightly pg_cron jobs that enforce the documented retention periods for API usage aggregates and expired mutation-rate-limit rows. It also updates the rate-limiting documentation to describe the enforced schedules.
- Retains `api_usage_daily` records for 180 days and cleans them at 03:15 UTC.
- Retains expired `mutation_rate_limits` records for one additional day and cleans them at 03:30 UTC.
- Uses the repository’s existing unschedule-then-schedule migration pattern for idempotent job registration.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable correctness or security issues identified.

The cleanup predicates match the tables’ UTC date and timestamp semantics, preserve all data needed by current consumers, and follow the established pg_cron migration pattern.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| supabase/migrations/20260807130000_add_usage_and_rate_limit_retention.sql | Adds two idempotently registered cleanup jobs whose predicates match the underlying date/timestamp schemas and current data-consumer requirements. |
| docs/RATE_LIMITING.md | Updates retention guidance to accurately document the new enforced policies and nightly schedules. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(api): schedule api\_usage\_daily and..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/45d76098cc2ddd8e7d8541b552bbd1fc061f5ab5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51044057)</sub>

<!-- /greptile_comment -->