### PR TITLE
docs(app): align privacy policy with current data practices

### DIFF
--- a/app/pages/privacy.vue
+++ b/app/pages/privacy.vue
@@ -205,8 +205,9 @@
             <li class="leading-relaxed">
               <strong>Cloudflare Pages & Workers:</strong>
               Web hosting, content delivery network (CDN), static asset serving, API request
-              handling, and edge key-value caching (limited to public, precomputed game data with a
-              7-day retention; no personal data is stored at the edge)
+              handling, and edge key-value caching. Edge caches hold public, precomputed game data
+              with a 7-day retention; shared profile and team responses (display names, progress,
+              and identifiers) are cached for only a few seconds to serve concurrent requests
             </li>
             <li class="leading-relaxed">
               <strong>OAuth Providers:</strong>
@@ -297,8 +298,9 @@
             </li>
             <li class="leading-relaxed">
               <strong>Cloudflare:</strong>
-              Web hosting, CDN, DDoS protection, API request handling, edge caching of public game
-              data, and performance optimization
+              Web hosting, CDN, DDoS protection, API request handling, edge caching (public game
+              data retained up to 7 days; shared profile and team data for a few seconds), and
+              performance optimization
             </li>
             <li class="leading-relaxed">
               <strong>Google Analytics and Microsoft Clarity:</strong>

--- a/app/pages/privacy.vue
+++ b/app/pages/privacy.vue
@@ -3,7 +3,7 @@
     <div class="prose prose-gray dark:prose-invert mx-auto max-w-4xl">
       <h1 class="mb-2 text-4xl font-bold">Privacy Policy</h1>
       <p class="text-surface-500 dark:text-surface-400 mb-12 text-sm">
-        Last Updated: June 30, 2026
+        Last Updated: August 10, 2026
       </p>
       <div class="space-y-12">
         <!-- INTRODUCTION -->
@@ -48,7 +48,7 @@
             <li class="leading-relaxed">
               <strong>Game Progress Data:</strong>
               Quest completions, hideout upgrade status, player level information, faction progress,
-              and game mode selections (PvP/PvE)
+              and game mode selections (PvP/PvE/Seasonal)
             </li>
             <li class="leading-relaxed">
               <strong>Team Collaboration Data:</strong>
@@ -65,6 +65,12 @@
               handles your payment. We do not store your full card number; we retain limited records
               such as your supporter status, tier, contribution history, and a processor customer or
               transaction identifier needed to manage perks, renewals, refunds, and disputes
+            </li>
+            <li class="leading-relaxed">
+              <strong>Imported Game Log Files:</strong>
+              If you use the EFT log import feature, your game log files are processed entirely
+              locally in your browser. They are never uploaded to or stored on our servers; only the
+              extracted progress data you choose to save is sent to us
             </li>
           </ul>
           <h3 class="mt-6 mb-3 text-xl font-semibold">2.2 Information Collected Automatically</h3>
@@ -84,11 +90,16 @@
             </li>
             <li class="leading-relaxed">
               <strong>Log Data:</strong>
-              IP address, access times, referring/exit pages, and error logs
+              Access times, referring/exit pages, and error logs. Your IP address appears only in
+              transient access logs maintained by our hosting providers (Cloudflare) under their own
+              privacy policies. Where we retain account-linked IP records for abuse prevention, we
+              store a one-way keyed hash (HMAC-SHA256) of the IP address along with your browser
+              User-Agent string — never the raw IP address itself
             </li>
             <li class="leading-relaxed">
               <strong>API Access Data:</strong>
-              API tokens, request timestamps, endpoints accessed, and rate limit information
+              API tokens, request timestamps, endpoints accessed, client User-Agent strings, and
+              rate limit information
             </li>
             <li class="leading-relaxed">
               <strong>Cookies and Similar Technologies:</strong>
@@ -117,7 +128,9 @@
             <li class="leading-relaxed">
               <strong>OAuth Providers:</strong>
               Profile information, email addresses, and authentication tokens from Twitch, Discord,
-              Google, GitHub, or other supported providers
+              Google, GitHub, or other supported providers. Some providers (such as Discord) require
+              us to request your email address to uniquely identify your account — we use it solely
+              for authentication and account recovery, and we do not send marketing email
             </li>
             <li class="leading-relaxed">
               <strong>Game Data Sources:</strong>
@@ -185,8 +198,9 @@
               AWS infrastructure in multiple regions)
             </li>
             <li class="leading-relaxed">
-              <strong>Cloudflare Pages:</strong>
-              Web hosting, content delivery network (CDN), and static asset serving
+              <strong>Cloudflare Pages & Workers:</strong>
+              Web hosting, content delivery network (CDN), static asset serving, API request
+              handling, and edge key-value caching
             </li>
             <li class="leading-relaxed">
               <strong>OAuth Providers:</strong>
@@ -277,7 +291,8 @@
             </li>
             <li class="leading-relaxed">
               <strong>Cloudflare:</strong>
-              Web hosting, CDN, DDoS protection, and performance optimization
+              Web hosting, CDN, DDoS protection, API request handling, edge caching, and performance
+              optimization
             </li>
             <li class="leading-relaxed">
               <strong>Google Analytics and Microsoft Clarity:</strong>
@@ -369,6 +384,10 @@
           <ul class="mb-4 ml-6 list-disc space-y-2">
             <li class="leading-relaxed">
               Remove your personal information and progress data from active systems within 30 days
+            </li>
+            <li class="leading-relaxed">
+              Permanently remove account-linked security audit records (such as hashed IP addresses
+              and User-Agent strings), which are deleted automatically when your account is removed
             </li>
             <li class="leading-relaxed">
               Anonymize or delete your data from team records (team names and shared data may

--- a/app/pages/privacy.vue
+++ b/app/pages/privacy.vue
@@ -90,11 +90,14 @@
             </li>
             <li class="leading-relaxed">
               <strong>Log Data:</strong>
-              Access times, referring/exit pages, and error logs. Your IP address appears only in
-              transient access logs maintained by our hosting providers (Cloudflare) under their own
-              privacy policies. Where we retain account-linked IP records for abuse prevention, we
-              store a one-way keyed hash (HMAC-SHA256) of the IP address along with your browser
-              User-Agent string — never the raw IP address itself
+              Access times, referring/exit pages, and error logs. Your IP address otherwise appears
+              only in transient access logs maintained by our hosting providers (Cloudflare) under
+              their own privacy policies. Where we retain account-linked IP records, we store a
+              one-way keyed hash (HMAC-SHA256) of the IP address along with your browser User-Agent
+              string — never the raw IP address. As limited exceptions, we store the raw IP address
+              with your User-Agent in account-deletion rate-limit records (retained for up to 90
+              days) and in administrative audit logs, solely for abuse prevention and security
+              auditing
             </li>
             <li class="leading-relaxed">
               <strong>API Access Data:</strong>
@@ -129,8 +132,10 @@
               <strong>OAuth Providers:</strong>
               Profile information, email addresses, and authentication tokens from Twitch, Discord,
               Google, GitHub, or other supported providers. Some providers (such as Discord) require
-              us to request your email address to uniquely identify your account — we use it solely
-              for authentication and account recovery, and we do not send marketing email
+              us to request your email address to uniquely identify your account — we use it for
+              authentication, account recovery, and the service-related email communications
+              described in this policy (technical notices, security alerts, support messages, and
+              policy-change notices). We do not send marketing email
             </li>
             <li class="leading-relaxed">
               <strong>Game Data Sources:</strong>
@@ -200,7 +205,8 @@
             <li class="leading-relaxed">
               <strong>Cloudflare Pages & Workers:</strong>
               Web hosting, content delivery network (CDN), static asset serving, API request
-              handling, and edge key-value caching
+              handling, and edge key-value caching (limited to public, precomputed game data with a
+              7-day retention; no personal data is stored at the edge)
             </li>
             <li class="leading-relaxed">
               <strong>OAuth Providers:</strong>
@@ -291,8 +297,8 @@
             </li>
             <li class="leading-relaxed">
               <strong>Cloudflare:</strong>
-              Web hosting, CDN, DDoS protection, API request handling, edge caching, and performance
-              optimization
+              Web hosting, CDN, DDoS protection, API request handling, edge caching of public game
+              data, and performance optimization
             </li>
             <li class="leading-relaxed">
               <strong>Google Analytics and Microsoft Clarity:</strong>
@@ -386,8 +392,10 @@
               Remove your personal information and progress data from active systems within 30 days
             </li>
             <li class="leading-relaxed">
-              Permanently remove account-linked security audit records (such as hashed IP addresses
-              and User-Agent strings), which are deleted automatically when your account is removed
+              Remove account-linked security audit records (such as hashed IP addresses and
+              User-Agent strings), which are deleted when your account is removed — except
+              account-deletion rate-limit records, which are kept for up to 90 days to prevent abuse
+              of the deletion process
             </li>
             <li class="leading-relaxed">
               Anonymize or delete your data from team records (team names and shared data may

--- a/supabase/migrations/20260810130000_schedule_deletion_attempts_cleanup.sql
+++ b/supabase/migrations/20260810130000_schedule_deletion_attempts_cleanup.sql
@@ -12,6 +12,9 @@
 -- idempotent unschedule-then-schedule guard (cron.schedule throws on a
 -- duplicate jobname and cron.unschedule raises when the job is missing).
 -- 45 3 UTC keeps it staggered behind the other nightly cleanup jobs.
+-- An 89-day window keeps actual retention at or under the disclosed 90-day
+-- maximum despite the once-daily run cadence (a row created just after a run
+-- would otherwise persist ~91 days).
 CREATE EXTENSION IF NOT EXISTS pg_cron SCHEMA extensions;
 
 DO $$
@@ -25,5 +28,5 @@ $$;
 SELECT cron.schedule(
   'account-deletion-attempts-cleanup',
   '45 3 * * *',
-  $$SELECT public.cleanup_old_deletion_attempts(90)$$
+  $$SELECT public.cleanup_old_deletion_attempts(89)$$
 );

--- a/supabase/migrations/20260810130000_schedule_deletion_attempts_cleanup.sql
+++ b/supabase/migrations/20260810130000_schedule_deletion_attempts_cleanup.sql
@@ -1,0 +1,29 @@
+-- Schedule the 90-day retention policy for account_deletion_attempts, matching
+-- the privacy-policy disclosure. The table holds raw IP and User-Agent strings
+-- captured at account-deletion request time, and the user_id foreign key is
+-- ON DELETE SET NULL so the rows survive account deletion; without this job
+-- they would persist indefinitely.
+--
+-- Uses public.cleanup_old_deletion_attempts() (service_role-only EXECUTE,
+-- pg_cron runs as the database owner) rather than an inline DELETE so the
+-- single retention implementations stay shared with any manual invocation.
+--
+-- Mirrors 20260807130000_add_usage_and_rate_limit_retention.sql, including the
+-- idempotent unschedule-then-schedule guard (cron.schedule throws on a
+-- duplicate jobname and cron.unschedule raises when the job is missing).
+-- 45 3 UTC keeps it staggered behind the other nightly cleanup jobs.
+CREATE EXTENSION IF NOT EXISTS pg_cron SCHEMA extensions;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM cron.job WHERE jobname = 'account-deletion-attempts-cleanup') THEN
+    PERFORM cron.unschedule('account-deletion-attempts-cleanup');
+  END IF;
+END;
+$$;
+
+SELECT cron.schedule(
+  'account-deletion-attempts-cleanup',
+  '45 3 * * *',
+  $$SELECT public.cleanup_old_deletion_attempts(90)$$
+);


### PR DESCRIPTION
## **User description**
## Summary

Updates `app/pages/privacy.vue` so the policy accurately reflects how data is actually handled today, and discloses practices that were undocumented. Prompted by community feedback (privacy concerns raised by testers) plus a review of recent infrastructure and account-audit changes.

## Changes

- **IP handling clarified (stronger than previously stated):** account-linked IP records are stored only as **HMAC-SHA256 keyed hashes** (server-side secret) along with the browser **User-Agent** string — never raw IPs (`app/server/api/account/activity.post.ts`, `account_ip_audit`). Raw IPs exist only in transient Cloudflare edge access logs covered by Cloudflare's own policy.
- **Account deletion:** notes that these audit records cascade-delete automatically with the account (matches the `ON DELETE CASCADE` schema).
- **EFT log import disclosure:** the import feature processes game log files **entirely client-side in the browser** — files are never uploaded to our servers (`useEftLogsImport` / `eftLogQuestParser`).
- **Seasonal game mode** added to the game progress data disclosure (PvP/PvE → PvP/PvE/Seasonal).
- **Cloudflare Pages & Workers:** provider/storage lists now cover the `api-gateway` Worker, API request handling, and edge KV caching (previously only "Cloudflare Pages").
- **API access data:** includes client User-Agent strings (matches `api_usage_daily`).
- **OAuth email scope:** explains Discord requires the email scope for account identification and that it is used solely for auth/account recovery (no marketing email — already stated in §3).
- Bumped **Last Updated** to August 10, 2026.

## Validation

- `prettier --write` / `--check` ✅
- `eslint app/pages/privacy.vue` ✅ clean
- `lint-blank-lines` ✅
- No locale keys touched (page copy remains hardcoded English as before)

Template-only text change: no runtime behavior affected.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Update privacy policy to reflect current data handling

### What Changed
- Clarifies that account-linked IP data is retained only as a one-way hash with browser details, while raw IPs remain in transient provider logs
- Discloses that EFT game log files are processed locally in the browser and are not uploaded
- Documents Seasonal game progress, API client browser details, Cloudflare Workers and edge caching, and provider-required OAuth email use
- Explains that security audit records are automatically removed when an account is deleted
- Updates the policy date to August 10, 2026

### Impact
`✅ Clearer IP and security data practices`
`✅ Clearer client-side game log privacy`
`✅ Clearer account deletion expectations`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated the privacy policy date.
  * Expanded disclosures covering game mode selections, locally processed log imports, hashed IP records, User-Agent logging, raw-IP retention exceptions, API access data, OAuth email usage, Cloudflare services, edge caching, and security audit record deletion.

* **Privacy**
  * Added automated cleanup of account-deletion attempt records after 90 days.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

----
## Summary by Gitar

- **Database & Migrations:**
    - Added `supabase/migrations/20260810130000_schedule_deletion_attempts_cleanup.sql` to schedule 90-day retention for `account_deletion_attempts` via `pg_cron`

<sub>This will update automatically on new commits.</sub>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the privacy policy to describe current IP, audit, OAuth, import, caching, and account-deletion practices, and schedules automatic cleanup of account-deletion attempt records.
- Documents raw-IP exceptions and the 90-day deletion-attempt retention period.
- Adds a nightly cleanup job using an 89-day eligibility threshold so daily scheduling does not exceed the disclosed maximum.
- Expands disclosures for locally processed EFT logs, Seasonal progress, OAuth email usage, API metadata, and Cloudflare Workers caching.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/pages/privacy.vue | Updates privacy disclosures and now accurately identifies the raw-IP exceptions and account-deletion-attempt retention behavior. |
| supabase/migrations/20260810130000_schedule_deletion_attempts_cleanup.sql | Schedules the existing cleanup function daily with an 89-day threshold, keeping actual retention within the disclosed 90-day maximum. |

</details>

<sub>Reviews (4): Last reviewed commit: ["docs(app): correct edge-cache scope and ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/3335d1b17bbc60312b327130448112b41191dc3a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51784405)</sub>

<!-- /greptile_comment -->