### PR TITLE
docs(config): standardize environment value entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -135,6 +135,7 @@ Formatting is enforced by Prettier + ESLint (see `.prettierrc`, `eslint.config.m
 
 - 2-space indent, 100-char lines, single quotes, semicolons, trailing commas (es5).
 - `.env.example` files use one-line `# === TITLE` section headers, not full-width `# ===...===` separator blocks. Tokenizers compress runs of repeated characters, so a long separator costs ~2–3 tokens — the same as a short one — and only adds agent token cost. These files are read often by agents; keep headers single-line and token-efficient.
+- Quote string values in `wrangler.toml`, where TOML requires string delimiters. Keep `.env`, `.env.*`, and `.dev.vars*` values unquoted by default to match dashboard entry style; quote only when dotenv semantics require it, such as preserving surrounding whitespace, `#`, or multiline content. Enter raw values without decorative quotes in Cloudflare dashboard value fields and interactive `wrangler secret put` prompts because Cloudflare preserves the submitted string. See `docs/ARCHITECTURE.md`.
 - Imports: alphabetically sorted, no blank lines between groups, group order: builtin → external → internal → parent → sibling → index → object → type.
 - Avoid unused imports/exports.
 - Keep functions small; prefer early returns. Avoid inline comments unless explaining a non-obvious decision.
@@ -252,6 +253,9 @@ Naming:
 - Browser log forwarding is opt-in: keep `NUXT_PUBLIC_CLIENT_LOG_SINK_URL` empty unless the sink is
   external or `/api/logs/client` is protected by an edge rate-limit rule.
 - Use platform-native names for Supabase Edge Functions (`SUPABASE_*`, `STRIPE_*`, `DISCORD_*`).
+- Treat `wrangler.toml` as the source of truth for Cloudflare Pages plaintext variables, bindings,
+  and placement in production and preview. Keep only encrypted secrets in the Pages dashboard; do
+  not duplicate `[vars]` there.
 - Do not add legacy aliases or fallback chains without explicit approval. Existing
   `NUXT_PUBLIC_SUPABASE_*` and `VITE_SUPABASE_*` fallbacks are migration compatibility only.
 - If an env var is renamed, update source, docs, examples, CI/deploy references, and tests in the same change.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -446,6 +446,39 @@ accepted temporarily for migration compatibility.
 
 Full resolution logic is in `app/utils/runtimeConfig.ts`.
 
+### Environment value entry standard
+
+Quote syntax depends on where a value is entered:
+
+- In `wrangler.toml`, write string values as TOML strings, for example
+  `APP_URL = "https://tarkovtracker.org"`. The TOML parser treats the quotation marks as syntax;
+  they are not part of the resulting value.
+- In `.env`, `.env.*`, and `.dev.vars*` files, use unquoted values by default, for example
+  `APP_URL=https://tarkovtracker.org`. Dotenv permits both quoted and unquoted values, but matching
+  dashboard entry style reduces copy/paste mistakes. Add quotes only when they are semantically
+  required, such as preserving leading or trailing whitespace, including `#` as data, or expressing
+  a supported multiline value.
+- In a Cloudflare Pages or Workers dashboard **Value** field, enter only the raw value, for example
+  `https://tarkovtracker.org`. Cloudflare stores and passes dashboard values as entered; quotation
+  marks typed into the field become part of the value.
+- At an interactive `wrangler secret put` value prompt, enter only the raw secret. Shell quotes used
+  around command arguments are shell syntax, but quotation marks pasted or piped as secret content
+  are data and are preserved.
+- Never place private credentials in `[vars]` or commit them to `wrangler.toml`. Store them as
+  encrypted Cloudflare secrets. It is safe for intentionally public identifiers such as the
+  Supabase anon key and Turnstile sitekey to remain plaintext configuration.
+
+Therefore, TOML strings stay quoted because TOML requires a string delimiter. Dotenv and dashboard
+values stay unquoted unless the dotenv value specifically requires quoting. Interactive secret
+fields never include decorative wrapping quotes.
+
+References: Cloudflare's Pages bindings and Workers secrets documentation, Cloudflare's Pages API
+(`env_vars.*.value` is the stored string), Node.js's dotenv specification, and TOML v1.0.
+
+Cloudflare Pages production and preview configuration is sourced from `wrangler.toml`. Dashboard
+entries are reserved for encrypted secrets; do not duplicate plaintext `[vars]` there. Smart
+Placement is enabled for both environments through the top-level `[placement]` block.
+
 **Client-side (browser) — Nuxt public runtime config:**
 
 | Variable                                         | Description                                              | Required   |

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -4,6 +4,9 @@ compatibility_date = "2026-01-09"
 compatibility_flags = ["nodejs_compat"]
 pages_build_output_dir = "dist"
 
+[placement]
+mode = "smart"
+
 # Atomic, globally-consistent rate limiter shared with the api-gateway Worker.
 # The ApiGatewayRateLimiter Durable Object class is owned and deployed by
 # workers/api-gateway; Pages binds to it by script_name (Pages cannot define a


### PR DESCRIPTION
## **User description**
## Summary
- document where configuration values must and must not include quote delimiters
- make `wrangler.toml` the source of truth for Pages plaintext variables, bindings, and placement
- preserve the live Pages Smart Placement setting in version-controlled configuration

## Validation
- `pnpm run lint:blank-lines`
- `git diff --check`
- `pnpm exec wrangler types --env-interface PagesEnv /tmp/tarkovtracker-pages-env.d.ts`
- `pnpm run build` with the canonical local production environment
- live Pages production/preview variable, secret, and binding comparison through Cloudflare API

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Standardize environment value entry and Cloudflare Pages configuration

### What Changed
- Documents when configuration values should include quotes in TOML, dotenv files, Cloudflare dashboard fields, and secret prompts
- Defines `wrangler.toml` as the source of truth for Pages plaintext variables, bindings, and deployment placement
- Keeps encrypted credentials out of plaintext configuration and reserves dashboard entries for secrets
- Enables Smart Placement for Pages deployments

### Impact
`✅ Fewer configuration value parsing errors`
`✅ Consistent production and preview settings`
`✅ Lower risk of exposing private credentials`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for quoting environment values across configuration files and Cloudflare settings.
  * Clarified configuration precedence, secret handling, and public identifier requirements.
  * Documented Smart Placement configuration for Cloudflare deployments.

* **New Features**
  * Enabled Smart Placement for deployments to improve runtime location selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR standardizes environment-value quoting guidance, establishes `wrangler.toml` as the source of truth for Cloudflare Pages plaintext configuration, and preserves Smart Placement in version control.
- Documents TOML, dotenv, dashboard, and interactive secret-entry conventions.
- Clarifies the division between committed plaintext variables and encrypted dashboard secrets.
- Enables Smart Placement through the top-level Pages placement configuration.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no concrete blocking or independently actionable non-blocking issues identified.

The documentation agrees with the checked deployment configuration, and the only runtime change adds Smart Placement without altering existing variables, secrets, or bindings.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds consistent environment-entry and Cloudflare Pages configuration guidance without changing runtime behavior. |
| docs/ARCHITECTURE.md | Documents value quoting, secret handling, and the version-controlled Pages configuration model consistently with the changed Wrangler file. |
| wrangler.toml | Adds a top-level Smart Placement block while leaving existing production and preview variables and bindings intact. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(config): standardize environment va..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/22a5dee7f6f6ac51e16ab1d2f7d7506c5c3e55eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51519379)</sub>

**Context used:**

- Knowledge Base — [Monorepo Build & Deploy Configuration](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/repo-build-config.md)

<!-- /greptile_comment -->