### PR TITLE
fix(ui): align contributor leaderboard rows

### DIFF
--- a/app/features/credits/CreditMember.vue
+++ b/app/features/credits/CreditMember.vue
@@ -1,6 +1,13 @@
 <template>
-  <li class="min-w-0">
+  <li class="min-w-0" :value="rank">
     <component :is="linkTag" v-bind="linkAttributes" :title="tooltip" :class="itemClasses">
+      <span
+        v-if="rank != null"
+        aria-hidden="true"
+        class="text-surface-300 w-7 shrink-0 text-right text-xs font-semibold tabular-nums"
+      >
+        {{ rank }}.
+      </span>
       <NuxtImg
         v-if="member.avatar"
         :src="member.avatar"
@@ -33,6 +40,7 @@
   const { t } = useI18n({ useScope: 'global' });
   const props = defineProps<{
     member: CreditMember;
+    rank?: number;
     variant: CreditMemberVariant;
   }>();
   const isRow = computed(() => props.variant === 'row');
@@ -48,6 +56,6 @@
   const avatarSize = computed(() => creditMemberAvatarSize(props.variant));
   const avatarClasses = computed(() => creditMemberAvatarClasses(props.variant));
   const itemClasses = computed(() =>
-    creditMemberClasses(props.variant, Boolean(props.member.link))
+    creditMemberClasses(props.variant, Boolean(props.member.link), props.rank != null)
   );
 </script>

--- a/app/features/credits/CreditMember.vue
+++ b/app/features/credits/CreditMember.vue
@@ -1,13 +1,7 @@
 <template>
   <li class="min-w-0" :value="rank">
     <component :is="linkTag" v-bind="linkAttributes" :title="tooltip" :class="itemClasses">
-      <span
-        v-if="rank != null"
-        aria-hidden="true"
-        class="text-surface-300 w-7 shrink-0 text-right text-xs font-semibold tabular-nums"
-      >
-        {{ rank }}.
-      </span>
+      <CreditMemberRank :rank="rank" />
       <NuxtImg
         v-if="member.avatar"
         :src="member.avatar"
@@ -31,6 +25,7 @@
 </template>
 <script setup lang="ts">
   import CreditContributionCount from '@/features/credits/CreditContributionCount.vue';
+  import CreditMemberRank from '@/features/credits/CreditMemberRank.vue';
   import {
     creditMemberAvatarClasses,
     creditMemberAvatarSize,

--- a/app/features/credits/CreditMemberList.vue
+++ b/app/features/credits/CreditMemberList.vue
@@ -28,9 +28,13 @@
     row: 'flex flex-col gap-2',
     grid: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
   };
+  const gridGapClasses = computed(() => {
+    if (props.variant !== 'grid') return '';
+    return props.ordered ? 'gap-x-6 gap-y-1' : 'gap-x-2';
+  });
   const listClasses = computed(() => [
     LIST_CLASSES[props.variant],
-    props.variant === 'grid' ? (props.ordered ? 'gap-x-6 gap-y-1' : 'gap-x-2') : '',
+    gridGapClasses.value,
     props.ordered ? 'list-none' : '',
   ]);
 </script>

--- a/app/features/credits/CreditMemberList.vue
+++ b/app/features/credits/CreditMemberList.vue
@@ -1,9 +1,10 @@
 <template>
   <component :is="listTag" role="list" :class="listClasses">
     <CreditMember
-      v-for="member in members"
+      v-for="(member, index) in members"
       :key="member.name"
       :member="member"
+      :rank="ordered ? index + 1 : undefined"
       :variant="variant"
     />
   </component>
@@ -25,10 +26,11 @@
   const listTag = computed(() => (props.ordered ? 'ol' : 'ul'));
   const LIST_CLASSES: Record<'row' | 'grid', string> = {
     row: 'flex flex-col gap-2',
-    grid: 'grid grid-cols-1 gap-x-2 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
+    grid: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4',
   };
   const listClasses = computed(() => [
     LIST_CLASSES[props.variant],
-    props.ordered ? 'list-decimal pl-5' : '',
+    props.variant === 'grid' ? (props.ordered ? 'gap-x-6 gap-y-1' : 'gap-x-2') : '',
+    props.ordered ? 'list-none' : '',
   ]);
 </script>

--- a/app/features/credits/CreditMemberRank.vue
+++ b/app/features/credits/CreditMemberRank.vue
@@ -1,0 +1,12 @@
+<template>
+  <span
+    v-if="rank != null"
+    :aria-label="String(rank)"
+    class="text-surface-300 w-7 shrink-0 text-right text-xs font-semibold tabular-nums"
+  >
+    {{ rank }}.
+  </span>
+</template>
+<script setup lang="ts">
+  defineProps<{ rank?: number }>();
+</script>

--- a/app/features/credits/CreditMemberRank.vue
+++ b/app/features/credits/CreditMemberRank.vue
@@ -1,7 +1,6 @@
 <template>
   <span
     v-if="rank != null"
-    :aria-label="String(rank)"
     class="text-surface-300 w-7 shrink-0 text-right text-xs font-semibold tabular-nums"
   >
     {{ rank }}.

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -83,8 +83,10 @@ describe('credits member presentation', () => {
       global,
     });
     expect(wrapper.get('li').attributes('value')).toBe('12');
-    expect(wrapper.get('a > span').text()).toBe('12.');
-    expect(wrapper.get('a > span').attributes('aria-hidden')).toBe('true');
+    const rank = wrapper.get('a > span');
+    expect(rank.text()).toBe('12.');
+    expect(rank.attributes('aria-hidden')).toBeUndefined();
+    expect(rank.attributes('aria-label')).toBe('12');
     expect(wrapper.get('a').classes()).toContain('border-white/5');
   });
   it('renders unlinked grid members without an external-link icon', () => {

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -69,6 +69,24 @@ describe('credits member presentation', () => {
       'i-mdi-open-in-new'
     );
   });
+  it('aligns an ordered rank inside the contributor row', () => {
+    const wrapper = mount(CreditMember, {
+      props: {
+        member: {
+          contributions: 20,
+          link: 'https://example.com/profile',
+          name: 'Contributor',
+        },
+        rank: 12,
+        variant: 'grid',
+      },
+      global,
+    });
+    expect(wrapper.get('li').attributes('value')).toBe('12');
+    expect(wrapper.get('a > span').text()).toBe('12.');
+    expect(wrapper.get('a > span').attributes('aria-hidden')).toBe('true');
+    expect(wrapper.get('a').classes()).toContain('border-white/5');
+  });
   it('renders unlinked grid members without an external-link icon', () => {
     const wrapper = mount(CreditMember, {
       props: { member: { name: 'Tester' }, variant: 'grid' },
@@ -84,10 +102,20 @@ describe('credits member presentation', () => {
       props: { members, ordered: true, variant: 'grid' },
       global,
     });
+    const unorderedGrid = mount(CreditMemberList, {
+      props: { members, variant: 'grid' },
+      global,
+    });
     const unordered = mount(CreditMemberList, { props: { members }, global });
     expect(ordered.element.tagName).toBe('OL');
     expect(ordered.classes()).toContain('grid');
-    expect(ordered.classes()).toContain('list-decimal');
+    expect(ordered.classes()).toContain('list-none');
+    expect(ordered.classes()).toContain('gap-x-6');
+    expect(ordered.classes()).toContain('gap-y-1');
+    expect(ordered.classes()).not.toContain('gap-x-2');
+    expect(unorderedGrid.classes()).toContain('gap-x-2');
+    expect(unorderedGrid.classes()).not.toContain('gap-x-6');
+    expect(ordered.findAll('li').map((item) => item.get('span').text())).toEqual(['1.', '2.']);
     expect(unordered.element.tagName).toBe('UL');
     expect(unordered.classes()).toContain('flex');
   });
@@ -99,6 +127,8 @@ describe('credits member presentation', () => {
     expect(creditMemberClasses('row', true).join(' ')).toContain('hover:bg-white/10');
     expect(creditMemberClasses('grid', false).join(' ')).not.toContain('hover:');
     expect(creditMemberClasses('grid', false).join(' ')).not.toContain('focus-visible:');
+    expect(creditMemberClasses('grid', true, true).join(' ')).toContain('bg-white/[0.02]');
+    expect(creditMemberClasses('grid', true, false).join(' ')).not.toContain('border-white/5');
   });
   it('keeps the static credit groups ordered and uniquely keyed', () => {
     expect(staticCreditSections.map((section) => section.key)).toEqual([

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -86,7 +86,7 @@ describe('credits member presentation', () => {
     const rank = wrapper.get('a > span');
     expect(rank.text()).toBe('12.');
     expect(rank.attributes('aria-hidden')).toBeUndefined();
-    expect(rank.attributes('aria-label')).toBe('12');
+    expect(rank.attributes('aria-label')).toBeUndefined();
     expect(wrapper.get('a').classes()).toContain('border-white/5');
   });
   it('renders unlinked grid members without an external-link icon', () => {

--- a/app/features/credits/creditMemberStyles.ts
+++ b/app/features/credits/creditMemberStyles.ts
@@ -16,8 +16,8 @@ export const creditMemberAvatarClasses = (variant: CreditMemberVariant) => {
 export const creditMemberClasses = (
   variant: CreditMemberVariant,
   linked: boolean,
-  ranked = false
-) => [
+  ranked: boolean = false
+): string[] => [
   BASE_CLASSES[variant],
   variant === 'grid' && ranked ? 'border border-white/5 bg-white/[0.02]' : '',
   linked

--- a/app/features/credits/creditMemberStyles.ts
+++ b/app/features/credits/creditMemberStyles.ts
@@ -13,8 +13,13 @@ export const creditMemberAvatarClasses = (variant: CreditMemberVariant) => {
   const size = variant === 'row' ? 'h-9 w-9' : 'h-7 w-7';
   return `${size} shrink-0 rounded-full border border-white/15 object-cover`;
 };
-export const creditMemberClasses = (variant: CreditMemberVariant, linked: boolean) => [
+export const creditMemberClasses = (
+  variant: CreditMemberVariant,
+  linked: boolean,
+  ranked = false
+) => [
   BASE_CLASSES[variant],
+  variant === 'grid' && ranked ? 'border border-white/5 bg-white/[0.02]' : '',
   linked
     ? [
         LINK_HOVER_CLASSES[variant],


### PR DESCRIPTION
## **User description**
# Pull Request

## Summary

Aligns the Credits contributor leaderboard so each rank, contributor identity, and contribution count is visually grouped and cannot overlap an adjacent entry.

## Changes

- Replaces detached browser list markers with explicit visual ranks inside each ordered contributor row while preserving ordered-list semantics.
- Adds subtle row boundaries and responsive spacing so rank, avatar/name, and contribution total share one centerline.
- Extends component tests for ordered ranks, ranked-row styling, and unchanged unordered credit groups.

## Related Issues

Closes #691

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. Open `/credits` at 1424×960 and confirm each rank, avatar/name, and contribution count shares one bounded, center-aligned row.
2. Resize to 1280, 1024, 768, and 390 px; confirm the grid transitions through 4/4/3/2/1 columns, ordered values remain 1–17, and the page has no horizontal overflow.
3. Run the focused credits test, changed-file lint/format checks, blank-line lint, Nuxt typecheck, and precompute TypeScript check.

### Results

- Focused Vitest: 8/8 passed.
- ESLint, Prettier, blank-line lint, Nuxt typecheck, and precompute TypeScript check passed.
- Browser geometry checks passed at all five widths: rank/name/count center spread was 0 px; adjacent multi-column count/rank fields retained at least 42 px separation.
- Full `pnpm run test` was also run on Windows. Its 18 failures were all isolated to `scripts/prod-db.test.mjs`, where Node cannot directly execute the extensionless POSIX `scripts/prod-db` wrapper on Windows (`ENOENT` and no NTFS execute bit). This PR does not touch that wrapper, and Git stores it with executable mode `100755`; Linux CI is the authoritative environment for those cases.

## Screenshots/Videos

- Before: attached to #691.
- After: validated in the local browser at 1424×960 and visually approved before publication.

## Documentation impact

- [ ] No behavior changed — documentation review not required
- [x] Behavior changed — existing documentation remains accurate
- [ ] Behavior changed — documentation updated in this PR
- [ ] Behavior changed — documentation follow-up is tracked

Documents reviewed:

- [x] Screenshots or diagrams
- [ ] Contributor/developer workflow docs
- [ ] API or integration docs
- [ ] Runbooks or deployment docs
- [ ] Agent/governance docs

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [ ] All existing tests pass locally
- [x] No breaking changes are introduced

## Additional Notes

The unchecked full-suite item reflects only the documented Windows test-harness limitation above. The changed Credits code and its focused tests pass locally.

___

## **CodeAnt-AI Description**
Align contributor leaderboard ranks, names, and contribution counts in each row

### What Changed
- Displays each ordered contributor’s rank inside the same row as their avatar, name, and contribution count
- Keeps ordered-list semantics while replacing detached browser markers with stable, visible ranks
- Adds spacing and subtle row boundaries to prevent leaderboard entries from overlapping across columns
- Preserves the existing layout and spacing for unordered credit groups

### Impact
`✅ No overlapping contributor ranks`
`✅ Clearer leaderboard rows`
`✅ Consistent responsive credit grids`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Credit member lists can now display contributor rankings.
  * Ranked entries use ordered-list semantics while preserving the existing visual layout.
  * Ranked grid entries receive updated spacing and subtle visual styling.
* **Bug Fixes**
  * Improved styling for linked, selected, and unselected credit members across list variants.
* **Accessibility**
  * Rank information is available to assistive technologies without duplicating visible content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns contributor leaderboard ranks, identities, and contribution counts within bounded responsive rows.
- Replaces detached list markers with ranks rendered inside each ordered row.
- Adds ranked-grid spacing, borders, and background styling.
- Extends component coverage for ranks, list semantics, and ordered versus unordered styling.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/features/credits/CreditMember.vue | Adds optional rank metadata and renders the rank within the existing member row. |
| app/features/credits/CreditMemberList.vue | Derives ranks for ordered lists and applies separate ordered-grid spacing and marker styling. |
| app/features/credits/CreditMemberRank.vue | Introduces the fixed-width visual rank used by ordered contributor rows. |
| app/features/credits/creditMemberStyles.ts | Adds subtle boundaries and backgrounds specifically to ranked grid entries. |
| app/features/credits/__tests__/creditsComponents.test.ts | Covers explicit rank rendering, ordered-list attributes, responsive gap classes, and unchanged unordered styling. |

</details>

<sub>Reviews (3): Last reviewed commit: ["fix(ui): expose contributor rank text di..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/545b7eb0057ae2d54f82fa46e01994bebe48a5ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51859753)</sub>

<!-- /greptile_comment -->