### PR TITLE
feat(ui): add official .org-vs-.io guide and video walkthroughs to resources

### DIFF
--- a/app/app.vue
+++ b/app/app.vue
@@ -73,7 +73,9 @@
     }
     return route.path;
   });
-  const pageOwnsCanonical = computed(() => route.path.startsWith('/resources/'));
+  const pageOwnsCanonical = computed(
+    () => route.path.startsWith('/resources/') && route.path !== '/resources/'
+  );
   useHead(() => ({
     htmlAttrs: {
       lang: locale.value,

--- a/app/app.vue
+++ b/app/app.vue
@@ -73,6 +73,7 @@
     }
     return route.path;
   });
+  const pageOwnsCanonical = computed(() => route.path.startsWith('/resources/'));
   useHead(() => ({
     htmlAttrs: {
       lang: locale.value,
@@ -87,10 +88,14 @@
         rel: 'dns-prefetch',
         href: 'https://api.iconify.design',
       },
-      {
-        rel: 'canonical',
-        href: `${siteUrl}${canonicalPath.value}`,
-      },
+      ...(pageOwnsCanonical.value
+        ? []
+        : [
+            {
+              rel: 'canonical' as const,
+              href: `${siteUrl}${canonicalPath.value}`,
+            },
+          ]),
     ],
   }));
   useSeoMeta({

--- a/app/app.vue
+++ b/app/app.vue
@@ -27,6 +27,7 @@
   import { useAppInitialization } from '@/composables/useAppInitialization';
   import { SETTINGS_ROUTE_PATHS } from '@/features/drawer/navigation';
   import { logger } from '@/utils/logger';
+  import { resolveCanonicalSiteUrl } from '@/utils/runtimeConfig';
   const CHUNK_ERROR_PATTERNS = [
     /ChunkLoadError/i,
     /Failed to fetch dynamically imported module/i,
@@ -47,7 +48,7 @@
   const route = useRoute();
   const { locale, t } = useI18n();
   const { public: publicConfig } = useRuntimeConfig();
-  const siteUrl = (publicConfig.appUrl || 'https://tarkovtracker.org').replace(/\/$/, '');
+  const siteUrl = resolveCanonicalSiteUrl(publicConfig.appUrl);
   const settingsHashCanonicalPaths: Record<string, string> = {
     '#progression': '/progression',
     '#settings-progression': '/progression',

--- a/app/features/dashboard/DashboardMigrationBanner.vue
+++ b/app/features/dashboard/DashboardMigrationBanner.vue
@@ -1,0 +1,42 @@
+<template>
+  <div v-if="!dismissed" class="mb-3" data-testid="dashboard-migration-banner">
+    <div class="panel px-3 py-2">
+      <div class="flex items-center justify-between gap-2">
+        <div class="flex min-w-0 items-center gap-2 text-sm font-semibold text-white">
+          <UIcon name="i-mdi-archive-arrow-up" class="text-warning-400 h-4 w-4 shrink-0" />
+          <span class="truncate">
+            {{ t('page.resources.migration_banner.title', 'Moving from TarkovTracker.io?') }}
+          </span>
+        </div>
+        <div class="flex shrink-0 items-center gap-1.5">
+          <UButton
+            size="xs"
+            color="primary"
+            variant="solid"
+            to="/resources/tarkovtracker_org_vs_io"
+            trailing-icon="i-mdi-arrow-right"
+          >
+            {{ t('page.resources.migration_banner.cta', 'Read the migration guide') }}
+          </UButton>
+          <UButton
+            size="xs"
+            color="neutral"
+            variant="ghost"
+            icon="i-mdi-close"
+            :aria-label="t('common.close', 'Close')"
+            @click="dismissed = true"
+          />
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+  import { usePreferencesStore } from '@/stores/usePreferences';
+  const { t } = useI18n({ useScope: 'global' });
+  const preferences = usePreferencesStore();
+  const dismissed = computed({
+    get: () => preferences.dashboardNoticeDismissed,
+    set: (value: boolean) => preferences.setDashboardNoticeDismissed(value),
+  });
+</script>

--- a/app/features/dashboard/__tests__/DashboardMigrationBanner.test.ts
+++ b/app/features/dashboard/__tests__/DashboardMigrationBanner.test.ts
@@ -1,0 +1,27 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { createPinia, setActivePinia } from 'pinia';
+import { beforeEach, describe, expect, it } from 'vitest';
+import DashboardMigrationBanner from '@/features/dashboard/DashboardMigrationBanner.vue';
+import { usePreferencesStore } from '@/stores/usePreferences';
+describe('DashboardMigrationBanner', () => {
+  beforeEach(() => setActivePinia(createPinia()));
+  it('links to the canonical guide and persists dismissal through the preferences store', async () => {
+    const wrapper = await mountSuspended(DashboardMigrationBanner, {
+      global: {
+        stubs: {
+          UButton: {
+            props: ['to', 'ariaLabel'],
+            template:
+              '<button :data-to="to" :aria-label="ariaLabel" @click="$emit(\'click\')"><slot /></button>',
+          },
+          UIcon: true,
+        },
+      },
+    });
+    const preferences = usePreferencesStore();
+    expect(wrapper.find('[data-to="/resources/tarkovtracker_org_vs_io"]').exists()).toBe(true);
+    await wrapper.findAll('button')[1]!.trigger('click');
+    expect(preferences.dashboardNoticeDismissed).toBe(true);
+    expect(wrapper.find('[data-testid="dashboard-migration-banner"]').exists()).toBe(false);
+  });
+});

--- a/app/features/resources/ResourceGuideActions.vue
+++ b/app/features/resources/ResourceGuideActions.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="flex flex-wrap items-center gap-2">
+    <UButton
+      v-if="primaryAction"
+      :href="primaryAction.href"
+      target="_blank"
+      rel="noopener noreferrer"
+      size="md"
+      color="primary"
+      variant="solid"
+      class="min-h-10"
+      :icon="primaryAction.icon"
+      trailing-icon="i-mdi-open-in-new"
+      :label="t(primaryAction.labelKey, primaryAction.labelFallback)"
+    />
+    <UButton
+      v-for="link in secondaryLinks"
+      :key="link.href"
+      :href="link.href"
+      target="_blank"
+      rel="noopener noreferrer"
+      size="sm"
+      color="neutral"
+      variant="soft"
+      class="min-h-10"
+      :icon="link.icon"
+      trailing-icon="i-mdi-open-in-new"
+      :label="t(link.labelKey, link.labelFallback)"
+    />
+  </div>
+</template>
+<script setup lang="ts">
+  import {
+    getGuidePrimaryAction,
+    getGuideSecondaryLinks,
+    type Resource,
+  } from '@/features/resources/resourceData';
+  const props = defineProps<{ resource: Resource }>();
+  const { t } = useI18n({ useScope: 'global' });
+  const primaryAction = computed(() => getGuidePrimaryAction(props.resource));
+  const secondaryLinks = computed(() => getGuideSecondaryLinks(props.resource));
+</script>

--- a/app/features/resources/ResourceGuideArticle.vue
+++ b/app/features/resources/ResourceGuideArticle.vue
@@ -22,11 +22,15 @@
   import ResourceGuideTips from '@/features/resources/ResourceGuideTips.vue';
   import ResourceGuideTroubleshooting from '@/features/resources/ResourceGuideTroubleshooting.vue';
   import ResourceGuideVideo from '@/features/resources/ResourceGuideVideo.vue';
-  import type { Resource } from '@/features/resources/resourceData';
-  const props = defineProps<{ resource: Resource; guideTitle: string; overview: string }>();
+  import type { ResourceWithGuide } from '@/features/resources/resourceData';
+  const props = defineProps<{
+    resource: ResourceWithGuide;
+    guideTitle: string;
+    overview: string;
+  }>();
   const { t } = useI18n({ useScope: 'global' });
   const enabledSections = computed(() => {
-    const guide = props.resource.guide!;
+    const guide = props.resource.guide;
     return [
       {
         id: 'video',

--- a/app/features/resources/ResourceGuideArticle.vue
+++ b/app/features/resources/ResourceGuideArticle.vue
@@ -1,0 +1,63 @@
+<template>
+  <article class="min-w-0 space-y-10">
+    <ResourceGuideSection
+      id="overview"
+      :title="t('common.overview', 'Overview')"
+      icon="i-mdi-information-outline"
+    >
+      <p class="text-surface-200 text-base leading-relaxed">{{ overview }}</p>
+    </ResourceGuideSection>
+    <component
+      :is="section.component"
+      v-for="section in enabledSections"
+      :key="section.id"
+      v-bind="section.props"
+    />
+  </article>
+</template>
+<script setup lang="ts">
+  import ResourceGuideFaq from '@/features/resources/ResourceGuideFaq.vue';
+  import ResourceGuideSection from '@/features/resources/ResourceGuideSection.vue';
+  import ResourceGuideSteps from '@/features/resources/ResourceGuideSteps.vue';
+  import ResourceGuideTips from '@/features/resources/ResourceGuideTips.vue';
+  import ResourceGuideTroubleshooting from '@/features/resources/ResourceGuideTroubleshooting.vue';
+  import ResourceGuideVideo from '@/features/resources/ResourceGuideVideo.vue';
+  import type { Resource } from '@/features/resources/resourceData';
+  const props = defineProps<{ resource: Resource; guideTitle: string; overview: string }>();
+  const { t } = useI18n({ useScope: 'global' });
+  const enabledSections = computed(() => {
+    const guide = props.resource.guide!;
+    return [
+      {
+        id: 'video',
+        component: ResourceGuideVideo,
+        enabled: Boolean(props.resource.videoId),
+        props: { resource: props.resource, guideTitle: props.guideTitle },
+      },
+      {
+        id: 'setup',
+        component: ResourceGuideSteps,
+        enabled: Boolean(guide.steps),
+        props: { resource: props.resource },
+      },
+      {
+        id: 'troubleshooting',
+        component: ResourceGuideTroubleshooting,
+        enabled: Boolean(guide.troubleshooting),
+        props: { resource: props.resource },
+      },
+      {
+        id: 'tips',
+        component: ResourceGuideTips,
+        enabled: Boolean(guide.tips),
+        props: { resource: props.resource },
+      },
+      {
+        id: 'faq',
+        component: ResourceGuideFaq,
+        enabled: Boolean(guide.faq),
+        props: { resource: props.resource },
+      },
+    ].filter((section) => section.enabled);
+  });
+</script>

--- a/app/features/resources/ResourceGuideCompatibility.vue
+++ b/app/features/resources/ResourceGuideCompatibility.vue
@@ -1,0 +1,18 @@
+<template>
+  <div
+    v-if="text"
+    class="bg-warning-500/10 border-warning-400/20 text-surface-200 flex items-start gap-3 rounded-xl border px-4 py-3 text-base leading-relaxed"
+  >
+    <UIcon name="i-mdi-alert-circle-outline" class="text-warning-400 mt-0.5 h-5 w-5 shrink-0" />
+    <p>
+      <span class="text-warning-200 font-semibold">
+        {{ t('page.resources.compatibility_label', 'Compatibility') }}:
+      </span>
+      {{ text }}
+    </p>
+  </div>
+</template>
+<script setup lang="ts">
+  defineProps<{ text: string }>();
+  const { t } = useI18n({ useScope: 'global' });
+</script>

--- a/app/features/resources/ResourceGuideFaq.vue
+++ b/app/features/resources/ResourceGuideFaq.vue
@@ -1,0 +1,30 @@
+<template>
+  <ResourceGuideSection
+    id="faq"
+    :title="t('page.resources.guide_sections.faq', 'Common Questions')"
+    icon="i-mdi-help-circle-outline"
+  >
+    <div class="divide-y divide-white/5 rounded-xl border border-white/10">
+      <details v-for="n in resource.guide?.faq ?? 0" :id="`faq-${n}`" :key="n" class="group px-4">
+        <summary
+          class="text-surface-100 hover:text-primary-200 focus-visible:ring-primary-400/40 flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 py-3 text-base font-medium transition-colors marker:content-none focus-visible:ring-2 focus-visible:outline-none [&::-webkit-details-marker]:hidden"
+        >
+          <span>{{ t(`page.resources.guides.${resource.slug}.faq_${n}_q`, '') }}</span>
+          <UIcon
+            name="i-mdi-chevron-down"
+            class="text-surface-500 h-5 w-5 shrink-0 transition-transform group-open:rotate-180"
+          />
+        </summary>
+        <p class="text-surface-300 pb-4 text-base leading-relaxed">
+          {{ t(`page.resources.guides.${resource.slug}.faq_${n}_a`, '') }}
+        </p>
+      </details>
+    </div>
+  </ResourceGuideSection>
+</template>
+<script setup lang="ts">
+  import ResourceGuideSection from '@/features/resources/ResourceGuideSection.vue';
+  import type { Resource } from '@/features/resources/resourceData';
+  defineProps<{ resource: Resource }>();
+  const { t } = useI18n({ useScope: 'global' });
+</script>

--- a/app/features/resources/ResourceGuideHeader.vue
+++ b/app/features/resources/ResourceGuideHeader.vue
@@ -1,0 +1,41 @@
+<template>
+  <nav
+    class="text-surface-400 flex flex-wrap items-center gap-1.5 text-sm"
+    :aria-label="t('page.resources.breadcrumb', 'Breadcrumb')"
+  >
+    <NuxtLink to="/resources" class="hover:text-primary-300 transition-colors">
+      {{ t('page.resources.title', 'Resources & Guides') }}
+    </NuxtLink>
+    <UIcon name="i-mdi-chevron-right" class="h-4 w-4 shrink-0 opacity-60" />
+    <NuxtLink to="/resources" class="hover:text-primary-300 transition-colors">
+      {{ categoryLabel }}
+    </NuxtLink>
+    <UIcon name="i-mdi-chevron-right" class="h-4 w-4 shrink-0 opacity-60" />
+    <span class="text-surface-200">{{ title }}</span>
+  </nav>
+  <header class="space-y-4">
+    <ResourceGuideIdentity
+      :resource="resource"
+      :title="title"
+      :description="description"
+      :meta-line="metaLine"
+    />
+    <ResourceGuideActions :resource="resource" />
+    <ResourceGuideCompatibility :text="compatibilityText" />
+  </header>
+</template>
+<script setup lang="ts">
+  import ResourceGuideActions from '@/features/resources/ResourceGuideActions.vue';
+  import ResourceGuideCompatibility from '@/features/resources/ResourceGuideCompatibility.vue';
+  import ResourceGuideIdentity from '@/features/resources/ResourceGuideIdentity.vue';
+  import type { Resource } from '@/features/resources/resourceData';
+  defineProps<{
+    resource: Resource;
+    title: string;
+    description: string;
+    categoryLabel: string;
+    metaLine: string;
+    compatibilityText: string;
+  }>();
+  const { t } = useI18n({ useScope: 'global' });
+</script>

--- a/app/features/resources/ResourceGuideIdentity.vue
+++ b/app/features/resources/ResourceGuideIdentity.vue
@@ -4,7 +4,7 @@
       v-if="resource.logo"
       class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white/5"
     >
-      <NuxtImg :src="resource.logo" :alt="title" class="h-full w-full object-contain" />
+      <NuxtImg :src="resource.logo" alt="" class="h-full w-full object-contain" />
     </div>
     <div
       v-else

--- a/app/features/resources/ResourceGuideIdentity.vue
+++ b/app/features/resources/ResourceGuideIdentity.vue
@@ -1,0 +1,41 @@
+<template>
+  <div class="flex items-start gap-4">
+    <div
+      v-if="resource.logo"
+      class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white/5"
+    >
+      <NuxtImg :src="resource.logo" :alt="title" class="h-full w-full object-contain" />
+    </div>
+    <div
+      v-else
+      class="bg-primary-500/15 text-primary-300 flex h-12 w-12 shrink-0 items-center justify-center rounded-xl"
+    >
+      <UIcon name="i-mdi-bookmark" class="h-6 w-6" />
+    </div>
+    <div class="min-w-0 flex-1 space-y-2">
+      <div>
+        <p class="text-primary-300/90 text-xs font-semibold tracking-[0.25em] uppercase">
+          {{ guideLabel }}
+        </p>
+        <h1 class="mt-1 text-2xl font-bold tracking-wide text-white sm:text-3xl">{{ title }}</h1>
+      </div>
+      <p class="text-surface-200 max-w-3xl text-base leading-relaxed">{{ description }}</p>
+      <p class="text-surface-400 text-sm">{{ metaLine }}</p>
+    </div>
+  </div>
+</template>
+<script setup lang="ts">
+  import type { Resource } from '@/features/resources/resourceData';
+  const props = defineProps<{
+    resource: Resource;
+    title: string;
+    description: string;
+    metaLine: string;
+  }>();
+  const { t } = useI18n({ useScope: 'global' });
+  const guideLabel = computed(() =>
+    props.resource.category === 'tarkovtracker_guides'
+      ? t('page.resources.official_guide_label', 'TarkovTracker.org Guide')
+      : t('page.resources.guide_label', 'Guide')
+  );
+</script>

--- a/app/features/resources/ResourceGuideSteps.vue
+++ b/app/features/resources/ResourceGuideSteps.vue
@@ -1,0 +1,35 @@
+<template>
+  <ResourceGuideSection
+    id="setup"
+    :title="t('common.getting_started', 'Getting Started')"
+    icon="i-mdi-playlist-check"
+  >
+    <ol class="space-y-5">
+      <li
+        v-for="n in resource.guide?.steps ?? 0"
+        :key="n"
+        class="flex items-start gap-4 border-b border-white/5 pb-5 last:border-0 last:pb-0"
+      >
+        <span
+          class="bg-primary-500/20 text-primary-300 mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-semibold"
+        >
+          {{ n }}
+        </span>
+        <div class="min-w-0 flex-1 space-y-1.5">
+          <h3 class="text-surface-100 text-base font-semibold sm:text-lg">
+            {{ t(`page.resources.guides.${resource.slug}.step_${n}_title`, '') }}
+          </h3>
+          <p class="text-surface-300 text-base leading-relaxed">
+            {{ t(`page.resources.guides.${resource.slug}.step_${n}_desc`, '') }}
+          </p>
+        </div>
+      </li>
+    </ol>
+  </ResourceGuideSection>
+</template>
+<script setup lang="ts">
+  import ResourceGuideSection from '@/features/resources/ResourceGuideSection.vue';
+  import type { Resource } from '@/features/resources/resourceData';
+  defineProps<{ resource: Resource }>();
+  const { t } = useI18n({ useScope: 'global' });
+</script>

--- a/app/features/resources/ResourceGuideTips.vue
+++ b/app/features/resources/ResourceGuideTips.vue
@@ -1,0 +1,26 @@
+<template>
+  <ResourceGuideSection
+    id="tips"
+    :title="t('page.resources.guide_sections.tips', 'Tips & Tricks')"
+    icon="i-mdi-lightbulb-on-outline"
+  >
+    <ul class="space-y-3">
+      <li
+        v-for="n in resource.guide?.tips ?? 0"
+        :key="n"
+        class="bg-surface-900/40 flex items-start gap-3 rounded-lg border border-white/5 px-3 py-3"
+      >
+        <UIcon name="i-mdi-lightbulb-outline" class="text-warning-400 mt-0.5 h-4 w-4 shrink-0" />
+        <span class="text-surface-200 text-base leading-relaxed">
+          {{ t(`page.resources.guides.${resource.slug}.tip_${n}`, '') }}
+        </span>
+      </li>
+    </ul>
+  </ResourceGuideSection>
+</template>
+<script setup lang="ts">
+  import ResourceGuideSection from '@/features/resources/ResourceGuideSection.vue';
+  import type { Resource } from '@/features/resources/resourceData';
+  defineProps<{ resource: Resource }>();
+  const { t } = useI18n({ useScope: 'global' });
+</script>

--- a/app/features/resources/ResourceGuideToc.vue
+++ b/app/features/resources/ResourceGuideToc.vue
@@ -1,0 +1,34 @@
+<template>
+  <aside class="hidden lg:block">
+    <div class="sticky top-16 space-y-3">
+      <p class="text-surface-400 text-xs font-semibold tracking-[0.2em] uppercase">
+        {{ t('page.resources.on_this_page', 'On this page') }}
+      </p>
+      <nav class="space-y-1" :aria-label="t('page.resources.on_this_page', 'On this page')">
+        <a
+          v-for="item in items"
+          :key="item.id"
+          :href="`#${item.id}`"
+          :class="[
+            'focus-visible:ring-primary-400/40 block rounded-md px-2 py-1.5 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none',
+            activeId === item.id
+              ? 'bg-primary-500/15 text-primary-200'
+              : 'text-surface-300 hover:text-primary-300 hover:bg-white/5',
+          ]"
+          @click="$emit('select', item.id, $event)"
+        >
+          {{ item.label }}
+        </a>
+      </nav>
+    </div>
+  </aside>
+</template>
+<script setup lang="ts">
+  export interface ResourceGuideTocItem {
+    id: string;
+    label: string;
+  }
+  defineProps<{ items: ResourceGuideTocItem[]; activeId: string }>();
+  defineEmits<{ select: [id: string, event: MouseEvent] }>();
+  const { t } = useI18n({ useScope: 'global' });
+</script>

--- a/app/features/resources/ResourceGuideTroubleshooting.vue
+++ b/app/features/resources/ResourceGuideTroubleshooting.vue
@@ -1,0 +1,28 @@
+<template>
+  <ResourceGuideSection
+    id="troubleshooting"
+    :title="t('page.resources.guide_sections.troubleshooting', 'Troubleshooting')"
+    icon="i-mdi-wrench-outline"
+  >
+    <div class="space-y-4">
+      <div
+        v-for="n in resource.guide?.troubleshooting ?? 0"
+        :key="n"
+        class="border-b border-white/5 pb-4 last:border-0 last:pb-0"
+      >
+        <h3 class="text-surface-100 text-base font-semibold">
+          {{ t(`page.resources.guides.${resource.slug}.troubleshooting_${n}_title`, '') }}
+        </h3>
+        <p class="text-surface-300 mt-1 text-base leading-relaxed">
+          {{ t(`page.resources.guides.${resource.slug}.troubleshooting_${n}_desc`, '') }}
+        </p>
+      </div>
+    </div>
+  </ResourceGuideSection>
+</template>
+<script setup lang="ts">
+  import ResourceGuideSection from '@/features/resources/ResourceGuideSection.vue';
+  import type { Resource } from '@/features/resources/resourceData';
+  defineProps<{ resource: Resource }>();
+  const { t } = useI18n({ useScope: 'global' });
+</script>

--- a/app/features/resources/ResourceGuideVideo.vue
+++ b/app/features/resources/ResourceGuideVideo.vue
@@ -1,0 +1,31 @@
+<template>
+  <ResourceGuideSection
+    id="video"
+    :title="t('page.resources.guide_sections.video_walkthrough', 'Video Walkthrough')"
+    icon="i-mdi-play-circle-outline"
+  >
+    <ResourceVideoEmbed :video-id="resource.videoId ?? ''" :title="videoTitle" />
+    <p class="text-surface-400 mt-2 text-sm">
+      {{
+        t(
+          'page.resources.video.caption',
+          'Community video walkthrough. Steps may differ slightly from the written guide.'
+        )
+      }}
+    </p>
+  </ResourceGuideSection>
+</template>
+<script setup lang="ts">
+  import ResourceGuideSection from '@/features/resources/ResourceGuideSection.vue';
+  import ResourceVideoEmbed from '@/features/resources/ResourceVideoEmbed.vue';
+  import type { Resource } from '@/features/resources/resourceData';
+  const props = defineProps<{ resource: Resource; guideTitle: string }>();
+  const { t } = useI18n({ useScope: 'global' });
+  const videoTitle = computed(() =>
+    t(
+      'page.resources.video.walkthrough_title',
+      { name: props.guideTitle },
+      `${props.guideTitle} video walkthrough`
+    )
+  );
+</script>

--- a/app/features/resources/ResourceVideoEmbed.vue
+++ b/app/features/resources/ResourceVideoEmbed.vue
@@ -1,0 +1,49 @@
+<template>
+  <div
+    class="overflow-hidden rounded-xl border border-white/10 bg-black shadow-[0_10px_40px_rgba(0,0,0,0.35)]"
+  >
+    <div v-if="!isLoaded" class="relative aspect-video w-full">
+      <NuxtImg
+        :src="`https://i.ytimg.com/vi/${videoId}/hqdefault.jpg`"
+        :alt="title"
+        class="absolute inset-0 h-full w-full object-cover"
+        loading="lazy"
+      />
+      <button
+        type="button"
+        class="group focus-visible:ring-primary-400/40 absolute inset-0 flex h-full w-full cursor-pointer items-center justify-center bg-black/30 transition-colors hover:bg-black/40 focus-visible:ring-2 focus-visible:outline-none focus-visible:ring-inset"
+        :aria-label="t('page.resources.video.play', { title }, `Play video: ${title}`)"
+        @click="isLoaded = true"
+      >
+        <span
+          class="bg-primary-500/90 group-hover:bg-primary-400 flex h-16 w-16 items-center justify-center rounded-full shadow-lg transition-transform group-hover:scale-105"
+        >
+          <UIcon name="i-mdi-play" class="h-8 w-8 text-white" />
+        </span>
+      </button>
+    </div>
+    <iframe
+      v-else
+      :src="`https://www.youtube-nocookie.com/embed/${videoId}?autoplay=1&rel=0`"
+      :title="title"
+      class="aspect-video w-full"
+      allow="
+        accelerometer;
+        autoplay;
+        clipboard-write;
+        encrypted-media;
+        gyroscope;
+        picture-in-picture;
+      "
+      allowfullscreen
+    />
+  </div>
+</template>
+<script setup lang="ts">
+  defineProps<{
+    videoId: string;
+    title: string;
+  }>();
+  const { t } = useI18n({ useScope: 'global' });
+  const isLoaded = ref(false);
+</script>

--- a/app/features/resources/__tests__/ResourceCard.test.ts
+++ b/app/features/resources/__tests__/ResourceCard.test.ts
@@ -83,6 +83,24 @@ describe('ResourceCard', () => {
     expect(wrapper.get('[data-testid="more-menu"]').text()).toContain('Open website');
     expect(wrapper.get('[data-testid="more-menu"]').text()).toContain('View source');
   });
+  it('renders the official guide badge and links only to the guide for first-party guides', () => {
+    const wrapper = mountCard(
+      {
+        slug: 'tarkovtracker_org_vs_io',
+        logo: '/img/logos/tarkovtrackerlogo-mini.webp',
+        category: 'tarkovtracker_guides',
+        hasGuide: true,
+        guide: { steps: 0, tips: 0, faq: 4 },
+        primaryAction: 'guide',
+        keywords: ['io', 'org'],
+        links: [],
+      },
+      true
+    );
+    expect(wrapper.text()).toContain('Official Guide');
+    expect(wrapper.get('a[href="/resources/tarkovtracker_org_vs_io"]').text()).toBe('Read guide');
+    expect(wrapper.find('[data-testid="more-menu"]').exists()).toBe(false);
+  });
   it('renders the placeholder icon and external primary action when configured', () => {
     const wrapper = mountCard({
       slug: 'cultistcircle',

--- a/app/features/resources/__tests__/ResourceGuideContent.test.ts
+++ b/app/features/resources/__tests__/ResourceGuideContent.test.ts
@@ -1,0 +1,72 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { describe, expect, it } from 'vitest';
+import { RESOURCES } from '@/features/resources/resourceData';
+import ResourceGuideArticle from '@/features/resources/ResourceGuideArticle.vue';
+import ResourceGuideHeader from '@/features/resources/ResourceGuideHeader.vue';
+const getResource = (slug: string) => {
+  const resource = RESOURCES.find((entry) => entry.slug === slug);
+  if (!resource) throw new Error(`${slug} missing`);
+  return resource;
+};
+const globalStubs = {
+  NuxtImg: { props: ['src', 'alt'], template: '<img :src="src" :alt="alt" />' },
+  NuxtLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
+  UButton: {
+    props: ['href', 'label'],
+    template: '<a :href="href">{{ label }}<slot /></a>',
+  },
+  UIcon: true,
+};
+describe('resource guide content', () => {
+  it('renders every configured companion-guide section through the shared layout', async () => {
+    const resource = getResource('tarkovmonitor');
+    const wrapper = await mountSuspended(ResourceGuideArticle, {
+      props: {
+        resource,
+        guideTitle: 'TarkovMonitor',
+        overview: 'Companion overview',
+      },
+      global: { stubs: globalStubs },
+    });
+    expect(wrapper.text()).toContain('Companion overview');
+    expect(wrapper.find('#video').exists()).toBe(true);
+    expect(wrapper.find('#setup').exists()).toBe(true);
+    expect(wrapper.find('#troubleshooting').exists()).toBe(true);
+    expect(wrapper.find('#tips').exists()).toBe(true);
+    expect(wrapper.find('#faq').exists()).toBe(true);
+  });
+  it('renders official-guide identity without an external primary action', async () => {
+    const resource = getResource('tarkovtracker_org_vs_io');
+    const wrapper = await mountSuspended(ResourceGuideHeader, {
+      props: {
+        resource,
+        title: 'TarkovTracker.org vs TarkovTracker.io',
+        description: 'Domain guide',
+        categoryLabel: 'TarkovTracker.org Guides',
+        metaLine: 'Official guide',
+        compatibilityText: '',
+      },
+      global: { stubs: globalStubs },
+    });
+    expect(wrapper.text()).toContain('TarkovTracker.org Guide');
+    expect(wrapper.text()).toContain('Official guide');
+    expect(wrapper.find('img').attributes('alt')).toBe('TarkovTracker.org vs TarkovTracker.io');
+    expect(wrapper.findAll('a')).toHaveLength(2);
+  });
+  it('renders companion actions and compatibility guidance', async () => {
+    const resource = getResource('tarkovmonitor');
+    const wrapper = await mountSuspended(ResourceGuideHeader, {
+      props: {
+        resource,
+        title: 'TarkovMonitor',
+        description: 'Automatic tracking',
+        categoryLabel: 'Companion Apps',
+        metaLine: 'Windows',
+        compatibilityText: 'Use a read-write token.',
+      },
+      global: { stubs: globalStubs },
+    });
+    expect(wrapper.text()).toContain('Download latest release');
+    expect(wrapper.text()).toContain('Use a read-write token.');
+  });
+});

--- a/app/features/resources/__tests__/ResourceGuideContent.test.ts
+++ b/app/features/resources/__tests__/ResourceGuideContent.test.ts
@@ -51,7 +51,7 @@ describe('resource guide content', () => {
     });
     expect(wrapper.text()).toContain('TarkovTracker.org Guide');
     expect(wrapper.text()).toContain('Official guide');
-    expect(wrapper.find('img').attributes('alt')).toBe('TarkovTracker.org vs TarkovTracker.io');
+    expect(wrapper.find('img').attributes('alt')).toBe('');
     expect(wrapper.findAll('a')).toHaveLength(2);
   });
   it('renders companion actions and compatibility guidance', async () => {

--- a/app/features/resources/__tests__/ResourceGuideContent.test.ts
+++ b/app/features/resources/__tests__/ResourceGuideContent.test.ts
@@ -3,9 +3,10 @@ import { describe, expect, it } from 'vitest';
 import { RESOURCES } from '@/features/resources/resourceData';
 import ResourceGuideArticle from '@/features/resources/ResourceGuideArticle.vue';
 import ResourceGuideHeader from '@/features/resources/ResourceGuideHeader.vue';
-const getResource = (slug: string) => {
+import type { ResourceWithGuide } from '@/features/resources/resourceData';
+const getResource = (slug: string): ResourceWithGuide => {
   const resource = RESOURCES.find((entry) => entry.slug === slug);
-  if (!resource) throw new Error(`${slug} missing`);
+  if (!resource?.hasGuide) throw new Error(`${slug} guide missing`);
   return resource;
 };
 const globalStubs = {

--- a/app/features/resources/__tests__/ResourceVideoEmbed.test.ts
+++ b/app/features/resources/__tests__/ResourceVideoEmbed.test.ts
@@ -1,0 +1,24 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { describe, expect, it } from 'vitest';
+import ResourceVideoEmbed from '@/features/resources/ResourceVideoEmbed.vue';
+describe('ResourceVideoEmbed', () => {
+  it('loads the privacy-enhanced player only after consent', async () => {
+    const wrapper = await mountSuspended(ResourceVideoEmbed, {
+      props: { videoId: 'HGwD4drUq0I', title: 'TarkovMonitor walkthrough' },
+      global: {
+        stubs: {
+          NuxtImg: { props: ['src', 'alt'], template: '<img :src="src" :alt="alt" />' },
+          UIcon: true,
+        },
+      },
+    });
+    expect(wrapper.find('img').attributes('src')).toBe(
+      'https://i.ytimg.com/vi/HGwD4drUq0I/hqdefault.jpg'
+    );
+    expect(wrapper.find('iframe').exists()).toBe(false);
+    await wrapper.get('button').trigger('click');
+    expect(wrapper.get('iframe').attributes('src')).toBe(
+      'https://www.youtube-nocookie.com/embed/HGwD4drUq0I?autoplay=1&rel=0'
+    );
+  });
+});

--- a/app/features/resources/__tests__/resourceData.test.ts
+++ b/app/features/resources/__tests__/resourceData.test.ts
@@ -153,6 +153,13 @@ describe('resourceData locale parity', () => {
       expect(resourcesLocale.guides[resource.slug]).toBeUndefined();
     }
   });
+  it('every guide with a videoId has a valid YouTube video id format', () => {
+    for (const resource of RESOURCES.filter((entry) => entry.videoId)) {
+      expect(resource.videoId, `${resource.slug} videoId`).toMatch(/^[\w-]{11}$/);
+    }
+    const orgGuide = RESOURCES.find((resource) => resource.videoId);
+    expect(orgGuide).toBeDefined();
+  });
   it('matches search queries against name, purpose, and keywords', () => {
     const ratScanner = RESOURCES.find((resource) => resource.slug === 'ratscanner');
     if (!ratScanner) throw new Error('ratscanner missing');
@@ -162,6 +169,18 @@ describe('resourceData locale parity', () => {
     expect(
       matchesResourceSearch(ratScanner, 'API', 'RatScanner', 'Scan tooltips', 'Companion Apps')
     ).toBe(false);
+  });
+  it('uses a read guide action and empty secondary links for official guides', () => {
+    const orgGuide = RESOURCES.find((resource) => resource.slug === 'tarkovtracker_org_vs_io');
+    if (!orgGuide) throw new Error('tarkovtracker_org_vs_io missing');
+    expect(orgGuide.category).toBe('tarkovtracker_guides');
+    const primary = getPrimaryAction(orgGuide);
+    expect(primary).toMatchObject({
+      kind: 'internal',
+      href: '/resources/tarkovtracker_org_vs_io',
+      labelFallback: 'Read guide',
+    });
+    expect(splitSecondaryActions(orgGuide)).toEqual({ highlighted: null, more: [] });
   });
   it('keeps one secondary action visible and groups the rest as more', () => {
     const tarkovdev = RESOURCES.find((resource) => resource.slug === 'tarkovdev');

--- a/app/features/resources/__tests__/resourceData.test.ts
+++ b/app/features/resources/__tests__/resourceData.test.ts
@@ -154,11 +154,11 @@ describe('resourceData locale parity', () => {
     }
   });
   it('every guide with a videoId has a valid YouTube video id format', () => {
-    for (const resource of RESOURCES.filter((entry) => entry.videoId)) {
+    const videoGuides = RESOURCES.filter((entry) => entry.videoId);
+    expect(videoGuides.length).toBeGreaterThan(0);
+    for (const resource of videoGuides) {
       expect(resource.videoId, `${resource.slug} videoId`).toMatch(/^[\w-]{11}$/);
     }
-    const orgGuide = RESOURCES.find((resource) => resource.videoId);
-    expect(orgGuide).toBeDefined();
   });
   it('matches search queries against name, purpose, and keywords', () => {
     const ratScanner = RESOURCES.find((resource) => resource.slug === 'ratscanner');

--- a/app/features/resources/resourceData.ts
+++ b/app/features/resources/resourceData.ts
@@ -1,5 +1,6 @@
 export type ResourceLinkType = 'website' | 'github' | 'discord' | 'api' | 'download';
-export type ResourceCategory = 'companion_apps' | 'data_and_apis' | 'calculators_and_reference';
+export type ResourceCategory =
+  'tarkovtracker_guides' | 'companion_apps' | 'data_and_apis' | 'calculators_and_reference';
 export type ResourcePrimaryAction = 'guide' | 'website' | 'api';
 export interface ResourceLink {
   type: ResourceLinkType;
@@ -18,6 +19,7 @@ export interface Resource {
   category: ResourceCategory;
   hasGuide: boolean;
   guide?: ResourceGuideConfig;
+  videoId?: string;
   links: ResourceLink[];
   primaryAction: ResourcePrimaryAction;
   keywords: string[];
@@ -31,23 +33,37 @@ export interface ResourceAction {
   external: boolean;
 }
 export const RESOURCE_CATEGORIES: ResourceCategory[] = [
+  'tarkovtracker_guides',
   'companion_apps',
   'data_and_apis',
   'calculators_and_reference',
 ];
 export const CATEGORY_LABEL_FALLBACKS: Record<ResourceCategory, string> = {
+  tarkovtracker_guides: 'TarkovTracker.org Guides',
   companion_apps: 'Companion Apps',
   data_and_apis: 'Data & Developer Tools',
   calculators_and_reference: 'Calculators & Reference',
 };
 export const CATEGORY_BADGE_FALLBACKS: Record<ResourceCategory, string> = {
+  tarkovtracker_guides: 'Official Guide',
   companion_apps: 'Desktop App',
   data_and_apis: 'Data Platform',
   calculators_and_reference: 'Reference',
 };
 export const RESOURCES: Resource[] = [
   {
+    slug: 'tarkovtracker_org_vs_io',
+    logo: '/img/logos/tarkovtrackerlogo-mini.webp',
+    category: 'tarkovtracker_guides',
+    hasGuide: true,
+    guide: { steps: 0, tips: 0, faq: 4 },
+    primaryAction: 'guide',
+    keywords: ['io', 'org', 'difference', 'domain', 'migration', 'official', 'faq'],
+    links: [],
+  },
+  {
     slug: 'tarkovmonitor',
+    videoId: 'HGwD4drUq0I',
     logo: '/img/logos/tarkovmonitorlogo.avif',
     category: 'companion_apps',
     hasGuide: true,
@@ -65,7 +81,8 @@ export const RESOURCES: Resource[] = [
     logo: '/img/logos/ratscannerlogo.webp',
     category: 'companion_apps',
     hasGuide: true,
-    guide: { steps: 4, tips: 2, faq: 3, troubleshooting: 4, compatibility: true },
+    videoId: 'EIyZYFCLgNo',
+    guide: { steps: 4, tips: 2, faq: 4, troubleshooting: 4, compatibility: true },
     primaryAction: 'guide',
     keywords: ['scanner', 'desktop', 'market', 'barter', 'tooltip', 'price', 'quest'],
     links: [
@@ -197,11 +214,14 @@ const defaultAction = (resource: Resource): ResourceAction | null => {
 };
 export const getPrimaryAction = (resource: Resource): ResourceAction | null => {
   if (resource.primaryAction === 'guide' && resource.hasGuide) {
+    const official = resource.category === 'tarkovtracker_guides';
     return {
       kind: 'internal',
       href: `/resources/${resource.slug}`,
-      labelKey: 'page.resources.actions.setup_guide',
-      labelFallback: 'Setup guide',
+      labelKey: official
+        ? 'page.resources.actions.read_guide'
+        : 'page.resources.actions.setup_guide',
+      labelFallback: official ? 'Read guide' : 'Setup guide',
       icon: 'i-mdi-book-open-page-variant',
       external: false,
     };

--- a/app/features/resources/resourceData.ts
+++ b/app/features/resources/resourceData.ts
@@ -32,6 +32,11 @@ export interface ResourceAction {
   icon: string;
   external: boolean;
 }
+export interface ResourceMetaItem {
+  labelKey?: string;
+  labelFallback?: string;
+  useCategoryLabel?: boolean;
+}
 export const RESOURCE_CATEGORIES: ResourceCategory[] = [
   'tarkovtracker_guides',
   'companion_apps',
@@ -50,13 +55,35 @@ export const CATEGORY_BADGE_FALLBACKS: Record<ResourceCategory, string> = {
   data_and_apis: 'Data Platform',
   calculators_and_reference: 'Reference',
 };
+export const RESOURCE_META_ITEMS: Record<ResourceCategory, ResourceMetaItem[]> = {
+  tarkovtracker_guides: [
+    { labelKey: 'page.resources.meta.official_guide', labelFallback: 'Official guide' },
+    {
+      labelKey: 'page.resources.meta.maintained_by_team',
+      labelFallback: 'Maintained by the TarkovTracker.org team',
+    },
+  ],
+  companion_apps: [
+    { labelKey: 'page.resources.meta.windows', labelFallback: 'Windows' },
+    { labelKey: 'page.resources.meta.companion_app', labelFallback: 'Companion App' },
+    { labelKey: 'page.resources.meta.setup_time', labelFallback: '5-minute setup' },
+  ],
+  data_and_apis: [
+    { useCategoryLabel: true },
+    { labelKey: 'page.resources.meta.community_data', labelFallback: 'Community maintained' },
+  ],
+  calculators_and_reference: [
+    { useCategoryLabel: true },
+    { labelKey: 'page.resources.meta.web_tool', labelFallback: 'Web tool' },
+  ],
+};
 export const RESOURCES: Resource[] = [
   {
     slug: 'tarkovtracker_org_vs_io',
     logo: '/img/logos/tarkovtrackerlogo-mini.webp',
     category: 'tarkovtracker_guides',
     hasGuide: true,
-    guide: { steps: 0, tips: 0, faq: 4 },
+    guide: { steps: 5, tips: 0, faq: 4 },
     primaryAction: 'guide',
     keywords: ['io', 'org', 'difference', 'domain', 'migration', 'official', 'faq'],
     links: [],
@@ -212,51 +239,38 @@ const defaultAction = (resource: Resource): ResourceAction | null => {
   }
   return websiteAction(resource);
 };
+const guideAction = (resource: Resource, useSetupLabel = true): ResourceAction => {
+  const setupGuide = useSetupLabel && resource.category !== 'tarkovtracker_guides';
+  return {
+    kind: 'internal',
+    href: `/resources/${resource.slug}`,
+    labelKey: setupGuide
+      ? 'page.resources.actions.setup_guide'
+      : 'page.resources.actions.read_guide',
+    labelFallback: setupGuide ? 'Setup guide' : 'Read guide',
+    icon: 'i-mdi-book-open-page-variant',
+    external: false,
+  };
+};
 export const getPrimaryAction = (resource: Resource): ResourceAction | null => {
   if (resource.primaryAction === 'guide' && resource.hasGuide) {
-    const official = resource.category === 'tarkovtracker_guides';
-    return {
-      kind: 'internal',
-      href: `/resources/${resource.slug}`,
-      labelKey: official
-        ? 'page.resources.actions.read_guide'
-        : 'page.resources.actions.setup_guide',
-      labelFallback: official ? 'Read guide' : 'Setup guide',
-      icon: 'i-mdi-book-open-page-variant',
-      external: false,
-    };
+    return guideAction(resource);
   }
   return defaultAction(resource);
 };
 export const getSecondaryActions = (resource: Resource): ResourceAction[] => {
   const primary = getPrimaryAction(resource);
-  const secondary: ResourceAction[] = [];
-  if (resource.hasGuide && resource.primaryAction !== 'guide') {
-    secondary.push({
-      kind: 'internal',
-      href: `/resources/${resource.slug}`,
-      labelKey: 'page.resources.actions.read_guide',
-      labelFallback: 'Read guide',
-      icon: 'i-mdi-book-open-page-variant',
-      external: false,
-    });
-  }
-  for (const link of resource.links) {
-    if (primary?.external && primary.href === link.url) continue;
-    secondary.push(linkAction(link));
-  }
-  return secondary;
+  const guideActions =
+    resource.hasGuide && resource.primaryAction !== 'guide' ? [guideAction(resource, false)] : [];
+  const linkActions = resource.links
+    .filter((link) => !(primary?.external && primary.href === link.url))
+    .map((link) => linkAction(link));
+  return [...guideActions, ...linkActions];
 };
 export const splitSecondaryActions = (
   resource: Resource
 ): { highlighted: ResourceAction | null; more: ResourceAction[] } => {
   const secondary = getSecondaryActions(resource);
-  if (secondary.length === 0) {
-    return { highlighted: null, more: [] };
-  }
-  if (secondary.length === 1) {
-    return { highlighted: secondary[0] ?? null, more: [] };
-  }
   return {
     highlighted: secondary[0] ?? null,
     more: secondary.slice(1),

--- a/app/features/resources/resourceData.ts
+++ b/app/features/resources/resourceData.ts
@@ -1,8 +1,8 @@
-export type ResourceLinkType = 'website' | 'github' | 'discord' | 'api' | 'download';
+type ResourceLinkType = 'website' | 'github' | 'discord' | 'api' | 'download';
 export type ResourceCategory =
   'tarkovtracker_guides' | 'companion_apps' | 'data_and_apis' | 'calculators_and_reference';
-export type ResourcePrimaryAction = 'guide' | 'website' | 'api';
-export interface ResourceLink {
+type ResourcePrimaryAction = 'guide' | 'website' | 'api';
+interface ResourceLink {
   type: ResourceLinkType;
   url: string;
 }
@@ -13,17 +13,24 @@ export interface ResourceGuideConfig {
   troubleshooting?: number;
   compatibility?: boolean;
 }
-export interface Resource {
+interface ResourceBase {
   slug: string;
   logo: string | null;
   category: ResourceCategory;
-  hasGuide: boolean;
-  guide?: ResourceGuideConfig;
   videoId?: string;
   links: ResourceLink[];
   primaryAction: ResourcePrimaryAction;
   keywords: string[];
 }
+export interface ResourceWithGuide extends ResourceBase {
+  hasGuide: true;
+  guide: ResourceGuideConfig;
+}
+export interface ResourceWithoutGuide extends ResourceBase {
+  hasGuide: false;
+  guide?: never;
+}
+export type Resource = ResourceWithGuide | ResourceWithoutGuide;
 export interface ResourceAction {
   kind: 'internal' | 'external';
   href: string;

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1345,11 +1345,13 @@
       "suggest_description": "Suggest a community tool or guide for inclusion on this page.",
       "suggest_cta": "Suggest a resource",
       "categories": {
+        "tarkovtracker_guides": "TarkovTracker.org Guides",
         "companion_apps": "Companion Apps",
         "data_and_apis": "Data & Developer Tools",
         "calculators_and_reference": "Calculators & Reference"
       },
       "category_badges": {
+        "tarkovtracker_guides": "Official Guide",
         "companion_apps": "Desktop App",
         "data_and_apis": "Data Platform",
         "calculators_and_reference": "Reference"
@@ -1370,6 +1372,8 @@
       "guide_not_found": "Guide not found. The resource you are looking for may not have a guide yet.",
       "guide_title_template": "{name} Guide",
       "meta": {
+        "official_guide": "Official guide",
+        "maintained_by_team": "Maintained by the TarkovTracker.org team",
         "windows": "Windows",
         "setup_time": "5-minute setup",
         "community_data": "Community maintained",
@@ -1384,11 +1388,16 @@
         "download": "Download"
       },
       "guide_sections": {
+        "video_walkthrough": "Video Walkthrough",
         "troubleshooting": "Troubleshooting",
         "tips": "Tips & Tricks",
         "faq": "Common Questions"
       },
       "items": {
+        "tarkovtracker_org_vs_io": {
+          "name": "TarkovTracker.org vs TarkovTracker.io",
+          "description": "Which TarkovTracker site should you use? How TarkovTracker.org relates to the original .io site, and how to move your progress over."
+        },
         "tarkovdev": {
           "name": "Tarkov.dev",
           "description": "Community-maintained item, quest, trader, and market data for players and developers."
@@ -1411,6 +1420,17 @@
         }
       },
       "guides": {
+        "tarkovtracker_org_vs_io": {
+          "overview": "TarkovTracker exists on two domains. TarkovTracker.io is the original site created by the TarkovTracker project founder and hosts the original codebase. TarkovTracker.org is the actively maintained continuation run by a long-time contributor and former maintainer of the original project, as a free and open-source fork under the same GNU GPLv3 license. This guide explains the differences and how to move your progress to TarkovTracker.org.",
+          "faq_1_q": "What is the difference between TarkovTracker.io and TarkovTracker.org?",
+          "faq_1_a": "TarkovTracker.io is the original site. It is relatively stable but has known issues and is no longer maintained - its last deployment was in August 2024 and there is no active development or support. TarkovTracker.org is the actively maintained fork: it receives regular updates, supports game changes after EFT 0.15, and adds new features. Because it is under active development it can occasionally have bugs or downtime, and while we work hard to prevent it, data loss cannot be ruled out entirely.",
+          "faq_2_q": "Which site should I use?",
+          "faq_2_a": "Use TarkovTracker.org. It is the only version that receives updates, bug fixes, and support for current Escape from Tarkov content. New accounts should always be created on TarkovTracker.org.",
+          "faq_3_q": "How do I migrate my progress from .io to .org?",
+          "faq_3_a": "Sign in to TarkovTracker.io, copy your API token (found in your profile settings), then on TarkovTracker.org go to Settings and use the .io import option with that token. Your task and hideout progress will be copied to your .org account. The import is a one-time copy - progress made afterwards on one site does not sync to the other.",
+          "faq_4_q": "Does the TarkovTracker.org team run TarkovTracker.io?",
+          "faq_4_a": "No. The .io domain and deployment are owned and controlled by the original project founder. We have no access to it and cannot fix, update, or provide support for anything on .io."
+        },
         "tarkovdev": {
           "overview": "Tarkov.dev is the backbone of the community data ecosystem. It maintains an open-source dataset of items, quests, traders, hideout stations, and more, all accessible through free static JSON endpoints at json.tarkov.dev. TarkovTracker itself uses these endpoints to stay up to date with the latest game data. If you build tools, write guides, or just want to look up item stats, Tarkov.dev is the authoritative source.",
           "step_1_title": "Browse the website",
@@ -1478,7 +1498,9 @@
           "faq_2_q": "Does RatScanner work with the flea market?",
           "faq_2_a": "Yes. It shows current flea-market prices and can help compare flea versus trader value.",
           "faq_3_q": "Can RatScanner show items needed for TarkovTracker?",
-          "faq_3_a": "It can show general item information from its data provider. For requirements based on your personal TarkovTracker progress, use the Needed Items page."
+          "faq_3_a": "It can show general item information from its data provider. For requirements based on your personal TarkovTracker progress, use the Needed Items page.",
+          "faq_4_q": "Does RatScanner work with TarkovTracker.org?",
+          "faq_4_a": "Yes. Install RatScanner, open the TarkovTracker section in its settings, and switch the TarkovTracker backend from .io to .org before entering your tarkovtracker.org API token. The TarkovTracker.org team now helps maintain RatScanner, so .org integration and defaults will keep improving in future releases."
         },
         "cultistcircle": {
           "overview": "CultistCircle is a free community-built calculator for the Cultist Circle feature in Escape from Tarkov. It lets you look up recipes — what items you can sacrifice and what you get in return — without having to experiment in-game. Built by a solo community developer, it is a handy reference for planning your circle trades efficiently.",
@@ -1493,7 +1515,13 @@
           "faq_2_q": "Is CultistCircle affiliated with TarkovTracker?",
           "faq_2_a": "No, CultistCircle is an independent project by a solo community developer. It is listed here as a useful community resource."
         }
-      }
+      },
+      "video": {
+        "walkthrough_title": "{name} video walkthrough",
+        "caption": "Community video walkthrough. Steps may differ slightly from the written guide.",
+        "play": "Play video: {title}"
+      },
+      "official_guide_label": "TarkovTracker.org Guide"
     }
   },
   "footer": {

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1344,6 +1344,10 @@
       "suggest_title": "Know a useful Tarkov resource?",
       "suggest_description": "Suggest a community tool or guide for inclusion on this page.",
       "suggest_cta": "Suggest a resource",
+      "migration_banner": {
+        "title": "Moving from TarkovTracker.io?",
+        "cta": "Read the migration guide"
+      },
       "categories": {
         "tarkovtracker_guides": "TarkovTracker.org Guides",
         "companion_apps": "Companion Apps",
@@ -1421,13 +1425,23 @@
       },
       "guides": {
         "tarkovtracker_org_vs_io": {
-          "overview": "TarkovTracker exists on two domains. TarkovTracker.io is the original site created by the TarkovTracker project founder and hosts the original codebase. TarkovTracker.org is the actively maintained continuation run by a long-time contributor and former maintainer of the original project, as a free and open-source fork under the same GNU GPLv3 license. This guide explains the differences and how to move your progress to TarkovTracker.org.",
+          "overview": "TarkovTracker exists on two domains. TarkovTracker.io is the original site created by the TarkovTracker project founder and hosts the original codebase. TarkovTracker.org is the actively maintained continuation run by a long-time contributor and former maintainer of the original project, as a free and open-source fork under the same GNU GPLv3 license. This guide explains the differences and the supported ways to rebuild your progress on TarkovTracker.org.",
+          "step_1_title": "Create or sign in to your TarkovTracker.org account",
+          "step_1_desc": "Create a TarkovTracker.org account or sign in to the account where you want to track your current wipe progress.",
+          "step_2_title": "Import your Tarkov.dev profile metadata",
+          "step_2_desc": "Open Settings, choose Imports, and use the Tarkov.dev profile import to restore supported profile details such as level, faction, and skills.",
+          "step_3_title": "Import your EFT game logs",
+          "step_3_desc": "In the same Imports tab, select your EFT logs folder to recover quest start and completion events that are still present in your local logs.",
+          "step_4_title": "Verify tasks and hideout progress",
+          "step_4_desc": "Check your task list and hideout, then manually restore progress that Tarkov.dev and your available game logs could not recover.",
+          "step_5_title": "Connect supported companion tools",
+          "step_5_desc": "Set up TarkovMonitor with a new TarkovTracker.org read-write API token so future supported progress updates go to your .org account.",
           "faq_1_q": "What is the difference between TarkovTracker.io and TarkovTracker.org?",
           "faq_1_a": "TarkovTracker.io is the original site. It is relatively stable but has known issues and is no longer maintained - its last deployment was in August 2024 and there is no active development or support. TarkovTracker.org is the actively maintained fork: it receives regular updates, supports game changes after EFT 0.15, and adds new features. Because it is under active development it can occasionally have bugs or downtime, and while we work hard to prevent it, data loss cannot be ruled out entirely.",
           "faq_2_q": "Which site should I use?",
           "faq_2_a": "Use TarkovTracker.org. It is the only version that receives updates, bug fixes, and support for current Escape from Tarkov content. New accounts should always be created on TarkovTracker.org.",
           "faq_3_q": "How do I migrate my progress from .io to .org?",
-          "faq_3_a": "Sign in to TarkovTracker.io, copy your API token (found in your profile settings), then on TarkovTracker.org go to Settings and use the .io import option with that token. Your task and hideout progress will be copied to your .org account. The import is a one-time copy - progress made afterwards on one site does not sync to the other.",
+          "faq_3_a": "TarkovTracker.org does not currently provide a direct .io token import. Create or sign in to your .org account, then use the supported Tarkov.dev profile and EFT game-log imports in Settings. Verify tasks and hideout progress manually because those sources may not contain everything recorded on .io. Progress does not sync between the two sites.",
           "faq_4_q": "Does the TarkovTracker.org team run TarkovTracker.io?",
           "faq_4_a": "No. The .io domain and deployment are owned and controlled by the original project founder. We have no access to it and cannot fix, update, or provide support for anything on .io."
         },

--- a/app/pages/__tests__/index.page.test.ts
+++ b/app/pages/__tests__/index.page.test.ts
@@ -159,6 +159,9 @@ const defaultGlobalStubs = {
   DashboardNextActions: {
     template: '<div data-testid="dashboard-focus-card"></div>',
   },
+  DashboardMigrationBanner: {
+    template: '<div data-testid="dashboard-migration-banner"></div>',
+  },
   DashboardProgressCard: {
     props: ['completed', 'total', 'percentage', 'label', 'icon', 'color'],
     template: `<div data-testid="progress-card" :data-completed="completed" :data-total="total" :data-percentage="percentage" :data-label="label"><slot /></div>`,

--- a/app/pages/__tests__/index.page.test.ts
+++ b/app/pages/__tests__/index.page.test.ts
@@ -193,6 +193,13 @@ describe('dashboard page', () => {
     });
     expect(wrapper.find('[data-testid="dashboard-focus-card"]').exists()).toBe(true);
   });
+  it('renders the migration guide banner', async () => {
+    const { DashboardPage } = await setup();
+    const wrapper = await mountSuspended(DashboardPage, {
+      global: { stubs: defaultGlobalStubs },
+    });
+    expect(wrapper.find('[data-testid="dashboard-migration-banner"]').exists()).toBe(true);
+  });
   it('renders dashboard progress cards', async () => {
     const { DashboardPage } = await setup();
     const wrapper = await mountSuspended(DashboardPage, {

--- a/app/pages/index.vue
+++ b/app/pages/index.vue
@@ -4,6 +4,7 @@
       <div class="mx-auto max-w-350 xl:max-w-400 2xl:max-w-450">
         <h1 class="sr-only">Tarkov Tracker - Escape from Tarkov Progress Tracker</h1>
         <DashboardNextActions />
+        <DashboardMigrationBanner />
         <DashboardChangelog />
         <div class="mb-8">
           <button

--- a/app/pages/resources/[slug].vue
+++ b/app/pages/resources/[slug].vue
@@ -51,7 +51,11 @@
           <div class="min-w-0 flex-1 space-y-2">
             <div>
               <p class="text-primary-300/90 text-xs font-semibold tracking-[0.25em] uppercase">
-                {{ t('page.resources.guide_label', 'Guide') }}
+                {{
+                  isOfficialGuide
+                    ? t('page.resources.official_guide_label', 'TarkovTracker.org Guide')
+                    : t('page.resources.guide_label', 'Guide')
+                }}
               </p>
               <h1 class="mt-1 text-2xl font-bold tracking-wide text-white sm:text-3xl">
                 {{ guideTitle }}
@@ -118,6 +122,22 @@
             icon="i-mdi-information-outline"
           >
             <p class="text-surface-200 text-base leading-relaxed">{{ overviewText }}</p>
+          </ResourceGuideSection>
+          <ResourceGuideSection
+            v-if="resource.videoId"
+            id="video"
+            :title="t('page.resources.guide_sections.video_walkthrough', 'Video Walkthrough')"
+            icon="i-mdi-play-circle-outline"
+          >
+            <ResourceVideoEmbed :video-id="resource.videoId" :title="videoTitle" />
+            <p class="text-surface-400 mt-2 text-sm">
+              {{
+                t(
+                  'page.resources.video.caption',
+                  'Community video walkthrough. Steps may differ slightly from the guide above.'
+                )
+              }}
+            </p>
           </ResourceGuideSection>
           <ResourceGuideSection
             v-if="resource.guide && resource.guide.steps > 0"
@@ -249,6 +269,7 @@
     getResourceBySlug,
   } from '@/features/resources/resourceData';
   import ResourceGuideSection from '@/features/resources/ResourceGuideSection.vue';
+  import ResourceVideoEmbed from '@/features/resources/ResourceVideoEmbed.vue';
   const { t } = useI18n({ useScope: 'global' });
   const route = useRoute();
   const slug = computed(() => {
@@ -274,10 +295,16 @@
       CATEGORY_LABEL_FALLBACKS[resource.value.category]
     );
   });
+  const isOfficialGuide = computed(() => resource.value?.category === 'tarkovtracker_guides');
   const metaLine = computed(() => {
     if (!resource.value) return '';
     const parts: string[] = [];
-    if (resource.value.category === 'companion_apps') {
+    if (resource.value.category === 'tarkovtracker_guides') {
+      parts.push(t('page.resources.meta.official_guide', 'Official guide'));
+      parts.push(
+        t('page.resources.meta.maintained_by_team', 'Maintained by the TarkovTracker.org team')
+      );
+    } else if (resource.value.category === 'companion_apps') {
       parts.push(t('page.resources.meta.windows', 'Windows'));
       parts.push(t('page.resources.meta.companion_app', 'Companion App'));
       parts.push(t('page.resources.meta.setup_time', '5-minute setup'));
@@ -290,6 +317,13 @@
     }
     return parts.join(' · ');
   });
+  const videoTitle = computed(() =>
+    t(
+      'page.resources.video.walkthrough_title',
+      { name: guideTitle.value },
+      `${guideTitle.value} video walkthrough`
+    )
+  );
   const compatibilityText = computed(() => {
     if (!resource.value?.guide?.compatibility) return '';
     return t(`page.resources.guides.${slug.value}.compatibility`, '');
@@ -302,6 +336,12 @@
   );
   const tocItems = computed(() => {
     const items = [{ id: 'overview', label: t('common.overview', 'Overview') }];
+    if (resource.value?.videoId) {
+      items.push({
+        id: 'video',
+        label: t('page.resources.guide_sections.video_walkthrough', 'Video Walkthrough'),
+      });
+    }
     if (resource.value?.guide && resource.value.guide.steps > 0) {
       items.push({
         id: 'setup',

--- a/app/pages/resources/[slug].vue
+++ b/app/pages/resources/[slug].vue
@@ -50,9 +50,11 @@
   import ResourceGuideToc, {
     type ResourceGuideTocItem,
   } from '@/features/resources/ResourceGuideToc.vue';
+  import { resolveCanonicalSiteUrl } from '@/utils/runtimeConfig';
   const { t } = useI18n({ useScope: 'global' });
   const route = useRoute();
   const runtimeConfig = useRuntimeConfig();
+  const siteUrl = resolveCanonicalSiteUrl(runtimeConfig.public.appUrl);
   const slug = computed(() => {
     const param = route.params.slug;
     return (Array.isArray(param) ? param[0] : param) ?? '';
@@ -162,9 +164,7 @@
         )
       : t('page.resources.title', 'Resources & Guides')
   );
-  const canonicalUrl = computed(
-    () => `${String(runtimeConfig.public.appUrl).replace(/\/$/, '')}/resources/${slug.value}`
-  );
+  const canonicalUrl = computed(() => `${siteUrl}/resources/${slug.value}`);
   const shouldIndexGuide = computed(() => resource.value?.hasGuide === true);
   useSeoMeta({
     title: seoTitle,

--- a/app/pages/resources/[slug].vue
+++ b/app/pages/resources/[slug].vue
@@ -165,15 +165,18 @@
   const canonicalUrl = computed(
     () => `${String(runtimeConfig.public.appUrl).replace(/\/$/, '')}/resources/${slug.value}`
   );
+  const shouldIndexGuide = computed(() => resource.value?.hasGuide === true);
   useSeoMeta({
     title: seoTitle,
     description: overviewText,
     ogTitle: seoTitle,
     ogDescription: overviewText,
-    ogUrl: canonicalUrl,
+    ogUrl: computed(() => (shouldIndexGuide.value ? canonicalUrl.value : undefined)),
     twitterTitle: seoTitle,
     twitterDescription: overviewText,
-    robots: 'index, follow',
+    robots: computed(() => (shouldIndexGuide.value ? 'index, follow' : 'noindex, nofollow')),
   });
-  useHead({ link: [{ rel: 'canonical', href: canonicalUrl }] });
+  useHead(() => ({
+    link: shouldIndexGuide.value ? [{ rel: 'canonical', href: canonicalUrl.value }] : [],
+  }));
 </script>

--- a/app/pages/resources/[slug].vue
+++ b/app/pages/resources/[slug].vue
@@ -20,243 +20,21 @@
       />
     </div>
     <div v-else class="space-y-6">
-      <nav
-        class="text-surface-400 flex flex-wrap items-center gap-1.5 text-sm"
-        :aria-label="t('page.resources.breadcrumb', 'Breadcrumb')"
-      >
-        <NuxtLink to="/resources" class="hover:text-primary-300 transition-colors">
-          {{ t('page.resources.title', 'Resources & Guides') }}
-        </NuxtLink>
-        <UIcon name="i-mdi-chevron-right" class="h-4 w-4 shrink-0 opacity-60" />
-        <NuxtLink to="/resources" class="hover:text-primary-300 transition-colors">
-          {{ categoryLabel }}
-        </NuxtLink>
-        <UIcon name="i-mdi-chevron-right" class="h-4 w-4 shrink-0 opacity-60" />
-        <span class="text-surface-200">{{ guideTitle }}</span>
-      </nav>
-      <header class="space-y-4">
-        <div class="flex items-start gap-4">
-          <div
-            v-if="resource.logo"
-            class="flex h-12 w-12 shrink-0 items-center justify-center overflow-hidden rounded-xl bg-white/5"
-          >
-            <NuxtImg :src="resource.logo" :alt="guideTitle" class="h-full w-full object-contain" />
-          </div>
-          <div
-            v-else
-            class="bg-primary-500/15 text-primary-300 flex h-12 w-12 shrink-0 items-center justify-center rounded-xl"
-          >
-            <UIcon name="i-mdi-bookmark" class="h-6 w-6" />
-          </div>
-          <div class="min-w-0 flex-1 space-y-2">
-            <div>
-              <p class="text-primary-300/90 text-xs font-semibold tracking-[0.25em] uppercase">
-                {{
-                  isOfficialGuide
-                    ? t('page.resources.official_guide_label', 'TarkovTracker.org Guide')
-                    : t('page.resources.guide_label', 'Guide')
-                }}
-              </p>
-              <h1 class="mt-1 text-2xl font-bold tracking-wide text-white sm:text-3xl">
-                {{ guideTitle }}
-              </h1>
-            </div>
-            <p class="text-surface-200 max-w-3xl text-base leading-relaxed">
-              {{ shortDescription }}
-            </p>
-            <p class="text-surface-400 text-sm">
-              {{ metaLine }}
-            </p>
-          </div>
-        </div>
-        <div class="flex flex-wrap items-center gap-2">
-          <UButton
-            v-if="primaryAction"
-            :href="primaryAction.href"
-            target="_blank"
-            rel="noopener noreferrer"
-            size="md"
-            color="primary"
-            variant="solid"
-            class="min-h-10"
-            :icon="primaryAction.icon"
-            trailing-icon="i-mdi-open-in-new"
-            :label="t(primaryAction.labelKey, primaryAction.labelFallback)"
-          />
-          <UButton
-            v-for="link in secondaryLinks"
-            :key="link.href"
-            :href="link.href"
-            target="_blank"
-            rel="noopener noreferrer"
-            size="sm"
-            color="neutral"
-            variant="soft"
-            class="min-h-10"
-            :icon="link.icon"
-            trailing-icon="i-mdi-open-in-new"
-            :label="t(link.labelKey, link.labelFallback)"
-          />
-        </div>
-        <div
-          v-if="compatibilityText"
-          class="bg-warning-500/10 border-warning-400/20 text-surface-200 flex items-start gap-3 rounded-xl border px-4 py-3 text-base leading-relaxed"
-        >
-          <UIcon
-            name="i-mdi-alert-circle-outline"
-            class="text-warning-400 mt-0.5 h-5 w-5 shrink-0"
-          />
-          <p>
-            <span class="text-warning-200 font-semibold">
-              {{ t('page.resources.compatibility_label', 'Compatibility') }}:
-            </span>
-            {{ compatibilityText }}
-          </p>
-        </div>
-      </header>
+      <ResourceGuideHeader
+        :resource="resource"
+        :title="guideTitle"
+        :description="shortDescription"
+        :category-label="categoryLabel"
+        :meta-line="metaLine"
+        :compatibility-text="compatibilityText"
+      />
       <div class="grid gap-8 lg:grid-cols-[minmax(0,1fr)_13rem]">
-        <article class="min-w-0 space-y-10">
-          <ResourceGuideSection
-            id="overview"
-            :title="t('common.overview', 'Overview')"
-            icon="i-mdi-information-outline"
-          >
-            <p class="text-surface-200 text-base leading-relaxed">{{ overviewText }}</p>
-          </ResourceGuideSection>
-          <ResourceGuideSection
-            v-if="resource.videoId"
-            id="video"
-            :title="t('page.resources.guide_sections.video_walkthrough', 'Video Walkthrough')"
-            icon="i-mdi-play-circle-outline"
-          >
-            <ResourceVideoEmbed :video-id="resource.videoId" :title="videoTitle" />
-            <p class="text-surface-400 mt-2 text-sm">
-              {{
-                t(
-                  'page.resources.video.caption',
-                  'Community video walkthrough. Steps may differ slightly from the guide above.'
-                )
-              }}
-            </p>
-          </ResourceGuideSection>
-          <ResourceGuideSection
-            v-if="resource.guide && resource.guide.steps > 0"
-            id="setup"
-            :title="t('common.getting_started', 'Getting Started')"
-            icon="i-mdi-playlist-check"
-          >
-            <ol class="space-y-5">
-              <li
-                v-for="n in resource.guide.steps"
-                :key="n"
-                class="flex items-start gap-4 border-b border-white/5 pb-5 last:border-0 last:pb-0"
-              >
-                <span
-                  class="bg-primary-500/20 text-primary-300 mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full text-sm font-semibold"
-                >
-                  {{ n }}
-                </span>
-                <div class="min-w-0 flex-1 space-y-1.5">
-                  <h3 class="text-surface-100 text-base font-semibold sm:text-lg">
-                    {{ t(`page.resources.guides.${resource.slug}.step_${n}_title`, '') }}
-                  </h3>
-                  <p class="text-surface-300 text-base leading-relaxed">
-                    {{ t(`page.resources.guides.${resource.slug}.step_${n}_desc`, '') }}
-                  </p>
-                </div>
-              </li>
-            </ol>
-          </ResourceGuideSection>
-          <ResourceGuideSection
-            v-if="resource.guide && (resource.guide.troubleshooting ?? 0) > 0"
-            id="troubleshooting"
-            :title="t('page.resources.guide_sections.troubleshooting', 'Troubleshooting')"
-            icon="i-mdi-wrench-outline"
-          >
-            <div class="space-y-4">
-              <div
-                v-for="n in resource.guide.troubleshooting"
-                :key="n"
-                class="border-b border-white/5 pb-4 last:border-0 last:pb-0"
-              >
-                <h3 class="text-surface-100 text-base font-semibold">
-                  {{ t(`page.resources.guides.${resource.slug}.troubleshooting_${n}_title`, '') }}
-                </h3>
-                <p class="text-surface-300 mt-1 text-base leading-relaxed">
-                  {{ t(`page.resources.guides.${resource.slug}.troubleshooting_${n}_desc`, '') }}
-                </p>
-              </div>
-            </div>
-          </ResourceGuideSection>
-          <ResourceGuideSection
-            v-if="resource.guide && resource.guide.tips > 0"
-            id="tips"
-            :title="t('page.resources.guide_sections.tips', 'Tips & Tricks')"
-            icon="i-mdi-lightbulb-on-outline"
-          >
-            <ul class="space-y-3">
-              <li
-                v-for="n in resource.guide.tips"
-                :key="n"
-                class="bg-surface-900/40 flex items-start gap-3 rounded-lg border border-white/5 px-3 py-3"
-              >
-                <UIcon
-                  name="i-mdi-lightbulb-outline"
-                  class="text-warning-400 mt-0.5 h-4 w-4 shrink-0"
-                />
-                <span class="text-surface-200 text-base leading-relaxed">
-                  {{ t(`page.resources.guides.${resource.slug}.tip_${n}`, '') }}
-                </span>
-              </li>
-            </ul>
-          </ResourceGuideSection>
-          <ResourceGuideSection
-            v-if="resource.guide && resource.guide.faq > 0"
-            id="faq"
-            :title="t('page.resources.guide_sections.faq', 'Common Questions')"
-            icon="i-mdi-help-circle-outline"
-          >
-            <div class="divide-y divide-white/5 rounded-xl border border-white/10">
-              <details v-for="n in resource.guide.faq" :id="`faq-${n}`" :key="n" class="group px-4">
-                <summary
-                  class="text-surface-100 hover:text-primary-200 focus-visible:ring-primary-400/40 flex min-h-11 cursor-pointer list-none items-center justify-between gap-3 py-3 text-base font-medium transition-colors marker:content-none focus-visible:ring-2 focus-visible:outline-none [&::-webkit-details-marker]:hidden"
-                >
-                  <span>{{ t(`page.resources.guides.${resource.slug}.faq_${n}_q`, '') }}</span>
-                  <UIcon
-                    name="i-mdi-chevron-down"
-                    class="text-surface-500 h-5 w-5 shrink-0 transition-transform group-open:rotate-180"
-                  />
-                </summary>
-                <p class="text-surface-300 pb-4 text-base leading-relaxed">
-                  {{ t(`page.resources.guides.${resource.slug}.faq_${n}_a`, '') }}
-                </p>
-              </details>
-            </div>
-          </ResourceGuideSection>
-        </article>
-        <aside class="hidden lg:block">
-          <div class="sticky top-16 space-y-3">
-            <p class="text-surface-400 text-xs font-semibold tracking-[0.2em] uppercase">
-              {{ t('page.resources.on_this_page', 'On this page') }}
-            </p>
-            <nav class="space-y-1" :aria-label="t('page.resources.on_this_page', 'On this page')">
-              <a
-                v-for="item in tocItems"
-                :key="item.id"
-                :href="`#${item.id}`"
-                :class="[
-                  'focus-visible:ring-primary-400/40 block rounded-md px-2 py-1.5 text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none',
-                  activeSectionId === item.id
-                    ? 'bg-primary-500/15 text-primary-200'
-                    : 'text-surface-300 hover:text-primary-300 hover:bg-white/5',
-                ]"
-                @click="onTocClick(item.id, $event)"
-              >
-                {{ item.label }}
-              </a>
-            </nav>
-          </div>
-        </aside>
+        <ResourceGuideArticle
+          :resource="resource"
+          :guide-title="guideTitle"
+          :overview="overviewText"
+        />
+        <ResourceGuideToc :items="tocItems" :active-id="activeSectionId" @select="onTocClick" />
       </div>
     </div>
   </div>
@@ -264,18 +42,20 @@
 <script setup lang="ts">
   import {
     CATEGORY_LABEL_FALLBACKS,
-    getGuidePrimaryAction,
-    getGuideSecondaryLinks,
     getResourceBySlug,
+    RESOURCE_META_ITEMS,
   } from '@/features/resources/resourceData';
-  import ResourceGuideSection from '@/features/resources/ResourceGuideSection.vue';
-  import ResourceVideoEmbed from '@/features/resources/ResourceVideoEmbed.vue';
+  import ResourceGuideArticle from '@/features/resources/ResourceGuideArticle.vue';
+  import ResourceGuideHeader from '@/features/resources/ResourceGuideHeader.vue';
+  import ResourceGuideToc, {
+    type ResourceGuideTocItem,
+  } from '@/features/resources/ResourceGuideToc.vue';
   const { t } = useI18n({ useScope: 'global' });
   const route = useRoute();
+  const runtimeConfig = useRuntimeConfig();
   const slug = computed(() => {
     const param = route.params.slug;
-    const value = Array.isArray(param) ? param[0] : param;
-    return value ?? '';
+    return (Array.isArray(param) ? param[0] : param) ?? '';
   });
   const resource = computed(() => getResourceBySlug(slug.value));
   const guideTitle = computed(() => t(`page.resources.items.${slug.value}.name`, slug.value));
@@ -289,84 +69,58 @@
         )
   );
   const categoryLabel = computed(() => {
-    if (!resource.value) return '';
-    return t(
-      `page.resources.categories.${resource.value.category}`,
-      CATEGORY_LABEL_FALLBACKS[resource.value.category]
-    );
+    const category = resource.value?.category;
+    return category
+      ? t(`page.resources.categories.${category}`, CATEGORY_LABEL_FALLBACKS[category])
+      : '';
   });
-  const isOfficialGuide = computed(() => resource.value?.category === 'tarkovtracker_guides');
   const metaLine = computed(() => {
-    if (!resource.value) return '';
-    const parts: string[] = [];
-    if (resource.value.category === 'tarkovtracker_guides') {
-      parts.push(t('page.resources.meta.official_guide', 'Official guide'));
-      parts.push(
-        t('page.resources.meta.maintained_by_team', 'Maintained by the TarkovTracker.org team')
-      );
-    } else if (resource.value.category === 'companion_apps') {
-      parts.push(t('page.resources.meta.windows', 'Windows'));
-      parts.push(t('page.resources.meta.companion_app', 'Companion App'));
-      parts.push(t('page.resources.meta.setup_time', '5-minute setup'));
-    } else if (resource.value.category === 'data_and_apis') {
-      parts.push(categoryLabel.value);
-      parts.push(t('page.resources.meta.community_data', 'Community maintained'));
-    } else {
-      parts.push(categoryLabel.value);
-      parts.push(t('page.resources.meta.web_tool', 'Web tool'));
-    }
-    return parts.join(' · ');
+    const category = resource.value?.category;
+    if (!category) return '';
+    return RESOURCE_META_ITEMS[category]
+      .map((item) =>
+        item.useCategoryLabel
+          ? categoryLabel.value
+          : t(item.labelKey ?? '', item.labelFallback ?? '')
+      )
+      .join(' · ');
   });
-  const videoTitle = computed(() =>
-    t(
-      'page.resources.video.walkthrough_title',
-      { name: guideTitle.value },
-      `${guideTitle.value} video walkthrough`
-    )
+  const compatibilityText = computed(() =>
+    resource.value?.guide?.compatibility
+      ? t(`page.resources.guides.${slug.value}.compatibility`, '')
+      : ''
   );
-  const compatibilityText = computed(() => {
-    if (!resource.value?.guide?.compatibility) return '';
-    return t(`page.resources.guides.${slug.value}.compatibility`, '');
-  });
-  const primaryAction = computed(() =>
-    resource.value ? getGuidePrimaryAction(resource.value) : null
-  );
-  const secondaryLinks = computed(() =>
-    resource.value ? getGuideSecondaryLinks(resource.value) : []
-  );
-  const tocItems = computed(() => {
-    const items = [{ id: 'overview', label: t('common.overview', 'Overview') }];
-    if (resource.value?.videoId) {
-      items.push({
+  const tocItems = computed<ResourceGuideTocItem[]>(() => {
+    const guide = resource.value?.guide;
+    const candidates: Array<ResourceGuideTocItem & { enabled: boolean }> = [
+      { id: 'overview', label: t('common.overview', 'Overview'), enabled: true },
+      {
         id: 'video',
         label: t('page.resources.guide_sections.video_walkthrough', 'Video Walkthrough'),
-      });
-    }
-    if (resource.value?.guide && resource.value.guide.steps > 0) {
-      items.push({
+        enabled: Boolean(resource.value?.videoId),
+      },
+      {
         id: 'setup',
         label: t('common.getting_started', 'Getting Started'),
-      });
-    }
-    if (resource.value?.guide && (resource.value.guide.troubleshooting ?? 0) > 0) {
-      items.push({
+        enabled: Boolean(guide?.steps),
+      },
+      {
         id: 'troubleshooting',
         label: t('page.resources.guide_sections.troubleshooting', 'Troubleshooting'),
-      });
-    }
-    if (resource.value?.guide && resource.value.guide.tips > 0) {
-      items.push({
+        enabled: Boolean(guide?.troubleshooting),
+      },
+      {
         id: 'tips',
         label: t('page.resources.guide_sections.tips', 'Tips & Tricks'),
-      });
-    }
-    if (resource.value?.guide && resource.value.guide.faq > 0) {
-      items.push({
+        enabled: Boolean(guide?.tips),
+      },
+      {
         id: 'faq',
         label: t('page.resources.guide_sections.faq', 'Common Questions'),
-      });
-    }
-    return items;
+        enabled: Boolean(guide?.faq),
+      },
+    ];
+    return candidates.filter((item) => item.enabled).map(({ id, label }) => ({ id, label }));
   });
   const activeSectionId = ref('overview');
   const SCROLL_OFFSET = 72;
@@ -379,16 +133,13 @@
     window.scrollTo({ top, behavior: 'smooth' });
     history.replaceState(null, '', `#${id}`);
   };
+  const getSectionPosition = (item: ResourceGuideTocItem) => {
+    const element = document.getElementById(item.id);
+    return element ? { id: item.id, top: element.getBoundingClientRect().top } : null;
+  };
   const updateActiveSection = () => {
-    const sections = tocItems.value
-      .map((item) => {
-        const el = document.getElementById(item.id);
-        if (!el) return null;
-        return { id: item.id, top: el.getBoundingClientRect().top };
-      })
-      .filter((entry): entry is { id: string; top: number } => entry !== null);
-    if (!sections.length) return;
-    const current = [...sections].reverse().find((section) => section.top <= SCROLL_OFFSET + 8);
+    const sections = tocItems.value.map(getSectionPosition).filter((entry) => entry !== null);
+    const current = sections.findLast((section) => section.top <= SCROLL_OFFSET + 8);
     activeSectionId.value = current?.id ?? sections[0]?.id ?? 'overview';
   };
   onMounted(() => {
@@ -400,20 +151,29 @@
     window.removeEventListener('scroll', updateActiveSection);
     window.removeEventListener('resize', updateActiveSection);
   });
-  watch(tocItems, () => {
-    nextTick(() => updateActiveSection());
-  });
+  watch(tocItems, () => nextTick(updateActiveSection));
   definePageMeta({ layout: 'default' });
+  const seoTitle = computed(() =>
+    resource.value?.hasGuide
+      ? t(
+          'page.resources.guide_title_template',
+          { name: guideTitle.value },
+          `${guideTitle.value} Guide`
+        )
+      : t('page.resources.title', 'Resources & Guides')
+  );
+  const canonicalUrl = computed(
+    () => `${String(runtimeConfig.public.appUrl).replace(/\/$/, '')}/resources/${slug.value}`
+  );
   useSeoMeta({
-    title: computed(() =>
-      resource.value?.hasGuide
-        ? t(
-            'page.resources.guide_title_template',
-            { name: guideTitle.value },
-            `${guideTitle.value} Guide`
-          )
-        : t('page.resources.title', 'Resources & Guides')
-    ),
-    description: computed(() => overviewText.value),
+    title: seoTitle,
+    description: overviewText,
+    ogTitle: seoTitle,
+    ogDescription: overviewText,
+    ogUrl: canonicalUrl,
+    twitterTitle: seoTitle,
+    twitterDescription: overviewText,
+    robots: 'index, follow',
   });
+  useHead({ link: [{ rel: 'canonical', href: canonicalUrl }] });
 </script>

--- a/app/stores/usePreferences.ts
+++ b/app/stores/usePreferences.ts
@@ -661,6 +661,9 @@ export const usePreferencesStore = defineStore('preferences', {
     setStreamerMode(mode: boolean) {
       this.streamerMode = mode;
     },
+    setDashboardNoticeDismissed(dismissed: boolean) {
+      this.dashboardNoticeDismissed = dismissed;
+    },
     setProfileSharePvpPublic(value: boolean) {
       this.profileSharePvpPublic = value;
     },

--- a/app/utils/__tests__/csp.test.ts
+++ b/app/utils/__tests__/csp.test.ts
@@ -106,6 +106,10 @@ describe('nuxt.config CSP', () => {
       'https://challenges.cloudflare.com'
     );
   });
+  it('allows privacy-enhanced YouTube walkthrough frames', () => {
+    const csp = buildContentSecurityPolicy();
+    expect(getDirectiveSources(csp, 'frame-src')).toContain('https://www.youtube-nocookie.com');
+  });
   it('builds a stricter overlay policy and requires explicit inline bootstrap opt-in', () => {
     const csp = buildOverlayContentSecurityPolicy();
     expect(getDirectiveSources(csp, 'default-src')).toEqual(["'none'"]);

--- a/app/utils/__tests__/runtimeConfig.test.ts
+++ b/app/utils/__tests__/runtimeConfig.test.ts
@@ -4,6 +4,7 @@ import {
   isPrimaryAppHostname,
   isPagesPreviewHostname,
   resolveClientLogSinkUrl,
+  resolveCanonicalSiteUrl,
   resolvePublicAppUrl,
   resolveSupabaseRuntimeConfig,
   shouldEnableAnalyticsIntegrations,
@@ -74,6 +75,14 @@ describe('resolvePublicAppUrl', () => {
   });
   it('falls back to localhost when no deployment url exists', () => {
     expect(resolvePublicAppUrl({})).toBe('http://localhost:3000');
+  });
+});
+describe('resolveCanonicalSiteUrl', () => {
+  it('uses the production origin when a production build has only the local fallback', () => {
+    expect(resolveCanonicalSiteUrl('http://localhost:3000')).toBe('https://tarkovtracker.org');
+  });
+  it('preserves deployed origins and removes trailing slashes', () => {
+    expect(resolveCanonicalSiteUrl('https://preview.pages.dev/')).toBe('https://preview.pages.dev');
   });
 });
 describe('shouldUseOfflineSupabaseFallback', () => {

--- a/app/utils/__tests__/runtimeConfig.test.ts
+++ b/app/utils/__tests__/runtimeConfig.test.ts
@@ -9,6 +9,7 @@ import {
   shouldEnableAnalyticsIntegrations,
   shouldUseOfflineSupabaseFallback,
   TARKOV_IMAGE_DOMAINS,
+  YOUTUBE_IMAGE_DOMAINS,
 } from '@/utils/runtimeConfig';
 describe('resolveSupabaseRuntimeConfig', () => {
   it('resolves shared Supabase env values', () => {
@@ -37,8 +38,13 @@ describe('resolveSupabaseRuntimeConfig', () => {
     });
   });
   it('includes Tarkov asset hosts alongside GitHub image hosts', () => {
-    expect([...GITHUB_IMAGE_DOMAINS, ...TARKOV_IMAGE_DOMAINS]).toEqual(
-      expect.arrayContaining(['assets.tarkov.dev', 'avatars.githubusercontent.com', 'github.com'])
+    expect([...GITHUB_IMAGE_DOMAINS, ...TARKOV_IMAGE_DOMAINS, ...YOUTUBE_IMAGE_DOMAINS]).toEqual(
+      expect.arrayContaining([
+        'assets.tarkov.dev',
+        'avatars.githubusercontent.com',
+        'github.com',
+        'i.ytimg.com',
+      ])
     );
   });
 });

--- a/app/utils/csp.ts
+++ b/app/utils/csp.ts
@@ -7,6 +7,7 @@ export type ContentSecurityPolicyOptions = {
   turnstileSiteKey?: string;
 };
 const TURNSTILE_CSP_ORIGIN = 'https://challenges.cloudflare.com';
+const YOUTUBE_EMBED_ORIGIN = 'https://www.youtube-nocookie.com';
 const GITHUB_IMAGE_ORIGINS = ['https://avatars.githubusercontent.com', 'https://github.com'];
 const hasConfiguredValue = (value: string | undefined): boolean => Boolean(value?.trim());
 const isLocalHttpHost = (hostname: string): boolean => {
@@ -116,6 +117,7 @@ export const getFrameSrcSources = (options: ContentSecurityPolicyOptions = {}): 
   return getUniqueSources([
     "'self'",
     'https://player.twitch.tv',
+    YOUTUBE_EMBED_ORIGIN,
     hasConfiguredValue(options.turnstileSiteKey) ? TURNSTILE_CSP_ORIGIN : null,
   ]);
 };

--- a/app/utils/runtimeConfig.ts
+++ b/app/utils/runtimeConfig.ts
@@ -1,5 +1,6 @@
 export const GITHUB_IMAGE_DOMAINS = ['avatars.githubusercontent.com', 'github.com'] as const;
 export const TARKOV_IMAGE_DOMAINS = ['assets.tarkov.dev'] as const;
+export const YOUTUBE_IMAGE_DOMAINS = ['i.ytimg.com'] as const;
 export const PRIMARY_APP_HOSTNAMES = ['tarkovtracker.org', 'www.tarkovtracker.org'] as const;
 const resolveEnvValue = (...values: Array<string | undefined>) =>
   values.find((value) => value?.trim())?.trim() || '';

--- a/app/utils/runtimeConfig.ts
+++ b/app/utils/runtimeConfig.ts
@@ -2,6 +2,8 @@ export const GITHUB_IMAGE_DOMAINS = ['avatars.githubusercontent.com', 'github.co
 export const TARKOV_IMAGE_DOMAINS = ['assets.tarkov.dev'] as const;
 export const YOUTUBE_IMAGE_DOMAINS = ['i.ytimg.com'] as const;
 export const PRIMARY_APP_HOSTNAMES = ['tarkovtracker.org', 'www.tarkovtracker.org'] as const;
+const PRODUCTION_APP_URL = 'https://tarkovtracker.org';
+const LOCAL_APP_HOSTNAMES = new Set(['localhost', '127.0.0.1']);
 const resolveEnvValue = (...values: Array<string | undefined>) =>
   values.find((value) => value?.trim())?.trim() || '';
 const resolveHostname = (value?: string): string => {
@@ -44,6 +46,15 @@ export const resolvePublicAppUrl = (env: NodeJS.ProcessEnv): string => {
     return 'http://localhost:3000';
   }
   return normalizePublicAppUrl(configuredUrl);
+};
+export const resolveCanonicalSiteUrl = (appUrl?: string): string => {
+  const normalizedUrl = normalizePublicAppUrl(appUrl || '').replace(/\/$/, '');
+  if (!normalizedUrl) {
+    return PRODUCTION_APP_URL;
+  }
+  return LOCAL_APP_HOSTNAMES.has(resolveHostname(normalizedUrl))
+    ? PRODUCTION_APP_URL
+    : normalizedUrl;
 };
 export const resolveClientLogSinkUrl = (env: NodeJS.ProcessEnv): string => {
   return resolveEnvValue(env.NUXT_PUBLIC_CLIENT_LOG_SINK_URL);

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,6 +16,7 @@ import {
   resolvePublicAppUrl,
   resolveSupabaseRuntimeConfig,
   TARKOV_IMAGE_DOMAINS,
+  YOUTUBE_IMAGE_DOMAINS,
 } from './app/utils/runtimeConfig';
 import { stripBareNodeImports } from './app/utils/stripBareNodeImports';
 import { TURNSTILE_TEST_SECRET_KEY, TURNSTILE_TEST_SITE_KEY } from './app/utils/turnstileKeys';
@@ -439,7 +440,7 @@ export default defineNuxtConfig({
     },
   },
   image: {
-    domains: [...GITHUB_IMAGE_DOMAINS, ...TARKOV_IMAGE_DOMAINS],
+    domains: [...GITHUB_IMAGE_DOMAINS, ...TARKOV_IMAGE_DOMAINS, ...YOUTUBE_IMAGE_DOMAINS],
   },
   ui: {
     theme: {


### PR DESCRIPTION
## **User description**
## Summary

Migrates the Discord FAQ forum content (the \`❓┃faq\` forum is archived, unused, and users rarely look there) into the site's Resources & Guides hub, where it's searchable, indexed, and easy to link when users ask.

### What changed

- **New first-party guide category**: \`tarkovtracker_guides\` ("TarkovTracker.org Guides") renders first on \`/resources\` with an "Official Guide" badge, clearly distinguishing our own guides from third-party tools.
- **New guide: \`/resources/tarkovtracker_org_vs_io\`** — 4-question FAQ migrated from the Discord FAQ forum:
  - Difference between .io and .org (.io = original, unmaintained since Aug 2024; .org = actively maintained fork)
  - Which site to use
  - How to migrate progress from .io → .org (API token import)
  - Whether we run .io (we don't)
- **Video walkthroughs**: consent-gated YouTube embed component (\`ResourceVideoEmbed.vue\` — thumbnail facade, only loads the \`youtube-nocookie.com\` iframe on click) wired into guide pages via a new \`videoId\` field:
  - TarkovMonitor guide → mrbreachie's full TT + TarkovMonitor + RatScanner setup video
  - RatScanner guide → mrbreachie's TarkovMonitor setup video
- **RatScanner guide: new FAQ "Does RatScanner work with TarkovTracker.org?"** — yes, switch the TarkovTracker backend from \`.io\` to \`.org\` in settings (verified against \`RatConfig.cs\` in RatScanner/RatScanner, which still defaults to \`tarkovtracker.io/api/v2\`); notes we now co-maintain RatScanner so integration will improve.

### Notes

- Slug uses underscores (\`tarkovtracker_org_vs_io\`) because \`i18n:check\` treats hyphens in locale key segments as snake_case violations.
- No new dependencies; no routing changes (existing \`/resources/[slug]\` pattern).
- Discord FAQ forum cleanup (4 threads, all archived) is a separate follow-up after this merges.

## Validation

- ✅ \`pnpm run typecheck\`
- ✅ \`pnpm run lint\` (zero warnings)
- ✅ \`pnpm run lint:blank-lines\`
- ✅ \`pnpm run i18n:check\` (no snake_case violations; Crowdin fallbacks non-fatal)
- ✅ \`vitest run app/features/resources\` — 32/32 pass (incl. new tests for official-guide badge/action, videoId, locale parity)
- ✅ Visual check (playwright): hub section order + official badge, new guide page (breadcrumbs, official label, FAQ accordion, sticky TOC), RatScanner video section with thumbnail facade

## Review focus

- FAQ wording accuracy (.io status, migration instructions, ownership claims)
- Video embed privacy approach (facade + \`youtube-nocookie\`)
- RatScanner backend-switch wording (new FAQ #4)

___

## **CodeAnt-AI Description**
Add official TarkovTracker.org guides and video walkthroughs to the Resources hub

### What Changed
- Added a first-party guide explaining the differences between TarkovTracker.org and TarkovTracker.io, which site to use, how to migrate progress, and who maintains each site
- Official guides now appear in their own category with clear “Official Guide” labels and direct “Read guide” actions
- Added click-to-play video walkthroughs to the TarkovMonitor and RatScanner guides without loading the video player until requested
- Added RatScanner guidance for connecting it to TarkovTracker.org

### Impact
`✅ Clearer .org versus .io guidance`
`✅ Easier progress migration`
`✅ Faster-loading resource guides`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added structured resource guides with setup steps, videos, troubleshooting, tips, FAQs, compatibility details, and external links.
  * Added consent-based, privacy-enhanced YouTube playback.
  * Added the official TarkovTracker guide and category.
  * Added a dismissible dashboard migration notice with persistent preferences.
  * Improved responsive navigation, accessibility, localization, and page metadata.

* **Tests**
  * Added coverage for guide content, actions, video consent, migration dismissal, and resource validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds first-party resource guides, consent-gated video walkthroughs, migration guidance, and supporting SEO, preferences, and CSP configuration.
- Adds an official TarkovTracker.org versus TarkovTracker.io guide and dashboard migration banner.
- Refactors resource guides into reusable sections and adds YouTube walkthrough facades.
- Allows privacy-enhanced YouTube frames through the application CSP and adds regression coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

The previously reported iframe failure is fixed because resource pages receive the shared CSP containing the exact YouTube NoCookie frame origin, so no blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/features/resources/ResourceVideoEmbed.vue | Adds a click-to-load YouTube NoCookie iframe whose origin now matches the application frame policy. |
| app/utils/csp.ts | Extends the shared application frame-src policy with the exact YouTube NoCookie embed origin. |
| app/pages/resources/[slug].vue | Refactors guide rendering into reusable components and adds guide-specific canonical and social metadata. |
| app/features/resources/resourceData.ts | Adds the official guide category, guide metadata, videos, and updated action selection. |
| app/features/dashboard/DashboardMigrationBanner.vue | Adds a persistently dismissible dashboard link to the migration guide. |

</details>

<sub>Reviews (7): Last reviewed commit: ["fix(ui): normalize canonical site origin..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/f98bb9d1005eac9fc76b7afb410c14aab3a18991) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51792274)</sub>

**Context used:**

- Knowledge Base — [Frontend App (Nuxt)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/frontend-app.md)

<!-- /greptile_comment -->