### PR TITLE
ci: update CI actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,7 @@ jobs:
         run: pnpm install --frozen-lockfile
       - name: Setup Deno
         if: matrix.shard == 1
-        uses: denoland/setup-deno@e95548e56dfa95d4e1a28d6f422fafe75c4c26fb
+        uses: denoland/setup-deno@22d081ff2d3a40755e97629de92e3bcbfa7cf2ed
         with:
           deno-version: v2.9.4
       - name: Run Deno tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,7 +156,7 @@ jobs:
         run: pnpm exec vitest run --coverage --shard=${{ matrix.shard }}/${{ matrix.total }}
       - name: Upload coverage to Codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
@@ -165,7 +165,7 @@ jobs:
           fail_ci_if_error: false
       - name: Upload test results to Codecov
         if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true) && !cancelled()
-        uses: codecov/codecov-action@0fb7174895f61a3b6b78fc075e0cd60383518dac
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:


### PR DESCRIPTION
## Summary

- update `denoland/setup-deno` from v2.0.3 to signed v2.0.5
- update both `codecov/codecov-action` uploads from v5.5.5 to signed v6.0.2
- retain Deno 2.9.4 and all existing Codecov upload inputs
- move every affected CI action from Node 20 to Node 24

## Root cause

The workflow directly pinned a Node 20 `setup-deno` release. After that pin was corrected, the runner still emitted the same warning because Codecov v5.5.5 internally invoked `actions/github-script` v7 on Node 20. Codecov v6.0.2 uses `github-script` v8 on Node 24 without changing the inputs used here.

Repository and organization Actions policies allow verified actions. All replacements are immutable signed commit SHAs.

## Validation

- `git diff --check`
- `pnpm exec prettier --check .github/workflows/ci.yml`
- `pnpm run lint:blank-lines`
- pre-commit hook for staged YAML
- verified upstream signatures, manifests, tag targets, and input compatibility
- CI runner-log verification on the final head

Closes #688

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

----
## Summary by Gitar

- **CI updates:**
    - Updated `codecov/codecov-action` to version `fb8b3582c8e4def4969c97caa2f19720cb33a72f` for Node 24 support

<sub>This will update automatically on new commits.</sub>

___

## **CodeAnt-AI Description**
Update CI actions for Node 24 compatibility

### What Changed
- CI now sets up Deno using the Node 24-compatible action release while keeping Deno 2.9.4
- Coverage and test-result uploads now use the Node 24-compatible Codecov action release
- Existing test, coverage, and fork-handling behavior remains unchanged

### Impact
`✅ Node 24-compatible CI runs`
`✅ Reliable coverage uploads`
`✅ Unchanged Deno test coverage`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR updates the pinned setup-deno and Codecov action revisions to Node 24-compatible releases while retaining the existing Deno version and upload configuration.

- Updates `denoland/setup-deno` in the test job.
- Updates both Codecov coverage and test-result upload steps.
- Preserves existing fork guards, upload paths, flags, and failure behavior.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/ci.yml | Updates three immutable action revisions without changing the surrounding CI conditions or inputs. |

</details>

<sub>Reviews (2): Last reviewed commit: ["ci: retrigger Node 24 verification"](https://github.com/tarkovtracker-org/tarkovtracker/commit/4f765f0ec5d4961841e1a362e8f20417dd6f1c33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51852396)</sub>

**Context used:**

- Knowledge Base — [CI/CD Workflows and PR Automation](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/ci-cd-workflows.md)

<!-- /greptile_comment -->