### PR TITLE
chore(api): api_usage_daily deny-all policy, drop dead indexes, tune autovacuum

### DIFF
--- a/supabase/migrations/20260807140000_advisor_cleanup_policy_index_autovacuum.sql
+++ b/supabase/migrations/20260807140000_advisor_cleanup_policy_index_autovacuum.sql
@@ -1,0 +1,58 @@
+-- Advisor cleanup. Every statement is metadata-only; no row is read or rewritten.
+--
+-- 1. Lint 0008 rls_enabled_no_policy on api_usage_daily. RLS is enabled with no
+--    policies and anon/authenticated have no table grants, so access is already
+--    denied twice over. Only service_role touches the table, via the SECURITY
+--    DEFINER record_api_usage/get_api_usage_summary functions, and service_role
+--    bypasses RLS. The explicit deny-all policy documents intent and clears the
+--    lint without changing behavior. Mirrors 20260630120000 for
+--    mutation_rate_limits.
+DROP POLICY IF EXISTS "No direct access" ON public.api_usage_daily;
+CREATE POLICY "No direct access"
+  ON public.api_usage_daily
+  FOR ALL
+  TO anon, authenticated
+  USING (false)
+  WITH CHECK (false);
+
+-- 2. Lint 0005 unused_index, limited to indexes with a proven replacement.
+--
+--    idx_team_memberships_user_id (0 scans) is a strict prefix of
+--    team_memberships_user_mode_unique on (user_id, game_mode), which serves
+--    every user_id lookup. idx_team_memberships_team_id is deliberately kept:
+--    it is the hottest index on the table.
+--
+--    idx_api_usage_daily_user_agent (0 scans) is a partial index created
+--    out-of-band; no migration defines it. User-agent values are read as
+--    attributes of a token/day row, never used as a search key.
+DROP INDEX IF EXISTS public.idx_team_memberships_user_id;
+DROP INDEX IF EXISTS public.idx_api_usage_daily_user_agent;
+
+-- 3. Autovacuum thresholds for the high-churn progress tables. Both sit just
+--    below the default trigger point (dead tuples vs 50 + 0.2 * live), so the
+--    main heaps had never been autovacuumed despite ~18% dead tuples. Lowering
+--    the scale factor makes vacuum run regularly, which keeps the visibility map
+--    and index health from degrading.
+--
+--    The toast.* settings matter more than the heap ones here: these tables are
+--    ~96% TOAST (user_progress is 15 MB heap / 432 MB TOAST) because every
+--    progress write rewrites a multi-kilobyte JSONB payload. This bounds TOAST
+--    growth going forward; it does not shrink the existing relation. Reclaiming
+--    that space requires retiring the legacy pvp_data/pve_data payload, not
+--    VACUUM FULL.
+--
+--    ALTER TABLE ... SET (storage parameters) takes SHARE UPDATE EXCLUSIVE,
+--    which does not block concurrent reads or writes.
+ALTER TABLE public.user_progress SET (
+  autovacuum_vacuum_scale_factor = 0.02,
+  autovacuum_vacuum_threshold = 1000,
+  autovacuum_analyze_scale_factor = 0.02,
+  toast.autovacuum_vacuum_scale_factor = 0.05
+);
+
+ALTER TABLE public.user_game_mode_progress SET (
+  autovacuum_vacuum_scale_factor = 0.02,
+  autovacuum_vacuum_threshold = 1000,
+  autovacuum_analyze_scale_factor = 0.02,
+  toast.autovacuum_vacuum_scale_factor = 0.05
+);


### PR DESCRIPTION
## **User description**
## Summary

Three metadata-only Supabase advisor cleanups. No statement reads or rewrites a row.

### 1. Deny-all policy on `api_usage_daily` (lint 0008)

Verified in production: `relrowsecurity = true`, `0` policies, and `anon`/`authenticated` have no `SELECT`. Access is already denied twice over. Only `service_role` touches the table via the `SECURITY DEFINER` `record_api_usage` / `get_api_usage_summary` functions, and `service_role` bypasses RLS. The policy documents intent and clears the informational lint without changing behavior. Mirrors `20260630120000` for `mutation_rate_limits`.

### 2. Drop two dead indexes (lint 0005)

Limited to indexes with a **proven** replacement, verified against `pg_stat_user_indexes`:

| Index | Scans | Disposition |
| --- | --- | --- |
| `idx_team_memberships_user_id` | 0 | **Dropped.** Strict prefix of `team_memberships_user_mode_unique (user_id, game_mode)`, which has 6,715 scans and serves every `user_id` lookup. |
| `idx_api_usage_daily_user_agent` | 0 | **Dropped.** Partial index defined by no migration. User-agent is read as an attribute of a token/day row, never as a search key. |
| `idx_team_memberships_team_id` | 275,388 | **Kept** — hottest index on the table. |
| `idx_api_usage_daily_day` | 1 | **Kept** — backs the retention job in #660. |

All other advisor-flagged unused indexes are left in place; they support cleanup, audit, Stripe, and cooldown paths.

### 3. Autovacuum thresholds on the progress tables

This is not purely prophylactic. Production shows `last_autovacuum = NULL` on both main heaps: `user_progress` has 3,477 dead vs 19,401 live tuples, just under the default `50 + 0.2 * live` trigger point, so vacuum had never run. Lowering the scale factor makes it run regularly.

The `toast.*` settings matter more here. Both tables are ~96% TOAST because every progress write rewrites a multi-kilobyte JSONB payload:

| Table | Total | Heap | TOAST |
| --- | --- | --- | --- |
| `user_progress` | 448 MB | 15 MB | 432 MB |
| `user_game_mode_progress` | 334 MB | 17 MB | 316 MB |

This bounds future TOAST growth. It does **not** shrink the existing relations — that requires retiring the legacy `pvp_data`/`pve_data` payload once all readers and writers are migrated, not `VACUUM FULL`.

## Risk

`ALTER TABLE ... SET (storage parameters)` takes `SHARE UPDATE EXCLUSIVE`, which does not block concurrent reads or writes. `DROP INDEX` takes a brief `ACCESS EXCLUSIVE`; on these tables (88–376 kB) that is milliseconds, matching the precedent set by `20260630150000`. Both drops are reversible from history.

## Testing

`supabase db reset` — all 108 migrations apply cleanly. Verified end state:

```
 policy     | No direct access             | *  | {anon,authenticated}
 index      | idx_api_usage_daily_day      |    |
 index      | idx_team_memberships_team_id |    |
 reloptions | user_progress                | {autovacuum_vacuum_scale_factor=0.02,autovacuum_vacuum_threshold=1000,autovacuum_analyze_scale_factor=0.02}
 reloptions | user_game_mode_progress      | {autovacuum_vacuum_scale_factor=0.02,autovacuum_vacuum_threshold=1000,autovacuum_analyze_scale_factor=0.02}
```

`idx_team_memberships_user_id` is gone and the two retained indexes remain. The `toast.*` option lands on the TOAST relation as expected:

```
         relname         |   toast_rel    |              toast_opts
-------------------------+----------------+---------------------------------------
 user_progress           | pg_toast_18685 | {autovacuum_vacuum_scale_factor=0.05}
 user_game_mode_progress | pg_toast_19227 | {autovacuum_vacuum_scale_factor=0.05}
```

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/661?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Keep progress data healthy while removing unused database overhead

### What Changed
- Progress tables are cleaned up and analyzed more regularly, including their large JSON data, to limit dead-row and storage buildup
- Removed two unused indexes while retaining the indexes needed for active lookups
- Explicitly blocks direct access to daily API usage records for anonymous and signed-in users

### Impact
`✅ Lower storage growth for progress data`
`✅ Healthier progress-table performance over time`
`✅ Fewer unused database indexes`
`✅ Clearer protection for API usage records`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a metadata-only Supabase migration to address database advisor findings.
- Adds an explicit deny-all RLS policy for direct access to `api_usage_daily`.
- Removes two unused indexes whose relevant query paths remain covered.
- Tunes heap and TOAST autovacuum settings for the progress tables.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no identified behavioral, security, or migration failure.

Existing API usage access remains available through service-role-only functions, membership queries retain suitable index coverage, and the autovacuum parameters are supported by the configured PostgreSQL version and target tables.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| supabase/migrations/20260807140000_advisor_cleanup_policy_index_autovacuum.sql | The policy, index removals, and storage parameters are compatible with the established schema and repository access paths; no actionable defect was identified. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(api): add api\_usage\_daily deny-all..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/bd5e32027e52514b6125607b50d6569f14873ce6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51044169)</sub>

<!-- /greptile_comment -->