### PR TITLE
refactor(config): remove legacy environment fallbacks

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,7 +22,7 @@ SUPABASE_ANON_KEY=
 # NUXT_SUPABASE_SERVICE_KEY=
 
 # === OPTIONAL: App and analytics configuration
-# NUXT_PUBLIC_APP_URL=http://localhost:3000  # APP_URL / CF_PAGES_URL are platform fallbacks
+# APP_URL=http://localhost:3000  # CF_PAGES_URL is the automatic Pages preview fallback
 # GA_MEASUREMENT_ID=G-XXXXXXXXXX
 # CLARITY_PROJECT_ID=xxxxxxxxxx
 # VITE_PERF_DEBUG=false  # client performance timing logs; accepts 1, true, yes, or on
@@ -48,7 +48,7 @@ STRIPE_PRICE_CHAD_YEARLY=
 
 # === OPTIONAL: Server Observability
 # NUXT_LOG_SINK_URL=  # HTTPS endpoint for centralized server logs
-# NUXT_PUBLIC_LOG_LEVEL=  # Client log level (debug, info, warn, error)
+# NUXT_PUBLIC_LOG_LEVEL=warn  # Client log level (debug, info, warn, error)
 
 # === OPTIONAL: Server API Limits/Cache
 # NUXT_TEAM_MEMBERS_RATE_LIMIT_PER_MINUTE=120

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -256,8 +256,9 @@ Naming:
 - Treat `wrangler.toml` as the source of truth for Cloudflare Pages plaintext variables, bindings,
   and placement in production and preview. Keep only encrypted secrets in the Pages dashboard; do
   not duplicate `[vars]` there.
-- Do not add legacy aliases or fallback chains without explicit approval. Existing
-  `NUXT_PUBLIC_SUPABASE_*` and `VITE_SUPABASE_*` fallbacks are migration compatibility only.
+- Do not add legacy aliases or fallback chains without explicit approval. The environment map uses
+  one canonical name per concept; deprecated Supabase, Nuxt, Vite, and Edge Function aliases have
+  been removed.
 - If an env var is renamed, update source, docs, examples, CI/deploy references, and tests in the same change.
 - See `docs/ARCHITECTURE.md` for the canonical env var map.
 

--- a/app/server/utils/logger.ts
+++ b/app/server/utils/logger.ts
@@ -75,10 +75,7 @@ function resolveLogSinkUrl(): string {
     }
   } catch {
     cachedLogSinkUrl = '';
-    return cachedLogSinkUrl;
   }
-  const envSink = process.env.LOG_SINK_URL;
-  cachedLogSinkUrl = typeof envSink === 'string' ? normalizeFetchTargetUrl(envSink.trim()) : '';
   return cachedLogSinkUrl;
 }
 function normalizeFetchTargetUrl(value: string): string {

--- a/app/utils/__tests__/runtimeConfig.test.ts
+++ b/app/utils/__tests__/runtimeConfig.test.ts
@@ -13,80 +13,28 @@ import {
 describe('resolveSupabaseRuntimeConfig', () => {
   it('resolves shared Supabase env values', () => {
     const config = resolveSupabaseRuntimeConfig({
-      SUPABASE_ANON_KEY: 'shared-anon-key',
-      SUPABASE_URL: 'https://shared.supabase.co',
+      SUPABASE_ANON_KEY: ' shared-anon-key ',
+      SUPABASE_URL: ' https://shared.supabase.co ',
     });
     expect(config.privateUrl).toBe('https://shared.supabase.co');
     expect(config.privateAnonKey).toBe('shared-anon-key');
     expect(config.publicUrl).toBe('https://shared.supabase.co');
     expect(config.publicAnonKey).toBe('shared-anon-key');
   });
-  it('supports legacy Nuxt public names during migration', () => {
-    const config = resolveSupabaseRuntimeConfig({
-      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
-      NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
-    });
-    expect(config.privateUrl).toBe('https://legacy-nuxt.supabase.co');
-    expect(config.privateAnonKey).toBe('legacy-nuxt-anon-key');
-    expect(config.publicUrl).toBe('https://legacy-nuxt.supabase.co');
-    expect(config.publicAnonKey).toBe('legacy-nuxt-anon-key');
-  });
-  it('supports legacy Vite names during migration', () => {
-    const config = resolveSupabaseRuntimeConfig({
-      VITE_SUPABASE_ANON_KEY: 'legacy-vite-anon-key',
-      VITE_SUPABASE_URL: 'https://legacy-vite.supabase.co',
-    });
-    expect(config.privateUrl).toBe('https://legacy-vite.supabase.co');
-    expect(config.privateAnonKey).toBe('legacy-vite-anon-key');
-    expect(config.publicUrl).toBe('https://legacy-vite.supabase.co');
-    expect(config.publicAnonKey).toBe('legacy-vite-anon-key');
-  });
-  it('ignores blank higher-priority values when a complete fallback exists', () => {
-    const config = resolveSupabaseRuntimeConfig({
-      NUXT_PUBLIC_SUPABASE_ANON_KEY: ' ',
-      NUXT_PUBLIC_SUPABASE_URL: '',
-      VITE_SUPABASE_ANON_KEY: 'legacy-vite-anon-key',
-      VITE_SUPABASE_URL: 'https://legacy-vite.supabase.co',
-    });
-    expect(config.privateUrl).toBe('https://legacy-vite.supabase.co');
-    expect(config.privateAnonKey).toBe('legacy-vite-anon-key');
-    expect(config.publicUrl).toBe('https://legacy-vite.supabase.co');
-    expect(config.publicAnonKey).toBe('legacy-vite-anon-key');
-  });
-  it('rejects partial credentials when no complete pair exists', () => {
+  it('rejects partial credentials', () => {
     expect(() =>
       resolveSupabaseRuntimeConfig({
         SUPABASE_ANON_KEY: 'shared-anon-key',
       })
     ).toThrow('[Config] Incomplete Supabase credentials: SUPABASE_*');
   });
-  it('rejects a partial canonical pair before using legacy credentials', () => {
-    expect(() =>
-      resolveSupabaseRuntimeConfig({
-        NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
-        NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
-        SUPABASE_URL: 'https://shared.supabase.co',
-      })
-    ).toThrow('[Config] Incomplete Supabase credentials: SUPABASE_*');
-  });
-  it('prefers a complete canonical pair over stray legacy values', () => {
-    const config = resolveSupabaseRuntimeConfig({
-      NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
-      SUPABASE_ANON_KEY: 'shared-anon-key',
-      SUPABASE_URL: 'https://shared.supabase.co',
+  it('allows both shared credentials to be absent for offline development', () => {
+    expect(resolveSupabaseRuntimeConfig({})).toEqual({
+      privateAnonKey: '',
+      privateUrl: '',
+      publicAnonKey: '',
+      publicUrl: '',
     });
-    expect(config.publicUrl).toBe('https://shared.supabase.co');
-    expect(config.publicAnonKey).toBe('shared-anon-key');
-  });
-  it('prefers canonical credentials when complete legacy pairs differ', () => {
-    const config = resolveSupabaseRuntimeConfig({
-      NUXT_PUBLIC_SUPABASE_ANON_KEY: 'legacy-nuxt-anon-key',
-      NUXT_PUBLIC_SUPABASE_URL: 'https://legacy-nuxt.supabase.co',
-      SUPABASE_ANON_KEY: 'shared-anon-key',
-      SUPABASE_URL: 'https://shared.supabase.co',
-    });
-    expect(config.publicUrl).toBe('https://shared.supabase.co');
-    expect(config.publicAnonKey).toBe('shared-anon-key');
   });
   it('includes Tarkov asset hosts alongside GitHub image hosts', () => {
     expect([...GITHUB_IMAGE_DOMAINS, ...TARKOV_IMAGE_DOMAINS]).toEqual(
@@ -104,15 +52,7 @@ describe('resolveClientLogSinkUrl', () => {
   });
 });
 describe('resolvePublicAppUrl', () => {
-  it('prefers NUXT_PUBLIC_APP_URL as canonical', () => {
-    expect(
-      resolvePublicAppUrl({
-        APP_URL: 'https://platform.example.com',
-        NUXT_PUBLIC_APP_URL: 'https://canonical.example.com',
-      })
-    ).toBe('https://canonical.example.com');
-  });
-  it('falls back to APP_URL as platform convenience', () => {
+  it('resolves APP_URL', () => {
     expect(
       resolvePublicAppUrl({
         APP_URL: 'https://platform.example.com',
@@ -125,13 +65,6 @@ describe('resolvePublicAppUrl', () => {
         CF_PAGES_URL: 'deploy-preview.pages.dev',
       })
     ).toBe('https://deploy-preview.pages.dev');
-  });
-  it('resolves NUXT_PUBLIC_APP_URL when set alone', () => {
-    expect(
-      resolvePublicAppUrl({
-        NUXT_PUBLIC_APP_URL: 'https://legacy-preview.example.com',
-      })
-    ).toBe('https://legacy-preview.example.com');
   });
   it('falls back to localhost when no deployment url exists', () => {
     expect(resolvePublicAppUrl({})).toBe('http://localhost:3000');

--- a/app/utils/logger.ts
+++ b/app/utils/logger.ts
@@ -77,10 +77,7 @@ const resolveLogLevel = (): LogLevel => {
   if (cachedLogLevel !== null) return cachedLogLevel;
   const nuxtApp = tryUseNuxtApp();
   const runtimeLevel = nuxtApp?.$config?.public?.logLevel;
-  const envLevel =
-    import.meta.env.NUXT_PUBLIC_LOG_LEVEL ||
-    // deprecated — remove after 2026-07-31
-    import.meta.env.VITE_LOG_LEVEL;
+  const envLevel = import.meta.env.NUXT_PUBLIC_LOG_LEVEL;
   const runtimeLevelString = typeof runtimeLevel === 'string' ? runtimeLevel.trim() : undefined;
   const rawLevel = runtimeLevelString ? runtimeLevelString : envLevel;
   const normalizedLevel = typeof rawLevel === 'string' ? rawLevel.toLowerCase() : undefined;

--- a/app/utils/runtimeConfig.ts
+++ b/app/utils/runtimeConfig.ts
@@ -24,53 +24,21 @@ const normalizePublicAppUrl = (value: string): string => {
   }
   return `https://${trimmed}`;
 };
-type SupabaseCredentialCandidate = { anonKey: string; source: string; url: string };
-const buildSupabaseCredentialCandidate = (
-  anonKey: string | undefined,
-  source: string,
-  url: string | undefined
-): SupabaseCredentialCandidate => ({
-  anonKey: anonKey?.trim() || '',
-  source,
-  url: url?.trim() || '',
-});
-const buildSupabaseCredentialCandidates = (
-  env: NodeJS.ProcessEnv
-): SupabaseCredentialCandidate[] => [
-  buildSupabaseCredentialCandidate(env.SUPABASE_ANON_KEY, 'SUPABASE_*', env.SUPABASE_URL),
-  buildSupabaseCredentialCandidate(
-    env.NUXT_PUBLIC_SUPABASE_ANON_KEY,
-    'NUXT_PUBLIC_SUPABASE_*',
-    env.NUXT_PUBLIC_SUPABASE_URL
-  ),
-  buildSupabaseCredentialCandidate(
-    env.VITE_SUPABASE_ANON_KEY,
-    'VITE_SUPABASE_*',
-    env.VITE_SUPABASE_URL
-  ),
-];
-const resolveSupabaseCredentialPair = (
-  candidates: SupabaseCredentialCandidate[]
-): SupabaseCredentialCandidate => {
-  const selectedIndex = candidates.findIndex(({ anonKey, url }) => anonKey && url);
-  const selected = candidates[selectedIndex];
-  const partial = candidates
-    .slice(0, selectedIndex === -1 ? candidates.length : selectedIndex)
-    .find(({ anonKey, url }) => Boolean(anonKey) !== Boolean(url));
-  if (partial) throw new Error(`[Config] Incomplete Supabase credentials: ${partial.source}`);
-  return selected ?? { anonKey: '', source: '', url: '' };
-};
 export const resolveSupabaseRuntimeConfig = (env: NodeJS.ProcessEnv) => {
-  const selected = resolveSupabaseCredentialPair(buildSupabaseCredentialCandidates(env));
+  const anonKey = env.SUPABASE_ANON_KEY?.trim() || '';
+  const url = env.SUPABASE_URL?.trim() || '';
+  if (Boolean(anonKey) !== Boolean(url)) {
+    throw new Error('[Config] Incomplete Supabase credentials: SUPABASE_*');
+  }
   return {
-    privateAnonKey: selected.anonKey,
-    privateUrl: selected.url,
-    publicAnonKey: selected.anonKey,
-    publicUrl: selected.url,
+    privateAnonKey: anonKey,
+    privateUrl: url,
+    publicAnonKey: anonKey,
+    publicUrl: url,
   };
 };
 export const resolvePublicAppUrl = (env: NodeJS.ProcessEnv): string => {
-  const configuredUrl = resolveEnvValue(env.NUXT_PUBLIC_APP_URL, env.APP_URL, env.CF_PAGES_URL);
+  const configuredUrl = resolveEnvValue(env.APP_URL, env.CF_PAGES_URL);
   if (!configuredUrl) {
     return 'http://localhost:3000';
   }

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -440,9 +440,8 @@ runtime config (server-only), `NUXT_PUBLIC_*` for Nuxt public runtime config (br
 plain names for platform/build-time or Supabase Edge Function settings.
 
 `SUPABASE_URL` and `SUPABASE_ANON_KEY` are the canonical shared Supabase values. Nuxt, Cloudflare
-Pages/Workers, and Supabase Edge Functions can all consume them, so they should not be duplicated as
-`NUXT_PUBLIC_*` values. The legacy `NUXT_PUBLIC_SUPABASE_*` and `VITE_SUPABASE_*` names remain
-accepted temporarily for migration compatibility.
+Pages/Workers, and Supabase Edge Functions can all consume them, so they must not be duplicated as
+`NUXT_PUBLIC_*` or `VITE_*` values.
 
 Full resolution logic is in `app/utils/runtimeConfig.ts`.
 
@@ -481,14 +480,13 @@ Placement is enabled for both environments through the top-level `[placement]` b
 
 **Client-side (browser) — Nuxt public runtime config:**
 
-| Variable                                         | Description                                              | Required   |
-| ------------------------------------------------ | -------------------------------------------------------- | ---------- |
-| `SUPABASE_URL`                                   | Shared Supabase project URL for auth and sync            | Yes¹       |
-| `SUPABASE_ANON_KEY`                              | Shared Supabase anon key for auth and sync               | Yes¹       |
-| `NUXT_PUBLIC_APP_URL`                            | Application URL                                          | Yes (prod) |
-| `NUXT_PUBLIC_CLIENT_LOG_SINK_URL`                | Optional browser log collector URL (disabled by default) | No         |
-| `NUXT_PUBLIC_TURNSTILE_SITE_KEY`                 | Turnstile widget sitekey for Tarkov.dev profile imports  | No²        |
-| `NUXT_PUBLIC_TARKOV_DEV_IMPORT_COOLDOWN_MINUTES` | Browser cooldown after a confirmed profile import        | No         |
+| Variable                                         | Description                                              | Required |
+| ------------------------------------------------ | -------------------------------------------------------- | -------- |
+| `SUPABASE_URL`                                   | Shared Supabase project URL for auth and sync            | Yes¹     |
+| `SUPABASE_ANON_KEY`                              | Shared Supabase anon key for auth and sync               | Yes¹     |
+| `NUXT_PUBLIC_CLIENT_LOG_SINK_URL`                | Optional browser log collector URL (disabled by default) | No       |
+| `NUXT_PUBLIC_TURNSTILE_SITE_KEY`                 | Turnstile widget sitekey for Tarkov.dev profile imports  | No²      |
+| `NUXT_PUBLIC_TARKOV_DEV_IMPORT_COOLDOWN_MINUTES` | Browser cooldown after a confirmed profile import        | No       |
 
 > **¹ Required in production.** These shared names are consumed by Nuxt, Pages, Workers, and Edge
 > Functions. Without Supabase configuration, auth, sync, realtime, and team features are unavailable;
@@ -538,25 +536,23 @@ builds. This is a Vite build-time variable, not Nuxt runtime configuration.
 
 **Build-time / platform:**
 
-| Variable             | Description                                  |
-| -------------------- | -------------------------------------------- |
-| `APP_URL`            | Platform/build-time application URL fallback |
-| `CF_PAGES_URL`       | Cloudflare Pages deployment URL fallback     |
-| `GA_MEASUREMENT_ID`  | Google Analytics measurement ID              |
-| `CLARITY_PROJECT_ID` | Microsoft Clarity project ID                 |
-| `GITHUB_TOKEN`       | Deprecated fallback for `NUXT_GITHUB_TOKEN`  |
-| `VITE_PERF_DEBUG`    | Client performance timing logs               |
+| Variable             | Description                            |
+| -------------------- | -------------------------------------- |
+| `APP_URL`            | Canonical production application URL   |
+| `CF_PAGES_URL`       | Automatic Cloudflare Pages preview URL |
+| `GA_MEASUREMENT_ID`  | Google Analytics measurement ID        |
+| `CLARITY_PROJECT_ID` | Microsoft Clarity project ID           |
+| `VITE_PERF_DEBUG`    | Client performance timing logs         |
 
 **Supabase Edge Functions** (set in Supabase Dashboard, not Cloudflare Pages):
 
-`SUPABASE_URL`, `SUPABASE_ANON_KEY`, `SUPABASE_SERVICE_ROLE_KEY` — all canonical for Edge
-Functions. (`SUPABASE_SERVICE_ROLE_KEY` is deprecated only as a Nuxt app fallback; use
-`NUXT_SUPABASE_SERVICE_KEY` for Nuxt.) The URL and anon key are shared with Nuxt and Workers, so
-configure them once per deployment platform instead of duplicating them under `NUXT_PUBLIC_*`.
-`STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are shared
-canonical names used by both Nuxt and Edge Functions. `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`,
-`DISCORD_SUPPORTER_ROLE_ID`, `DISCORD_LINKED_ROLE_ID`, `CLOUDFLARE_ZONE_ID`,
-`CLOUDFLARE_API_TOKEN` are Edge-only. See `supabase/functions/.env.example`.
+`SUPABASE_URL`, `SUPABASE_ANON_KEY`, and `SUPABASE_SERVICE_ROLE_KEY` are platform-managed canonical
+Edge Function values. Nuxt uses `NUXT_SUPABASE_SERVICE_KEY` for the privileged key. `APP_URL` is the
+canonical application URL used by `admin-cache-purge`; it has no alias fallback.
+`STRIPE_SECRET_KEY` and `STRIPE_WEBHOOK_SECRET` are shared canonical names used by both Nuxt and
+Edge Functions. `DISCORD_BOT_TOKEN`, `DISCORD_GUILD_ID`, `DISCORD_SUPPORTER_ROLE_ID`,
+`DISCORD_LINKED_ROLE_ID`, `CLOUDFLARE_ZONE_ID`, and `CLOUDFLARE_API_TOKEN` are Edge-only. See
+`supabase/functions/.env.example`.
 
 **Cloudflare Workers** (`workers/api-gateway`, set via `wrangler secret put`):
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -715,8 +715,8 @@ through the Nitro proxy `/api/tarkov-dev/profile`, which layers cost and abuse c
   the public sitekey and private secret together, so the client cannot submit before its widget is
   ready. Without the pair the route behaves as before (no token required). Siteverify availability
   failures allow the request; explicit verification failures reject it with `403 turnstile_failed`.
-- Siteverify responses are pinned to the `NUXT_PUBLIC_APP_URL` hostname, so a token minted on
-  another origin is rejected with `hostname-mismatch`. Cloudflare's test secret is exempt because it
+- Siteverify responses are pinned to the canonical `APP_URL` hostname, so a token minted on another
+  origin is rejected with `hostname-mismatch`. Cloudflare's test secret is exempt because it
   reports `example.com` for every origin; it only validates test-key tokens, never production ones.
 - Cached and upstream `200` payloads must pass the import profile schema before use. Invalid cached
   entries are treated as misses, and invalid upstream payloads fail without entering shared cache.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -4,12 +4,12 @@
 
 Naming: `NUXT_*` = Nuxt private (server-only), `NUXT_PUBLIC_*` = Nuxt public (browser-exposed).
 
-**Nuxt app (set in Cloudflare Pages):**
+**Nuxt app (Cloudflare Pages):**
 
-- `NUXT_PUBLIC_SUPABASE_URL` — Supabase project URL (`SUPABASE_URL` also works as fallback)
-- `NUXT_PUBLIC_SUPABASE_ANON_KEY` — Supabase anon key (`SUPABASE_ANON_KEY` also works)
-- `NUXT_SUPABASE_SERVICE_KEY` — Supabase service role key
-- `NUXT_PUBLIC_APP_URL` — Application URL (`APP_URL` / `CF_PAGES_URL` also work)
+- `SUPABASE_URL` — Supabase project URL, managed as plaintext in `wrangler.toml`
+- `SUPABASE_ANON_KEY` — Supabase anon key, managed as plaintext in `wrangler.toml`
+- `NUXT_SUPABASE_SERVICE_KEY` — encrypted Supabase service role key in the Pages dashboard
+- `APP_URL` — production application URL in `wrangler.toml`; previews use `CF_PAGES_URL`
 - `API_ALLOWED_HOSTS` — production host allowlist
 - `API_TRUST_PROXY` — only when overriding proxy auto-detection (forwarded headers are trusted
   only when `API_TRUST_PROXY=true` or `NITRO_PRESET` is explicitly set to a `cloudflare*`
@@ -39,6 +39,7 @@ Set these in Supabase Dashboard → Project Settings → Edge Functions:
   (per-tier role IDs `DISCORD_SCAV_ROLE_ID` / `DISCORD_TIMMY_ROLE_ID` / `DISCORD_CHAD_ROLE_ID`
   are optional)
 - `DISCORD_LINKED_ROLE_ID` for the role applied after a user links Discord from Settings.
+- `APP_URL` for `admin-cache-purge` cache-key construction.
 
 Configure the Stripe webhook endpoint to send:
 

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -117,65 +117,22 @@ export default defineNuxtConfig({
   runtimeConfig: {
     // Server-only (private) runtime config
     supabaseUrl: PRIVATE_SUPABASE_URL,
-    supabaseServiceKey:
-      process.env.NUXT_SUPABASE_SERVICE_KEY ||
-      // deprecated — remove after 2026-07-31
-      process.env.SUPABASE_SERVICE_ROLE_KEY ||
-      '',
+    supabaseServiceKey: process.env.NUXT_SUPABASE_SERVICE_KEY || '',
     supabaseAnonKey: PRIVATE_SUPABASE_ANON_KEY,
-    githubToken: process.env.NUXT_GITHUB_TOKEN?.trim() || process.env.GITHUB_TOKEN?.trim() || '',
+    githubToken: process.env.NUXT_GITHUB_TOKEN?.trim() || '',
     githubContributorsExclude:
       process.env.NUXT_GITHUB_CONTRIBUTORS_EXCLUDE ||
-      // deprecated — remove after 2026-07-31
-      process.env.GITHUB_CONTRIBUTORS_EXCLUDE ||
       'claude,claude[bot],semantic-release-bot,semantic-release[bot]',
     githubContributorsCacheTtlMs:
-      Number(
-        process.env.NUXT_GITHUB_CONTRIBUTORS_CACHE_TTL_MS ||
-          // deprecated — remove after 2026-07-31
-          process.env.GITHUB_CONTRIBUTORS_CACHE_TTL_MS ||
-          '1800000'
-      ) || 1800000,
-    githubTimeoutMs:
-      Number(
-        process.env.NUXT_GITHUB_TIMEOUT_MS ||
-          // deprecated — remove after 2026-07-31
-          process.env.GITHUB_TIMEOUT_MS ||
-          '8000'
-      ) || 8000,
-    tarkovJsonBaseUrl:
-      process.env.NUXT_TARKOV_JSON_BASE_URL ||
-      // deprecated — remove after 2026-07-31
-      process.env.TARKOV_JSON_BASE_URL ||
-      '',
-    logSinkUrl:
-      process.env.NUXT_LOG_SINK_URL ||
-      // deprecated — remove after 2026-07-31
-      process.env.LOG_SINK_URL ||
-      '',
-    twitchClientId:
-      process.env.NUXT_TWITCH_CLIENT_ID ||
-      // deprecated — remove after 2026-07-31
-      process.env.TWITCH_CLIENT_ID ||
-      'kimne78kx3ncx6brgo4mv6wki5h1ko',
-    publicCacheBypassEnabled:
-      process.env.NUXT_CACHE_BYPASS_ENABLED === 'true' ||
-      // deprecated — remove after 2026-07-31
-      process.env.NUXT_PUBLIC_CACHE_BYPASS_ENABLED === 'true',
-    teamMembersCacheTtlMs:
-      Number(
-        process.env.NUXT_TEAM_MEMBERS_CACHE_TTL_MS ||
-          // deprecated — remove after 2026-07-31
-          process.env.TEAM_MEMBERS_CACHE_TTL_MS ||
-          '5000'
-      ) || 5000,
+      Number(process.env.NUXT_GITHUB_CONTRIBUTORS_CACHE_TTL_MS || '1800000') || 1800000,
+    githubTimeoutMs: Number(process.env.NUXT_GITHUB_TIMEOUT_MS || '8000') || 8000,
+    tarkovJsonBaseUrl: process.env.NUXT_TARKOV_JSON_BASE_URL || '',
+    logSinkUrl: process.env.NUXT_LOG_SINK_URL || '',
+    twitchClientId: process.env.NUXT_TWITCH_CLIENT_ID || 'kimne78kx3ncx6brgo4mv6wki5h1ko',
+    publicCacheBypassEnabled: process.env.NUXT_CACHE_BYPASS_ENABLED === 'true',
+    teamMembersCacheTtlMs: Number(process.env.NUXT_TEAM_MEMBERS_CACHE_TTL_MS || '5000') || 5000,
     teamMembersRateLimitPerMinute:
-      Number(
-        process.env.NUXT_TEAM_MEMBERS_RATE_LIMIT_PER_MINUTE ||
-          // deprecated — remove after 2026-07-31
-          process.env.TEAM_MEMBERS_RATE_LIMIT_PER_MINUTE ||
-          '120'
-      ) || 120,
+      Number(process.env.NUXT_TEAM_MEMBERS_RATE_LIMIT_PER_MINUTE || '120') || 120,
     stripeSecretKey: (process.env.STRIPE_SECRET_KEY ?? '').trim(),
     stripePriceScavMonthly: (process.env.STRIPE_PRICE_SCAV_MONTHLY ?? '').trim(),
     stripePriceScav6month: (process.env.STRIPE_PRICE_SCAV_6MONTH ?? '').trim(),
@@ -187,20 +144,9 @@ export default defineNuxtConfig({
     stripePriceChad6month: (process.env.STRIPE_PRICE_CHAD_6MONTH ?? '').trim(),
     stripePriceChadYearly: (process.env.STRIPE_PRICE_CHAD_YEARLY ?? '').trim(),
     accountIpHashSecret: (process.env.NUXT_ACCOUNT_IP_HASH_SECRET ?? '').trim(),
-    sharedProfileCacheTtlMs:
-      Number(
-        process.env.NUXT_SHARED_PROFILE_CACHE_TTL_MS ||
-          // deprecated — remove after 2026-07-31
-          process.env.SHARED_PROFILE_CACHE_TTL_MS ||
-          '5000'
-      ) || 5000,
+    sharedProfileCacheTtlMs: Number(process.env.NUXT_SHARED_PROFILE_CACHE_TTL_MS || '5000') || 5000,
     sharedProfileRateLimitPerMinute:
-      Number(
-        process.env.NUXT_SHARED_PROFILE_RATE_LIMIT_PER_MINUTE ||
-          // deprecated — remove after 2026-07-31
-          process.env.SHARED_PROFILE_RATE_LIMIT_PER_MINUTE ||
-          '120'
-      ) || 120,
+      Number(process.env.NUXT_SHARED_PROFILE_RATE_LIMIT_PER_MINUTE || '120') || 120,
     tarkovDevProfileCacheTtlMs:
       Number(process.env.NUXT_TARKOV_DEV_PROFILE_CACHE_TTL_MS || '900000') || 900000,
     tarkovDevProfileRateLimitPerMinute:
@@ -236,11 +182,7 @@ export default defineNuxtConfig({
     },
     public: {
       NODE_ENV: process.env.NODE_ENV || 'production',
-      logLevel:
-        process.env.NUXT_PUBLIC_LOG_LEVEL ||
-        // deprecated — remove after 2026-07-31
-        process.env.VITE_LOG_LEVEL ||
-        '',
+      logLevel: process.env.NUXT_PUBLIC_LOG_LEVEL || '',
       appUrl: PUBLIC_APP_URL,
       appVersion,
       googleAnalyticsMeasurementId: IS_PRODUCTION_BUILD ? GOOGLE_ANALYTICS_MEASUREMENT_ID : '',

--- a/supabase/functions/.env.example
+++ b/supabase/functions/.env.example
@@ -52,11 +52,8 @@ DISCORD_CHAD_ROLE_ID=
 CLOUDFLARE_API_TOKEN=
 CLOUDFLARE_ZONE_ID=
 
-# === App URLs [optional — cache purge prefixes and CORS origin]
-# Fallback chain: APP_URL → APP_BASE_URL → SITE_URL → hardcoded default
+# === App URL [required for admin-cache-purge]
 APP_URL=https://tarkovtracker.org
-# APP_BASE_URL=
-# SITE_URL=
 
 # Extra CORS origins (comma-separated) added to the default allowlist
 # Default allowlist: https://tarkovtracker.org, https://www.tarkovtracker.org

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -159,24 +159,17 @@ async function purgeTarkovDataCache(
   apiToken: string,
   baseUrl: string
 ): Promise<CloudflarePurgeResponse> {
-  const normalizedBaseUrl = baseUrl.trim();
-  const baseUrls = (() => {
-    try {
-      const parsed = new URL(normalizedBaseUrl);
-      const origins = new Set<string>();
-      origins.add(parsed.origin);
-      const host = parsed.hostname;
-      const portSuffix = parsed.port ? `:${parsed.port}` : '';
-      if (host.startsWith('www.')) {
-        origins.add(`${parsed.protocol}//${host.replace(/^www\./, '')}${portSuffix}`);
-      } else {
-        origins.add(`${parsed.protocol}//www.${host}${portSuffix}`);
-      }
-      return Array.from(origins);
-    } catch {
-      return ['https://tarkovtracker.org', 'https://www.tarkovtracker.org'];
-    }
-  })();
+  const parsed = new URL(baseUrl);
+  const origins = new Set<string>();
+  origins.add(parsed.origin);
+  const host = parsed.hostname;
+  const portSuffix = parsed.port ? `:${parsed.port}` : '';
+  if (host.startsWith('www.')) {
+    origins.add(`${parsed.protocol}//${host.replace(/^www\./, '')}${portSuffix}`);
+  } else {
+    origins.add(`${parsed.protocol}//www.${host}${portSuffix}`);
+  }
+  const baseUrls = Array.from(origins);
   const urlsToPurge: string[] = [];
   for (const base of baseUrls) {
     const cacheBase = `${base}${EDGE_CACHE_PATH}`;
@@ -322,10 +315,19 @@ Deno.serve(async (req) => {
       return createErrorResponse('Cloudflare credentials not configured', 500, req);
     }
     // Get base URL for cache key construction
-    const baseUrl = Deno.env.get('APP_URL');
+    const baseUrl = Deno.env.get('APP_URL')?.trim();
     if (!baseUrl) {
       console.error('[admin-cache-purge] Missing APP_URL');
       return createErrorResponse('Application URL not configured', 500, req);
+    }
+    try {
+      const protocol = new URL(baseUrl).protocol;
+      if (protocol !== 'http:' && protocol !== 'https:') {
+        throw new Error('Unsupported APP_URL protocol');
+      }
+    } catch {
+      console.error('[admin-cache-purge] Invalid APP_URL');
+      return createErrorResponse('Application URL invalid', 500, req);
     }
     // Execute cache purge
     let purgeResult: CloudflarePurgeResponse;

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -322,11 +322,11 @@ Deno.serve(async (req) => {
       return createErrorResponse('Cloudflare credentials not configured', 500, req);
     }
     // Get base URL for cache key construction
-    const baseUrl =
-      Deno.env.get('APP_URL') ||
-      Deno.env.get('APP_BASE_URL') ||
-      Deno.env.get('SITE_URL') ||
-      'https://tarkovtracker.org';
+    const baseUrl = Deno.env.get('APP_URL');
+    if (!baseUrl) {
+      console.error('[admin-cache-purge] Missing APP_URL');
+      return createErrorResponse('Application URL not configured', 500, req);
+    }
     // Execute cache purge
     let purgeResult: CloudflarePurgeResponse;
     if (purgeType === 'all') {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,17 +1,11 @@
 import { defineVitestConfig } from '@nuxt/test-utils/config';
 import { configDefaults } from 'vitest/config';
-// Allow environment variable overrides for Supabase config in tests
-// Falls back to local Supabase instance on port 54321
-const supabaseUrl = process.env.SUPABASE_URL || 'http://localhost:54321';
-const supabaseAnonKey = process.env.SUPABASE_ANON_KEY || 'test-anon-key';
-const logLevel = process.env.VITE_LOG_LEVEL || 'warn';
+const logLevel = process.env.NUXT_PUBLIC_LOG_LEVEL || 'warn';
 const isSharded = Boolean(process.env.VITEST_SHARD);
 const ciReporters = isSharded ? ['default', 'junit', 'github-actions'] : ['default', 'junit'];
 export default defineVitestConfig({
   define: {
-    'import.meta.env.VITE_SUPABASE_URL': JSON.stringify(supabaseUrl),
-    'import.meta.env.VITE_SUPABASE_ANON_KEY': JSON.stringify(supabaseAnonKey),
-    'import.meta.env.VITE_LOG_LEVEL': JSON.stringify(logLevel),
+    'import.meta.env.NUXT_PUBLIC_LOG_LEVEL': JSON.stringify(logLevel),
   },
   test: {
     environment: 'nuxt',


### PR DESCRIPTION
## **User description**
## Summary
- remove retired Nuxt, Vite, GitHub, Supabase, logging, Twitch, cache, and rate-limit environment aliases
- require the canonical `SUPABASE_URL` / `SUPABASE_ANON_KEY` pair and canonical Nuxt variable names
- require the now-configured hosted Supabase `APP_URL` for `admin-cache-purge`
- update runtime tests, examples, system invariants, architecture, runbook, and agent guidance

## Environment preflight
- Cloudflare Pages production and preview contain the canonical encrypted secrets
- Pages plaintext variables and bindings are managed by `wrangler.toml`
- hosted Supabase `APP_URL=https://tarkovtracker.org` was set and verified before this PR
- hosted Supabase has no `APP_BASE_URL` or `SITE_URL` custom secrets

## Validation
- `pnpm run test` — 236 files, 2,298 tests passed
- `pnpm run lint`
- `pnpm run lint:fallow`
- `pnpm run typecheck`
- `pnpm run i18n:check`
- `pnpm run format:check`
- `pnpm run validate:openapi`
- `pnpm run build` with canonical production environment values
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Remove legacy environment aliases and require canonical configuration names

### What Changed
- Supabase, application URL, logging, GitHub, cache, rate-limit, Twitch, and service-key settings now use their canonical environment names without legacy fallbacks.
- Supabase credentials may be omitted for offline development, but production configuration must provide both `SUPABASE_URL` and `SUPABASE_ANON_KEY`.
- Cache purging now requires `APP_URL` and returns a clear configuration error when it is missing instead of using alternate variables or a hardcoded URL.
- Updated examples, documentation, runbooks, and tests to reflect the canonical environment map.

### Impact
`✅ Fewer configuration surprises from stale environment variables`
`✅ Clearer production errors for incomplete Supabase or cache-purge settings`
`✅ Consistent deployment configuration across Nuxt, Cloudflare, and Supabase`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Configuration**
  - Standardized environment variables for Supabase and application URLs.
  - Legacy Nuxt/Vite aliases and fallback values are no longer supported.
  - Logging now defaults to warning-level output and ignores deprecated log-level settings.
  - Cache purging requires `APP_URL`; requests fail clearly when it is missing.

- **Documentation**
  - Updated deployment, environment-variable, architecture, and operational guidance to reflect the required configuration and Turnstile URL pairing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR standardizes application and Edge Function configuration on canonical environment-variable names and removes deprecated fallback chains.
- Uses the shared `SUPABASE_URL` and `SUPABASE_ANON_KEY` pair throughout Nuxt runtime configuration.
- Standardizes application URLs on `APP_URL`, with `CF_PAGES_URL` retained for Pages previews.
- Requires and validates `APP_URL` before constructing cache-purge URLs.
- Updates runtime tests, examples, operational documentation, and logging configuration.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR should not merge until the previously reported setup and contributing guidance is aligned with the canonical Supabase variable names.

Repository setup and contributing documentation still directs contributors to configure aliases that the updated resolver no longer reads, leaving documented installations without Supabase-backed authentication, synchronization, realtime, and team functionality.

**Files Needing Attention:** app/utils/runtimeConfig.ts and the stale setup/contributing documentation
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/utils/runtimeConfig.ts | Replaces Supabase and application-URL fallback chains with canonical environment-variable resolution and pair validation. |
| nuxt.config.ts | Removes deprecated runtime configuration aliases while preserving canonical defaults and mappings. |
| supabase/functions/admin-cache-purge/index.ts | Requires a valid HTTP(S) `APP_URL` and derives purge origins from the validated URL. |
| app/utils/__tests__/runtimeConfig.test.ts | Updates runtime configuration tests for canonical variables, whitespace normalization, partial-pair rejection, and offline development. |
| vitest.config.ts | Removes obsolete Supabase Vite definitions and injects the canonical public log-level variable. |
| docs/runbook.md | Documents canonical Cloudflare Pages and Supabase Edge Function environment settings. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(config): reject invalid cache purge ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/6d7d91e6f8e1e560845fc6c4eae7f49900485a19) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51525168)</sub>

<!-- /greptile_comment -->