### PR TITLE
docs: correct the realtime publication table list in the runbook

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -232,8 +232,13 @@ These show up in Supabase logs / query performance and are expected. Do not trea
    - Source: Supabase Realtime's continuous WAL poller. Tops the chart by call volume, not
      latency (low mean time, ~99.9999% cache hit). Expected for an always-on poller.
    - Health checks: replication slots are `active`/`streaming` with `0 GB` lag, and the
-     `supabase_realtime` publication is narrowly scoped to `public.user_progress` only (not
-     `FOR ALL TABLES`). This is the desired configuration.
+     `supabase_realtime` publication is explicitly scoped to a named table list (not
+     `FOR ALL TABLES`). This is the desired configuration. The current list is
+     `public.user_progress`, `public.user_game_mode_progress`, `public.team_memberships`, and
+     `public.supporters`, added by `20251205120619`, `20260804043342` (the latter two tables), and
+     `20260714065213` respectively. Verify with
+     `SELECT tablename FROM pg_publication_tables WHERE pubname = 'supabase_realtime';` and update
+     this list whenever a migration adds or removes a table.
    - Watch for: occasional high max-time correlates with an inactive/lagging replication slot.
      Verify with `supabase inspect db replication-slots --linked` (lag should stay ~0).
 

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -234,9 +234,9 @@ These show up in Supabase logs / query performance and are expected. Do not trea
    - Health checks: replication slots are `active`/`streaming` with `0 GB` lag, and the
      `supabase_realtime` publication is explicitly scoped to a named table list (not
      `FOR ALL TABLES`). This is the desired configuration. The current list is
-     `public.user_progress`, `public.user_game_mode_progress`, `public.team_memberships`, and
-     `public.supporters`, added by `20251205120619`, `20260804043342` (the latter two tables), and
-     `20260714065213` respectively. Verify with
+     `public.user_progress` (added by `20251205120619`), `public.supporters` (added by
+     `20260714065213`), and `public.user_game_mode_progress` plus `public.team_memberships` (both
+     added by `20260804043342`). Verify with
      `SELECT tablename FROM pg_publication_tables WHERE pubname = 'supabase_realtime';` and update
      this list whenever a migration adds or removes a table.
    - Watch for: occasional high max-time correlates with an inactive/lagging replication slot.


### PR DESCRIPTION
## Summary

The runbook's Realtime health-check note claimed the `supabase_realtime` publication is "narrowly scoped to `public.user_progress` only". Three later migrations added tables and the doc was never updated:

- `20260714065213` → `public.supporters`
- `20260804043342` → `public.user_game_mode_progress` and `public.team_memberships`

Verified against production:

```
 realtime | user_progress
 realtime | team_memberships
 realtime | supporters
 realtime | user_game_mode_progress
```

The important part of the original claim — that the publication uses a named table list rather than `FOR ALL TABLES` — is still true and is preserved. Adds the verification query and an instruction to keep the list current, since the `AGENTS.md` maintenance contract requires this doc to move in the same PR as a migration that changes the publication.

Docs only, no code or schema change.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR corrects the Realtime publication runbook by explicitly mapping each published table to its migration, removing the previously reported ambiguous attribution.
- Documents all four tables currently included in `supabase_realtime`.
- Adds a catalog query for verifying the publication.
- Reminds maintainers to update the list when migrations change publication membership.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the prior ambiguous migration attribution is now explicit and matches the referenced migrations.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/runbook.md | The revised wording accurately attributes each Realtime table to its migration and fully resolves the prior ambiguity. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: name each migration&#39;s realtime tab..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/50f21f9fba52c5aaa5075faf0e4c9d32f1022bed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51044225)</sub>

<!-- /greptile_comment -->