### PR TITLE
perf(ui): bundle all icons locally to eliminate Iconify CDN calls

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -17,6 +17,8 @@
     "scripts/**/*.test.mjs"
   ],
   "ignoreDependencies": [
+    "@iconify-json/heroicons",
+    "@iconify-json/lucide",
     "@nuxt/image",
     "@nuxtjs/i18n",
     "@nuxtjs/sitemap",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,14 @@ Naming:
 - Use union/string literal types for constrained values. `as const` for literal inference.
 - Do not duplicate types already in Supabase generated files.
 
+## Icons
+
+- Icons use `@nuxt/icon` (registered automatically by `@nuxt/ui`). Use `<UIcon name="i-{collection}-{name}" />` or the `icon` prop on UI components.
+- Three Iconify collections are installed locally: `@iconify-json/mdi` (primary), `@iconify-json/heroicons`, `@iconify-json/lucide` (Nuxt UI internal).
+- `icon.clientBundle.scan` in `nuxt.config.ts` bundles all statically-referenced icons at build time into the client bundle. This eliminates runtime CDN fetches for the vast majority of icons.
+- Dynamically-bound icon names (`:name="variable"`) that the scanner cannot resolve at build time fall back to the Iconify CDN at runtime. The CSP `connect-src` entry for `api.iconify.design` exists for this fallback path.
+- When adding new icons, prefer icons from the installed collections (mdi, heroicons, lucide). Adding a new collection requires installing `@iconify-json/{collection}` and adding it to `.fallowrc.json` `ignoreDependencies`.
+
 ## Localization
 
 - Non-English files (`cs`, `de`, `es`, `fr`, `it`, `ko`, `pl`, `pt`, `ru`, `uk`, `zh`) are Crowdin-owned exports.

--- a/app/app.vue
+++ b/app/app.vue
@@ -82,15 +82,6 @@
       lang: locale.value,
     },
     link: [
-      {
-        rel: 'preconnect',
-        href: 'https://api.iconify.design',
-        crossorigin: 'anonymous',
-      },
-      {
-        rel: 'dns-prefetch',
-        href: 'https://api.iconify.design',
-      },
       ...(pageOwnsCanonical.value
         ? []
         : [

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -442,6 +442,11 @@ export default defineNuxtConfig({
   image: {
     domains: [...GITHUB_IMAGE_DOMAINS, ...TARKOV_IMAGE_DOMAINS, ...YOUTUBE_IMAGE_DOMAINS],
   },
+  icon: {
+    clientBundle: {
+      scan: true,
+    },
+  },
   ui: {
     theme: {
       colors: [

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
   },
   "version": "1.68.3",
   "dependencies": {
+    "@iconify-json/heroicons": "^1.2.3",
+    "@iconify-json/lucide": "^1.2.122",
     "@iconify-json/mdi": "^1.2.3",
     "@nuxt/image": "^2.0.0",
     "@nuxt/ui": "^4.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,12 @@ importers:
 
   .:
     dependencies:
+      '@iconify-json/heroicons':
+        specifier: ^1.2.3
+        version: 1.2.3
+      '@iconify-json/lucide':
+        specifier: ^1.2.122
+        version: 1.2.122
       '@iconify-json/mdi':
         specifier: ^1.2.3
         version: 1.2.3
@@ -1201,6 +1207,12 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@iconify-json/heroicons@1.2.3':
+    resolution: {integrity: sha512-n+vmCEgTesRsOpp5AB5ILB6srsgsYK+bieoQBNlafvoEhjVXLq8nIGN4B0v/s4DUfa0dOrjwE/cKJgIKdJXOEg==}
+
+  '@iconify-json/lucide@1.2.122':
+    resolution: {integrity: sha512-Dpt+ZbYTyKZqyRkEHmxEcsSsRW9yRTmkaweT2A1hfH7zKHZZ7FKmcn5evTh93ZlkYq2Vpb1YZUBsjc9AxZlcUg==}
 
   '@iconify-json/mdi@1.2.3':
     resolution: {integrity: sha512-O3cLwbDOK7NNDf2ihaQOH5F9JglnulNDFV7WprU2dSoZu3h3cWH//h74uQAB87brHmvFVxIOkuBX2sZSzYhScg==}
@@ -10266,6 +10278,14 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@iconify-json/heroicons@1.2.3':
+    dependencies:
+      '@iconify/types': 2.0.0
+
+  '@iconify-json/lucide@1.2.122':
+    dependencies:
+      '@iconify/types': 2.0.0
 
   '@iconify-json/mdi@1.2.3':
     dependencies:


### PR DESCRIPTION
## **User description**
## Summary

Bundle all icons (MDI, heroicons, lucide) locally at build time instead of fetching them from the Iconify CDN at runtime. This eliminates ~30+ network requests on first load, fixes CLS from icons rendering asynchronously, and improves FCP/LCP.

## Changes

- **Install `@iconify-json/heroicons` and `@iconify-json/lucide`** — provides local icon data for build-time bundling
- **Enable `icon.clientBundle.scan`** in nuxt.config.ts — scans source files at build time and bundles all used icons (299 icons, 93KB uncompressed / ~15-20KB gzipped)
- **Remove preconnect/dns-prefetch** for `api.iconify.design` in app.vue — no longer needed since icons are served from the client bundle

## Why

Previously:
- MDI icons (653 usages) were bundled ✓
- Heroicons (24 usages across 12 files) were fetched from CDN ✗
- Nuxt UI internal icons (lucide: chevrons, close, search, loading spinner, etc.) were fetched from CDN ✗

Every `UButton`, `USelect`, `UModal` close button, dropdown arrow, and UI chrome icon triggered a runtime network request. This caused:
- Layout shifts (CLS) as icons popped in after API response
- Network waterfall delays affecting FCP/LCP
- Dependency on external API availability

## Validation

- `nuxt prepare`: 299 icons bundled (93.38KB uncompressed) — up from 43 icons (10.40KB)
- `pnpm run typecheck`: ✓ passed
- `pnpm run lint`: ✓ 0 errors, 0 warnings
- `pnpm run test`: ✓ 2352 passed, 1 pre-existing failure (idleScheduler infinite loop — reproduces on main)

## Risk

Zero functional risk. Icons render identically — the only change is where they're loaded from (local bundle vs CDN). The trade-off is ~15-20KB additional gzipped JS in exchange for eliminating 30+ network round-trips and removing CLS.

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Bundle all application icons locally so they appear without waiting for an external icon service

### What Changed
- Heroicons, Lucide icons, and other used icons are included in the application bundle at build time
- The app no longer makes runtime requests to the Iconify API for icons
- Removed external connection hints that were only needed for the Iconify API

### Impact
`✅ Fewer first-load network requests`
`✅ Fewer icon-related layout shifts`
`✅ Faster initial icon rendering`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR configures Nuxt to bundle statically referenced MDI, Heroicons, and Lucide icons locally while retaining CDN fallback for dynamic names.
- Adds the required local Iconify collection packages and lockfile entries.
- Enables client-bundle icon scanning and removes obsolete connection hints.
- Documents the icon build, delivery, fallback, and maintenance workflow in `AGENTS.md`.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains; the previously reported documentation gap is addressed by the new Icons section in AGENTS.md.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| nuxt.config.ts | Enables build-time scanning for the Nuxt Icon client bundle; the configuration is now documented. |
| AGENTS.md | Adds accurate guidance covering local icon collections, static scanning, dynamic fallback, CSP, and dependency maintenance. |
| package.json | Adds the Heroicons and Lucide Iconify data packages required by the local bundle. |
| app/app.vue | Removes Iconify preconnect and DNS-prefetch hints while documented dynamic icons retain CSP-permitted CDN fallback. |
| .fallowrc.json | Exempts the build-consumed Iconify collection packages from unused-dependency reporting. |
| pnpm-lock.yaml | Records the new Iconify collection packages consistently with the manifest. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: document icon bundling pipeline in..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/95057dd0efda20dd7487a2f6678f504df03d0a1a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51922528)</sub>

**Context used:**

- Knowledge Base — [Frontend App (Nuxt)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/frontend-app.md)
- Knowledge Base — [Monorepo Build & Deploy Configuration](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/repo-build-config.md)

<!-- /greptile_comment -->