### PR TITLE
feat(ui): improve credits and footer navigation

### DIFF
--- a/app/features/credits/ContributorsList.vue
+++ b/app/features/credits/ContributorsList.vue
@@ -1,0 +1,39 @@
+<template>
+  <section class="bg-surface-900/80 rounded-lg border border-white/10 p-5 sm:p-6 md:col-span-2">
+    <div class="flex flex-wrap items-baseline justify-between gap-x-4 gap-y-1">
+      <h2 class="text-primary-300/80 text-xs font-semibold tracking-widest uppercase">
+        {{ t('page.credits.sections.contributors') }}
+      </h2>
+      <span class="text-surface-400 text-xs tabular-nums">
+        {{ contributorCountLabel }}
+      </span>
+    </div>
+    <div v-if="pending" class="text-surface-300 mt-4 flex items-center gap-2 text-sm">
+      <UIcon name="i-mdi-loading" class="h-4 w-4 animate-spin" />
+      <span>{{ t('page.credits.contributors.loading') }}</span>
+    </div>
+    <div v-else-if="showError" class="mt-4 space-y-3">
+      <p class="text-error-300 text-sm">
+        {{ t('page.credits.contributors.error') }}
+      </p>
+      <UButton size="sm" color="neutral" variant="soft" @click="() => refresh()">
+        {{ t('common.retry') }}
+      </UButton>
+    </div>
+    <p v-else-if="!contributors.length" class="text-surface-300 mt-4 text-sm">
+      {{ t('page.credits.contributors.empty') }}
+    </p>
+    <CreditMemberList v-else :members="contributors" variant="grid" ordered class="mt-4" />
+  </section>
+</template>
+<script setup lang="ts">
+  import CreditMemberList from '@/features/credits/CreditMemberList.vue';
+  import { useContributors } from '@/features/credits/useContributors';
+  const { t } = useI18n({ useScope: 'global' });
+  const { contributors, pending, refresh, showError } = useContributors();
+  const contributorCountLabel = computed(() =>
+    contributors.value.length
+      ? t('page.credits.contributors.total', { count: contributors.value.length })
+      : ''
+  );
+</script>

--- a/app/features/credits/ContributorsList.vue
+++ b/app/features/credits/ContributorsList.vue
@@ -8,11 +8,11 @@
         {{ contributorCountLabel }}
       </span>
     </div>
-    <div v-if="pending" class="text-surface-300 mt-4 flex items-center gap-2 text-sm">
+    <div v-if="pending" role="status" class="text-surface-300 mt-4 flex items-center gap-2 text-sm">
       <UIcon name="i-mdi-loading" class="h-4 w-4 animate-spin" />
       <span>{{ t('page.credits.contributors.loading') }}</span>
     </div>
-    <div v-else-if="showError" class="mt-4 space-y-3">
+    <div v-else-if="showError" role="alert" class="mt-4 space-y-3">
       <p class="text-error-300 text-sm">
         {{ t('page.credits.contributors.error') }}
       </p>
@@ -33,7 +33,11 @@
   const { contributors, pending, refresh, showError } = useContributors();
   const contributorCountLabel = computed(() =>
     contributors.value.length
-      ? t('page.credits.contributors.total', { count: contributors.value.length })
+      ? t(
+          'page.credits.contributors.total',
+          { count: contributors.value.length },
+          contributors.value.length
+        )
       : ''
   );
 </script>

--- a/app/features/credits/CreditContributionCount.vue
+++ b/app/features/credits/CreditContributionCount.vue
@@ -1,0 +1,16 @@
+<template>
+  <span
+    v-if="count != null"
+    class="text-surface-400 group-hover:text-surface-300 shrink-0 text-xs font-semibold tabular-nums"
+  >
+    <span aria-hidden="true">{{ count }}</span>
+    <span class="sr-only">{{ contributionLabel }}</span>
+  </span>
+</template>
+<script setup lang="ts">
+  const props = defineProps<{ count?: number }>();
+  const { t } = useI18n({ useScope: 'global' });
+  const contributionLabel = computed(() =>
+    t('page.credits.contributors.contributions', { count: props.count }, props.count ?? 0)
+  );
+</script>

--- a/app/features/credits/CreditMember.vue
+++ b/app/features/credits/CreditMember.vue
@@ -12,9 +12,11 @@
       />
       <span class="truncate" :class="{ 'min-w-0 flex-1': showsCount }">{{ member.name }}</span>
       <CreditContributionCount :count="member.contributions" />
+      <span v-if="member.link" class="sr-only">({{ t('common.opens_in_new_tab') }})</span>
       <UIcon
         v-if="showExternalIcon"
         name="i-mdi-open-in-new"
+        aria-hidden="true"
         class="text-surface-400 ml-auto h-4 w-4 shrink-0"
       />
     </component>
@@ -28,6 +30,7 @@
     creditMemberClasses,
   } from '@/features/credits/creditMemberStyles';
   import type { CreditMember, CreditMemberVariant } from '@/features/credits/types';
+  const { t } = useI18n({ useScope: 'global' });
   const props = defineProps<{
     member: CreditMember;
     variant: CreditMemberVariant;

--- a/app/features/credits/CreditMember.vue
+++ b/app/features/credits/CreditMember.vue
@@ -1,0 +1,50 @@
+<template>
+  <li class="min-w-0">
+    <component :is="linkTag" v-bind="linkAttributes" :title="tooltip" :class="itemClasses">
+      <NuxtImg
+        v-if="member.avatar"
+        :src="member.avatar"
+        alt=""
+        :class="avatarClasses"
+        :width="avatarSize"
+        :height="avatarSize"
+        loading="lazy"
+      />
+      <span class="truncate" :class="{ 'min-w-0 flex-1': showsCount }">{{ member.name }}</span>
+      <CreditContributionCount :count="member.contributions" />
+      <UIcon
+        v-if="showExternalIcon"
+        name="i-mdi-open-in-new"
+        class="text-surface-400 ml-auto h-4 w-4 shrink-0"
+      />
+    </component>
+  </li>
+</template>
+<script setup lang="ts">
+  import CreditContributionCount from '@/features/credits/CreditContributionCount.vue';
+  import {
+    creditMemberAvatarClasses,
+    creditMemberAvatarSize,
+    creditMemberClasses,
+  } from '@/features/credits/creditMemberStyles';
+  import type { CreditMember, CreditMemberVariant } from '@/features/credits/types';
+  const props = defineProps<{
+    member: CreditMember;
+    variant: CreditMemberVariant;
+  }>();
+  const isRow = computed(() => props.variant === 'row');
+  const showsCount = computed(() => props.member.contributions != null);
+  const showExternalIcon = computed(() => isRow.value && Boolean(props.member.link));
+  const linkTag = computed(() => (props.member.link ? 'a' : 'div'));
+  const tooltip = computed(() => (isRow.value ? undefined : props.member.name));
+  const linkAttributes = computed(() =>
+    props.member.link
+      ? { href: props.member.link, target: '_blank', rel: 'noopener noreferrer' }
+      : {}
+  );
+  const avatarSize = computed(() => creditMemberAvatarSize(props.variant));
+  const avatarClasses = computed(() => creditMemberAvatarClasses(props.variant));
+  const itemClasses = computed(() =>
+    creditMemberClasses(props.variant, Boolean(props.member.link))
+  );
+</script>

--- a/app/features/credits/CreditMemberList.vue
+++ b/app/features/credits/CreditMemberList.vue
@@ -27,5 +27,8 @@
     row: 'flex flex-col gap-2',
     grid: 'grid grid-cols-1 gap-x-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
   };
-  const listClasses = computed(() => LIST_CLASSES[props.variant]);
+  const listClasses = computed(() => [
+    LIST_CLASSES[props.variant],
+    props.ordered ? 'list-decimal pl-5' : '',
+  ]);
 </script>

--- a/app/features/credits/CreditMemberList.vue
+++ b/app/features/credits/CreditMemberList.vue
@@ -1,0 +1,31 @@
+<template>
+  <component :is="listTag" role="list" :class="listClasses">
+    <CreditMember
+      v-for="member in members"
+      :key="member.name"
+      :member="member"
+      :variant="variant"
+    />
+  </component>
+</template>
+<script setup lang="ts">
+  import CreditMember from '@/features/credits/CreditMember.vue';
+  import type { CreditMember as CreditMemberData } from '@/features/credits/types';
+  const props = withDefaults(
+    defineProps<{
+      members: CreditMemberData[];
+      variant?: 'row' | 'grid';
+      ordered?: boolean;
+    }>(),
+    {
+      variant: 'row',
+      ordered: false,
+    }
+  );
+  const listTag = computed(() => (props.ordered ? 'ol' : 'ul'));
+  const LIST_CLASSES: Record<'row' | 'grid', string> = {
+    row: 'flex flex-col gap-2',
+    grid: 'grid grid-cols-1 gap-x-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+  };
+  const listClasses = computed(() => LIST_CLASSES[props.variant]);
+</script>

--- a/app/features/credits/__tests__/ContributorsList.test.ts
+++ b/app/features/credits/__tests__/ContributorsList.test.ts
@@ -13,8 +13,10 @@ vi.mock('@/features/credits/useContributors', () => ({
 vi.mock('vue-i18n', async (importOriginal) => ({
   ...(await importOriginal<typeof import('vue-i18n')>()),
   useI18n: () => ({
-    t: (key: string, params?: Record<string, unknown>) =>
-      params?.count == null ? key : `${params.count} contributors`,
+    t: (key: string, params?: Record<string, unknown>, choice?: number) =>
+      params?.count == null
+        ? key
+        : `${params.count} ${choice === 1 ? 'contributor' : 'contributors'}`,
   }),
 }));
 const mountList = () =>
@@ -45,10 +47,12 @@ describe('ContributorsList', () => {
     pending.value = true;
     const wrapper = mountList();
     expect(wrapper.text()).toContain('page.credits.contributors.loading');
+    expect(wrapper.get('[role="status"]').attributes('role')).toBe('status');
     pending.value = false;
     showError.value = true;
     await wrapper.vm.$nextTick();
     expect(wrapper.text()).toContain('page.credits.contributors.error');
+    expect(wrapper.get('[role="alert"]').attributes('role')).toBe('alert');
     await wrapper.get('button').trigger('click');
     expect(refresh).toHaveBeenCalledOnce();
   });
@@ -59,5 +63,8 @@ describe('ContributorsList', () => {
     await wrapper.vm.$nextTick();
     expect(wrapper.text()).toContain('2 contributors');
     expect(wrapper.findAll('li')).toHaveLength(2);
+    contributors.value = [{ name: 'One' }];
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain('1 contributor');
   });
 });

--- a/app/features/credits/__tests__/ContributorsList.test.ts
+++ b/app/features/credits/__tests__/ContributorsList.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ref } from 'vue';
+import ContributorsList from '@/features/credits/ContributorsList.vue';
+const contributors = ref<{ name: string }[]>([]);
+const pending = ref(false);
+const showError = ref(false);
+const refresh = vi.fn();
+vi.mock('@/features/credits/useContributors', () => ({
+  useContributors: () => ({ contributors, pending, refresh, showError }),
+}));
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({
+    t: (key: string, params?: Record<string, unknown>) =>
+      params?.count == null ? key : `${params.count} contributors`,
+  }),
+}));
+const mountList = () =>
+  mount(ContributorsList, {
+    global: {
+      stubs: {
+        CreditMemberList: {
+          props: ['members'],
+          template:
+            '<ol><li v-for="member in members" :key="member.name">{{ member.name }}</li></ol>',
+        },
+        UButton: {
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+        },
+        UIcon: true,
+      },
+    },
+  });
+describe('ContributorsList', () => {
+  beforeEach(() => {
+    contributors.value = [];
+    pending.value = false;
+    showError.value = false;
+    refresh.mockReset();
+  });
+  it('renders loading, error, and retry states', async () => {
+    pending.value = true;
+    const wrapper = mountList();
+    expect(wrapper.text()).toContain('page.credits.contributors.loading');
+    pending.value = false;
+    showError.value = true;
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain('page.credits.contributors.error');
+    await wrapper.get('button').trigger('click');
+    expect(refresh).toHaveBeenCalledOnce();
+  });
+  it('renders empty and populated contributor states', async () => {
+    const wrapper = mountList();
+    expect(wrapper.text()).toContain('page.credits.contributors.empty');
+    contributors.value = [{ name: 'One' }, { name: 'Two' }];
+    await wrapper.vm.$nextTick();
+    expect(wrapper.text()).toContain('2 contributors');
+    expect(wrapper.findAll('li')).toHaveLength(2);
+  });
+});

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -97,7 +97,8 @@ describe('credits member presentation', () => {
     expect(creditMemberAvatarClasses('row')).toContain('h-9 w-9');
     expect(creditMemberAvatarClasses('grid')).toContain('h-7 w-7');
     expect(creditMemberClasses('row', true).join(' ')).toContain('hover:bg-white/10');
-    expect(creditMemberClasses('grid', false)).toContain('');
+    expect(creditMemberClasses('grid', false).join(' ')).not.toContain('hover:');
+    expect(creditMemberClasses('grid', false).join(' ')).not.toContain('focus-visible:');
   });
   it('keeps the static credit groups ordered and uniquely keyed', () => {
     expect(staticCreditSections.map((section) => section.key)).toEqual([

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -64,6 +64,7 @@ describe('credits member presentation', () => {
       target: '_blank',
     });
     expect(wrapper.get('img').attributes('alt')).toBe('');
+    expect(wrapper.text()).toContain('common.opens_in_new_tab');
     expect(wrapper.get('[data-icon="i-mdi-open-in-new"]').attributes('data-icon')).toBe(
       'i-mdi-open-in-new'
     );
@@ -86,6 +87,7 @@ describe('credits member presentation', () => {
     const unordered = mount(CreditMemberList, { props: { members }, global });
     expect(ordered.element.tagName).toBe('OL');
     expect(ordered.classes()).toContain('grid');
+    expect(ordered.classes()).toContain('list-decimal');
     expect(unordered.element.tagName).toBe('UL');
     expect(unordered.classes()).toContain('flex');
   });

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import CreditContributionCount from '@/features/credits/CreditContributionCount.vue';
+import CreditMember from '@/features/credits/CreditMember.vue';
+import CreditMemberList from '@/features/credits/CreditMemberList.vue';
+import {
+  creditMemberAvatarClasses,
+  creditMemberAvatarSize,
+  creditMemberClasses,
+} from '@/features/credits/creditMemberStyles';
+import { staticCreditSections } from '@/features/credits/creditSections';
+const translation = vi.fn((key: string, params?: Record<string, unknown>, choice?: number) =>
+  key === 'page.credits.contributors.contributions'
+    ? `${params?.count} ${choice === 1 ? 'contribution' : 'contributions'}`
+    : key
+);
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({ t: translation }),
+}));
+const global = {
+  stubs: {
+    NuxtImg: {
+      props: ['src', 'alt', 'width', 'height'],
+      template: '<img :src="src" :alt="alt" :width="width" :height="height" />',
+    },
+    UIcon: { props: ['name'], template: '<i :data-icon="name" />' },
+  },
+};
+describe('credits member presentation', () => {
+  beforeEach(() => translation.mockClear());
+  it('renders singular and plural contribution labels for assistive technology', () => {
+    const singular = mount(CreditContributionCount, { props: { count: 1 } });
+    const plural = mount(CreditContributionCount, { props: { count: 4 } });
+    expect(singular.text()).toContain('1 contribution');
+    expect(plural.text()).toContain('4 contributions');
+    expect(translation).toHaveBeenCalledWith(
+      'page.credits.contributors.contributions',
+      { count: 1 },
+      1
+    );
+  });
+  it('does not render a contribution count when it is absent', () => {
+    expect(mount(CreditContributionCount).html()).toBe('<!--v-if-->');
+  });
+  it('renders linked row members with safe external-link attributes', () => {
+    const wrapper = mount(CreditMember, {
+      props: {
+        member: {
+          avatar: 'https://example.com/avatar.png',
+          contributions: 2,
+          link: 'https://example.com/profile',
+          name: 'Contributor',
+        },
+        variant: 'row',
+      },
+      global,
+    });
+    const link = wrapper.get('a');
+    expect(link.attributes()).toMatchObject({
+      href: 'https://example.com/profile',
+      rel: 'noopener noreferrer',
+      target: '_blank',
+    });
+    expect(wrapper.get('img').attributes('alt')).toBe('');
+    expect(wrapper.get('[data-icon="i-mdi-open-in-new"]').attributes('data-icon')).toBe(
+      'i-mdi-open-in-new'
+    );
+  });
+  it('renders unlinked grid members without an external-link icon', () => {
+    const wrapper = mount(CreditMember, {
+      props: { member: { name: 'Tester' }, variant: 'grid' },
+      global,
+    });
+    expect(wrapper.get('div').attributes('title')).toBe('Tester');
+    expect(wrapper.find('a').exists()).toBe(false);
+    expect(wrapper.find('[data-icon]').exists()).toBe(false);
+  });
+  it('selects ordered and unordered list semantics and variant classes', () => {
+    const members = [{ name: 'One' }, { name: 'Two' }];
+    const ordered = mount(CreditMemberList, {
+      props: { members, ordered: true, variant: 'grid' },
+      global,
+    });
+    const unordered = mount(CreditMemberList, { props: { members }, global });
+    expect(ordered.element.tagName).toBe('OL');
+    expect(ordered.classes()).toContain('grid');
+    expect(unordered.element.tagName).toBe('UL');
+    expect(unordered.classes()).toContain('flex');
+  });
+  it('returns stable avatar dimensions and interactive classes', () => {
+    expect(creditMemberAvatarSize('row')).toBe(36);
+    expect(creditMemberAvatarSize('grid')).toBe(28);
+    expect(creditMemberAvatarClasses('row')).toContain('h-9 w-9');
+    expect(creditMemberAvatarClasses('grid')).toContain('h-7 w-7');
+    expect(creditMemberClasses('row', true).join(' ')).toContain('hover:bg-white/10');
+    expect(creditMemberClasses('grid', false)).toContain('');
+  });
+  it('keeps the static credit groups ordered and uniquely keyed', () => {
+    expect(staticCreditSections.map((section) => section.key)).toEqual([
+      'original_creator',
+      'staff',
+      'support_members',
+      'beta_testers',
+    ]);
+    expect(new Set(staticCreditSections.map((section) => section.key)).size).toBe(
+      staticCreditSections.length
+    );
+    expect(staticCreditSections.every((section) => section.members.length > 0)).toBe(true);
+  });
+});

--- a/app/features/credits/creditMemberStyles.ts
+++ b/app/features/credits/creditMemberStyles.ts
@@ -1,0 +1,21 @@
+import type { CreditMemberVariant } from '@/features/credits/types';
+const BASE_CLASSES: Record<CreditMemberVariant, string> = {
+  row: 'flex min-h-12 items-center gap-3 rounded-md bg-white/5 px-4 py-2.5 text-base font-medium text-white',
+  grid: 'group flex min-h-8 items-center gap-2 rounded px-2 py-1 text-sm text-white/85',
+};
+const LINK_HOVER_CLASSES: Record<CreditMemberVariant, string> = {
+  row: 'hover:bg-white/10 hover:text-primary-100',
+  grid: 'hover:bg-white/5 hover:text-white',
+};
+export const creditMemberAvatarSize = (variant: CreditMemberVariant) =>
+  variant === 'row' ? 36 : 28;
+export const creditMemberAvatarClasses = (variant: CreditMemberVariant) => {
+  const size = variant === 'row' ? 'h-9 w-9' : 'h-7 w-7';
+  return `${size} shrink-0 rounded-full border border-white/15 object-cover`;
+};
+export const creditMemberClasses = (variant: CreditMemberVariant, linked: boolean) => [
+  BASE_CLASSES[variant],
+  linked
+    ? `${LINK_HOVER_CLASSES[variant]} focus-visible:ring-primary-500 transition-colors focus-visible:ring-2 focus-visible:outline-none`
+    : '',
+];

--- a/app/features/credits/creditMemberStyles.ts
+++ b/app/features/credits/creditMemberStyles.ts
@@ -16,6 +16,9 @@ export const creditMemberAvatarClasses = (variant: CreditMemberVariant) => {
 export const creditMemberClasses = (variant: CreditMemberVariant, linked: boolean) => [
   BASE_CLASSES[variant],
   linked
-    ? `${LINK_HOVER_CLASSES[variant]} focus-visible:ring-primary-500 transition-colors focus-visible:ring-2 focus-visible:outline-none`
+    ? [
+        LINK_HOVER_CLASSES[variant],
+        'focus-visible:ring-primary-500 transition-colors focus-visible:ring-2 focus-visible:outline-none',
+      ].join(' ')
     : '',
 ];

--- a/app/features/credits/creditSections.ts
+++ b/app/features/credits/creditSections.ts
@@ -1,0 +1,53 @@
+import type { CreditMember } from '@/features/credits/types';
+export interface CreditSection {
+  key: string;
+  members: CreditMember[];
+  fullWidth?: boolean;
+  compact?: boolean;
+}
+const githubAvatar = (username: string) => `https://github.com/${username}.png?size=120`;
+const githubProfile = (username: string) => `https://github.com/${username}`;
+const githubMember = (name: string, username: string): CreditMember => ({
+  name,
+  avatar: githubAvatar(username),
+  link: githubProfile(username),
+});
+const sortMembers = (members: CreditMember[]) =>
+  [...members].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
+export const staticCreditSections: CreditSection[] = [
+  { key: 'original_creator', members: [githubMember('Thaddeus', 'thaddeus')] },
+  {
+    key: 'staff',
+    members: sortMembers([
+      githubMember('DysektAI', 'dysektai'),
+      githubMember('Niv', 'nivmizz7'),
+      githubMember('Chica999', 'chica999'),
+    ]),
+  },
+  {
+    key: 'support_members',
+    members: sortMembers([
+      githubMember('Adealia', 'adealia'),
+      { name: 'Dio' },
+      { name: 'MrBreachie' },
+    ]),
+    fullWidth: true,
+    compact: true,
+  },
+  {
+    key: 'beta_testers',
+    members: sortMembers([
+      githubMember('Adealia', 'adealia'),
+      { name: 'Dio' },
+      { name: 'GanjaManNL' },
+      githubMember('Giribaldi_TTV', 'giribaldittv'),
+      { name: 'LS4Tonio' },
+      { name: 'Medivha' },
+      { name: 'MrBreachie' },
+      { name: 'mike' },
+      { name: 'RuiApostolo' },
+    ]),
+    fullWidth: true,
+    compact: true,
+  },
+];

--- a/app/features/credits/types.ts
+++ b/app/features/credits/types.ts
@@ -1,0 +1,7 @@
+export interface CreditMember {
+  contributions?: number;
+  name: string;
+  avatar?: string;
+  link?: string;
+}
+export type CreditMemberVariant = 'row' | 'grid';

--- a/app/features/credits/useContributors.ts
+++ b/app/features/credits/useContributors.ts
@@ -1,0 +1,27 @@
+import type { CreditMember } from '@/features/credits/types';
+import type { ContributorApiItem, ContributorsResponse } from '@/types/contributors';
+const mapContributorToMember = (item: ContributorApiItem): CreditMember => ({
+  avatar: item.avatar,
+  contributions: item.contributions,
+  link: item.url,
+  name: item.login,
+});
+export const useContributors = () => {
+  const runtimeConfig = useRuntimeConfig();
+  const cacheVersion =
+    import.meta.env.VITE_CONTRIBUTORS_CACHE_VERSION?.trim() ||
+    String(runtimeConfig.public.appVersion ?? '').trim() ||
+    '0.0.0-dev';
+  const request = useFetch<ContributorsResponse>(`/api/contributors?v=${cacheVersion}`, {
+    key: `credits-contributors-${cacheVersion}`,
+    default: () => ({ items: [] }),
+    server: false,
+  });
+  const contributors = computed<CreditMember[]>(() =>
+    (request.data.value?.items ?? []).map(mapContributorToMember)
+  );
+  const showError = computed(
+    () => Boolean(request.error.value) || Boolean(request.data.value?.error)
+  );
+  return { contributors, pending: request.pending, refresh: request.refresh, showError };
+};

--- a/app/features/credits/useContributors.ts
+++ b/app/features/credits/useContributors.ts
@@ -8,10 +8,7 @@ const mapContributorToMember = (item: ContributorApiItem): CreditMember => ({
 });
 export const useContributors = () => {
   const runtimeConfig = useRuntimeConfig();
-  const cacheVersion =
-    import.meta.env.VITE_CONTRIBUTORS_CACHE_VERSION?.trim() ||
-    String(runtimeConfig.public.appVersion ?? '').trim() ||
-    '0.0.0-dev';
+  const cacheVersion = String(runtimeConfig.public.appVersion ?? '').trim() || '0.0.0-dev';
   const request = useFetch<ContributorsResponse>(`/api/contributors?v=${cacheVersion}`, {
     key: `credits-contributors-${cacheVersion}`,
     default: () => ({ items: [] }),

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1203,17 +1203,11 @@
     },
     "credits": {
       "sections": {
-        "original_creator": "Original creator of the project:",
-        "staff": "TarkovTracker.org Staff:",
-        "support_members": "Support Members:",
-        "beta_testers": "Nuxt - Closed Beta Testers:",
-        "contributors": "Open source contributors:"
-      },
-      "labels": {
-        "creators": "Creators",
-        "staff": "Core Team",
-        "testers": "Beta Testers",
-        "contributors": "Contributors"
+        "original_creator": "Original Creator",
+        "staff": "TarkovTracker.org Staff",
+        "support_members": "Support Members",
+        "beta_testers": "Nuxt - Closed Beta Testers",
+        "contributors": "Open Source Contributors"
       },
       "notes": {
         "alphabetical": "Listed alphabetically; order does not reflect contribution.",
@@ -1223,8 +1217,10 @@
         "loading": "Loading contributors...",
         "error": "Unable to load contributors right now.",
         "empty": "No contributors found yet.",
-        "contributions": "{count} contributions"
-      }
+        "contributions": "{count} contribution | {count} contributions",
+        "total": "{count} contributors"
+      },
+      "description": "Meet the creators, staff, support members, beta testers, and open source contributors behind Tarkov Tracker."
     },
     "login": {
       "subtitle": "Sign in to access your account",
@@ -1506,7 +1502,13 @@
       "github": "GitHub"
     },
     "analytics_preferences": "Analytics Preferences",
-    "game_attribution": "Escape from Tarkov and related game content and materials are trademarks and copyrighted works of Battlestate Games Limited and its licensors. All rights reserved. TarkovTracker is an unofficial fan project and is not affiliated with or endorsed by Battlestate Games."
+    "game_attribution": "Escape from Tarkov and related game content and materials are trademarks and copyrighted works of Battlestate Games Limited and its licensors. All rights reserved. TarkovTracker is an unofficial fan project and is not affiliated with or endorsed by Battlestate Games.",
+    "tagline": "Track your Escape from Tarkov quests, hideout upgrades, and item requirements in one place.",
+    "sections": {
+      "explore": "Explore",
+      "project": "Project",
+      "legal": "Legal"
+    }
   },
   "navigation_drawer": {
     "main_navigation": "Main Navigation",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1218,7 +1218,7 @@
         "error": "Unable to load contributors right now.",
         "empty": "No contributors found yet.",
         "contributions": "{count} contribution | {count} contributions",
-        "total": "{count} contributors"
+        "total": "{count} contributor | {count} contributors"
       },
       "description": "Meet the creators, staff, support members, beta testers, and open source contributors behind Tarkov Tracker."
     },

--- a/app/pages/__tests__/credits.test.ts
+++ b/app/pages/__tests__/credits.test.ts
@@ -35,5 +35,10 @@ describe('credits page', () => {
         title: expect.any(Object),
       })
     );
+    const metadata = seoMeta.mock.calls[0]?.[0];
+    expect(metadata.title.value).toBe('common.credits');
+    expect(metadata.description.value).toBe(
+      'Meet the team, testers, and open source contributors behind Tarkov Tracker.'
+    );
   });
 });

--- a/app/pages/__tests__/credits.test.ts
+++ b/app/pages/__tests__/credits.test.ts
@@ -1,0 +1,39 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+const { seoMeta } = vi.hoisted(() => ({ seoMeta: vi.fn() }));
+mockNuxtImport('useSeoMeta', () => seoMeta);
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+describe('credits page', () => {
+  it('renders every static section and configures localized metadata', async () => {
+    const { default: CreditsPage } = await import('@/pages/credits.vue');
+    const wrapper = mount(CreditsPage, {
+      global: {
+        stubs: {
+          ContributorsList: { template: '<div data-testid="contributors" />' },
+          CreditMemberList: {
+            props: ['members'],
+            template:
+              '<ul><li v-for="member in members" :key="member.name">{{ member.name }}</li></ul>',
+          },
+          UContainer: { template: '<main><slot /></main>' },
+        },
+      },
+    });
+    expect(wrapper.findAll('section')).toHaveLength(4);
+    expect(wrapper.find('[data-testid="contributors"]').exists()).toBe(true);
+    expect(wrapper.text()).toContain('page.credits.sections.original_creator');
+    expect(seoMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: expect.any(Object),
+        title: expect.any(Object),
+      })
+    );
+  });
+});

--- a/app/pages/credits.vue
+++ b/app/pages/credits.vue
@@ -1,235 +1,57 @@
 <template>
-  <UContainer class="px-4 py-8">
-    <div class="mx-auto flex w-full max-w-5xl flex-col gap-8">
-      <header class="text-center">
-        <h1 class="sr-only">{{ t('common.credits') }}</h1>
-        <p class="text-xs text-white/55">
+  <UContainer class="px-4 py-10 sm:px-6 sm:py-14">
+    <div class="mx-auto flex w-full max-w-6xl flex-col gap-10">
+      <header class="border-surface-700/60 mx-auto w-full max-w-2xl border-b pb-8 text-center">
+        <h1 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          {{ t('common.credits') }}
+        </h1>
+        <p class="text-surface-400 mt-3 text-sm leading-relaxed">
           {{ t('page.credits.notes.alphabetical') }}
         </p>
-        <p class="text-xs text-white/45">
+        <p class="text-surface-400 mt-1 text-sm leading-relaxed">
           {{ t('page.credits.notes.contributors') }}
         </p>
       </header>
-      <div class="grid gap-6 md:grid-cols-2">
+      <div class="grid items-start gap-6 md:grid-cols-2">
         <section
           v-for="section in staticCreditSections"
           :key="section.key"
-          :class="[
-            'bg-surface-900/80 rounded-2xl border border-white/10 p-6 shadow-[0_10px_40px_rgba(0,0,0,0.35)]',
-            section.fullWidth ? 'md:col-span-2' : '',
-          ]"
+          :class="sectionClasses(section)"
         >
-          <div class="mb-4">
-            <p class="text-primary-300/80 text-xs font-semibold tracking-[0.3em] uppercase">
-              {{ section.pretitle }}
-            </p>
-            <h2 class="mt-2 text-2xl font-semibold text-white">
-              {{ t(`page.credits.sections.${section.key}`) }}
-            </h2>
-          </div>
-          <ul class="space-y-3">
-            <li
-              v-for="member in section.members"
-              :key="member.name"
-              class="rounded-xl bg-white/5 px-4 py-3 text-lg font-medium text-white"
-            >
-              <component
-                :is="member.link ? 'a' : 'div'"
-                v-bind="
-                  member.link
-                    ? { href: member.link, target: '_blank', rel: 'noopener noreferrer' }
-                    : {}
-                "
-                class="flex items-center gap-3"
-                :class="{ 'hover:text-primary-200 transition-colors': member.link }"
-              >
-                <NuxtImg
-                  v-if="member.avatar"
-                  :src="member.avatar"
-                  :alt="member.name"
-                  class="h-12 w-12 rounded-full border border-white/20 object-cover"
-                  width="48"
-                  height="48"
-                  loading="lazy"
-                />
-                <span>{{ member.name }}</span>
-              </component>
-            </li>
-          </ul>
+          <h2 class="text-primary-300/80 text-xs font-semibold tracking-widest uppercase">
+            {{ t(`page.credits.sections.${section.key}`) }}
+          </h2>
+          <CreditMemberList
+            :members="section.members"
+            :variant="section.compact ? 'grid' : 'row'"
+            class="mt-4"
+          />
         </section>
-        <section
-          class="bg-surface-900/80 rounded-2xl border border-white/10 p-6 shadow-[0_10px_40px_rgba(0,0,0,0.35)] md:col-span-2"
-        >
-          <div class="mb-4">
-            <p class="text-primary-300/80 text-xs font-semibold tracking-[0.3em] uppercase">
-              {{ t('page.credits.labels.contributors') }}
-            </p>
-            <h2 class="mt-2 text-2xl font-semibold text-white">
-              {{ t('page.credits.sections.contributors') }}
-            </h2>
-          </div>
-          <div v-if="contributorsPending" class="text-surface-300 flex items-center gap-2 text-sm">
-            <UIcon name="i-mdi-loading" class="h-4 w-4 animate-spin" />
-            <span>{{ t('page.credits.contributors.loading') }}</span>
-          </div>
-          <div v-else-if="showContributorsError" class="space-y-3">
-            <p class="text-error-300 text-sm">
-              {{ t('page.credits.contributors.error') }}
-            </p>
-            <UButton size="sm" color="neutral" variant="soft" @click="() => refreshContributors()">
-              {{ t('common.retry') }}
-            </UButton>
-          </div>
-          <p v-else-if="!contributors.length" class="text-surface-300 text-sm">
-            {{ t('page.credits.contributors.empty') }}
-          </p>
-          <ul v-else class="space-y-3">
-            <li
-              v-for="contributor in contributors"
-              :key="contributor.name"
-              class="rounded-xl bg-white/5 px-4 py-3 text-lg font-medium text-white"
-            >
-              <component
-                :is="contributor.link ? 'a' : 'div'"
-                :href="contributor.link || undefined"
-                :target="contributor.link ? '_blank' : undefined"
-                :rel="contributor.link ? 'noopener noreferrer' : undefined"
-                class="flex items-center gap-3"
-                :class="{ 'hover:text-primary-200 transition-colors': contributor.link }"
-              >
-                <NuxtImg
-                  v-if="contributor.avatar"
-                  :src="contributor.avatar"
-                  :alt="contributor.name"
-                  class="h-12 w-12 rounded-full border border-white/20 object-cover"
-                  width="48"
-                  height="48"
-                  loading="lazy"
-                />
-                <span>{{ contributor.name }}</span>
-                <span class="text-surface-400 ml-auto text-xs font-semibold">
-                  {{
-                    t('page.credits.contributors.contributions', {
-                      count: contributor.contributions,
-                    })
-                  }}
-                </span>
-              </component>
-            </li>
-          </ul>
-        </section>
+        <ContributorsList />
       </div>
     </div>
   </UContainer>
 </template>
 <script setup lang="ts">
-  import type { ContributorApiItem, ContributorsResponse } from '@/types/contributors';
+  import ContributorsList from '@/features/credits/ContributorsList.vue';
+  import CreditMemberList from '@/features/credits/CreditMemberList.vue';
+  import { staticCreditSections, type CreditSection } from '@/features/credits/creditSections';
   const { t } = useI18n({ useScope: 'global' });
+  const creditsDescription = computed(() =>
+    t(
+      'page.credits.description',
+      'Meet the team, testers, and open source contributors behind Tarkov Tracker.'
+    )
+  );
   useSeoMeta({
     title: computed(() => t('common.credits')),
+    description: creditsDescription,
+    ogTitle: computed(() => t('common.credits')),
+    ogDescription: creditsDescription,
   });
-  interface CreditMember {
-    contributions?: number;
-    name: string;
-    avatar?: string;
-    link?: string;
-  }
-  interface CreditSection {
-    key: string;
-    pretitle: string;
-    members: CreditMember[];
-    fullWidth?: boolean;
-  }
-  const githubAvatar = (username: string) => `https://github.com/${username}.png?size=120`;
-  const githubProfile = (username: string) => `https://github.com/${username}`;
-  const runtimeConfig = useRuntimeConfig();
-  const CONTRIBUTORS_CACHE_VERSION =
-    import.meta.env.VITE_CONTRIBUTORS_CACHE_VERSION?.trim() ||
-    String(runtimeConfig.public.appVersion ?? '').trim() ||
-    '0.0.0-dev';
-  const sortMembers = (members: CreditMember[]) =>
-    [...members].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
-  const {
-    data: contributorsData,
-    error: contributorsError,
-    pending: contributorsPending,
-    refresh: refreshContributors,
-  } = useFetch<ContributorsResponse>(`/api/contributors?v=${CONTRIBUTORS_CACHE_VERSION}`, {
-    key: `credits-contributors-${CONTRIBUTORS_CACHE_VERSION}`,
-    default: () => ({ items: [] }),
-    server: false,
-  });
-  const showContributorsError = computed(() => {
-    return Boolean(contributorsError.value) || Boolean(contributorsData.value?.error);
-  });
-  const mapContributorToMember = (item: ContributorApiItem): CreditMember => ({
-    avatar: item.avatar,
-    contributions: item.contributions,
-    link: item.url,
-    name: item.login,
-  });
-  const contributors = computed<CreditMember[]>(() => {
-    const items = contributorsData.value?.items ?? [];
-    return items.map(mapContributorToMember);
-  });
-  const staticCreditSections = computed<CreditSection[]>(() => [
-    {
-      key: 'original_creator',
-      pretitle: t('page.credits.labels.creators'),
-      members: sortMembers([
-        {
-          name: 'Thaddeus',
-          avatar: githubAvatar('thaddeus'),
-          link: githubProfile('thaddeus'),
-        },
-      ]),
-    },
-    {
-      key: 'staff',
-      pretitle: t('page.credits.labels.staff'),
-      members: sortMembers([
-        { name: 'DysektAI', avatar: githubAvatar('dysektai'), link: githubProfile('dysektai') },
-        { name: 'Niv', avatar: githubAvatar('nivmizz7'), link: githubProfile('nivmizz7') },
-        { name: 'Chica999', avatar: githubAvatar('chica999'), link: githubProfile('chica999') },
-      ]),
-    },
-    {
-      key: 'support_members',
-      pretitle: t('common.support'),
-      members: sortMembers([
-        {
-          name: 'Adealia',
-          avatar: githubAvatar('adealia'),
-          link: githubProfile('adealia'),
-        },
-        {
-          name: 'Dio',
-        },
-        {
-          name: 'MrBreachie',
-        },
-      ]),
-      fullWidth: true,
-    },
-    {
-      key: 'beta_testers',
-      pretitle: t('page.credits.labels.testers'),
-      members: sortMembers([
-        { name: 'Adealia', avatar: githubAvatar('adealia'), link: githubProfile('adealia') },
-        { name: 'Dio' },
-        { name: 'GanjaManNL' },
-        {
-          name: 'Giribaldi_TTV',
-          avatar: githubAvatar('giribaldittv'),
-          link: githubProfile('giribaldittv'),
-        },
-        { name: 'LS4Tonio' },
-        { name: 'Medivha' },
-        { name: 'MrBreachie' },
-        { name: 'mike' },
-        { name: 'RuiApostolo' },
-      ]),
-      fullWidth: true,
-    },
-  ]);
+  const SECTION_CLASSES = 'bg-surface-900/80 rounded-lg border border-white/10 p-5 sm:p-6';
+  const sectionClasses = (section: CreditSection) => [
+    SECTION_CLASSES,
+    section.fullWidth ? 'md:col-span-2' : '',
+  ];
 </script>

--- a/app/shell/AppFooter.vue
+++ b/app/shell/AppFooter.vue
@@ -1,44 +1,48 @@
 <template>
-  <footer class="bg-surface-900/60 border-surface-800/70 w-full border-t px-6 py-8">
-    <div class="mx-auto flex w-full max-w-4xl flex-col items-center gap-5 text-center">
-      <div class="flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-sm">
-        <router-link
-          to="/terms-of-service"
-          class="text-info-400 hover:text-info-300 transition-colors"
-        >
-          {{ t('common.terms_of_service') }}
-        </router-link>
-        <span class="text-surface-500">·</span>
-        <router-link to="/privacy" class="text-info-400 hover:text-info-300 transition-colors">
-          {{ t('common.privacy_policy') }}
-        </router-link>
-        <span class="text-surface-500">·</span>
-        <router-link to="/credits" class="text-info-400 hover:text-info-300 transition-colors">
-          {{ t('common.credits') }}
-        </router-link>
-        <template v-if="analyticsConfigured">
-          <span class="text-surface-500">·</span>
-          <button
-            type="button"
-            class="text-info-400 hover:text-info-300 transition-colors"
-            @click="openAnalyticsPreferences"
+  <footer class="bg-surface-900/60 border-surface-800/70 w-full border-t px-4 py-8 sm:px-6">
+    <div class="mx-auto flex w-full max-w-6xl flex-col gap-6">
+      <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-5">
+        <div class="min-w-0 lg:col-span-2">
+          <NuxtLink
+            to="/"
+            class="focus-visible:ring-primary-500 inline-flex items-center gap-2.5 rounded focus-visible:ring-2 focus-visible:outline-none"
           >
-            {{ t('footer.analytics_preferences') }}
-          </button>
-        </template>
-      </div>
-      <div class="text-surface-500 text-center text-xs">
-        <div class="text-surface-400 flex flex-wrap items-center justify-center gap-x-2 gap-y-1">
-          <span>TarkovTracker &copy; 2020–{{ new Date().getFullYear() }}</span>
-          <span class="text-surface-500">·</span>
-          <span class="text-surface-400 font-mono">v{{ appVersion }}</span>
+            <NuxtImg
+              src="/img/logos/tarkovtrackerlogo-light.webp"
+              alt=""
+              width="36"
+              height="36"
+              class="h-9 w-9 shrink-0"
+              loading="lazy"
+            />
+            <span class="text-base font-medium text-white">
+              {{ t('navigation_drawer.brand_name') }}
+            </span>
+          </NuxtLink>
+          <p class="text-surface-400 mt-3 max-w-sm text-xs leading-relaxed">
+            {{ t('footer.tagline') }}
+          </p>
         </div>
-        <p class="text-surface-400 mt-1">{{ t('footer.game_attribution') }}</p>
+        <AppFooterColumn :title="t('footer.sections.explore')" :items="exploreItems" />
+        <AppFooterColumn :title="t('footer.sections.project')" :items="projectItems" />
+        <AppFooterColumn :title="t('footer.sections.legal')" :items="legalItems" />
+      </div>
+      <div
+        class="border-surface-800/70 flex flex-col gap-2 border-t pt-5 text-xs sm:flex-row sm:items-center sm:justify-between"
+      >
+        <p class="text-surface-400">
+          TarkovTracker &copy; 2020–{{ new Date().getFullYear() }}
+          <span class="text-surface-400 font-mono">v{{ appVersion }}</span>
+        </p>
+        <p class="text-surface-400 max-w-xl leading-relaxed">
+          {{ t('footer.game_attribution') }}
+        </p>
       </div>
     </div>
   </footer>
 </template>
 <script setup lang="ts">
+  import AppFooterColumn from '@/shell/AppFooterColumn.vue';
   import { logger } from '@/utils/logger';
   import { shouldEnableAnalyticsIntegrations } from '@/utils/runtimeConfig';
   const { t } = useI18n({ useScope: 'global' });
@@ -65,4 +69,28 @@
   const openAnalyticsPreferences = () => {
     analyticsConsentApi.value?.openPreferences();
   };
+  const exploreItems = computed(() => [
+    { label: t('common.dashboard'), to: '/' },
+    { label: t('common.tasks'), to: '/tasks' },
+    { label: t('common.hideout'), to: '/hideout' },
+    { label: t('common.needed_items'), to: '/needed-items' },
+    { label: t('common.storyline'), to: '/storyline' },
+  ]);
+  const projectItems = computed(() => [
+    { label: t('common.team'), to: '/team' },
+    { label: t('common.supporter'), to: '/supporter' },
+    { label: t('navigation_drawer.resources'), to: '/resources' },
+    { label: t('common.credits'), to: '/credits' },
+    { label: t('page.changelog.title'), to: '/changelog' },
+  ]);
+  const legalItems = computed(() => {
+    const items: { label: string; to?: string; onClick?: () => void }[] = [
+      { label: t('common.terms_of_service'), to: '/terms-of-service' },
+      { label: t('common.privacy_policy'), to: '/privacy' },
+    ];
+    if (analyticsConfigured) {
+      items.push({ label: t('footer.analytics_preferences'), onClick: openAnalyticsPreferences });
+    }
+    return items;
+  });
 </script>

--- a/app/shell/AppFooter.vue
+++ b/app/shell/AppFooter.vue
@@ -45,6 +45,7 @@
   import AppFooterColumn from '@/shell/AppFooterColumn.vue';
   import { logger } from '@/utils/logger';
   import { shouldEnableAnalyticsIntegrations } from '@/utils/runtimeConfig';
+  import type { FooterNavItem } from '@/shell/footerNavigation';
   const { t } = useI18n({ useScope: 'global' });
   const runtimeConfig = useRuntimeConfig();
   const appVersion = runtimeConfig.public.appVersion || 'dev';
@@ -84,10 +85,7 @@
     { label: t('page.changelog.title'), to: '/changelog' },
   ]);
   const legalItems = computed(() => {
-    const items: (
-      | { label: string; to: string; onClick?: never }
-      | { label: string; onClick: () => void; to?: never }
-    )[] = [
+    const items: FooterNavItem[] = [
       { label: t('common.terms_of_service'), to: '/terms-of-service' },
       { label: t('common.privacy_policy'), to: '/privacy' },
     ];

--- a/app/shell/AppFooter.vue
+++ b/app/shell/AppFooter.vue
@@ -84,7 +84,10 @@
     { label: t('page.changelog.title'), to: '/changelog' },
   ]);
   const legalItems = computed(() => {
-    const items: { label: string; to?: string; onClick?: () => void }[] = [
+    const items: (
+      | { label: string; to: string; onClick?: never }
+      | { label: string; onClick: () => void; to?: never }
+    )[] = [
       { label: t('common.terms_of_service'), to: '/terms-of-service' },
       { label: t('common.privacy_policy'), to: '/privacy' },
     ];

--- a/app/shell/AppFooterColumn.vue
+++ b/app/shell/AppFooterColumn.vue
@@ -1,14 +1,14 @@
 <template>
   <nav :aria-label="title">
     <h2 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">{{ title }}</h2>
-    <ul class="mt-3 flex flex-col gap-0.5">
-      <li v-for="item in items" :key="item.label">
+    <div role="list" class="mt-3 flex flex-col gap-0.5">
+      <div v-for="item in items" :key="item.label" role="listitem">
         <button v-if="item.onClick" type="button" :class="linkClass" @click="item.onClick">
           {{ item.label }}
         </button>
         <NuxtLink v-else :to="item.to" :class="linkClass">{{ item.label }}</NuxtLink>
-      </li>
-    </ul>
+      </div>
+    </div>
   </nav>
 </template>
 <script setup lang="ts">

--- a/app/shell/AppFooterColumn.vue
+++ b/app/shell/AppFooterColumn.vue
@@ -1,14 +1,14 @@
 <template>
   <nav :aria-label="title">
     <h2 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">{{ title }}</h2>
-    <div role="list" class="mt-3 flex flex-col gap-0.5">
-      <div v-for="item in items" :key="item.label" role="listitem">
+    <ul class="mt-3 flex list-disc flex-col gap-0.5 marker:text-transparent">
+      <li v-for="item in items" :key="item.label">
         <button v-if="item.onClick" type="button" :class="linkClass" @click="item.onClick">
           {{ item.label }}
         </button>
         <NuxtLink v-else :to="item.to" :class="linkClass">{{ item.label }}</NuxtLink>
-      </div>
-    </div>
+      </li>
+    </ul>
   </nav>
 </template>
 <script setup lang="ts">

--- a/app/shell/AppFooterColumn.vue
+++ b/app/shell/AppFooterColumn.vue
@@ -1,7 +1,7 @@
 <template>
   <nav :aria-label="title">
     <h2 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">{{ title }}</h2>
-    <ul role="list" class="mt-3 flex flex-col gap-0.5">
+    <ul class="mt-3 flex flex-col gap-0.5">
       <li v-for="item in items" :key="item.label">
         <button v-if="item.onClick" type="button" :class="linkClass" @click="item.onClick">
           {{ item.label }}
@@ -12,11 +12,12 @@
   </nav>
 </template>
 <script setup lang="ts">
-  interface FooterNavItem {
+  interface FooterNavItemBase {
     label: string;
-    to?: string;
-    onClick?: () => void;
   }
+  type FooterNavItem =
+    | (FooterNavItemBase & { to: string; onClick?: never })
+    | (FooterNavItemBase & { onClick: () => void; to?: never });
   defineProps<{
     title: string;
     items: FooterNavItem[];

--- a/app/shell/AppFooterColumn.vue
+++ b/app/shell/AppFooterColumn.vue
@@ -1,0 +1,26 @@
+<template>
+  <nav :aria-label="title">
+    <h2 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">{{ title }}</h2>
+    <ul role="list" class="mt-3 flex flex-col gap-0.5">
+      <li v-for="item in items" :key="item.label">
+        <button v-if="item.onClick" type="button" :class="linkClass" @click="item.onClick">
+          {{ item.label }}
+        </button>
+        <NuxtLink v-else :to="item.to" :class="linkClass">{{ item.label }}</NuxtLink>
+      </li>
+    </ul>
+  </nav>
+</template>
+<script setup lang="ts">
+  interface FooterNavItem {
+    label: string;
+    to?: string;
+    onClick?: () => void;
+  }
+  defineProps<{
+    title: string;
+    items: FooterNavItem[];
+  }>();
+  const linkClass =
+    'text-info-400 hover:text-info-300 focus-visible:ring-primary-500 inline-flex min-h-8 items-center rounded text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none';
+</script>

--- a/app/shell/AppFooterColumn.vue
+++ b/app/shell/AppFooterColumn.vue
@@ -12,12 +12,7 @@
   </nav>
 </template>
 <script setup lang="ts">
-  interface FooterNavItemBase {
-    label: string;
-  }
-  type FooterNavItem =
-    | (FooterNavItemBase & { to: string; onClick?: never })
-    | (FooterNavItemBase & { onClick: () => void; to?: never });
+  import type { FooterNavItem } from '@/shell/footerNavigation';
   defineProps<{
     title: string;
     items: FooterNavItem[];

--- a/app/shell/AppFooterColumn.vue
+++ b/app/shell/AppFooterColumn.vue
@@ -1,7 +1,7 @@
 <template>
   <nav :aria-label="title">
     <h2 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">{{ title }}</h2>
-    <ul class="mt-3 flex list-disc flex-col gap-0.5 marker:text-transparent">
+    <ul class="mt-3 list-disc space-y-0.5 marker:text-transparent">
       <li v-for="item in items" :key="item.label">
         <button v-if="item.onClick" type="button" :class="linkClass" @click="item.onClick">
           {{ item.label }}

--- a/app/shell/__tests__/AppFooter.test.ts
+++ b/app/shell/__tests__/AppFooter.test.ts
@@ -1,0 +1,55 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const { openPreferences, runtimeConfig } = vi.hoisted(() => ({
+  openPreferences: vi.fn(),
+  runtimeConfig: {
+    public: {
+      appUrl: 'https://tarkovtracker.org',
+      appVersion: '1.2.3',
+      googleAnalyticsMeasurementId: 'G-TEST',
+      microsoftClarityProjectId: '',
+    },
+  },
+}));
+mockNuxtImport('useRuntimeConfig', () => () => runtimeConfig);
+mockNuxtImport('useAnalyticsConsent', () => () => ({ openPreferences }));
+vi.mock('@/utils/runtimeConfig', () => ({
+  shouldEnableAnalyticsIntegrations: () => true,
+}));
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+const mountFooter = async () => {
+  const { default: AppFooter } = await import('@/shell/AppFooter.vue');
+  return mount(AppFooter, {
+    global: {
+      stubs: {
+        AppFooterColumn: {
+          props: ['title', 'items'],
+          template:
+            '<section :data-title="title"><button v-for="item in items" :key="item.label" @click="item.onClick?.()">{{ item.label }}</button></section>',
+        },
+        NuxtImg: true,
+        NuxtLink: { template: '<a><slot /></a>' },
+      },
+    },
+  });
+};
+describe('AppFooter', () => {
+  beforeEach(() => openPreferences.mockReset());
+  it('renders the navigation groups, version, and analytics preferences action', async () => {
+    const wrapper = await mountFooter();
+    expect(wrapper.text()).toContain('navigation_drawer.brand_name');
+    expect(wrapper.text()).toContain('v1.2.3');
+    expect(wrapper.findAll('section')).toHaveLength(3);
+    const analyticsButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'footer.analytics_preferences');
+    expect(analyticsButton).toBeDefined();
+    await analyticsButton?.trigger('click');
+    expect(openPreferences).toHaveBeenCalledOnce();
+  });
+});

--- a/app/shell/__tests__/AppFooterColumn.test.ts
+++ b/app/shell/__tests__/AppFooterColumn.test.ts
@@ -20,6 +20,7 @@ describe('AppFooterColumn', () => {
       global: { stubs: { NuxtLink: NuxtLinkStub } },
     });
     expect(wrapper.get('nav').attributes('aria-label')).toBe('Legal');
+    expect(wrapper.get('ul').classes()).toContain('list-disc');
     expect(wrapper.get('a').attributes('href')).toBe('/privacy');
     await wrapper.get('button').trigger('click');
     expect(onClick).toHaveBeenCalledOnce();

--- a/app/shell/__tests__/AppFooterColumn.test.ts
+++ b/app/shell/__tests__/AppFooterColumn.test.ts
@@ -1,0 +1,27 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import AppFooterColumn from '@/shell/AppFooterColumn.vue';
+const NuxtLinkStub = {
+  props: ['to'],
+  template: '<a :href="to"><slot /></a>',
+};
+describe('AppFooterColumn', () => {
+  it('renders navigation links and actions with an accessible label', async () => {
+    const onClick = vi.fn();
+    const wrapper = mount(AppFooterColumn, {
+      props: {
+        title: 'Legal',
+        items: [
+          { label: 'Privacy', to: '/privacy' },
+          { label: 'Analytics preferences', onClick },
+        ],
+      },
+      global: { stubs: { NuxtLink: NuxtLinkStub } },
+    });
+    expect(wrapper.get('nav').attributes('aria-label')).toBe('Legal');
+    expect(wrapper.get('a').attributes('href')).toBe('/privacy');
+    await wrapper.get('button').trigger('click');
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/app/shell/footerNavigation.ts
+++ b/app/shell/footerNavigation.ts
@@ -1,0 +1,6 @@
+interface FooterNavItemBase {
+  label: string;
+}
+export type FooterNavItem =
+  | (FooterNavItemBase & { to: string; onClick?: never })
+  | (FooterNavItemBase & { onClick: () => void; to?: never });


### PR DESCRIPTION
## **User description**
## Summary

- redesign the credits page with compact reusable member and contributor components
- expand the footer into responsive Explore, Project, and Legal navigation groups
- improve SEO metadata, accessibility labels, contrast, focus targets, and responsive layout
- keep contributor fetching isolated and preserve loading, empty, error, and retry behavior

## User impact

Credits are easier to scan across desktop and mobile layouts, contributor counts remain available with screen-reader context, and the footer now provides direct navigation to core areas of the application.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run lint:fallow`
- `pnpm run i18n:check`
- desktop and 390px browser render/overflow checks
- hydrated Lighthouse accessibility audit

## Deployment and rollback

Frontend-only change with no migrations, environment variables, dependencies, or API contract changes. Standard Cloudflare Pages rollback applies.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Redesign the credits page and give the footer clearer paths to key areas

### What Changed
- Credits are presented in compact, responsive sections with avatars, external profile links, contribution counts, and accessible labels
- Contributor loading, empty, error, and retry states remain available in a dedicated section with a contributor total
- The footer now includes Explore, Project, and Legal navigation groups, plus the site logo and a short product description
- Footer links and credit profiles have clearer hover states and keyboard focus indicators
- Credits pages now include descriptive search and social sharing metadata

### Impact
`✅ Faster access to key site areas`
`✅ Easier-to-scan credits on mobile and desktop`
`✅ Clearer contributor counts and loading errors`
`✅ Improved keyboard navigation`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a redesigned credits page with responsive member listings, contribution counts, profile links, avatars, and contributor totals.
  * Added live contributor loading with clear loading, empty, error, and retry states.
  * Added a responsive, multi-column footer with branding and Explore, Project, and Legal navigation.
* **Enhancements**
  * Improved accessibility with localized labels, semantic lists, keyboard states, and screen-reader-friendly contribution details.
  * Updated English copy for credits, footer navigation, attribution, and contribution counts.
  * Added localized SEO descriptions for the credits page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reorganizes the credits experience into reusable components and expands the application footer with responsive navigation.

- Adds compact static and fetched contributor lists with loading, error, empty, retry, and contribution-count states.
- Adds localized credits metadata and accessibility improvements for profile links and counts.
- Adds Explore, Project, and Legal footer groups while retaining analytics preferences when configured.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/pages/credits.vue | Replaces the monolithic credits page with reusable section and contributor components plus localized SEO metadata. |
| app/features/credits/useContributors.ts | Isolates contributor fetching and maps the existing API response into the shared credit-member model. |
| app/features/credits/CreditMember.vue | Provides shared linked and unlinked member presentation with safe external-link attributes and accessible count text. |
| app/features/credits/ContributorsList.vue | Preserves loading, error, retry, empty, and populated states in a dedicated contributor section. |
| app/shell/AppFooter.vue | Reworks the footer into responsive branding and navigation groups while retaining the configured analytics action. |
| app/shell/AppFooterColumn.vue | Renders reusable accessible footer groups containing internal links or button actions. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ui): retain footer list item display"](https://github.com/tarkovtracker-org/tarkovtracker/commit/4b624ea6c6a00712e512ea82a1964978433d9cc1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51760287)</sub>

**Context used:**

- Knowledge Base — [Frontend App (Nuxt)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/frontend-app.md)

<!-- /greptile_comment -->