### PR TITLE
docs(docs): agent context accuracy refresh and token trim

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -3,7 +3,8 @@
 <!-- AGENT QUICK REFERENCE
 Progress API host: api.tarkovtracker.org (Bearer api_token auth).
 Internal routes: /api/tarkov/* (cached game-data proxy, NOT a public integration surface).
-Team/profile routes: /api/team/*, /api/profile/* (Supabase JWT auth).
+Team routes: /api/team/* (Supabase JWT auth).
+Profile routes: /api/profile/* (public, rate-limited — no auth for shared profiles).
 Game modes in API: regular (pvp), pve, pvp-season (seasonal).
 Rate limits: §Rate Limits. OpenAPI spec: workers/api-gateway/src/openapi.ts.
 -->

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,5 +1,13 @@
 # TarkovTracker API Documentation
 
+<!-- AGENT QUICK REFERENCE
+Progress API host: api.tarkovtracker.org (Bearer api_token auth).
+Internal routes: /api/tarkov/* (cached game-data proxy, NOT a public integration surface).
+Team/profile routes: /api/team/*, /api/profile/* (Supabase JWT auth).
+Game modes in API: regular (pvp), pve, pvp-season (seasonal).
+Rate limits: §Rate Limits. OpenAPI spec: workers/api-gateway/src/openapi.ts.
+-->
+
 ## Overview
 
 TarkovTracker provides internal API routes for fetching game data and team information. Game data is proxied through Nuxt server routes to `json.tarkov.dev` with caching and overlay corrections applied.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,5 +1,12 @@
 # TarkovTracker Architecture Documentation
 
+<!-- AGENT QUICK REFERENCE
+Canonical env var map: §Environment Variables (~40 vars with descriptions).
+Naming: SUPABASE_* shared, NUXT_* private server, NUXT_PUBLIC_* browser-exposed.
+wrangler.toml is source of truth for Cloudflare Pages vars/bindings.
+Quoting: quote in TOML, unquoted in .env/.dev.vars unless dotenv requires it.
+-->
+
 ## Overview
 
 TarkovTracker is a sophisticated single-page application (SPA) for tracking progress in Escape from Tarkov. Built with Nuxt 4, Vue 3, and Supabase, it provides real-time multi-device synchronization, team collaboration, and comprehensive task/hideout tracking.

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -1,5 +1,13 @@
 # Rate Limiting & Abuse Controls
 
+<!-- AGENT QUICK REFERENCE
+Design: ONE primary enforcer per traffic class at the closest trusted edge.
+Check §Traffic classes before adding a new limiter — someone may already own it.
+Layers: Cloudflare WAF → Pages Function → Worker DO → Edge Function RPC → Postgres.
+API gateway: Durable Object token-bucket (workers/api-gateway).
+App routes: Nitro middleware + Supabase RPC per-user limits.
+-->
+
 This document is the **ownership map** for every rate-limit / abuse system in TarkovTracker.
 
 If you are about to add a new limiter, read this first. Most confusion in this repo comes from

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -2,7 +2,7 @@
 
 <!-- AGENT QUICK REFERENCE
 Design: ONE primary enforcer per traffic class at the closest trusted edge.
-Check §Traffic classes before adding a new limiter — someone may already own it.
+Check §Traffic classes and owners before adding a new limiter — someone may already own it.
 Layers: Cloudflare WAF → Pages Function → Worker DO → Edge Function RPC → Postgres.
 API gateway: Durable Object token-bucket (workers/api-gateway).
 App routes: Nitro middleware + Supabase RPC per-user limits.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -4,7 +4,7 @@
 Endpoint table with cache TTLs: §1 (Tarkov.dev data integration)
 Each section ends with code-binding INVARIANTS — check these when modifying a system.
 Game-mode + seasonal progress storage: §7
-Key implementing files per system are listed in each section header.
+Implementing files are listed within each section body.
 -->
 
 This document explains **how the non-obvious systems in TarkovTracker actually work**, in plain

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1,5 +1,12 @@
 # TarkovTracker Systems Spec
 
+<!-- AGENT QUICK REFERENCE
+Endpoint table with cache TTLs: §1 (Tarkov.dev data integration)
+Each section ends with code-binding INVARIANTS — check these when modifying a system.
+Game-mode + seasonal progress storage: §7
+Key implementing files per system are listed in each section header.
+-->
+
 This document explains **how the non-obvious systems in TarkovTracker actually work**, in plain
 language with diagrams. It is the spec you point at when you want to ask "why does the app do X?"
 and have an agent verify the answer against the code.

--- a/docs/agent-context/summary/components.md
+++ b/docs/agent-context/summary/components.md
@@ -5,30 +5,39 @@
 
 ## Pinia Stores (`app/stores/`)
 
-| Component             | File                | Responsibility                                                                                                                                                                         |
-| --------------------- | ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `useTarkovStore`      | `useTarkov.ts`      | Owns user progress (tasks, objectives, hideout, level, skills, prestige). Coordinates localStorage persistence, Supabase sync init/reset, migrations, and task repair.                 |
-| `useMetadataStore`    | `useMetadata.ts`    | Loads + caches static game data (tasks, items, maps, traders, hideout, prestige). Two-phase loading, IndexedDB caching, item hydration, dependency graph building, cache-purge checks. |
-| `usePreferencesStore` | `usePreferences.ts` | UI settings and filter state (task/needed-items/hideout/map view options, streamer mode, profile sharing). Persisted and synced to `user_preferences`.                                 |
-| `useProgressStore`    | `useProgress.ts`    | Computed facade: per-team task completions, unlocked tasks (prereq-aware), hideout levels, objective completions, invalid-task detection.                                              |
-| `useTeamStore`        | `useTeamStore.ts`   | Team membership, teammate stores, invite codes, teammate progress aggregation.                                                                                                         |
-| `useSystemStore`      | `useSystemStore.ts` | Session/system state: `user_id`, tokens, team ids (pvp/pve), admin flag.                                                                                                               |
-| `useApp`              | `useApp.ts`         | UI chrome state (drawer rail/show, mobile drawer).                                                                                                                                     |
-| `progressState`       | `progressState.ts`  | Low-level progress mutation primitives (set/toggle task, objective, hideout, skill, trader, story, prestige, game-mode switch/migration).                                              |
+| Component               | File                       | Responsibility                                                                                                                                                                         |
+| ----------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `useTarkovStore`        | `useTarkov.ts`             | Owns user progress (tasks, objectives, hideout, level, skills, prestige). Coordinates localStorage persistence, Supabase sync init/reset, migrations, and task repair.                 |
+| `useMetadataStore`      | `useMetadata.ts`           | Loads + caches static game data (tasks, items, maps, traders, hideout, prestige). Two-phase loading, IndexedDB caching, item hydration, dependency graph building, cache-purge checks. |
+| `usePreferencesStore`   | `usePreferences.ts`        | UI settings and filter state (task/needed-items/hideout/map view options, streamer mode, profile sharing). Persisted and synced to `user_preferences`.                                 |
+| `useProgressStore`      | `useProgress.ts`           | Computed facade: per-team task completions, unlocked tasks (prereq-aware), hideout levels, objective completions, invalid-task detection.                                              |
+| `useTeamStore`          | `useTeamStore.ts`          | Team membership, teammate stores, invite codes, teammate progress aggregation.                                                                                                         |
+| `useSystemStore`        | `useSystemStore.ts`        | Session/system state: `user_id`, tokens, team ids (pvp/pve/seasonal), admin flag.                                                                                                      |
+| `useApp`                | `useApp.ts`                | UI chrome state (drawer rail/show, mobile drawer).                                                                                                                                     |
+| `progressState`         | `progressState.ts`         | Low-level progress mutation primitives (set/toggle task, objective, hideout, skill, trader, story, prestige, game-mode switch/migration).                                              |
+| `taskAvailability`      | `taskAvailability.ts`      | Task prerequisite-aware availability state.                                                                                                                                            |
+| `useActionHistoryStore` | `useActionHistoryStore.ts` | Undo/redo action history tracking.                                                                                                                                                     |
+| `useActivityLogStore`   | `useActivityLogStore.ts`   | User activity log entries.                                                                                                                                                             |
 
 ### Tarkov store internals (`app/stores/tarkov/`)
 
-| File                   | Responsibility                                         |
-| ---------------------- | ------------------------------------------------------ |
-| `realtimeListener.ts`  | Supabase realtime subscription lifecycle for progress. |
-| `progressMerge.ts`     | Merge remote/local progress with conflict rules.       |
-| `conflictDetection.ts` | Detect divergence between local and remote state.      |
-| `prestige.ts`          | Prestige run logic and prestige-level handling.        |
-| `hideoutPrereqs.ts`    | Enforce hideout prerequisite completion.               |
-| `resetEngine.ts`       | Reset progress (all / per-mode / current mode).        |
-| `localStorage.ts`      | User-scoped persistence helpers.                       |
-| `promiseStore.ts`      | In-flight request de-duplication.                      |
-| `apiUpdateNotifier.ts` | Surface API-driven task update notifications.          |
+| File                     | Responsibility                                           |
+| ------------------------ | -------------------------------------------------------- |
+| `realtimeListener.ts`    | Supabase realtime subscription lifecycle for progress.   |
+| `progressMerge.ts`       | Merge remote/local progress with conflict rules.         |
+| `conflictDetection.ts`   | Detect divergence between local and remote state.        |
+| `prestige.ts`            | Prestige run logic and prestige-level handling.          |
+| `hideoutPrereqs.ts`      | Enforce hideout prerequisite completion.                 |
+| `resetEngine.ts`         | Reset progress (all / per-mode / current mode).          |
+| `localStorage.ts`        | User-scoped persistence helpers.                         |
+| `promiseStore.ts`        | In-flight request de-duplication.                        |
+| `apiUpdateNotifier.ts`   | Surface API-driven task update notifications.            |
+| `progressPersistence.ts` | Supabase persistence layer for progress sync.            |
+| `metadataStoreBridge.ts` | Bridge between metadata store and tarkov store.          |
+| `syncTimeline.ts`        | Ordered timeline of sync events for conflict resolution. |
+| `deepEqual.ts`           | Deep equality comparison for progress diffing.           |
+| `itemPicker.ts`          | Item selection logic for hideout/task item picking.      |
+| `fetchResponse.ts`       | Typed fetch response handling for store operations.      |
 
 ## Composables (`app/composables/`)
 
@@ -83,19 +92,25 @@ Client-only plugins, **numbered to control load order**:
 
 Each slice contains its Vue components and slice-local helpers/composables. High-traffic examples:
 
-| Slice            | Key components                                                                                                 |
-| ---------------- | -------------------------------------------------------------------------------------------------------------- |
-| `tasks`          | `TaskCard.vue`, `TaskFilterBar.vue`, `TaskObjective.vue`, `TaskGraphView.vue`, `composables/useTaskFilters.ts` |
-| `hideout`        | `HideoutCard.vue`, `HideoutRequirement.vue`, `HideoutSettingsDrawer.vue`                                       |
-| `maps`           | `LeafletMap.vue`, `LeafletObjectiveTooltip.vue`, `composables/useLeafletMapControls.ts`                        |
-| `neededitems`    | `NeededItem*.vue` (row/card/grouped/modal), filter bar + settings drawer                                       |
-| `dashboard`      | `DashboardNextActions.vue`, `DashboardTraderCard.vue`, `DashboardChangelog.vue`                                |
-| `settings`       | `DataManagementCard.vue`, `ApiTokens.vue`, `PrestigeCard.vue`, `SkillsCard.vue`, `AccountDeletionCard.vue`     |
-| `team`           | `MyTeam.vue`, `TeamInvite.vue`, `TeamMemberCard.vue`                                                           |
-| `profile`        | `ProfileProgression.vue`, `Profile*Tab.vue`                                                                    |
-| `supporter`      | `SupporterTierCard.vue`, `SupporterOneTime.vue`, `SupporterStatusBanner.vue`                                   |
-| `streamer-tools` | `StreamerToolsPanel.vue`, `composables/useStreamerToolsOverlay.ts`                                             |
-| `kappa`          | `KappaTaskRow.vue`, `useKappaOverview.ts`                                                                      |
+| Slice            | Key components                                                                                                  |
+| ---------------- | --------------------------------------------------------------------------------------------------------------- |
+| `tasks`          | `TaskCard.vue`, `TaskFilterBar.vue`, `TaskObjective.vue`, `TaskGraphView.vue`, `composables/useTaskFilters.ts`  |
+| `hideout`        | `HideoutCard.vue`, `HideoutRequirement.vue`, `HideoutSettingsDrawer.vue`                                        |
+| `maps`           | `LeafletMap.vue`, `LeafletObjectiveTooltip.vue`, `composables/useLeafletMapControls.ts`                         |
+| `neededitems`    | `NeededItem*.vue` (row/card/grouped/modal), filter bar + settings drawer                                        |
+| `dashboard`      | `DashboardNextActions.vue`, `DashboardTraderCard.vue`, `DashboardChangelog.vue`, `DashboardMigrationBanner.vue` |
+| `settings`       | `DataManagementCard.vue`, `ApiTokens.vue`, `PrestigeCard.vue`, `SkillsCard.vue`, `AccountDeletionCard.vue`      |
+| `team`           | `MyTeam.vue`, `TeamInvite.vue`, `TeamMemberCard.vue`                                                            |
+| `profile`        | `ProfileProgression.vue`, `Profile*Tab.vue`                                                                     |
+| `supporter`      | `SupporterTierCard.vue`, `SupporterOneTime.vue`, `SupporterStatusBanner.vue`                                    |
+| `streamer-tools` | `StreamerToolsPanel.vue`, `composables/useStreamerToolsOverlay.ts`                                              |
+| `kappa`          | `KappaTaskRow.vue`, `useKappaOverview.ts`                                                                       |
+| `resources`      | `ResourceGuideHeader.vue`, `ResourceGuideArticle.vue`, `ResourceVideoEmbed.vue`, `resourceData.ts`              |
+| `omnibar`        | `Omnibar.vue`, `useOmnibarSearch.ts`                                                                            |
+| `credits`        | `ContributorsList.vue`, `CreditMember.vue`, `CreditMemberList.vue`, `useContributors.ts`                        |
+| `admin`          | `AdminSupporterAccessCard.vue`, `AdminAuditLog.vue`, `AdminCacheCard.vue`                                       |
+| `drawer`         | `DrawerGameSettings.vue`, `DrawerItem.vue`, `DrawerLinks.vue`, `DrawerLevel.vue`, `navigation.ts`               |
+| `storyline`      | Storyline chapter progression components                                                                        |
 
 ## Server Components (`app/server/`)
 

--- a/docs/agent-context/summary/data_models.md
+++ b/docs/agent-context/summary/data_models.md
@@ -201,7 +201,8 @@ erDiagram
     }
     user_system {
         uuid user_id
-        uuid team_id
+        uuid pvp_team_id
+        uuid pve_team_id
         uuid seasonal_team_id
         bool is_admin
     }

--- a/docs/agent-context/summary/data_models.md
+++ b/docs/agent-context/summary/data_models.md
@@ -164,10 +164,10 @@ Maps keyed by id: `taskObjectives`, `taskCompletions`, `hideoutParts`, `hideoutM
 Defined in `app/types/tarkov.ts`:
 
 - `SystemState` / `SystemGetters` — `user_id`, `tokens`, `team`, `pvp_team_id`, `pve_team_id`,
-  `is_admin`; getters `userTokens`, `userTeam`, `userTeamIsOwn`, `isAdmin`.
+  `seasonal_team_id`, `is_admin`; getters `userTokens`, `userTeam`, `userTeamIsOwn`, `isAdmin`.
 - `TeamState` / `TeamGetters` — `owner`, `joinCode`, `members`, `memberProfiles`; getters
   `teamOwner`, `isOwner`, `inviteCode`, `teamMembers`, `teammates`.
-- `MemberProfile` — `displayName`, `level`, `tasksCompleted`, `gameMode` (`pvp`|`pve`).
+- `MemberProfile` — `displayName`, `level`, `tasksCompleted`, `gameMode` (`'pvp'|'pve'|'seasonal'`).
 
 ## Supabase Data Model
 
@@ -177,6 +177,7 @@ through RPCs/Edge Functions for elevated privileges or rate limiting.
 ```mermaid
 erDiagram
     user_progress ||--|| auth_users : "user_id"
+    user_game_mode_progress }o--|| auth_users : "user_id"
     user_system ||--|| auth_users : "user_id"
     user_preferences ||--|| auth_users : "user_id"
     teams ||--o{ team_memberships : "team_id"
@@ -191,9 +192,17 @@ erDiagram
         text game_mode
         int progress_epoch
     }
+    user_game_mode_progress {
+        uuid user_id
+        text game_mode
+        smallint season_number
+        jsonb progress_data
+        bool profile_public
+    }
     user_system {
         uuid user_id
         uuid team_id
+        uuid seasonal_team_id
         bool is_admin
     }
     user_preferences {
@@ -226,22 +235,25 @@ erDiagram
     }
 ```
 
-| Table / object               | Role                                                                                        |
-| ---------------------------- | ------------------------------------------------------------------------------------------- |
-| `user_progress`              | Per-user, per-mode progress JSON; realtime-enabled; payload sanitized via trigger/RPC       |
-| `user_system`                | Per-user system row (team linkage, admin flag — admin column privilege-locked)              |
-| `user_preferences`           | Per-user UI preferences (columns added incrementally via migrations)                        |
-| `teams` / `team_memberships` | Team ownership + membership (game-mode aware; RLS tuned to avoid recursion)                 |
-| `api_tokens`                 | Hashed API tokens for the gateway                                                           |
-| `supporters`                 | Supporter tier + Stripe customer linkage                                                    |
-| `stripe_events`              | Idempotency/retention for webhook events                                                    |
-| `prestige_runs`              | Prestige run history (+ progress epoch)                                                     |
-| `account_deletion_jobs`      | Account deletion job tracking                                                               |
-| `admin_audit_log`            | Admin action audit trail                                                                    |
-| RPCs                         | API gateway functions, atomic prestige progress, mutation rate limiting, ownership transfer |
+| Table / object               | Role                                                                                      |
+| ---------------------------- | ----------------------------------------------------------------------------------------- |
+| `user_progress`              | Legacy per-user progress (pvp_data/pve_data); compatibility row for rolling deploys       |
+| `user_game_mode_progress`    | Normalized per-mode progress; PK `(user_id, game_mode, season_number)`; realtime-enabled  |
+| `user_system`                | Per-user system row (team linkage, seasonal_team_id, admin flag)                          |
+| `user_preferences`           | Per-user UI preferences (columns added incrementally via migrations)                      |
+| `teams` / `team_memberships` | Team ownership + membership (game-mode aware; accepts pvp/pve/seasonal)                   |
+| `api_tokens`                 | Hashed API tokens for the gateway (prefixed PVP_/PVE_/SZN_)                               |
+| `supporters`                 | Supporter tier + Stripe customer linkage                                                  |
+| `stripe_events`              | Idempotency/retention for webhook events                                                  |
+| `prestige_runs`              | Prestige run history (+ progress epoch)                                                   |
+| `account_deletion_jobs`      | Account deletion job tracking                                                             |
+| `admin_audit_log`            | Admin action audit trail                                                                  |
+| RPCs                         | `sync_user_game_mode_progress`, `merge_progress_data`, prestige, rate limiting, ownership |
 
-> Game modes appear as `regular`/`pve` in the game-data API and `pvp`/`pve` in
-> team/profile/membership contexts. Treat them as the same two-mode concept across layers.
+> Game modes: `pvp`, `pve`, `seasonal` internally. Game-data API uses `regular`/`pve`/`pvp-season`.
+> Seasonal progress is keyed by season number (pvp/pve always use season_number=0).
+> `private.active_season_number()` returns the current season; the app constant `ACTIVE_SEASON`
+> in `app/utils/constants.ts` must stay synchronized with it.
 
 ## Static Local Data
 

--- a/docs/agent-context/summary/dependencies.md
+++ b/docs/agent-context/summary/dependencies.md
@@ -14,9 +14,8 @@
 | `vue`, `vue-router`                              | Vue 3 runtime + routing.                                                           |
 | `@nuxt/ui`                                       | Primary component library.                                                         |
 | `@nuxt/image`                                    | Image optimization.                                                                |
+| `@vueuse/core`                                   | Composition utility library (sensors, state, browser APIs).                        |
 | `reka-ui`, `tailwind-merge`, `tailwind-variants` | UI primitives + class composition (transitive via `@nuxt/ui`, used in components). |
-| `motion-v` / `framer-motion`                     | Animations.                                                                        |
-| `embla-carousel*`                                | Carousels.                                                                         |
 
 ### Styling
 

--- a/docs/agent-context/summary/interfaces.md
+++ b/docs/agent-context/summary/interfaces.md
@@ -1,8 +1,7 @@
 # Interfaces — TarkovTracker
 
-> APIs, interfaces, and integration points. The authoritative endpoint reference (with full
-> request/response examples) is `docs/API.md`. This file summarizes the surface and the boundaries
-> between subsystems.
+> APIs, interfaces, and integration points. For full endpoint tables with request/response
+> shapes, see `docs/API.md`. This file summarizes the boundaries between subsystems.
 
 ## Interface Map
 
@@ -30,54 +29,21 @@ graph LR
     EdgeFns -->|role sync| Discord
 ```
 
-## 1. Nitro Game-Data Endpoints (`/api/tarkov/*`)
+## Endpoint Summary
 
-Public, cached proxies to `json.tarkov.dev` with overlay corrections. Common query params:
-`lang` (default `en`), `gameMode` (`regular` | `pve`, where applicable), `cacheBust=1` to bypass.
+- **`/api/tarkov/*`** — public cached proxies to `json.tarkov.dev` with overlay corrections. 12h–24h edge TTLs. See `docs/API.md` §Game Data for the full table.
+- **`/api/team/*`, `/api/profile/*`, `/api/stripe/*`** — authenticated app routes (Supabase JWT). See `docs/API.md` §Application Endpoints.
+- **`/overlay/*`** — server-rendered streamer overlays (Nitro route, not Page Function).
 
-| Endpoint                           | Returns                                                 | Cache TTL |
-| ---------------------------------- | ------------------------------------------------------- | --------- |
-| `GET /api/tarkov/bootstrap`        | Player levels (minimal)                                 | 12h       |
-| `GET /api/tarkov/tasks-core`       | Tasks, maps, traders                                    | 12h       |
-| `GET /api/tarkov/tasks-objectives` | Task objectives + fail conditions                       | 12h       |
-| `GET /api/tarkov/tasks-rewards`    | Task rewards (start/finish/failure)                     | 12h       |
-| `GET /api/tarkov/hideout`          | Hideout stations + requirements + crafts                | 12h       |
-| `GET /api/tarkov/items-lite`       | Items (id, name, shortName, image)                      | 24h       |
-| `GET /api/tarkov/items`            | Full item data                                          | 24h       |
-| `GET /api/tarkov/prestige`         | Prestige levels (sourced from `regular`, lang-only key) | 24h       |
-| `GET /api/tarkov/map-spawns`       | Map spawn points                                        | 12h       |
-| `GET /api/tarkov/cache-meta`       | Server purge timestamp                                  | 5m edge   |
-
-Responses are wrapped as `{ "data": { ... } }`. See `docs/API.md` for shapes.
-
-## 2. Nitro Application Endpoints
-
-| Endpoint                              | Method | Auth                  | Purpose                                                   |
-| ------------------------------------- | ------ | --------------------- | --------------------------------------------------------- |
-| `/api/team/members?teamId=`           | GET    | Supabase JWT          | Team member profiles                                      |
-| `/api/profile/[userId]/[mode]`        | GET    | Public (rate limited) | Shared/public profile progress                            |
-| `/api/tarkov-dev/profile?...`         | GET    | Public (rate limited) | Proxy to `players.tarkov.dev/profile/{uid}.json`          |
-| `/api/stripe/checkout`                | POST   | Supabase JWT          | Create Stripe Checkout session (subscription or one-time) |
-| `/api/stripe/portal`                  | POST   | Supabase JWT          | Create Stripe Customer Portal session                     |
-| `/api/admin/supporter`                | POST   | Admin                 | Manage supporter access                                   |
-| `/api/streamer/[userId]/[mode]/kappa` | GET    | Public                | Streamer kappa data                                       |
-| `/api/twitch/live`                    | GET    | Public                | Twitch live status                                        |
-| `/api/changelog`                      | GET    | Public                | Changelog feed                                            |
-| `/api/contributors`                   | GET    | Public                | Contributors list (GitHub)                                |
-| `/overlay/kappa/[userId]/[mode]`      | GET    | Public                | Server-rendered streamer overlay (under `server/routes`)  |
-
-### Stripe request bodies (summary)
+### Stripe Request Bodies
 
 - Checkout (subscription): `{ mode: "subscription", tier: "scav"|"timmy"|"chad", interval: "monthly"|"6month"|"yearly" }`
 - Checkout (one-time): `{ mode: "payment", amount: <1..999> }`
-- Portal: `{ returnUrl?: <absolute URL on app origin> }` — host must match app URL or it falls back to `${appUrl}/supporter`.
+- Portal: `{ returnUrl?: <absolute URL on app origin> }` — host must match app URL or falls back to `${appUrl}/supporter`.
 
-## 3. Public API Gateway (Cloudflare Worker)
+## Public API Gateway (Cloudflare Worker)
 
-`workers/api-gateway` — a standalone REST API for third-party clients, authenticated by
-**Bearer API tokens** (SHA-256 hashed; created/revoked via Edge Functions). It uses a Durable
-Object (`ApiGatewayRateLimiter`) for rate limiting and ships an OpenAPI document
-(`workers/api-gateway/src/openapi.ts`, validated by `pnpm run validate:openapi`).
+`workers/api-gateway` — standalone REST API for third-party clients. Bearer API tokens (SHA-256 hashed), Durable Object rate limiter, OpenAPI spec at `workers/api-gateway/src/openapi.ts`.
 
 ```mermaid
 sequenceDiagram
@@ -95,13 +61,11 @@ sequenceDiagram
     GW-->>Client: transformed JSON + rate-limit headers
 ```
 
-Handlers: `progress.ts` (get/update tasks, objective, level), `team.ts` (team progress),
-`token.ts` (token info). Consult `openapi.ts` for the exact route/version contract.
+Handlers: `progress.ts`, `team.ts`, `token.ts`. Validate with `pnpm run validate:openapi`.
 
-## 4. Supabase Edge Functions (invoked from client / Stripe)
+## Supabase Edge Functions
 
-Invoked via `app/composables/api/useEdgeFunctions.ts` (or Stripe webhooks). All use
-`_shared/auth.ts` for auth + CORS and `_shared/rate-limit.ts` (RPC) for per-user limits.
+Invoked via `app/composables/api/useEdgeFunctions.ts` or Stripe webhooks. Auth: `_shared/auth.ts`. Rate limit: `_shared/rate-limit.ts` (RPC).
 
 | Function                                                                  | Trigger      | Purpose                                    |
 | ------------------------------------------------------------------------- | ------------ | ------------------------------------------ |
@@ -111,22 +75,20 @@ Invoked via `app/composables/api/useEdgeFunctions.ts` (or Stripe webhooks). All 
 | `stripe-webhook`                                                          | Stripe       | Supporter grant/revoke + Discord role sync |
 | `admin-cache-purge`                                                       | Admin client | Purge Cloudflare + data caches             |
 
-## 5. External Integrations
+## External Integrations
 
-| Integration                          | Direction               | Notes                                                           |
-| ------------------------------------ | ----------------------- | --------------------------------------------------------------- |
-| `json.tarkov.dev`                    | Outbound (server)       | Static game data; override base via `NUXT_TARKOV_JSON_BASE_URL` |
-| `tarkov-data-overlay` (GitHub)       | Outbound (server)       | Community data corrections (`overlay.ts`)                       |
-| `players.tarkov.dev`                 | Outbound (server proxy) | Profile import JSON                                             |
-| Supabase                             | Bidirectional           | Auth, DB, Realtime, Edge Functions                              |
-| Stripe                               | Outbound + webhook      | Supporter payments                                              |
-| Discord                              | Outbound (edge)         | Supporter role sync                                             |
-| Twitch / GitHub                      | Outbound (server)       | Live status / contributors                                      |
-| Google Analytics / Microsoft Clarity | Client (consent-gated)  | Product analytics                                               |
+| Integration                    | Direction               | Notes                                                      |
+| ------------------------------ | ----------------------- | ---------------------------------------------------------- |
+| `json.tarkov.dev`              | Outbound (server)       | Static game data; override via `NUXT_TARKOV_JSON_BASE_URL` |
+| `tarkov-data-overlay` (GitHub) | Outbound (server)       | Community data corrections                                 |
+| `players.tarkov.dev`           | Outbound (server proxy) | Profile import JSON                                        |
+| Supabase                       | Bidirectional           | Auth, DB, Realtime, Edge Functions                         |
+| Stripe                         | Outbound + webhook      | Supporter payments                                         |
+| Discord                        | Outbound (edge)         | Supporter role sync                                        |
+| Google Analytics / Clarity     | Client (consent-gated)  | Product analytics                                          |
 
 ## Error Conventions
 
 Nitro endpoints return errors as `{ error, statusCode, statusMessage }`. Typical statuses:
-`400` (bad params), `401` (missing/invalid token), `403` (not a team member / not admin),
-`404` (no Stripe customer), `5xx`/`502` (upstream/config failures). See `docs/API.md` for the
-per-endpoint error tables.
+`400` (bad params), `401` (missing/invalid token), `403` (forbidden), `404` (not found),
+`5xx`/`502` (upstream failures). See `docs/API.md` for per-endpoint error tables.

--- a/docs/agent-context/summary/interfaces.md
+++ b/docs/agent-context/summary/interfaces.md
@@ -31,8 +31,9 @@ graph LR
 
 ## Endpoint Summary
 
-- **`/api/tarkov/*`** — public cached proxies to `json.tarkov.dev` with overlay corrections. 12h–24h edge TTLs. See `docs/API.md` §Game Data for the full table.
-- **`/api/team/*`, `/api/profile/*`, `/api/stripe/*`** — authenticated app routes (Supabase JWT). See `docs/API.md` §Application Endpoints.
+- **`/api/tarkov/*`** — public cached proxies to `json.tarkov.dev` with overlay corrections. Most use 12h–24h edge TTLs (cache-meta: 5m). See `docs/API.md` §Tarkov Data Endpoints for the full table.
+- **`/api/team/*`, `/api/stripe/*`** — authenticated app routes (Supabase JWT). See `docs/API.md` §Team Endpoints / §Supporter / Stripe Endpoints.
+- **`/api/profile/*`** — public shared profiles (rate-limited, no auth required).
 - **`/overlay/*`** — server-rendered streamer overlays (Nitro route, not Page Function).
 
 ### Stripe Request Bodies


### PR DESCRIPTION
## Summary

Comprehensive accuracy update to agent context files + token efficiency improvements.

## Changes

### Token reduction
- **`interfaces.md`**: removed endpoint tables duplicating `docs/API.md` (~900 tokens saved). Kept: Mermaid interface map, Stripe body examples, Worker sequence diagram, Edge Functions table, error conventions.

### Accuracy fixes (stale data)
- **`dependencies.md`**: removed `motion-v`/`framer-motion` and `embla-carousel*` (not in package.json — they were never direct deps). Added missing `@vueuse/core`.
- **`components.md`**: added 6 missing feature slices (`resources/`, `omnibar/`, `credits/`, `admin/`, `drawer/`, `storyline/`), 3 missing stores (`taskAvailability`, `useActionHistoryStore`, `useActivityLogStore`), 6 missing `tarkov/` internal files. Updated `useSystemStore` for `seasonal_team_id`.
- **`data_models.md`**: added `user_game_mode_progress` table (composite PK, season_number semantics), updated ER diagram, corrected game-mode documentation to 3 modes (pvp/pve/seasonal), added `SZN_` token prefix, updated RPCs.

### Agent efficiency (quick-reference headers)
- Added HTML comment `AGENT QUICK REFERENCE` blocks to top of `SYSTEMS.md`, `ARCHITECTURE.md`, `API.md`, `RATE_LIMITING.md` — gives agents key facts (env var locations, auth methods, design principles, section pointers) without reading the full 5K–12K token doc. Invisible in rendered markdown, visible to agents reading raw files.

## What was tested

- `pnpm run lint:blank-lines` — passed
- Pre-commit hooks (prettier) — passed
- No code changes; documentation only

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR refreshes agent-facing documentation to match the current seasonal progress, team, dependency, component, and API models while reducing duplicated endpoint material.
- Adds concise quick-reference headers to the primary architecture, API, rate-limiting, and systems documents.
- Updates agent summaries for current feature slices, stores, dependencies, game modes, progress storage, and mode-specific team columns.
- Consolidates endpoint details in `docs/API.md` and keeps `interfaces.md` focused on subsystem boundaries.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

No blocking failure remains; the previously reported profile-auth and removed-team-column inaccuracies are corrected at the current head.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| docs/API.md | Adds an accurate quick reference distinguishing public shared-profile access from JWT-authenticated team routes and token-authenticated gateway routes. |
| docs/agent-context/summary/interfaces.md | Removes duplicated endpoint tables and correctly identifies shared profiles as public, rate-limited routes. |
| docs/agent-context/summary/data_models.md | Replaces the removed generic team column with current mode-specific columns and documents normalized seasonal progress storage. |
| docs/agent-context/summary/components.md | Expands the component and store inventory to cover current feature slices and seasonal team state. |
| docs/agent-context/summary/dependencies.md | Removes dependencies absent from the manifest and adds the currently used VueUse package. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(docs): address review — section refs..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/fc897630258a9078e12b548868a89be3667d6a11) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51858987)</sub>

<!-- /greptile_comment -->