### PR TITLE
feat(api): allow renaming API tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -195,6 +195,9 @@ Naming:
   Tarkov.dev profile and EFT-log
   imports must remain unavailable for Seasonal until their Season profile data is verified.
 - Public progress API clients must send a 5–200 character `User-Agent`; infrastructure routes are exempt. Usage reporting stores the latest normalized value per token/day.
+- API token renames update only `api_tokens.note` through authenticated owner-scoped RLS. They
+  must never rotate or replace the token or change its ID, value or hash, permissions, game mode,
+  or usage data.
 - Mock Supabase/network calls in tests. Keep tests deterministic.
 
 ## Error Handling

--- a/app/features/settings/ApiTokenNameEditor.vue
+++ b/app/features/settings/ApiTokenNameEditor.vue
@@ -1,0 +1,97 @@
+<template>
+  <div class="flex min-w-0 items-center gap-2">
+    <UIcon name="i-mdi-key-variant" class="text-primary-400 h-5 w-5" />
+    <form
+      v-if="editing"
+      class="flex min-w-0 flex-1 items-center gap-1.5"
+      @submit.prevent="submitName"
+    >
+      <UInput
+        v-model="draft"
+        autofocus
+        size="sm"
+        class="min-w-0 flex-1 sm:max-w-xs"
+        :aria-label="t('page.settings.card.apitokens.edit_name')"
+        :placeholder="t('page.settings.card.apitokens.form.note_placeholder')"
+        @keydown.esc.prevent="$emit('cancel')"
+      />
+      <UTooltip :text="t('page.settings.card.apitokens.save_name')">
+        <UButton
+          type="submit"
+          icon="i-mdi-check"
+          color="success"
+          variant="ghost"
+          size="xs"
+          :padded="false"
+          :loading="loading"
+          :disabled="!hasChanges"
+          :aria-label="t('page.settings.card.apitokens.save_name')"
+        />
+      </UTooltip>
+      <UTooltip :text="t('page.settings.card.apitokens.cancel_name_edit')">
+        <UButton
+          type="button"
+          icon="i-mdi-close"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          :padded="false"
+          :disabled="loading"
+          :aria-label="t('page.settings.card.apitokens.cancel_name_edit')"
+          @click="$emit('cancel')"
+        />
+      </UTooltip>
+    </form>
+    <template v-else>
+      <span class="text-surface-50 truncate font-medium">
+        {{ displayName }}
+      </span>
+      <UTooltip :text="t('page.settings.card.apitokens.edit_name')">
+        <UButton
+          type="button"
+          icon="i-mdi-pencil-outline"
+          color="neutral"
+          variant="ghost"
+          size="xs"
+          :padded="false"
+          :disabled="disabled"
+          :aria-label="t('page.settings.card.apitokens.edit_name_aria', { name: displayName })"
+          @click="$emit('edit')"
+        />
+      </UTooltip>
+    </template>
+  </div>
+</template>
+<script setup lang="ts">
+  const props = defineProps<{
+    disabled: boolean;
+    editing: boolean;
+    loading: boolean;
+    name: string | null;
+  }>();
+  const emit = defineEmits<{
+    cancel: [];
+    edit: [];
+    save: [name: string | null];
+  }>();
+  const { t } = useI18n({ useScope: 'global' });
+  const draft = ref('');
+  const normalizeName = (value: string | null) => value?.trim() || null;
+  const displayName = computed(() => props.name || t('page.settings.card.apitokens.default_note'));
+  const hasChanges = computed(
+    () => !props.loading && normalizeName(draft.value) !== normalizeName(props.name)
+  );
+  const submitName = () => {
+    if (!hasChanges.value) return;
+    emit('save', normalizeName(draft.value));
+  };
+  watch(
+    () => props.editing,
+    (editing) => {
+      if (editing) {
+        draft.value = props.name || '';
+      }
+    },
+    { immediate: true }
+  );
+</script>

--- a/app/features/settings/ApiTokens.vue
+++ b/app/features/settings/ApiTokens.vue
@@ -59,12 +59,15 @@
         >
           <div class="flex flex-wrap items-start justify-between gap-3">
             <div class="w-full space-y-2">
-              <div class="flex items-center gap-2">
-                <UIcon name="i-mdi-key-variant" class="text-primary-400 h-5 w-5" />
-                <span class="text-surface-50 font-medium">
-                  {{ token.note || t('page.settings.card.apitokens.default_note') }}
-                </span>
-              </div>
+              <ApiTokenNameEditor
+                :name="token.note"
+                :editing="editingTokenId === token.id"
+                :loading="renamingId === token.id"
+                :disabled="renamingId !== null"
+                @edit="startTokenNameEdit(token.id)"
+                @cancel="cancelTokenNameEdit"
+                @save="renameToken(token, $event)"
+              />
               <div class="flex flex-wrap gap-1.5 text-xs">
                 <UBadge
                   :color="
@@ -167,6 +170,7 @@
                 icon="i-mdi-close-circle"
                 size="xs"
                 :loading="revokingId === token.id"
+                :disabled="renamingId === token.id"
                 @click="revokeToken(token.id)"
               >
                 {{ t('page.settings.card.apitokens.revoke_button') }}
@@ -290,6 +294,7 @@
 <script setup lang="ts">
   import { useEdgeFunctions } from '@/composables/api/useEdgeFunctions';
   import { useDiagnosticToast } from '@/composables/useDiagnosticToast';
+  import ApiTokenNameEditor from '@/features/settings/ApiTokenNameEditor.vue';
   import {
     API_PERMISSIONS,
     API_TOKEN_PREFIXES,
@@ -308,6 +313,9 @@
     token_value?: string;
     user_id: string;
   };
+  type ApiTokenUpdatePayload = {
+    note: string | null;
+  };
   type SupabaseTokenError = {
     code?: string;
     message?: string;
@@ -315,6 +323,7 @@
   interface SupabaseTable {
     select: (query: string) => SupabaseTable;
     insert: (data: ApiTokenInsertPayload) => SupabaseTable;
+    update: (data: ApiTokenUpdatePayload) => SupabaseTable;
     eq: (column: string, value: string) => SupabaseTable;
     order: (column: string, options?: { ascending: boolean }) => SupabaseTable;
     single: () => Promise<{ data: { token_id: string } | null; error: SupabaseTokenError }>;
@@ -334,6 +343,8 @@
   const loading = ref(false);
   const creating = ref(false);
   const revokingId = ref<string | null>(null);
+  const renamingId = ref<string | null>(null);
+  const editingTokenId = ref<string | null>(null);
   const tokens = ref<TokenRow[]>([]);
   const selectedGameMode = ref<GameMode>(GAME_MODES.PVP);
   const selectedPermissions = ref<TokenPermission[]>(['GP']);
@@ -343,6 +354,7 @@
   const supportsRawTokens = ref(true);
   let createTokenRequestId = 0;
   let loadTokensRequestId = 0;
+  let renameTokenRequestId = 0;
   const userLoggedIn = computed(() => $supabase.user.loggedIn);
   const permissionOptions = computed(() =>
     Object.entries(API_PERMISSIONS).map(([key, value]) => ({
@@ -424,12 +436,18 @@
   const invalidateTokenCreates = () => {
     createTokenRequestId += 1;
   };
+  const invalidateTokenRenames = () => {
+    renameTokenRequestId += 1;
+  };
   const resetUserScopedState = () => {
     invalidateTokenCreates();
     invalidateTokenLoads();
+    invalidateTokenRenames();
     loading.value = false;
     creating.value = false;
     revokingId.value = null;
+    renamingId.value = null;
+    editingTokenId.value = null;
     tokens.value = [];
     visibleTokens.value = new Set();
     showCreateDialog.value = false;
@@ -442,6 +460,13 @@
   };
   const isCurrentTokenCreate = (requestId: number, userId: string) => {
     return requestId === createTokenRequestId && getActiveUserId() === userId;
+  };
+  const isCurrentTokenRename = (requestId: number, userId: string, tokenId: string) => {
+    return (
+      requestId === renameTokenRequestId &&
+      getActiveUserId() === userId &&
+      editingTokenId.value === tokenId
+    );
   };
   const loadTokens = async () => {
     const table = tableClient();
@@ -683,6 +708,98 @@
     if (!token) return '';
     if (token.length <= 12) return token;
     return `${token.substring(0, 8)}...${token.substring(token.length - 4)}`;
+  };
+  const startTokenNameEdit = (tokenId: string) => {
+    if (renamingId.value !== null) return;
+    editingTokenId.value = tokenId;
+  };
+  const cancelTokenNameEdit = () => {
+    if (renamingId.value !== null) return;
+    editingTokenId.value = null;
+  };
+  const getTokenRenameContext = (tokenId: string) => {
+    const table = tableClient();
+    const userId = getActiveUserId();
+    const blocked = [!table, !userId, editingTokenId.value !== tokenId, renamingId.value !== null];
+    if (blocked.includes(true)) {
+      return null;
+    }
+    return { table: table as SupabaseTable, userId: userId as string };
+  };
+  const persistTokenName = async (
+    table: SupabaseTable,
+    tokenId: string,
+    userId: string,
+    name: string | null
+  ) => {
+    const { data, error } = await table
+      .update({ note: name })
+      .eq('token_id', tokenId)
+      .eq('user_id', userId)
+      .select('token_id')
+      .single();
+    if (error) {
+      throw error;
+    }
+    if (data?.token_id !== tokenId) {
+      throw new Error('Token rename returned no matching token');
+    }
+  };
+  const showTokenRenameError = (error: unknown, tokenId: string, userId: string) => {
+    logger.error('[ApiTokens] Failed to rename token:', error);
+    showErrorToast({
+      title: t('page.settings.card.apitokens.name_update_error'),
+      error,
+      context: {
+        action: 'rename',
+        area: 'api_tokens',
+        tokenId,
+        userId,
+      },
+      reportTitle: t('page.settings.card.apitokens.report.rename_failed'),
+    });
+  };
+  const finishTokenRename = (requestId: number) => {
+    if (requestId === renameTokenRequestId) {
+      renamingId.value = null;
+    }
+  };
+  const applyTokenRename = (
+    requestId: number,
+    token: TokenRow,
+    userId: string,
+    nextName: string | null
+  ) => {
+    if (!isCurrentTokenRename(requestId, userId, token.id)) return;
+    token.note = nextName;
+    editingTokenId.value = null;
+    toast.add({
+      title: t('page.settings.card.apitokens.name_updated'),
+      color: 'success',
+    });
+  };
+  const handleTokenRenameFailure = (
+    requestId: number,
+    error: unknown,
+    tokenId: string,
+    userId: string
+  ) => {
+    if (!isCurrentTokenRename(requestId, userId, tokenId)) return;
+    showTokenRenameError(error, tokenId, userId);
+  };
+  const renameToken = async (token: TokenRow, nextName: string | null) => {
+    const context = getTokenRenameContext(token.id);
+    if (!context) return;
+    const requestId = ++renameTokenRequestId;
+    renamingId.value = token.id;
+    try {
+      await persistTokenName(context.table, token.id, context.userId, nextName);
+      applyTokenRename(requestId, token, context.userId, nextName);
+    } catch (error) {
+      handleTokenRenameFailure(requestId, error, token.id, context.userId);
+    } finally {
+      finishTokenRename(requestId);
+    }
   };
   const revokeToken = async (tokenId: string) => {
     if (!tokenId) return;

--- a/app/features/settings/ApiTokens.vue
+++ b/app/features/settings/ApiTokens.vue
@@ -766,12 +766,13 @@
   };
   const applyTokenRename = (
     requestId: number,
-    token: TokenRow,
+    tokenId: string,
     userId: string,
     nextName: string | null
   ) => {
-    if (!isCurrentTokenRename(requestId, userId, token.id)) return;
-    token.note = nextName;
+    if (!isCurrentTokenRename(requestId, userId, tokenId)) return;
+    const currentToken = tokens.value.find((token) => token.id === tokenId);
+    if (currentToken) currentToken.note = nextName;
     editingTokenId.value = null;
     toast.add({
       title: t('page.settings.card.apitokens.name_updated'),
@@ -794,7 +795,7 @@
     renamingId.value = token.id;
     try {
       await persistTokenName(context.table, token.id, context.userId, nextName);
-      applyTokenRename(requestId, token, context.userId, nextName);
+      applyTokenRename(requestId, token.id, context.userId, nextName);
     } catch (error) {
       handleTokenRenameFailure(requestId, error, token.id, context.userId);
     } finally {

--- a/app/features/settings/__tests__/ApiTokens.test.ts
+++ b/app/features/settings/__tests__/ApiTokens.test.ts
@@ -411,6 +411,44 @@ describe('ApiTokens', () => {
     ).toHaveLength(0);
     expect(wrapper.text()).not.toContain('Renamed Token A');
   });
+  it('applies a token rename to the current row after a concurrent list reload', async () => {
+    let resolveRename: ((value: { data: { token_id: string }; error: null }) => void) | undefined;
+    mockUpdateSingle.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRename = resolve;
+        })
+    );
+    mockRevokeToken.mockResolvedValueOnce(undefined);
+    const wrapper = await createWrapper();
+    await flushPromises();
+    resolveLoadMany('user-a', [
+      makeTokenRow('user-a', 'Existing Token', { token_id: 'user-a-token' }),
+      makeTokenRow('user-a', 'Other Token', { token_id: 'user-a-other-token' }),
+    ]);
+    await flushPromises();
+    await wrapper
+      .findAll('button[aria-label="page.settings.card.apitokens.edit_name_aria"]')[0]!
+      .trigger('click');
+    await wrapper
+      .find('input[aria-label="page.settings.card.apitokens.edit_name"]')
+      .setValue('Renamed Token');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+    const revokeButtons = wrapper
+      .findAll('button')
+      .filter((button) => button.text() === 'page.settings.card.apitokens.revoke_button');
+    await revokeButtons[1]!.trigger('click');
+    await flushPromises();
+    resolveLoadMany('user-a', [
+      makeTokenRow('user-a', 'Existing Token', { token_id: 'user-a-token' }),
+    ]);
+    await flushPromises();
+    resolveRename?.({ data: { token_id: 'user-a-token' }, error: null });
+    await flushPromises();
+    expect(wrapper.text()).toContain('Renamed Token');
+    expect(wrapper.text()).not.toContain('Existing Token');
+  });
   it('shows an error instead of bypassing the function when token creation throws a statusless error', async () => {
     mockCreateToken.mockRejectedValueOnce(new Error('Internal server error'));
     const wrapper = await createWrapper();

--- a/app/features/settings/__tests__/ApiTokens.test.ts
+++ b/app/features/settings/__tests__/ApiTokens.test.ts
@@ -3,10 +3,15 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { reactive } from 'vue';
-const { mockCreateToken, mockRevokeToken } = vi.hoisted(() => ({
-  mockCreateToken: vi.fn(),
-  mockRevokeToken: vi.fn(),
-}));
+const { mockCreateToken, mockEq, mockRevokeToken, mockUpdate, mockUpdateSingle } = vi.hoisted(
+  () => ({
+    mockCreateToken: vi.fn(),
+    mockEq: vi.fn(),
+    mockRevokeToken: vi.fn(),
+    mockUpdate: vi.fn(),
+    mockUpdateSingle: vi.fn(),
+  })
+);
 const mockSupabaseUser = reactive({
   loggedIn: true,
   id: 'user-a',
@@ -43,14 +48,24 @@ const pendingCreates = new Map<
 const mockInsert = vi.fn();
 const mockInsertSingle = vi.fn();
 const mockFrom = vi.fn(() => {
+  let operation: 'insert' | 'select' | 'update' = 'select';
   let currentUserId = '';
   const table = {
     insert: vi.fn((payload: Record<string, unknown>) => {
+      operation = 'insert';
       mockInsert(payload);
       return table;
     }),
-    eq: vi.fn((_column: string, userId: string) => {
-      currentUserId = userId;
+    update: vi.fn((payload: Record<string, unknown>) => {
+      operation = 'update';
+      mockUpdate(payload);
+      return table;
+    }),
+    eq: vi.fn((column: string, value: string) => {
+      mockEq(column, value);
+      if (column === 'user_id') {
+        currentUserId = value;
+      }
       return table;
     }),
     order: vi.fn(
@@ -60,7 +75,7 @@ const mockFrom = vi.fn(() => {
         })
     ),
     select: vi.fn(() => table),
-    single: vi.fn(() => mockInsertSingle()),
+    single: vi.fn(() => (operation === 'update' ? mockUpdateSingle() : mockInsertSingle())),
   };
   return table;
 });
@@ -104,10 +119,10 @@ const createWrapper = async () => {
           template: '<span><slot /></span>',
         },
         UButton: {
-          props: ['disabled', 'loading'],
+          props: ['ariaLabel', 'disabled', 'loading', 'type'],
           emits: ['click'],
           template:
-            '<button :disabled="disabled" :data-loading="loading" @click="$emit(\'click\')"><slot /></button>',
+            '<button :type="type" :aria-label="ariaLabel" :disabled="disabled" :data-loading="loading" @click="$emit(\'click\')"><slot /></button>',
         },
         UCard: {
           template: '<div><slot /></div>',
@@ -123,10 +138,10 @@ const createWrapper = async () => {
         },
         UIcon: true,
         UInput: {
-          props: ['modelValue'],
+          props: ['ariaLabel', 'modelValue'],
           emits: ['update:modelValue'],
           template:
-            '<input :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
+            '<input :aria-label="ariaLabel" :value="modelValue" @input="$emit(\'update:modelValue\', $event.target.value)" />',
         },
         UModal: {
           props: ['open'],
@@ -209,8 +224,11 @@ describe('ApiTokens', () => {
     mockSupabaseUser.loggedIn = true;
     mockSupabaseUser.id = 'user-a';
     mockCreateToken.mockReset();
+    mockEq.mockReset();
     mockInsert.mockReset();
     mockInsertSingle.mockReset();
+    mockUpdate.mockReset();
+    mockUpdateSingle.mockReset();
     mockCreateToken.mockImplementation(
       () =>
         new Promise((resolve) => {
@@ -284,6 +302,114 @@ describe('ApiTokens', () => {
         ([payload]) => payload.title === 'page.settings.card.apitokens.create_token_success'
       )
     ).toHaveLength(1);
+  });
+  it('renames a token inline and trims the saved name', async () => {
+    mockUpdateSingle.mockResolvedValueOnce({
+      data: { token_id: 'user-a-token' },
+      error: null,
+    });
+    const wrapper = await createWrapper();
+    await flushPromises();
+    resolveLoad('user-a', 'Existing Token');
+    await flushPromises();
+    const editButton = wrapper.find(
+      'button[aria-label="page.settings.card.apitokens.edit_name_aria"]'
+    );
+    expect(editButton.exists()).toBe(true);
+    await editButton.trigger('click');
+    const nameInput = wrapper.find('input[aria-label="page.settings.card.apitokens.edit_name"]');
+    expect((nameInput.element as HTMLInputElement).value).toBe('Existing Token');
+    const saveButton = wrapper.find('button[aria-label="page.settings.card.apitokens.save_name"]');
+    expect(saveButton.attributes('disabled')).toBeDefined();
+    await nameInput.setValue('  Renamed Token  ');
+    expect(saveButton.attributes('disabled')).toBeUndefined();
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+    expect(mockUpdate).toHaveBeenCalledWith({ note: 'Renamed Token' });
+    expect(mockEq).toHaveBeenCalledWith('token_id', 'user-a-token');
+    expect(mockEq).toHaveBeenCalledWith('user_id', 'user-a');
+    expect(wrapper.text()).toContain('Renamed Token');
+    expect(wrapper.text()).not.toContain('Existing Token');
+    expect(mockToast.add).toHaveBeenCalledWith({
+      title: 'page.settings.card.apitokens.name_updated',
+      color: 'success',
+    });
+  });
+  it('allows clearing a token name back to the untitled fallback', async () => {
+    mockUpdateSingle.mockResolvedValueOnce({
+      data: { token_id: 'user-a-token' },
+      error: null,
+    });
+    const wrapper = await createWrapper();
+    await flushPromises();
+    resolveLoad('user-a', 'Existing Token');
+    await flushPromises();
+    await wrapper
+      .find('button[aria-label="page.settings.card.apitokens.edit_name_aria"]')
+      .trigger('click');
+    await wrapper.find('input[aria-label="page.settings.card.apitokens.edit_name"]').setValue(' ');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+    expect(mockUpdate).toHaveBeenCalledWith({ note: null });
+    expect(wrapper.text()).toContain('page.settings.card.apitokens.default_note');
+  });
+  it('keeps the name editor open when a rename fails', async () => {
+    mockUpdateSingle.mockResolvedValueOnce({
+      data: null,
+      error: { message: 'Rename failed' },
+    });
+    const wrapper = await createWrapper();
+    await flushPromises();
+    resolveLoad('user-a', 'Existing Token');
+    await flushPromises();
+    await wrapper
+      .find('button[aria-label="page.settings.card.apitokens.edit_name_aria"]')
+      .trigger('click');
+    await wrapper
+      .find('input[aria-label="page.settings.card.apitokens.edit_name"]')
+      .setValue('Retry Token');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+    expect(
+      wrapper.find('input[aria-label="page.settings.card.apitokens.edit_name"]').exists()
+    ).toBe(true);
+    expect(mockToast.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: 'Rename failed',
+        title: 'page.settings.card.apitokens.name_update_error',
+      })
+    );
+  });
+  it('ignores a token rename response after an account switch', async () => {
+    let resolveRename: ((value: { data: { token_id: string }; error: null }) => void) | undefined;
+    mockUpdateSingle.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveRename = resolve;
+        })
+    );
+    const wrapper = await createWrapper();
+    await flushPromises();
+    resolveLoad('user-a', 'Token A');
+    await flushPromises();
+    await wrapper
+      .find('button[aria-label="page.settings.card.apitokens.edit_name_aria"]')
+      .trigger('click');
+    await wrapper
+      .find('input[aria-label="page.settings.card.apitokens.edit_name"]')
+      .setValue('Renamed Token A');
+    await wrapper.find('form').trigger('submit');
+    await flushPromises();
+    mockSupabaseUser.id = 'user-b';
+    await flushPromises();
+    resolveRename?.({ data: { token_id: 'user-a-token' }, error: null });
+    await flushPromises();
+    expect(
+      mockToast.add.mock.calls.filter(
+        ([payload]) => payload.title === 'page.settings.card.apitokens.name_updated'
+      )
+    ).toHaveLength(0);
+    expect(wrapper.text()).not.toContain('Renamed Token A');
   });
   it('shows an error instead of bypassing the function when token creation throws a statusless error', async () => {
     mockCreateToken.mockRejectedValueOnce(new Error('Internal server error'));

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1111,6 +1111,12 @@
           "load_tokens_error": "Failed to load API tokens.",
           "copy_failed": "Failed to copy token.",
           "copy_token": "Copy token",
+          "edit_name": "Edit token name",
+          "edit_name_aria": "Edit token name for {name}",
+          "save_name": "Save token name",
+          "cancel_name_edit": "Cancel token name edit",
+          "name_updated": "Token name updated",
+          "name_update_error": "Failed to update token name. Please try again.",
           "token_created": "Token created",
           "token_created_description": "Copy and store this token now. You will not be able to view it again.",
           "token_created_close": "Done",
@@ -1132,6 +1138,7 @@
           "report": {
             "load_failed": "API token load failed",
             "create_failed": "API token creation failed",
+            "rename_failed": "API token rename failed",
             "revoke_failed": "API token revoke failed"
           },
           "list": {

--- a/docs/API.md
+++ b/docs/API.md
@@ -407,6 +407,10 @@ Polling integrators (TarkovMonitor, tarkov.dev, RatScanner) should poll read end
 
 Each account may have at most **3 active API tokens**. This is enforced by a database trigger, so token rotation cannot bypass it. The `token-create` Edge Function returns `409` with `error: "Token limit reached (3 active)"` when the cap is reached. Revoke an existing token before creating a new one. Token creation is only allowed through the `token-create` Edge Function (authenticated clients cannot insert into `api_tokens` directly) and is rate-limited to 3 creates per hour per account.
 
+Token names can be changed from Settings → API Tokens without rotating the token. Renaming updates
+only the token's optional `note`: authenticated users receive column-level `UPDATE (note)` permission,
+and row-level security requires the token owner for both the existing and resulting row.
+
 ### Token Prefixes
 
 Progress API tokens are prefixed `PVP_`, `PVE_`, or `SZN_`. The prefix declares the token's mode,

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -155,6 +155,8 @@ RPC + table: migration `supabase/migrations/20260404120000_add_mutation_rate_lim
   `ApiTokens.vue`). Keep that flag off in production so create stays on the Edge limiter.
 - **Token revoke** has an automatic unavailable-function fallback to direct delete in
   `useEdgeFunctions.revokeToken`. That path **skips** the Edge limiter; DB/RLS still apply.
+- **Token rename** is a direct PostgREST update and is not Edge-rate-limited. Database grants restrict
+  authenticated updates to the `note` column, and RLS restricts the row to its owner.
 - The DB still enforces the **max 3 active tokens** trigger even if rate limiting is skipped.
 - Prefer keeping create/revoke behind Edge Functions in production and avoid enabling create
   fallbacks.

--- a/supabase/migrations/20260810140000_limit_api_token_updates_to_note.sql
+++ b/supabase/migrations/20260810140000_limit_api_token_updates_to_note.sql
@@ -1,0 +1,37 @@
+BEGIN;
+
+REVOKE UPDATE ON TABLE public.api_tokens FROM PUBLIC, anon, authenticated;
+
+DO $$
+DECLARE
+  update_columns text;
+BEGIN
+  SELECT string_agg(format('%I', attname), ', ' ORDER BY attnum)
+    INTO update_columns
+  FROM pg_attribute
+  WHERE attrelid = 'public.api_tokens'::regclass
+    AND attnum > 0
+    AND NOT attisdropped;
+
+  IF update_columns IS NULL THEN
+    RAISE EXCEPTION 'No columns found for public.api_tokens';
+  END IF;
+
+  EXECUTE format(
+    'REVOKE UPDATE (%s) ON public.api_tokens FROM PUBLIC, anon, authenticated',
+    update_columns
+  );
+END;
+$$;
+
+GRANT UPDATE (note) ON TABLE public.api_tokens TO authenticated;
+
+DROP POLICY IF EXISTS "Users can update own API tokens" ON public.api_tokens;
+
+CREATE POLICY "Users can update own API tokens" ON public.api_tokens
+  FOR UPDATE
+  TO authenticated
+  USING ((SELECT auth.uid()) = user_id)
+  WITH CHECK ((SELECT auth.uid()) = user_id);
+
+COMMIT;

--- a/workers/api-gateway/src/__tests__/token-note-update-migration.test.ts
+++ b/workers/api-gateway/src/__tests__/token-note-update-migration.test.ts
@@ -1,0 +1,37 @@
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+const migrationPath = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  '../../../../supabase/migrations/20260810140000_limit_api_token_updates_to_note.sql'
+);
+const migrationSql = readFileSync(migrationPath, 'utf-8');
+describe('API token note update migration', () => {
+  it('revokes broad table and column update privileges', () => {
+    expect(migrationSql).toContain(
+      'REVOKE UPDATE ON TABLE public.api_tokens FROM PUBLIC, anon, authenticated'
+    );
+    expect(migrationSql).toContain("attrelid = 'public.api_tokens'::regclass");
+    expect(migrationSql).toContain(
+      'REVOKE UPDATE (%s) ON public.api_tokens FROM PUBLIC, anon, authenticated'
+    );
+  });
+  it('grants authenticated users update access to note only', () => {
+    expect(migrationSql).toContain(
+      'GRANT UPDATE (note) ON TABLE public.api_tokens TO authenticated'
+    );
+    expect(migrationSql).not.toMatch(/GRANT UPDATE \((?!note\))[^)]*\)/);
+  });
+  it('limits the update policy to the authenticated owner', () => {
+    expect(migrationSql).toMatch(
+      /CREATE POLICY "Users can update own API tokens"[\s\S]*FOR UPDATE[\s\S]*TO authenticated/
+    );
+    expect(migrationSql).toContain('USING ((SELECT auth.uid()) = user_id)');
+    expect(migrationSql).toContain('WITH CHECK ((SELECT auth.uid()) = user_id)');
+  });
+  it('applies the privilege and policy changes atomically', () => {
+    expect(migrationSql.trimStart()).toMatch(/^BEGIN;/);
+    expect(migrationSql.trimEnd()).toMatch(/COMMIT;$/);
+  });
+});

--- a/workers/api-gateway/src/__tests__/token-note-update-migration.test.ts
+++ b/workers/api-gateway/src/__tests__/token-note-update-migration.test.ts
@@ -22,6 +22,12 @@ describe('API token note update migration', () => {
       'GRANT UPDATE (note) ON TABLE public.api_tokens TO authenticated'
     );
     expect(migrationSql).not.toMatch(/GRANT UPDATE \((?!note\))[^)]*\)/);
+    expect(migrationSql).not.toMatch(
+      /GRANT UPDATE ON TABLE public\.api_tokens TO (?:PUBLIC|anon|authenticated)/
+    );
+    expect(migrationSql).not.toMatch(
+      /GRANT UPDATE \(note\) ON TABLE public\.api_tokens TO (?:PUBLIC|anon)/
+    );
   });
   it('limits the update policy to the authenticated owner', () => {
     expect(migrationSql).toMatch(


### PR DESCRIPTION
## **User description**
## Summary

- add an accessible inline pencil control beside each API token name
- let users save a trimmed name or clear it to restore the Untitled token fallback
- persist only the token note and ignore stale responses after an account switch
- restrict authenticated `api_tokens` updates to the `note` column with owner-scoped RLS
- document token renaming and add UI plus migration contract coverage

## Why

API token labels could only be set when the token was created. Users had no visible way to correct or clarify a token name later.

## Security

- revoke broad authenticated `UPDATE` privileges on `api_tokens`
- grant `UPDATE(note)` only
- enforce ownership in both the RLS `USING` and `WITH CHECK` clauses
- leave service-role behavior unchanged

## Validation

- `pnpm exec vitest run app/features/settings/__tests__/ApiTokens.test.ts` — 12 passed
- API gateway test suite — 162 passed
- Nuxt and precompute TypeScript checks — passed
- ESLint and blank-line lint — passed
- changed-file fallow audit — passed
- i18n check — passed
- targeted Prettier check — passed
- systems documentation check — passed
- production build with `CI=true` — passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline editing for API token names in Settings.
  * Users can save, cancel, clear, and rename token names without rotating tokens.
  * Added success, loading, and error feedback during renaming.

* **Security**
  * Restricted token updates to the optional name field and the token owner.

* **Documentation**
  * Documented API token renaming, permissions, ownership requirements, and rate-limit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

___

## **CodeAnt-AI Description**
Let users rename API tokens without replacing them

### What Changed
- API token names can be edited inline from Settings, with save, cancel, and clear-to-“Untitled token” actions
- Names are trimmed before saving, and users receive success or error feedback
- Failed renames keep the editor open for another attempt
- Renaming updates only the token name for its owner; token values, permissions, IDs, and usage data remain unchanged
- Stale rename responses are ignored after an account switch or token list refresh

### Impact
`✅ Clearer API token names`
`✅ No token rotation during renaming`
`✅ Safer owner-only token updates`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds inline API-token renaming while limiting authenticated database updates to the token note owned by the current user.
- Adds an accessible editor with trimming, clearing, cancellation, loading, and error states.
- Persists renames through an owner-filtered Supabase update and safely reconciles concurrent list reloads and account switches.
- Adds an atomic migration restricting authenticated updates to `note` under owner-scoped RLS.
- Documents the token-renaming contract and adds focused UI and migration coverage.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/features/settings/ApiTokenNameEditor.vue | Adds an accessible inline editor that normalizes names and emits explicit edit, cancel, and save actions. |
| app/features/settings/ApiTokens.vue | Persists note-only renames, ignores stale account responses, and applies successful results to the current token row after list replacement. |
| app/features/settings/__tests__/ApiTokens.test.ts | Covers trimming, clearing, errors, account switching, and concurrent list reload behavior. |
| supabase/migrations/20260810140000_limit_api_token_updates_to_note.sql | Atomically narrows authenticated updates to the note column and enforces ownership in both RLS predicates. |
| AGENTS.md | Records the canonical note-only and owner-scoped API-token rename contract. |
| workers/api-gateway/src/__tests__/token-note-update-migration.test.ts | Verifies privilege narrowing, owner-scoped RLS, and migration atomicity. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant UI as API Token Settings
  participant DB as Supabase
  U->>UI: Edit and save token name
  UI->>DB: UPDATE api_tokens.note by token_id and user_id
  DB->>DB: Enforce UPDATE(note) grant and owner RLS
  DB-->>UI: Return matching token_id
  UI->>UI: Find current row by ID and apply name
  UI-->>U: Show updated token name
```
</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): address token rename review fe..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/43906f5b36dfbf996ec883887e2f21002006823f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51813028)</sub>

<!-- /greptile_comment -->