### PR TITLE
docs(docs): deduplicate and trim AGENTS.md — save ~410 tokens

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,11 +90,9 @@ Before finishing any agent task:
 - State what validation was run and what passed/failed.
 - Do not run the full test suite unless you changed test logic or executable code that could break tests.
 - Respect existing lint warnings; do not introduce new ones.
-- Formatting is handled by the pre-commit hook (husky + lint-staged runs prettier, ESLint, and the blank-line fixer on staged files). Do not run `pnpm run format` manually unless the hook is bypassed or cannot run (missing `node_modules` / husky harness). CI `format:check` is the gate; never commit knowing hooks were skipped without formatting staged paths yourself.
-- Coverage is uploaded to Codecov by the CI `test` job (see `.github/workflows/ci.yml`). Repo-level config is in `codecov.yml`. Uses the org-level `CODECOV_TOKEN` secret for token-authenticated uploads (required on protected branches).
-- Bundle analysis is uploaded by the CI `validate` job during `pnpm run build` via `@codecov/nuxt-plugin` (configured in `nuxt.config.ts`). The plugin only activates when `CODECOV_TOKEN` is set, so local builds are unaffected.
-- Test results (JUnit XML) are uploaded by the CI `test` job via `codecov/codecov-action` with `report_type: test_results`. Vitest outputs `test-report.junit.xml` when `CI=true` (configured in `vitest.config.ts`). The upload step is `!cancelled()`-gated so failing shards' JUnit reports still reach Codecov.
-- The CI `test` job runs as a 4-way shard matrix (`Test (shard 1/4)` through `Test (shard 4/4)`). Each shard sets `VITEST_SHARD=N/4`, which enables the `github-actions` reporter (annotates failed tests on the PR diff) and disables per-shard coverage thresholds (Codecov merges the per-shard lcov uploads and enforces an absolute floor via the `absolute-floor` project status in `codecov.yml`). Local `pnpm run test` / `pnpm run test:coverage` remain unsharded with vitest thresholds active.
+- Formatting is handled by the pre-commit hook. Do not run `pnpm run format` manually unless the hook is bypassed. CI `format:check` is the gate.
+- Coverage, bundle analysis, JUnit test results, and shard configuration are handled by CI — see
+  `docs/WORKFLOW_AUTOMATION.md`. Local `pnpm run test` / `pnpm run test:coverage` remain unsharded.
 
 ## Production Readiness Review
 
@@ -123,11 +121,8 @@ When asked to "review for production readiness", "deep review", "is this safe to
   the implicit `PUBLIC` grant and leaves those explicit role grants in place, which trips advisor
   lint 0028 on `SECURITY DEFINER` functions. Trigger functions and service-role-only helpers must
   name all three roles. Grant back to `service_role` explicitly when the service role needs it.
-- **Never put a bulk data rewrite in a migration.** The deployment runner applies each migration file
-  atomically even when `-- supabase:disable-transaction` is present, so a timeout rolls back the file
-  while other deploy targets can still succeed. Ship schema separately, make every read tolerate
-  missing rows, and use an approved operation with one independently committed range only when data
-  must be materialized. See the Database Migrations section of `docs/runbook.md`.
+- **Never put a bulk data rewrite in a migration.** Ship schema separately, make reads tolerate
+  missing rows. See the Database Migrations section of `docs/runbook.md`.
 - **Keep changes scoped** to the requested task. Prefer small, reviewable diffs.
 
 ## Coding Conventions
@@ -136,7 +131,8 @@ Formatting is enforced by Prettier + ESLint (see `.prettierrc`, `eslint.config.m
 
 - 2-space indent, 100-char lines, single quotes, semicolons, trailing commas (es5).
 - `.env.example` files use one-line `# === TITLE` section headers, not full-width `# ===...===` separator blocks. Tokenizers compress runs of repeated characters, so a long separator costs ~2–3 tokens — the same as a short one — and only adds agent token cost. These files are read often by agents; keep headers single-line and token-efficient.
-- Quote string values in `wrangler.toml`, where TOML requires string delimiters. Keep `.env`, `.env.*`, and `.dev.vars*` values unquoted by default to match dashboard entry style; quote only when dotenv semantics require it, such as preserving surrounding whitespace, `#`, or multiline content. Enter raw values without decorative quotes in Cloudflare dashboard value fields and interactive `wrangler secret put` prompts because Cloudflare preserves the submitted string. See `docs/ARCHITECTURE.md`.
+- Quote string values in `wrangler.toml` (TOML requires it). Keep `.env`/`.dev.vars` values unquoted
+  unless dotenv semantics require it. See `docs/ARCHITECTURE.md` for the full quoting convention.
 - Imports: alphabetically sorted, no blank lines between groups, group order: builtin → external → internal → parent → sibling → index → object → type.
 - Avoid unused imports/exports.
 - Keep functions small; prefer early returns. Avoid inline comments unless explaining a non-obvious decision.
@@ -171,7 +167,6 @@ Naming:
 
 ## Localization
 
-- `app/locales/en.json` is the source locale. Only edit this file.
 - Non-English files (`cs`, `de`, `es`, `fr`, `it`, `ko`, `pl`, `pt`, `ru`, `uk`, `zh`) are Crowdin-owned exports.
 - vue-i18n fallback locale is `en` (`app/i18n.config.ts`). Missing non-English keys render English automatically.
 - `pnpm run i18n:check` is fatal only for snake_case naming violations in `en.json`. Missing/orphaned keys in non-English files are informational.
@@ -237,13 +232,12 @@ Naming:
 
 - Prefer a normal branch in the current checkout (with existing `node_modules` and husky hooks) for the first in-flight task.
 - Before edits, run `git status --short --branch`.
-- Never mix unrelated changes in one commit or PR.
 - Do not use `git stash` for normal context switching unless the user asks.
 - Worktree policy (parallel work isolation):
   - Default to the main checkout for the first in-flight task. Do not create a worktree for solo work or for batched pre-PR edits the user is accumulating before opening a PR.
   - Create a worktree only when starting a SECOND concurrent task while the first is still in flight (uncommitted edits in the main checkout, or an open PR waiting on CI/review). The first task stays in the main checkout; the new task gets a worktree. This is what enables parallel agents without one agent reverting another's uncommitted changes.
   - Worktree convention: path `.wt/<branch>` (co-located, gitignored), created via `bash scripts/wt.sh add <branch>`. The script runs `scripts/setup-worktree.sh` so husky + lint-staged work on commit. State the worktree path in every status update so the user knows which checkout the agent is operating in.
-  - One agent per worktree. Never operate in a worktree another agent is using. Never run `git worktree remove` on a worktree you did not create. Never run `git restore`, `git checkout --`, `git clean`, or `git reset` on a working tree with changes you did not make — if the tree is unexpectedly dirty, stop and ask the user instead of cleaning it.
+  - One agent per worktree. Never operate in a worktree another agent is using. Never run `git worktree remove` on a worktree you did not create. If the tree is unexpectedly dirty, stop and ask the user instead of cleaning it.
   - After a worktree's PR merges, remove it with `bash scripts/wt.sh rm <branch>` so stale worktrees and branches don't accumulate.
 - Before every commit: ensure hooks can run (`node_modules` present and `core.hooksPath` / `.husky/_` exist). If they cannot, either run the bootstrap script or manually format/lint staged paths (Prettier for docs/markdown; ESLint for app TS/Vue; `node scripts/lint-blank-lines.mjs --fix` for supported source/config files) so CI `format:check` will pass. Do not commit with known-skipped hooks and unformatted staged files.
 - Commit scopes (from `commitlint.config.js`): `app`, `workers`, `api`, `ui`, `tasks`, `hideout`, `maps`, `team`, `settings`, `admin`, `i18n`, `deps`, `config`, `ci`, `test`, `docs`, `release`. Do not invent new scopes; omit the scope if none fits. Map common cases: `ui` for theme/styling/shell work, `docs` for repository/process documentation such as `AGENTS.md`.

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -296,11 +296,11 @@ pnpm --filter api-gateway exec wrangler deploy
 
 ### Coverage Reports
 
-Coverage reporting can be enabled by:
-
-- Adding `CODECOV_TOKEN` secret to repository
-- Configuring vitest with coverage options
-- Adding coverage upload step to CI workflow
+- Coverage is uploaded to Codecov by the CI `test` job. Repo-level config is in `codecov.yml`. Uses the org-level `CODECOV_TOKEN` secret for token-authenticated uploads (required on protected branches).
+- Bundle analysis is uploaded by the CI `validate` job during `pnpm run build` via `@codecov/nuxt-plugin` (configured in `nuxt.config.ts`). The plugin only activates when `CODECOV_TOKEN` is set, so local builds are unaffected.
+- Test results (JUnit XML) are uploaded via `codecov/codecov-action` with `report_type: test_results`. Vitest outputs `test-report.junit.xml` when `CI=true` (configured in `vitest.config.ts`). The upload step is `!cancelled()`-gated so failing shards' reports still reach Codecov.
+- The CI `test` job runs as a 4-way shard matrix (`Test (shard 1/4)` through `Test (shard 4/4)`). Each shard sets `VITEST_SHARD=N/4`, which enables the `github-actions` reporter (annotates failed tests on the PR diff) and disables per-shard coverage thresholds. Codecov merges the per-shard lcov uploads and enforces an absolute floor via the `absolute-floor` project status in `codecov.yml`.
+- Local `pnpm run test` / `pnpm run test:coverage` remain unsharded with vitest thresholds active.
 
 ## Local Development Workflow
 


### PR DESCRIPTION
## **User description**
## Summary

Removes internal duplication and trims explanatory text that's verbatim in deeper docs. ~410 tokens saved from the always-loaded AGENTS.md.

## Changes

**Deduplication (same rule stated in multiple places — keep one, remove others):**
- `en.json` edit restriction: kept in Hard Rules, removed from Localization intro
- "Never mix unrelated changes": kept as "Keep changes scoped" in Hard Rules, removed from Git Workflow
- Destructive git command list: kept in Hard Rules, removed from worktree policy paragraph
- Formatting hook obligation: condensed in Validation Policy (detail stays in Git Workflow hooks section)

**Trimmed explanations → xrefs (rationale lives in the deeper doc):**
- Bulk-migration prohibition: 5 lines → 2 lines + xref to `docs/runbook.md`
- Env var quoting convention: 4 lines → 2 lines + xref to `docs/ARCHITECTURE.md`
- CI operational trivia (Codecov upload, bundle analysis, JUnit XML, 4-way sharding): 4 paragraphs → 2-line summary + xref to `docs/WORKFLOW_AUTOMATION.md`

## Token impact

| File | Before | After | Saved |
|---|---|---|---|
| AGENTS.md | ~6,778 tokens | ~6,369 tokens | ~410 |

Combined with PR #687, always-loaded agent context is now ~6,440 tokens (down from ~7,640 at session start).

## What was tested

- `pnpm run lint:blank-lines` — passed
- Pre-commit hooks (prettier) — passed
- No code changes; documentation only

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/692?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Trim AGENTS.md and link detailed guidance from focused documentation

### What Changed
- Removes repeated rules and detailed CI, formatting, migration, environment variable, and worktree explanations from the always-loaded agent guide.
- Keeps the essential instructions in AGENTS.md while directing readers to `docs/WORKFLOW_AUTOMATION.md`, `docs/runbook.md`, and `docs/ARCHITECTURE.md` for full details.
- Preserves key local testing, formatting, localization, scope, and worktree guidance in a shorter form.

### Impact
`✅ Lower agent context usage`
`✅ Faster access to task-specific guidance`
`✅ Fewer duplicated repository instructions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR reduces duplication in the always-loaded agent guide while moving detailed CI guidance into the focused workflow document.
- Condenses repeated formatting, migration, environment-variable, localization, scope, and worktree instructions in `AGENTS.md`.
- Expands `docs/WORKFLOW_AUTOMATION.md` with the CI details needed by the new cross-reference.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Deduplicates repository guidance and redirects detailed CI behavior to the workflow automation document; the prior cross-reference omission is resolved. |
| docs/WORKFLOW_AUTOMATION.md | Adds the previously missing bundle-analysis, JUnit-upload, and four-way-sharding details referenced by AGENTS.md. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs(docs): add CI test infrastructure d..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/b0f0760beb6ac382fec25d929fe7d6f60ce4c086) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51851202)</sub>

**Context used:**

- Knowledge Base — [CI/CD Workflows and PR Automation](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/ci-cd-workflows.md)
- Knowledge Base — [Dev Tooling Scripts](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/dev-tooling-scripts.md)

<!-- /greptile_comment -->