### PR TITLE
refactor(config): consolidate shared environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,22 +16,13 @@
 SUPABASE_URL=
 SUPABASE_ANON_KEY=
 
-# === OPTIONAL: Nuxt-only Supabase configuration
-# Used by: Nuxt server routes. Never expose the service-role key to the browser.
+# === REQUIRED FOR PRODUCTION: Nuxt-only Supabase configuration
+# Optional for local offline development. Used by Nuxt server routes in production.
+# Never expose the service-role key to the browser.
 # NUXT_SUPABASE_SERVICE_KEY=
 
-# === OPTIONAL: Production database observer (read-only tooling)
-# Use a direct database connection for the dedicated observer role, not the
-# transaction pooler. The wrapper rejects the documented transaction-pooler port 6543.
-# Never use the service role, postgres admin, or a migration credential here. Set
-# PROD_DB_TARGET=local for local inspection.
-# PROD_DB_URL=
-# PROD_DB_TARGET=primary
-# PROD_DB_APPLICATION_NAME=pi-prod-observer
-# PROD_DB_TIMEOUT_MS=15000
-# PROD_DB_MAX_OUTPUT_BYTES=1000000
-
-
+# === OPTIONAL: App and analytics configuration
+# NUXT_PUBLIC_APP_URL=http://localhost:3000  # APP_URL / CF_PAGES_URL are platform fallbacks
 # GA_MEASUREMENT_ID=G-XXXXXXXXXX
 # CLARITY_PROJECT_ID=xxxxxxxxxx
 # VITE_PERF_DEBUG=false  # client performance timing logs; accepts 1, true, yes, or on

--- a/.env.example
+++ b/.env.example
@@ -2,47 +2,49 @@
 # Copy this file to .env and fill in your values.
 #
 # Naming convention:
-#   NUXT_*          — Nuxt private runtime config (server-only)
-#   NUXT_PUBLIC_*   — Nuxt public runtime config (browser-exposed)
-#   Plain names     — Platform/build-time or Supabase Edge Functions
-
-# =============================================================================
-# OPTIONAL: Supabase Configuration (for login/sync features)
-# =============================================================================
-# The app works without Supabase - you just won't have login/sync functionality.
-# Get these from: https://supabase.com/dashboard/project/_/settings/api
+#   SUPABASE_*       — shared Supabase project settings (Nuxt, Pages, Workers, Edge Functions)
+#   NUXT_*           — Nuxt private runtime config (server-only)
+#   NUXT_PUBLIC_*    — Nuxt public runtime config (browser-exposed)
+#   Plain names      — platform/build-time or Supabase Edge Function settings
 #
-# Preferred: NUXT_PUBLIC_* (Nuxt canonical). Plain SUPABASE_* also works as a
-# cross-platform fallback.
+# The shared SUPABASE_* values are the canonical names for values used by more than one
+# runtime. Nuxt reads them directly, so do not duplicate them as NUXT_PUBLIC_* values.
 
-NUXT_PUBLIC_SUPABASE_URL=
-NUXT_PUBLIC_SUPABASE_ANON_KEY=
-# SUPABASE_URL=        # cross-platform fallback (also used by Supabase Edge Functions)
-# SUPABASE_ANON_KEY=   # cross-platform fallback
+# === REQUIRED: Shared Supabase project configuration
+# Used by: Nuxt local/Pages builds, Cloudflare Workers, and Supabase Edge Functions.
+# Get these from: https://supabase.com/dashboard/project/_/settings/api
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
 
-# Server-side only (for admin API routes - keep secret!)
+# === OPTIONAL: Nuxt-only Supabase configuration
+# Used by: Nuxt server routes. Never expose the service-role key to the browser.
 # NUXT_SUPABASE_SERVICE_KEY=
 
-# =============================================================================
-# OPTIONAL: App Configuration
-# =============================================================================
-# NUXT_PUBLIC_APP_URL=http://localhost:3000
-# APP_URL=             # platform fallback (Cloudflare Pages, CI)
+# === OPTIONAL: Production database observer (read-only tooling)
+# Use a direct database connection for the dedicated observer role, not the
+# transaction pooler. The wrapper rejects the documented transaction-pooler port 6543.
+# Never use the service role, postgres admin, or a migration credential here. Set
+# PROD_DB_TARGET=local for local inspection.
+# PROD_DB_URL=
+# PROD_DB_TARGET=primary
+# PROD_DB_APPLICATION_NAME=pi-prod-observer
+# PROD_DB_TIMEOUT_MS=15000
+# PROD_DB_MAX_OUTPUT_BYTES=1000000
+
+
 # GA_MEASUREMENT_ID=G-XXXXXXXXXX
 # CLARITY_PROJECT_ID=xxxxxxxxxx
+# VITE_PERF_DEBUG=false  # client performance timing logs; accepts 1, true, yes, or on
 
-# =============================================================================
-# OPTIONAL: GitHub (for contributors page)
-# =============================================================================
-# GITHUB_TOKEN=
+# === OPTIONAL: GitHub (for contributors page)
+# NUXT_GITHUB_TOKEN=
 
-# =============================================================================
-# REQUIRED FOR PRODUCTION: Stripe Configuration
-# =============================================================================
+# === REQUIRED FOR PRODUCTION: Stripe Configuration
 # Server-side Stripe secret key for creating Checkout Sessions
 STRIPE_SECRET_KEY=
 
-# Stripe Price IDs for each subscription tier/interval (create in Stripe Dashboard)
+# Stripe Price IDs for each subscription tier/interval (create in Stripe Dashboard).
+# Shared with the stripe-webhook Edge Function (supabase/functions/.env.example) — same values in both.
 STRIPE_PRICE_SCAV_MONTHLY=
 STRIPE_PRICE_SCAV_6MONTH=
 STRIPE_PRICE_SCAV_YEARLY=
@@ -53,15 +55,11 @@ STRIPE_PRICE_CHAD_MONTHLY=
 STRIPE_PRICE_CHAD_6MONTH=
 STRIPE_PRICE_CHAD_YEARLY=
 
-# =============================================================================
-# OPTIONAL: Server Observability
-# =============================================================================
+# === OPTIONAL: Server Observability
 # NUXT_LOG_SINK_URL=  # HTTPS endpoint for centralized server logs
 # NUXT_PUBLIC_LOG_LEVEL=  # Client log level (debug, info, warn, error)
 
-# =============================================================================
-# OPTIONAL: Server API Limits/Cache
-# =============================================================================
+# === OPTIONAL: Server API Limits/Cache
 # NUXT_TEAM_MEMBERS_RATE_LIMIT_PER_MINUTE=120
 # NUXT_TEAM_MEMBERS_CACHE_TTL_MS=5000
 # NUXT_SHARED_PROFILE_RATE_LIMIT_PER_MINUTE=120

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,7 @@ When asked to "review for production readiness", "deep review", "is this safe to
 Formatting is enforced by Prettier + ESLint (see `.prettierrc`, `eslint.config.mjs`). Key rules:
 
 - 2-space indent, 100-char lines, single quotes, semicolons, trailing commas (es5).
+- `.env.example` files use one-line `# === TITLE` section headers, not full-width `# ===...===` separator blocks. Tokenizers compress runs of repeated characters, so a long separator costs ~2–3 tokens — the same as a short one — and only adds agent token cost. These files are read often by agents; keep headers single-line and token-efficient.
 - Imports: alphabetically sorted, no blank lines between groups, group order: builtin → external → internal → parent → sibling → index → object → type.
 - Avoid unused imports/exports.
 - Keep functions small; prefer early returns. Avoid inline comments unless explaining a non-obvious decision.
@@ -243,13 +244,16 @@ Naming:
 
 ## Environment Variables
 
-- Use one canonical env var name per concept.
-- Use `NUXT_PUBLIC_*` for browser-exposed Nuxt runtime config.
+- Use one canonical env var name per concept. Shared Supabase project settings use `SUPABASE_URL`
+  and `SUPABASE_ANON_KEY` across Nuxt, Pages, Workers, and Edge Functions; do not duplicate them
+  as `NUXT_PUBLIC_SUPABASE_*` values.
+- Use `NUXT_PUBLIC_*` for browser-exposed Nuxt-only runtime config.
 - Use `NUXT_*` for private Nuxt runtime config (server-only).
 - Browser log forwarding is opt-in: keep `NUXT_PUBLIC_CLIENT_LOG_SINK_URL` empty unless the sink is
   external or `/api/logs/client` is protected by an edge rate-limit rule.
 - Use platform-native names for Supabase Edge Functions (`SUPABASE_*`, `STRIPE_*`, `DISCORD_*`).
-- Do not add legacy aliases or fallback chains without explicit approval.
+- Do not add legacy aliases or fallback chains without explicit approval. Existing
+  `NUXT_PUBLIC_SUPABASE_*` and `VITE_SUPABASE_*` fallbacks are migration compatibility only.
 - If an env var is renamed, update source, docs, examples, CI/deploy references, and tests in the same change.
 - See `docs/ARCHITECTURE.md` for the canonical env var map.
 

--- a/README.md
+++ b/README.md
@@ -68,12 +68,13 @@ pnpm install
 pnpm run dev           # http://localhost:3000
 ```
 
-Copy `.env.example` to `.env` and fill in your Supabase values. Without Supabase configured, the
-app runs in offline mode with localStorage only — auth, sync, realtime, and team features are
-unavailable.
+Copy `.env.example` to `.env` and fill in `SUPABASE_URL` and `SUPABASE_ANON_KEY`. These shared
+names are used by Nuxt, Cloudflare Pages/Workers, and Supabase Edge Functions, so the same values do
+not need to be duplicated under `NUXT_PUBLIC_*`. Without Supabase configured, the app runs in
+offline mode with localStorage only — auth, sync, realtime, and team features are unavailable.
 
-> Only `NUXT_PUBLIC_SUPABASE_URL` and `NUXT_PUBLIC_SUPABASE_ANON_KEY` are required for login/sync.
-> Everything else is optional and documented in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+> `SUPABASE_URL` and `SUPABASE_ANON_KEY` are required for login/sync. Everything else is optional and
+> documented in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
 **Tech stack:** Nuxt 4 (SPA, `ssr: false`), Vue 3 Composition API, TypeScript strict, Pinia,
 Supabase, Tailwind CSS v4, Vitest, Cloudflare Pages/Workers.

--- a/app/error.vue
+++ b/app/error.vue
@@ -156,7 +156,7 @@
     if (combinedText.includes('supabase')) {
       return t(
         'error.supabase_config_hint',
-        'This deployment is missing public Supabase configuration. Set shared SUPABASE_URL and SUPABASE_ANON_KEY for previews, or allow preview builds to run in offline mode.'
+        'This deployment is missing public Supabase configuration. Set SUPABASE_URL and SUPABASE_ANON_KEY for previews, or allow preview builds to run in offline mode.'
       );
     }
     if (combinedText.includes('403')) {

--- a/app/error.vue
+++ b/app/error.vue
@@ -156,7 +156,7 @@
     if (combinedText.includes('supabase')) {
       return t(
         'error.supabase_config_hint',
-        'This deployment is missing public Supabase configuration. Set SUPABASE_URL and SUPABASE_ANON_KEY for previews, or allow preview builds to run in offline mode.'
+        'This deployment is missing public Supabase configuration. Set shared SUPABASE_URL and SUPABASE_ANON_KEY for previews, or allow preview builds to run in offline mode.'
       );
     }
     if (combinedText.includes('403')) {

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -132,7 +132,7 @@
     "something_went_wrong": "Something Went Wrong",
     "unexpected_description": "An unexpected error occurred while processing your request.",
     "invalid_host_hint": "This preview host is blocked by API host validation. Add the preview hostname to API_ALLOWED_HOSTS or derive it from CF_PAGES_URL.",
-    "supabase_config_hint": "This deployment is missing public Supabase configuration. Set NUXT_PUBLIC_SUPABASE_URL and NUXT_PUBLIC_SUPABASE_ANON_KEY for previews, or allow preview builds to run in offline mode.",
+    "supabase_config_hint": "This deployment is missing public Supabase configuration. Set shared SUPABASE_URL and SUPABASE_ANON_KEY for previews, or allow preview builds to run in offline mode.",
     "request_blocked_hint": "A request required to render this page was blocked. Open the technical details and include the failing request URL when reporting the issue."
   },
   "loading_screen": {

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -132,7 +132,7 @@
     "something_went_wrong": "Something Went Wrong",
     "unexpected_description": "An unexpected error occurred while processing your request.",
     "invalid_host_hint": "This preview host is blocked by API host validation. Add the preview hostname to API_ALLOWED_HOSTS or derive it from CF_PAGES_URL.",
-    "supabase_config_hint": "This deployment is missing public Supabase configuration. Set shared SUPABASE_URL and SUPABASE_ANON_KEY for previews, or allow preview builds to run in offline mode.",
+    "supabase_config_hint": "This deployment is missing public Supabase configuration. Set SUPABASE_URL and SUPABASE_ANON_KEY for previews, or allow preview builds to run in offline mode.",
     "request_blocked_hint": "A request required to render this page was blocked. Open the technical details and include the failing request URL when reporting the issue."
   },
   "loading_screen": {

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -24,8 +24,7 @@ export default defineNuxtPlugin({
     const runtimeConfig = useRuntimeConfig();
     const supabaseUrl = String(runtimeConfig.public.supabaseUrl || '').trim();
     const supabaseKey = String(runtimeConfig.public.supabaseAnonKey || '').trim();
-    const missingConfigMessage =
-      '[Supabase] Missing runtimeConfig.public.supabaseUrl or runtimeConfig.public.supabaseAnonKey';
+    const missingConfigMessage = '[Supabase] Missing SUPABASE_URL or SUPABASE_ANON_KEY';
     const buildStubBuilder = () => {
       const result = Promise.resolve({ data: null, error: null });
       const proxy = new Proxy(
@@ -145,13 +144,13 @@ export default defineNuxtPlugin({
         isProduction: import.meta.env.PROD,
       });
       if (!allowOfflineFallback) {
-        logger.error(`${missingConfigMessage}. Set shared SUPABASE_URL and SUPABASE_ANON_KEY.`);
+        logger.error(missingConfigMessage);
         throw new Error(missingConfigMessage);
       }
       logger.warn(
         `${missingConfigMessage}. Running in offline mode${
           import.meta.env.PROD ? ' for this preview deployment' : ' for development'
-        }. Set shared SUPABASE_URL and SUPABASE_ANON_KEY to enable auth and sync.`
+        }. Set SUPABASE_URL and SUPABASE_ANON_KEY to enable auth and sync.`
       );
       const stub = buildStub();
       return { provide: { supabase: stub } };

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -145,13 +145,13 @@ export default defineNuxtPlugin({
         isProduction: import.meta.env.PROD,
       });
       if (!allowOfflineFallback) {
-        logger.error(`${missingConfigMessage}. Set SUPABASE_URL and SUPABASE_ANON_KEY.`);
+        logger.error(`${missingConfigMessage}. Set shared SUPABASE_URL and SUPABASE_ANON_KEY.`);
         throw new Error(missingConfigMessage);
       }
       logger.warn(
         `${missingConfigMessage}. Running in offline mode${
           import.meta.env.PROD ? ' for this preview deployment' : ' for development'
-        }. Set SUPABASE_URL and SUPABASE_ANON_KEY to enable auth and sync.`
+        }. Set shared SUPABASE_URL and SUPABASE_ANON_KEY to enable auth and sync.`
       );
       const stub = buildStub();
       return { provide: { supabase: stub } };

--- a/app/utils/__tests__/runtimeConfig.test.ts
+++ b/app/utils/__tests__/runtimeConfig.test.ts
@@ -31,17 +31,56 @@ describe('resolveSupabaseRuntimeConfig', () => {
     expect(config.publicUrl).toBe('https://legacy-nuxt.supabase.co');
     expect(config.publicAnonKey).toBe('legacy-nuxt-anon-key');
   });
-  it('prefers shared names over legacy Nuxt public names', () => {
+  it('supports legacy Vite names during migration', () => {
     const config = resolveSupabaseRuntimeConfig({
-      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
-      NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
-      SUPABASE_ANON_KEY: 'shared-anon-key',
-      SUPABASE_URL: 'https://shared.supabase.co',
+      VITE_SUPABASE_ANON_KEY: 'legacy-vite-anon-key',
+      VITE_SUPABASE_URL: 'https://legacy-vite.supabase.co',
     });
-    expect(config.privateUrl).toBe('https://shared.supabase.co');
-    expect(config.privateAnonKey).toBe('shared-anon-key');
-    expect(config.publicUrl).toBe('https://shared.supabase.co');
-    expect(config.publicAnonKey).toBe('shared-anon-key');
+    expect(config.privateUrl).toBe('https://legacy-vite.supabase.co');
+    expect(config.privateAnonKey).toBe('legacy-vite-anon-key');
+    expect(config.publicUrl).toBe('https://legacy-vite.supabase.co');
+    expect(config.publicAnonKey).toBe('legacy-vite-anon-key');
+  });
+  it('ignores blank higher-priority values when a complete fallback exists', () => {
+    const config = resolveSupabaseRuntimeConfig({
+      NUXT_PUBLIC_SUPABASE_ANON_KEY: ' ',
+      NUXT_PUBLIC_SUPABASE_URL: '',
+      VITE_SUPABASE_ANON_KEY: 'legacy-vite-anon-key',
+      VITE_SUPABASE_URL: 'https://legacy-vite.supabase.co',
+    });
+    expect(config.privateUrl).toBe('https://legacy-vite.supabase.co');
+    expect(config.privateAnonKey).toBe('legacy-vite-anon-key');
+    expect(config.publicUrl).toBe('https://legacy-vite.supabase.co');
+    expect(config.publicAnonKey).toBe('legacy-vite-anon-key');
+  });
+  it('rejects partial credential pairs instead of mixing sources', () => {
+    expect(() =>
+      resolveSupabaseRuntimeConfig({
+        SUPABASE_ANON_KEY: 'shared-anon-key',
+        VITE_SUPABASE_ANON_KEY: 'legacy-vite-anon-key',
+        VITE_SUPABASE_URL: 'https://legacy-vite.supabase.co',
+      })
+    ).toThrow('[Config] Incomplete Supabase credentials: SUPABASE_*');
+  });
+  it('accepts matching canonical and legacy credential pairs', () => {
+    const config = resolveSupabaseRuntimeConfig({
+      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'same-anon-key',
+      NUXT_PUBLIC_SUPABASE_URL: 'https://same.supabase.co',
+      SUPABASE_ANON_KEY: 'same-anon-key',
+      SUPABASE_URL: 'https://same.supabase.co',
+    });
+    expect(config.publicUrl).toBe('https://same.supabase.co');
+    expect(config.publicAnonKey).toBe('same-anon-key');
+  });
+  it('rejects conflicting canonical and legacy credential pairs', () => {
+    expect(() =>
+      resolveSupabaseRuntimeConfig({
+        NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
+        NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
+        SUPABASE_ANON_KEY: 'shared-anon-key',
+        SUPABASE_URL: 'https://shared.supabase.co',
+      })
+    ).toThrow('[Config] Conflicting Supabase credentials');
   });
   it('includes Tarkov asset hosts alongside GitHub image hosts', () => {
     expect([...GITHUB_IMAGE_DOMAINS, ...TARKOV_IMAGE_DOMAINS]).toEqual(
@@ -62,8 +101,8 @@ describe('resolvePublicAppUrl', () => {
   it('prefers NUXT_PUBLIC_APP_URL as canonical', () => {
     expect(
       resolvePublicAppUrl({
-        NUXT_PUBLIC_APP_URL: 'https://canonical.example.com',
         APP_URL: 'https://platform.example.com',
+        NUXT_PUBLIC_APP_URL: 'https://canonical.example.com',
       })
     ).toBe('https://canonical.example.com');
   });

--- a/app/utils/__tests__/runtimeConfig.test.ts
+++ b/app/utils/__tests__/runtimeConfig.test.ts
@@ -11,47 +11,37 @@ import {
   TARKOV_IMAGE_DOMAINS,
 } from '@/utils/runtimeConfig';
 describe('resolveSupabaseRuntimeConfig', () => {
-  it('resolves Supabase env values', () => {
+  it('resolves shared Supabase env values', () => {
     const config = resolveSupabaseRuntimeConfig({
-      SUPABASE_ANON_KEY: 'public-anon-key',
-      SUPABASE_URL: 'https://public.supabase.co',
+      SUPABASE_ANON_KEY: 'shared-anon-key',
+      SUPABASE_URL: 'https://shared.supabase.co',
     });
-    expect(config.privateUrl).toBe('https://public.supabase.co');
-    expect(config.privateAnonKey).toBe('public-anon-key');
-    expect(config.publicUrl).toBe('https://public.supabase.co');
-    expect(config.publicAnonKey).toBe('public-anon-key');
+    expect(config.privateUrl).toBe('https://shared.supabase.co');
+    expect(config.privateAnonKey).toBe('shared-anon-key');
+    expect(config.publicUrl).toBe('https://shared.supabase.co');
+    expect(config.publicAnonKey).toBe('shared-anon-key');
   });
-  it('resolves Supabase env values from canonical names', () => {
+  it('supports legacy Nuxt public names during migration', () => {
     const config = resolveSupabaseRuntimeConfig({
-      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'nuxt-public-anon-key',
-      NUXT_PUBLIC_SUPABASE_URL: 'https://nuxt-public.supabase.co',
+      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
+      NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
     });
-    expect(config.privateUrl).toBe('https://nuxt-public.supabase.co');
-    expect(config.privateAnonKey).toBe('nuxt-public-anon-key');
-    expect(config.publicUrl).toBe('https://nuxt-public.supabase.co');
-    expect(config.publicAnonKey).toBe('nuxt-public-anon-key');
+    expect(config.privateUrl).toBe('https://legacy-nuxt.supabase.co');
+    expect(config.privateAnonKey).toBe('legacy-nuxt-anon-key');
+    expect(config.publicUrl).toBe('https://legacy-nuxt.supabase.co');
+    expect(config.publicAnonKey).toBe('legacy-nuxt-anon-key');
   });
-  it('falls back to SUPABASE_URL / SUPABASE_ANON_KEY as platform convenience', () => {
+  it('prefers shared names over legacy Nuxt public names', () => {
     const config = resolveSupabaseRuntimeConfig({
-      SUPABASE_ANON_KEY: 'platform-anon-key',
-      SUPABASE_URL: 'https://platform.supabase.co',
+      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
+      NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
+      SUPABASE_ANON_KEY: 'shared-anon-key',
+      SUPABASE_URL: 'https://shared.supabase.co',
     });
-    expect(config.privateUrl).toBe('https://platform.supabase.co');
-    expect(config.privateAnonKey).toBe('platform-anon-key');
-    expect(config.publicUrl).toBe('https://platform.supabase.co');
-    expect(config.publicAnonKey).toBe('platform-anon-key');
-  });
-  it('prefers NUXT_PUBLIC_* over SUPABASE_* for Nuxt runtime config', () => {
-    const config = resolveSupabaseRuntimeConfig({
-      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'nuxt-anon-key',
-      NUXT_PUBLIC_SUPABASE_URL: 'https://nuxt.supabase.co',
-      SUPABASE_ANON_KEY: 'platform-anon-key',
-      SUPABASE_URL: 'https://platform.supabase.co',
-    });
-    expect(config.privateUrl).toBe('https://nuxt.supabase.co');
-    expect(config.privateAnonKey).toBe('nuxt-anon-key');
-    expect(config.publicUrl).toBe('https://nuxt.supabase.co');
-    expect(config.publicAnonKey).toBe('nuxt-anon-key');
+    expect(config.privateUrl).toBe('https://shared.supabase.co');
+    expect(config.privateAnonKey).toBe('shared-anon-key');
+    expect(config.publicUrl).toBe('https://shared.supabase.co');
+    expect(config.publicAnonKey).toBe('shared-anon-key');
   });
   it('includes Tarkov asset hosts alongside GitHub image hosts', () => {
     expect([...GITHUB_IMAGE_DOMAINS, ...TARKOV_IMAGE_DOMAINS]).toEqual(

--- a/app/utils/__tests__/runtimeConfig.test.ts
+++ b/app/utils/__tests__/runtimeConfig.test.ts
@@ -60,6 +60,15 @@ describe('resolveSupabaseRuntimeConfig', () => {
       })
     ).toThrow('[Config] Incomplete Supabase credentials: SUPABASE_*');
   });
+  it('rejects a partial canonical pair before using legacy credentials', () => {
+    expect(() =>
+      resolveSupabaseRuntimeConfig({
+        NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
+        NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
+        SUPABASE_URL: 'https://shared.supabase.co',
+      })
+    ).toThrow('[Config] Incomplete Supabase credentials: SUPABASE_*');
+  });
   it('prefers a complete canonical pair over stray legacy values', () => {
     const config = resolveSupabaseRuntimeConfig({
       NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',

--- a/app/utils/__tests__/runtimeConfig.test.ts
+++ b/app/utils/__tests__/runtimeConfig.test.ts
@@ -53,34 +53,31 @@ describe('resolveSupabaseRuntimeConfig', () => {
     expect(config.publicUrl).toBe('https://legacy-vite.supabase.co');
     expect(config.publicAnonKey).toBe('legacy-vite-anon-key');
   });
-  it('rejects partial credential pairs instead of mixing sources', () => {
+  it('rejects partial credentials when no complete pair exists', () => {
     expect(() =>
       resolveSupabaseRuntimeConfig({
         SUPABASE_ANON_KEY: 'shared-anon-key',
-        VITE_SUPABASE_ANON_KEY: 'legacy-vite-anon-key',
-        VITE_SUPABASE_URL: 'https://legacy-vite.supabase.co',
       })
     ).toThrow('[Config] Incomplete Supabase credentials: SUPABASE_*');
   });
-  it('accepts matching canonical and legacy credential pairs', () => {
+  it('prefers a complete canonical pair over stray legacy values', () => {
     const config = resolveSupabaseRuntimeConfig({
-      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'same-anon-key',
-      NUXT_PUBLIC_SUPABASE_URL: 'https://same.supabase.co',
-      SUPABASE_ANON_KEY: 'same-anon-key',
-      SUPABASE_URL: 'https://same.supabase.co',
+      NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
+      SUPABASE_ANON_KEY: 'shared-anon-key',
+      SUPABASE_URL: 'https://shared.supabase.co',
     });
-    expect(config.publicUrl).toBe('https://same.supabase.co');
-    expect(config.publicAnonKey).toBe('same-anon-key');
+    expect(config.publicUrl).toBe('https://shared.supabase.co');
+    expect(config.publicAnonKey).toBe('shared-anon-key');
   });
-  it('rejects conflicting canonical and legacy credential pairs', () => {
-    expect(() =>
-      resolveSupabaseRuntimeConfig({
-        NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
-        NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
-        SUPABASE_ANON_KEY: 'shared-anon-key',
-        SUPABASE_URL: 'https://shared.supabase.co',
-      })
-    ).toThrow('[Config] Conflicting Supabase credentials');
+  it('prefers canonical credentials when complete legacy pairs differ', () => {
+    const config = resolveSupabaseRuntimeConfig({
+      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
+      NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
+      SUPABASE_ANON_KEY: 'shared-anon-key',
+      SUPABASE_URL: 'https://shared.supabase.co',
+    });
+    expect(config.publicUrl).toBe('https://shared.supabase.co');
+    expect(config.publicAnonKey).toBe('shared-anon-key');
   });
   it('includes Tarkov asset hosts alongside GitHub image hosts', () => {
     expect([...GITHUB_IMAGE_DOMAINS, ...TARKOV_IMAGE_DOMAINS]).toEqual(

--- a/app/utils/runtimeConfig.ts
+++ b/app/utils/runtimeConfig.ts
@@ -24,36 +24,55 @@ const normalizePublicAppUrl = (value: string): string => {
   }
   return `https://${trimmed}`;
 };
+type SupabaseCredentialCandidate = { anonKey: string; source: string; url: string };
+const buildSupabaseCredentialCandidate = (
+  anonKey: string | undefined,
+  source: string,
+  url: string | undefined
+): SupabaseCredentialCandidate => ({
+  anonKey: anonKey?.trim() || '',
+  source,
+  url: url?.trim() || '',
+});
+const buildSupabaseCredentialCandidates = (
+  env: NodeJS.ProcessEnv
+): SupabaseCredentialCandidate[] => [
+  buildSupabaseCredentialCandidate(env.SUPABASE_ANON_KEY, 'SUPABASE_*', env.SUPABASE_URL),
+  buildSupabaseCredentialCandidate(
+    env.NUXT_PUBLIC_SUPABASE_ANON_KEY,
+    'NUXT_PUBLIC_SUPABASE_*',
+    env.NUXT_PUBLIC_SUPABASE_URL
+  ),
+  buildSupabaseCredentialCandidate(
+    env.VITE_SUPABASE_ANON_KEY,
+    'VITE_SUPABASE_*',
+    env.VITE_SUPABASE_URL
+  ),
+];
+const resolveSupabaseCredentialPair = (
+  candidates: SupabaseCredentialCandidate[]
+): SupabaseCredentialCandidate => {
+  const partial = candidates.find(({ anonKey, url }) => Boolean(anonKey) !== Boolean(url));
+  if (partial) throw new Error(`[Config] Incomplete Supabase credentials: ${partial.source}`);
+  const complete = candidates.filter(({ anonKey, url }) => anonKey && url);
+  const selected = complete[0] ?? { anonKey: '', source: '', url: '' };
+  const conflicting = complete.find(
+    ({ anonKey, url }) => anonKey !== selected.anonKey || url !== selected.url
+  );
+  if (conflicting) {
+    throw new Error(
+      `[Config] Conflicting Supabase credentials: ${selected.source} and ${conflicting.source}`
+    );
+  }
+  return selected;
+};
 export const resolveSupabaseRuntimeConfig = (env: NodeJS.ProcessEnv) => {
+  const selected = resolveSupabaseCredentialPair(buildSupabaseCredentialCandidates(env));
   return {
-    privateAnonKey: resolveEnvValue(
-      env.SUPABASE_ANON_KEY,
-      // deprecated — remove after 2026-07-31
-      env.NUXT_PUBLIC_SUPABASE_ANON_KEY,
-      // deprecated — remove after 2026-07-31
-      env.VITE_SUPABASE_ANON_KEY
-    ),
-    privateUrl: resolveEnvValue(
-      env.SUPABASE_URL,
-      // deprecated — remove after 2026-07-31
-      env.NUXT_PUBLIC_SUPABASE_URL,
-      // deprecated — remove after 2026-07-31
-      env.VITE_SUPABASE_URL
-    ),
-    publicAnonKey: resolveEnvValue(
-      env.SUPABASE_ANON_KEY,
-      // deprecated — remove after 2026-07-31
-      env.NUXT_PUBLIC_SUPABASE_ANON_KEY,
-      // deprecated — remove after 2026-07-31
-      env.VITE_SUPABASE_ANON_KEY
-    ),
-    publicUrl: resolveEnvValue(
-      env.SUPABASE_URL,
-      // deprecated — remove after 2026-07-31
-      env.NUXT_PUBLIC_SUPABASE_URL,
-      // deprecated — remove after 2026-07-31
-      env.VITE_SUPABASE_URL
-    ),
+    privateAnonKey: selected.anonKey,
+    privateUrl: selected.url,
+    publicAnonKey: selected.anonKey,
+    publicUrl: selected.url,
   };
 };
 export const resolvePublicAppUrl = (env: NodeJS.ProcessEnv): string => {

--- a/app/utils/runtimeConfig.ts
+++ b/app/utils/runtimeConfig.ts
@@ -52,19 +52,11 @@ const buildSupabaseCredentialCandidates = (
 const resolveSupabaseCredentialPair = (
   candidates: SupabaseCredentialCandidate[]
 ): SupabaseCredentialCandidate => {
+  const selected = candidates.find(({ anonKey, url }) => anonKey && url);
+  if (selected) return selected;
   const partial = candidates.find(({ anonKey, url }) => Boolean(anonKey) !== Boolean(url));
   if (partial) throw new Error(`[Config] Incomplete Supabase credentials: ${partial.source}`);
-  const complete = candidates.filter(({ anonKey, url }) => anonKey && url);
-  const selected = complete[0] ?? { anonKey: '', source: '', url: '' };
-  const conflicting = complete.find(
-    ({ anonKey, url }) => anonKey !== selected.anonKey || url !== selected.url
-  );
-  if (conflicting) {
-    throw new Error(
-      `[Config] Conflicting Supabase credentials: ${selected.source} and ${conflicting.source}`
-    );
-  }
-  return selected;
+  return { anonKey: '', source: '', url: '' };
 };
 export const resolveSupabaseRuntimeConfig = (env: NodeJS.ProcessEnv) => {
   const selected = resolveSupabaseCredentialPair(buildSupabaseCredentialCandidates(env));

--- a/app/utils/runtimeConfig.ts
+++ b/app/utils/runtimeConfig.ts
@@ -27,26 +27,30 @@ const normalizePublicAppUrl = (value: string): string => {
 export const resolveSupabaseRuntimeConfig = (env: NodeJS.ProcessEnv) => {
   return {
     privateAnonKey: resolveEnvValue(
-      env.NUXT_PUBLIC_SUPABASE_ANON_KEY,
       env.SUPABASE_ANON_KEY,
+      // deprecated — remove after 2026-07-31
+      env.NUXT_PUBLIC_SUPABASE_ANON_KEY,
       // deprecated — remove after 2026-07-31
       env.VITE_SUPABASE_ANON_KEY
     ),
     privateUrl: resolveEnvValue(
-      env.NUXT_PUBLIC_SUPABASE_URL,
       env.SUPABASE_URL,
+      // deprecated — remove after 2026-07-31
+      env.NUXT_PUBLIC_SUPABASE_URL,
       // deprecated — remove after 2026-07-31
       env.VITE_SUPABASE_URL
     ),
     publicAnonKey: resolveEnvValue(
-      env.NUXT_PUBLIC_SUPABASE_ANON_KEY,
       env.SUPABASE_ANON_KEY,
+      // deprecated — remove after 2026-07-31
+      env.NUXT_PUBLIC_SUPABASE_ANON_KEY,
       // deprecated — remove after 2026-07-31
       env.VITE_SUPABASE_ANON_KEY
     ),
     publicUrl: resolveEnvValue(
-      env.NUXT_PUBLIC_SUPABASE_URL,
       env.SUPABASE_URL,
+      // deprecated — remove after 2026-07-31
+      env.NUXT_PUBLIC_SUPABASE_URL,
       // deprecated — remove after 2026-07-31
       env.VITE_SUPABASE_URL
     ),

--- a/app/utils/runtimeConfig.ts
+++ b/app/utils/runtimeConfig.ts
@@ -52,11 +52,13 @@ const buildSupabaseCredentialCandidates = (
 const resolveSupabaseCredentialPair = (
   candidates: SupabaseCredentialCandidate[]
 ): SupabaseCredentialCandidate => {
-  const selected = candidates.find(({ anonKey, url }) => anonKey && url);
-  if (selected) return selected;
-  const partial = candidates.find(({ anonKey, url }) => Boolean(anonKey) !== Boolean(url));
+  const selectedIndex = candidates.findIndex(({ anonKey, url }) => anonKey && url);
+  const selected = candidates[selectedIndex];
+  const partial = candidates
+    .slice(0, selectedIndex === -1 ? candidates.length : selectedIndex)
+    .find(({ anonKey, url }) => Boolean(anonKey) !== Boolean(url));
   if (partial) throw new Error(`[Config] Incomplete Supabase credentials: ${partial.source}`);
-  return { anonKey: '', source: '', url: '' };
+  return selected ?? { anonKey: '', source: '', url: '' };
 };
 export const resolveSupabaseRuntimeConfig = (env: NodeJS.ProcessEnv) => {
   const selected = resolveSupabaseCredentialPair(buildSupabaseCredentialCandidates(env));

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -435,9 +435,14 @@ Node.js version: 24.x
 
 ### Environment Variables
 
-Naming convention: `NUXT_*` for Nuxt private runtime config (server-only), `NUXT_PUBLIC_*`
-for Nuxt public runtime config (browser-exposed), plain names for platform/build-time or
-Supabase Edge Functions.
+Naming convention: `SUPABASE_*` for shared Supabase project settings, `NUXT_*` for Nuxt private
+runtime config (server-only), `NUXT_PUBLIC_*` for Nuxt public runtime config (browser-exposed), and
+plain names for platform/build-time or Supabase Edge Function settings.
+
+`SUPABASE_URL` and `SUPABASE_ANON_KEY` are the canonical shared Supabase values. Nuxt, Cloudflare
+Pages/Workers, and Supabase Edge Functions can all consume them, so they should not be duplicated as
+`NUXT_PUBLIC_*` values. The legacy `NUXT_PUBLIC_SUPABASE_*` and `VITE_SUPABASE_*` names remain
+accepted temporarily for migration compatibility.
 
 Full resolution logic is in `app/utils/runtimeConfig.ts`.
 
@@ -445,19 +450,24 @@ Full resolution logic is in `app/utils/runtimeConfig.ts`.
 
 | Variable                                         | Description                                              | Required   |
 | ------------------------------------------------ | -------------------------------------------------------- | ---------- |
-| `NUXT_PUBLIC_SUPABASE_URL`                       | Supabase project URL for auth and sync                   | Yes¹       |
-| `NUXT_PUBLIC_SUPABASE_ANON_KEY`                  | Supabase anon key for auth and sync                      | Yes¹       |
+| `SUPABASE_URL`                                   | Shared Supabase project URL for auth and sync            | Yes¹       |
+| `SUPABASE_ANON_KEY`                              | Shared Supabase anon key for auth and sync               | Yes¹       |
 | `NUXT_PUBLIC_APP_URL`                            | Application URL                                          | Yes (prod) |
 | `NUXT_PUBLIC_CLIENT_LOG_SINK_URL`                | Optional browser log collector URL (disabled by default) | No         |
 | `NUXT_PUBLIC_TURNSTILE_SITE_KEY`                 | Turnstile widget sitekey for Tarkov.dev profile imports  | No²        |
 | `NUXT_PUBLIC_TARKOV_DEV_IMPORT_COOLDOWN_MINUTES` | Browser cooldown after a confirmed profile import        | No         |
 
-> **¹ Required in production.** `SUPABASE_URL` and `SUPABASE_ANON_KEY` work as cross-platform
-> build-time fallbacks. Without Supabase configuration, auth, sync, realtime, and team features
-> are unavailable; the app runs in offline mode with localStorage only.
+> **¹ Required in production.** These shared names are consumed by Nuxt, Pages, Workers, and Edge
+> Functions. Without Supabase configuration, auth, sync, realtime, and team features are unavailable;
+> the app runs in offline mode with localStorage only.
 >
 > **² Turnstile is optional, but its public sitekey and private secret must be configured together.
 > Local development uses Cloudflare's always-pass test keys automatically.**
+
+`VITE_PERF_DEBUG` is an opt-in client performance debugging switch. Set it to `1`, `true`, `yes`,
+or `on` before starting the dev server or building the app to enable timing logs from
+`app/utils/perf.ts` through the shared client logger. Leave it unset or set it to `false` for normal
+builds. This is a Vite build-time variable, not Nuxt runtime configuration.
 
 **Server-side (Nuxt private runtime config):**
 
@@ -469,6 +479,7 @@ Full resolution logic is in `app/utils/runtimeConfig.ts`.
 | `NUXT_TWITCH_CLIENT_ID`                         | Twitch API client ID                                | No         |
 | `NUXT_GITHUB_CONTRIBUTORS_EXCLUDE`              | Bot accounts excluded from contributors             | No         |
 | `NUXT_GITHUB_TIMEOUT_MS`                        | GitHub API timeout                                  | No         |
+| `NUXT_GITHUB_TOKEN`                             | GitHub API token                                    | No         |
 | `NUXT_CACHE_BYPASS_ENABLED`                     | Enable server-side cache bypass header              | No         |
 | `API_ALLOWED_HOSTS`                             | Allowed origin hosts                                | No         |
 | `API_TRUSTED_IP_RANGES`                         | Trusted IP ranges (CIDR)                            | No         |
@@ -494,19 +505,22 @@ Full resolution logic is in `app/utils/runtimeConfig.ts`.
 
 **Build-time / platform:**
 
-| Variable             | Description                     |
-| -------------------- | ------------------------------- |
-| `APP_URL`            | App URL (CF Pages / CI)         |
-| `CF_PAGES_URL`       | Cloudflare Pages deploy URL     |
-| `GA_MEASUREMENT_ID`  | Google Analytics measurement ID |
-| `CLARITY_PROJECT_ID` | Microsoft Clarity project ID    |
-| `GITHUB_TOKEN`       | GitHub API token                |
+| Variable             | Description                                 |
+| -------------------- | ------------------------------------------- |
+| `APP_URL`            | App URL (CF Pages / CI)                     |
+| `CF_PAGES_URL`       | Cloudflare Pages deploy URL                 |
+| `GA_MEASUREMENT_ID`  | Google Analytics measurement ID             |
+| `CLARITY_PROJECT_ID` | Microsoft Clarity project ID                |
+| `GITHUB_TOKEN`       | Deprecated fallback for `NUXT_GITHUB_TOKEN` |
+| `VITE_PERF_DEBUG`    | Client performance timing logs              |
 
 **Supabase Edge Functions** (set in Supabase Dashboard, not Cloudflare Pages):
 
 `SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` — all canonical for Edge
 Functions. (`SUPABASE_SERVICE_ROLE_KEY` is deprecated only as a Nuxt app fallback; use
-`NUXT_SUPABASE_SERVICE_KEY` for Nuxt.) `STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are shared
+`NUXT_SUPABASE_SERVICE_KEY` for Nuxt.) The URL and anon key are shared with Nuxt and Workers, so
+configure them once per deployment platform instead of duplicating them under `NUXT_PUBLIC_*`.
+`STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are shared
 canonical names used by both Nuxt and Edge Functions. `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`,
 `DISCORD_SUPPORTER_ROLE_ID`, `DISCORD_LINKED_ROLE_ID`, `CLOUDFLARE_ZONE_ID`,
 `CLOUDFLARE_API_TOKEN` are Edge-only. See `supabase/functions/.env.example`.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -505,14 +505,14 @@ builds. This is a Vite build-time variable, not Nuxt runtime configuration.
 
 **Build-time / platform:**
 
-| Variable             | Description                                 |
-| -------------------- | ------------------------------------------- |
-| `APP_URL`            | App URL (CF Pages / CI)                     |
-| `CF_PAGES_URL`       | Cloudflare Pages deploy URL                 |
-| `GA_MEASUREMENT_ID`  | Google Analytics measurement ID             |
-| `CLARITY_PROJECT_ID` | Microsoft Clarity project ID                |
-| `GITHUB_TOKEN`       | Deprecated fallback for `NUXT_GITHUB_TOKEN` |
-| `VITE_PERF_DEBUG`    | Client performance timing logs              |
+| Variable             | Description                                  |
+| -------------------- | -------------------------------------------- |
+| `APP_URL`            | Platform/build-time application URL fallback |
+| `CF_PAGES_URL`       | Cloudflare Pages deployment URL fallback     |
+| `GA_MEASUREMENT_ID`  | Google Analytics measurement ID              |
+| `CLARITY_PROJECT_ID` | Microsoft Clarity project ID                 |
+| `GITHUB_TOKEN`       | Deprecated fallback for `NUXT_GITHUB_TOKEN`  |
+| `VITE_PERF_DEBUG`    | Client performance timing logs               |
 
 **Supabase Edge Functions** (set in Supabase Dashboard, not Cloudflare Pages):
 

--- a/docs/agent-context/style-and-validation.md
+++ b/docs/agent-context/style-and-validation.md
@@ -22,6 +22,7 @@ Deeper conventions for agents. Root `AGENTS.md` links here for reference; these 
 
 ## Styling Details
 
+- `.env.example` files use one-line `# === TITLE` section headers (not full-width `# =====` separator blocks). Full-width separators tokenize to ~2–3 tokens each — the same cost as a short marker — so they only add agent token cost without readability gain. Agents read these files frequently; keep headers single-line and token-aware.
 - Tailwind classes are auto-sorted by Prettier via `prettier-plugin-tailwindcss`. Keep class lists tidy.
 - Use Tailwind theme layer for colors — no hex values in templates.
 - For complex animations or utilities not available in Tailwind, define them in `app/assets/css/tailwind.css` using `@theme` or `@keyframes`.

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -61,6 +61,10 @@ source — do not duplicate its rules here. Key reminders for new contributors:
   logger.error('Error message', error);
   ```
 
+- For local client performance profiling, set `VITE_PERF_DEBUG=true` in `.env` before starting the
+  dev server. The flag also accepts `1`, `yes`, or `on`; it enables timing logs from
+  `app/utils/perf.ts` and should remain unset or `false` for normal development.
+
 ## Commit Conventions
 
 - Follow [Conventional Commits](https://www.conventionalcommits.org/): `type(scope): summary`. The

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -123,11 +123,7 @@ export default defineNuxtConfig({
       process.env.SUPABASE_SERVICE_ROLE_KEY ||
       '',
     supabaseAnonKey: PRIVATE_SUPABASE_ANON_KEY,
-    githubToken:
-      process.env.NUXT_GITHUB_TOKEN ||
-      // deprecated — remove after 2026-09-30
-      process.env.GITHUB_TOKEN ||
-      '',
+    githubToken: process.env.NUXT_GITHUB_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim() || '',
     githubContributorsExclude:
       process.env.NUXT_GITHUB_CONTRIBUTORS_EXCLUDE ||
       // deprecated — remove after 2026-07-31

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -123,7 +123,11 @@ export default defineNuxtConfig({
       process.env.SUPABASE_SERVICE_ROLE_KEY ||
       '',
     supabaseAnonKey: PRIVATE_SUPABASE_ANON_KEY,
-    githubToken: process.env.GITHUB_TOKEN || '',
+    githubToken:
+      process.env.NUXT_GITHUB_TOKEN ||
+      // deprecated — remove after 2026-09-30
+      process.env.GITHUB_TOKEN ||
+      '',
     githubContributorsExclude:
       process.env.NUXT_GITHUB_CONTRIBUTORS_EXCLUDE ||
       // deprecated — remove after 2026-07-31

--- a/supabase/.env.example
+++ b/supabase/.env.example
@@ -1,6 +1,4 @@
-# =============================================================================
-# Supabase Platform — Environment Variables (config.toml references)
-# =============================================================================
+# === Supabase Platform — Environment Variables (config.toml references)
 # Copy to .env.local (this directory) for `supabase start` local dev.
 # In hosted Supabase, these are set in Dashboard → Project Settings → Auth/Storage.
 # These are NOT edge function secrets — they configure the local Supabase stack.
@@ -9,32 +7,22 @@
 #   [required]  — local `supabase start` needs this for the feature to work
 #   [optional]  — feature disabled by default or only for local Studio
 
-# =============================================================================
-# Auth: Google OAuth [required if Google sign-in is used locally]
-# =============================================================================
+# === Auth: Google OAuth [required if Google sign-in is used locally]
 # Google Cloud Console → Credentials → OAuth 2.0 Client
 SUPABASE_AUTH_EXTERNAL_GOOGLE_CLIENT_ID=
 SUPABASE_AUTH_EXTERNAL_GOOGLE_SECRET=
 
-# =============================================================================
-# Auth: Apple Sign-In [optional — disabled in config.toml by default]
-# =============================================================================
+# === Auth: Apple Sign-In [optional — disabled in config.toml by default]
 # SUPABASE_AUTH_EXTERNAL_APPLE_SECRET=
 
-# =============================================================================
-# Auth: Twilio SMS [optional — disabled in config.toml by default]
-# =============================================================================
+# === Auth: Twilio SMS [optional — disabled in config.toml by default]
 # SUPABASE_AUTH_SMS_TWILIO_AUTH_TOKEN=
 
-# =============================================================================
-# Supabase Studio AI [optional — local dev only]
-# =============================================================================
+# === Supabase Studio AI [optional — local dev only]
 # OpenAI key for the AI assistant in local Studio dashboard
 # OPENAI_API_KEY=
 
-# =============================================================================
-# Experimental: OrioleDB S3 Storage [optional — not currently active]
-# =============================================================================
+# === Experimental: OrioleDB S3 Storage [optional — not currently active]
 # S3_HOST=
 # S3_REGION=
 # S3_ACCESS_KEY=

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -1,6 +1,4 @@
-# =============================================================================
-# Supabase Edge Functions — Environment Variables
-# =============================================================================
+# === Supabase Edge Functions — Environment Variables
 # Copy to .env.local (same directory) for `supabase functions serve --env-file`.
 # In hosted Supabase, set these in Dashboard → Project Settings → Edge Functions.
 #
@@ -9,17 +7,13 @@
 #   [auto]      — auto-injected by Supabase hosting; only needed for local dev
 #   [optional]  — feature degrades gracefully or has a sensible default
 
-# =============================================================================
-# Supabase Core [auto in hosted, required for local dev]
-# =============================================================================
+# === Supabase Core [auto in hosted, required for local dev]
 # Used by: all functions (via _shared/auth.ts, stripe-webhook/index.ts)
 SUPABASE_URL=http://localhost:54321
 SUPABASE_SERVICE_ROLE_KEY=
 SUPABASE_ANON_KEY=
 
-# =============================================================================
-# Stripe [required for stripe-webhook]
-# =============================================================================
+# === Stripe [required for stripe-webhook]
 # Webhook signing secret: Stripe Dashboard → Webhooks → Signing secret
 STRIPE_WEBHOOK_SECRET=whsec_...
 # The same price IDs used by the Nuxt checkout route. Required to resolve
@@ -39,9 +33,7 @@ STRIPE_PRICE_CHAD_YEARLY=
 # originating subscription/customer before revoking supporter access.
 STRIPE_SECRET_KEY=sk_live_...
 
-# =============================================================================
-# Discord Bot [required for role sync in stripe-webhook]
-# =============================================================================
+# === Discord Bot [required for role sync in stripe-webhook]
 # Bot token: Discord Developer Portal → Bot → Token
 DISCORD_BOT_TOKEN=
 
@@ -55,16 +47,12 @@ DISCORD_SCAV_ROLE_ID=
 DISCORD_TIMMY_ROLE_ID=
 DISCORD_CHAD_ROLE_ID=
 
-# =============================================================================
-# Cloudflare [required for admin-cache-purge]
-# =============================================================================
+# === Cloudflare [required for admin-cache-purge]
 # API token with Zone → Cache Purge permission
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ZONE_ID=
 
-# =============================================================================
-# App URLs [optional — cache purge prefixes and CORS origin]
-# =============================================================================
+# === App URLs [optional — cache purge prefixes and CORS origin]
 # Fallback chain: APP_URL → APP_BASE_URL → SITE_URL → hardcoded default
 APP_URL=https://tarkovtracker.org
 # APP_BASE_URL=
@@ -74,7 +62,5 @@ APP_URL=https://tarkovtracker.org
 # Default allowlist: https://tarkovtracker.org, https://www.tarkovtracker.org
 # SUPABASE_ALLOWED_ORIGINS=https://staging.tarkovtracker.org
 
-# =============================================================================
-# Development [optional — local dev only, do NOT set in production]
-# =============================================================================
+# === Development [optional — local dev only, do NOT set in production]
 # ALLOW_LOCALHOST_CORS=true


### PR DESCRIPTION
## **User description**
## Summary
- make `SUPABASE_URL` and `SUPABASE_ANON_KEY` the canonical shared project settings across Nuxt, Pages, Workers, and Edge Functions
- retain `NUXT_PUBLIC_SUPABASE_*` and `VITE_SUPABASE_*` as migration fallbacks while preferring shared names
- rename the app's GitHub contributors token to `NUXT_GITHUB_TOKEN`, retaining `GITHUB_TOKEN` as a temporary compatibility fallback
- document `VITE_PERF_DEBUG` and simplify `.env.example` section headers
- update runtime tests and user-facing missing-configuration guidance

## Production safety
- no production database or schema changes
- current Wrangler production and preview configuration already defines the canonical `SUPABASE_*` names
- existing legacy names continue to work, so this does not require an atomic environment-variable cutover
- the public Supabase values were verified in a Cloudflare Pages production build artifact

## Validation
- `pnpm exec vitest run app/utils/__tests__/runtimeConfig.test.ts` — 19 passed
- `pnpm run lint`
- `pnpm run lint:fallow`
- `pnpm run typecheck`
- `pnpm run i18n:check` — only existing informational Crowdin differences
- `pnpm run format:check:prettier`
- `CI=true ... pnpm run build` with Cloudflare Pages production settings
- `git diff --check`

## Review note
The local Cubic CLI review could not run because the repository subscription is expired. Normal PR review integrations and CI should perform the independent review cycle.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Standardize shared environment settings across deployments

### What Changed
- Nuxt, Cloudflare Pages/Workers, and Supabase Edge Functions now use `SUPABASE_URL` and `SUPABASE_ANON_KEY` as the shared Supabase settings.
- Existing `NUXT_PUBLIC_SUPABASE_*` and `VITE_SUPABASE_*` values continue to work temporarily, but shared names take precedence when both are configured.
- GitHub contributor access now uses `NUXT_GITHUB_TOKEN`, with `GITHUB_TOKEN` retained as a migration fallback.
- Missing Supabase configuration messages, setup examples, and documentation now point to the shared variable names.
- Documents the opt-in `VITE_PERF_DEBUG` setting and uses shorter environment-file section headers.

### Impact
`✅ One Supabase configuration across Nuxt, Pages, Workers, and Edge Functions`
`✅ Fewer deployment configuration duplicates`
`✅ Clearer missing-configuration guidance`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup and architecture guidance to use shared Supabase configuration across local development, previews, and deployment environments.
  * Clarified required login and synchronization settings, migration fallbacks, GitHub configuration, Stripe webhooks, and performance profiling.
  * Simplified environment template headings for easier scanning.

* **Bug Fixes**
  * Shared Supabase settings now take precedence over legacy names while preserving compatibility.
  * Improved configuration error messages and preview troubleshooting guidance.
  * Updated GitHub token handling to support the preferred configuration name with a legacy fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR consolidates shared Supabase configuration under canonical `SUPABASE_*` names while retaining paired legacy fallbacks, and renames the private GitHub token setting with compatibility support.

- Resolves Supabase URL and anonymous-key values as prioritized, source-consistent pairs.
- Updates Nuxt runtime configuration, tests, environment templates, diagnostics, and deployment documentation.
- Adds `NUXT_GITHUB_TOKEN` as the preferred contributors API token name.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/utils/runtimeConfig.ts | Selects complete Supabase credential pairs by source and rejects incomplete higher-priority configurations, addressing the previously reported credential-mixing failures. |
| app/utils/__tests__/runtimeConfig.test.ts | Covers canonical precedence, paired legacy fallbacks, blank values, and incomplete credential configurations. |
| nuxt.config.ts | Uses the preferred private GitHub token name with a trimmed legacy fallback and consumes the resolved Supabase pair. |
| app/plugins/supabase.client.ts | Updates missing-configuration diagnostics to reference the canonical shared Supabase names. |
| .env.example | Documents canonical shared Supabase settings, the renamed GitHub token, and performance debugging configuration. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(config): validate higher-priority Su..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/f723ac8e802838b1e0068e134998bf193f88309b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51487565)</sub>

**Context used:**

- Knowledge Base — [Frontend App (Nuxt)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/frontend-app.md)
- Knowledge Base — [Monorepo Build & Deploy Configuration](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/repo-build-config.md)

<!-- /greptile_comment -->