### PR TITLE
fix(hideout): stop context menu event propagation before async queue

### DIFF
--- a/app/features/hideout/HideoutRequirement.vue
+++ b/app/features/hideout/HideoutRequirement.vue
@@ -259,6 +259,7 @@
   };
   const openContextMenu = (event: MouseEvent): void => {
     editValue.value = currentCount.value;
+    event.stopPropagation();
     if (contextMenu.value) {
       contextMenu.value.open(event);
     } else {


### PR DESCRIPTION
## **User description**
Follow-up from #695 — addresses [CodeRabbit review comment](https://github.com/tarkovtracker-org/TarkovTracker/pull/695#discussion_r3752091613) posted just before merge.

When the async ContextMenu chunk hasn't loaded on first right-click, `openContextMenu` queues the event but didn't call `event.stopPropagation()`. This allowed the event to bubble to parent handlers inconsistently (first click bubbles, subsequent clicks don't because `ContextMenu.open()` handles it).

Adds `event.stopPropagation()` synchronously before the async branch.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Prevent hideout context-menu clicks from triggering parent actions

### What Changed
- Right-clicking a hideout requirement now stops the event immediately, including while the context menu is still loading
- Queued first-click events no longer bubble to parent handlers before the menu opens

### Impact
`✅ Consistent context-menu behavior on the first right-click`
`✅ Fewer unintended parent click actions`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved context-menu behavior in the hideout requirements view by preventing unintended event propagation when opening or queuing the menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR synchronously stops propagation of hideout requirement context-menu events before the asynchronously loaded menu is available.
- Prevents first-use context-menu events from bubbling while the menu chunk loads.
- Leaves subsequent-use behavior unchanged because `ContextMenu.open()` already stops propagation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The new synchronous propagation cancellation aligns the first-use asynchronous path with the existing loaded-menu path, which already stops the same event.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/features/hideout/HideoutRequirement.vue | Moves propagation cancellation ahead of the asynchronous context-menu branch, consistently handling first and subsequent right-clicks without introducing an actionable issue. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(hideout): stop context menu event pr..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/ee8a0d6fed5c75e6f553ca38987d9ab88e3f0353) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51909579)</sub>

<!-- /greptile_comment -->