### PR TITLE
docs(api): align observer validation metadata

### DIFF
--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -776,7 +776,7 @@ flowchart LR
    It rejects privileged/write-capable roles and unbounded transaction or lock timeouts before it
    runs the telemetry reports. It never reads application rows or runs migration preflight.
 7. `preflight --migration <path>` parses the migration to identify referenced relations and
-   operation classes, then collects table/index, traffic, vacuum, query, lock, and blocking reports
+   operation classes, then collects table/index, traffic, vacuum, outliers, lock, and blocking reports
    sequentially to avoid a burst of production inspection queries. It returns an evidence-only JSON
    report. Unsupported or ambiguous syntax fails closed with `assessment: incomplete`,
    `risk: unknown`, and `requires_manual_review: true`. It does not execute the migration.

--- a/package.json
+++ b/package.json
@@ -190,9 +190,6 @@
       "prettier --write",
       "node scripts/lint-blank-lines.mjs --fix"
     ],
-    "scripts/prod-db": [
-      "node scripts/lint-blank-lines.mjs --fix"
-    ],
     "supabase/**/*.json": [
       "prettier --write",
       "node scripts/lint-blank-lines.mjs --fix"


### PR DESCRIPTION
Post-merge recovery for the two final Cubic findings on #667. Aligns the preflight report list with the implemented outliers command and removes a no-op lint-staged rule for the extensionless wrapper.\n\nValidation: systems:check, format:check, lint:fallow, git diff --check.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR aligns production database observer documentation with the implemented migration-preflight report set and removes an ineffective lint-staged matcher.
- Replaces the documented `query` report with the implemented `outliers` report.
- Removes a `scripts/prod-db` lint-staged entry whose blank-line command skipped the extensionless wrapper.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The documentation now matches the implemented preflight report sequence, and removing the ineffective lint-staged matcher does not alter validation behavior.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/SYSTEMS.md | Correctly updates the documented migration-preflight reports to match the observer implementation. |
| package.json | Safely removes a lint-staged matcher that could not process the matched extensionless file. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(api): align observer validation met..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/00c39331f96fb063f0187abfebf2df9479bc9952) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51796962)</sub>

**Context used:**

- Knowledge Base — [Monorepo Build & Deploy Configuration](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/repo-build-config.md)

<!-- /greptile_comment -->