### PR TITLE
fix(ui): align compact credit member cards

### DIFF
--- a/app/features/credits/CreditMember.vue
+++ b/app/features/credits/CreditMember.vue
@@ -51,6 +51,6 @@
   const avatarSize = computed(() => creditMemberAvatarSize(props.variant));
   const avatarClasses = computed(() => creditMemberAvatarClasses(props.variant));
   const itemClasses = computed(() =>
-    creditMemberClasses(props.variant, Boolean(props.member.link), props.rank != null)
+    creditMemberClasses(props.variant, Boolean(props.member.link))
   );
 </script>

--- a/app/features/credits/CreditMemberList.vue
+++ b/app/features/credits/CreditMemberList.vue
@@ -30,7 +30,7 @@
   };
   const gridGapClasses = computed(() => {
     if (props.variant !== 'grid') return '';
-    return props.ordered ? 'gap-x-6 gap-y-1' : 'gap-x-2';
+    return 'gap-x-6 gap-y-1';
   });
   const listClasses = computed(() => [
     LIST_CLASSES[props.variant],

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -115,8 +115,14 @@ describe('credits member presentation', () => {
     expect(ordered.classes()).toContain('gap-x-6');
     expect(ordered.classes()).toContain('gap-y-1');
     expect(ordered.classes()).not.toContain('gap-x-2');
-    expect(unorderedGrid.classes()).toContain('gap-x-2');
-    expect(unorderedGrid.classes()).not.toContain('gap-x-6');
+    expect(unorderedGrid.classes()).toContain('gap-x-6');
+    expect(unorderedGrid.classes()).toContain('gap-y-1');
+    expect(unorderedGrid.classes()).not.toContain('gap-x-2');
+    expect(
+      unorderedGrid
+        .findAll('li')
+        .every((item) => item.get('div').classes().includes('border-white/5'))
+    ).toBe(true);
     expect(ordered.findAll('li').map((item) => item.get('span').text())).toEqual(['1.', '2.']);
     expect(unordered.element.tagName).toBe('UL');
     expect(unordered.classes()).toContain('flex');
@@ -129,8 +135,10 @@ describe('credits member presentation', () => {
     expect(creditMemberClasses('row', true).join(' ')).toContain('hover:bg-white/10');
     expect(creditMemberClasses('grid', false).join(' ')).not.toContain('hover:');
     expect(creditMemberClasses('grid', false).join(' ')).not.toContain('focus-visible:');
-    expect(creditMemberClasses('grid', true, true).join(' ')).toContain('bg-white/[0.02]');
-    expect(creditMemberClasses('grid', true, false).join(' ')).not.toContain('border-white/5');
+    expect(creditMemberClasses('grid', false).join(' ')).toContain('min-h-10');
+    expect(creditMemberClasses('grid', true).join(' ')).toContain('bg-white/[0.02]');
+    expect(creditMemberClasses('grid', false).join(' ')).toContain('border-white/5');
+    expect(creditMemberClasses('row', false).join(' ')).not.toContain('border-white/5');
   });
   it('keeps the static credit groups ordered and uniquely keyed', () => {
     expect(staticCreditSections.map((section) => section.key)).toEqual([

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -100,7 +100,7 @@ describe('credits member presentation', () => {
   });
   it('selects ordered and unordered list semantics and variant classes', () => {
     const members = [{ name: 'One' }, { name: 'Two' }];
-    const gridMembers = [members[0], { ...members[1], link: 'https://example.com/two' }];
+    const gridMembers = [{ name: 'One' }, { name: 'Two', link: 'https://example.com/two' }];
     const ordered = mount(CreditMemberList, {
       props: { members, ordered: true, variant: 'grid' },
       global,

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -100,12 +100,13 @@ describe('credits member presentation', () => {
   });
   it('selects ordered and unordered list semantics and variant classes', () => {
     const members = [{ name: 'One' }, { name: 'Two' }];
+    const gridMembers = [members[0], { ...members[1], link: 'https://example.com/two' }];
     const ordered = mount(CreditMemberList, {
       props: { members, ordered: true, variant: 'grid' },
       global,
     });
     const unorderedGrid = mount(CreditMemberList, {
-      props: { members, variant: 'grid' },
+      props: { members: gridMembers, variant: 'grid' },
       global,
     });
     const unordered = mount(CreditMemberList, { props: { members }, global });
@@ -118,10 +119,13 @@ describe('credits member presentation', () => {
     expect(unorderedGrid.classes()).toContain('gap-x-6');
     expect(unorderedGrid.classes()).toContain('gap-y-1');
     expect(unorderedGrid.classes()).not.toContain('gap-x-2');
+    const unorderedGridItems = unorderedGrid.findAll('li');
+    expect(unorderedGridItems.map((item) => item.get('a, div').element.tagName)).toEqual([
+      'DIV',
+      'A',
+    ]);
     expect(
-      unorderedGrid
-        .findAll('li')
-        .every((item) => item.get('div').classes().includes('border-white/5'))
+      unorderedGridItems.every((item) => item.get('a, div').classes().includes('border-white/5'))
     ).toBe(true);
     expect(ordered.findAll('li').map((item) => item.get('span').text())).toEqual(['1.', '2.']);
     expect(unordered.element.tagName).toBe('UL');
@@ -137,6 +141,7 @@ describe('credits member presentation', () => {
     expect(creditMemberClasses('grid', false).join(' ')).not.toContain('focus-visible:');
     expect(creditMemberClasses('grid', false).join(' ')).toContain('min-h-10');
     expect(creditMemberClasses('grid', true).join(' ')).toContain('bg-white/[0.02]');
+    expect(creditMemberClasses('grid', false).join(' ')).toContain('bg-white/[0.02]');
     expect(creditMemberClasses('grid', false).join(' ')).toContain('border-white/5');
     expect(creditMemberClasses('row', false).join(' ')).not.toContain('border-white/5');
   });

--- a/app/features/credits/creditMemberStyles.ts
+++ b/app/features/credits/creditMemberStyles.ts
@@ -1,7 +1,7 @@
 import type { CreditMemberVariant } from '@/features/credits/types';
 const BASE_CLASSES: Record<CreditMemberVariant, string> = {
   row: 'flex min-h-12 items-center gap-3 rounded-md bg-white/5 px-4 py-2.5 text-base font-medium text-white',
-  grid: 'group flex min-h-8 items-center gap-2 rounded px-2 py-1 text-sm text-white/85',
+  grid: 'group flex min-h-10 items-center gap-2 rounded px-2 py-1 text-sm text-white/85',
 };
 const LINK_HOVER_CLASSES: Record<CreditMemberVariant, string> = {
   row: 'hover:bg-white/10 hover:text-primary-100',
@@ -13,13 +13,9 @@ export const creditMemberAvatarClasses = (variant: CreditMemberVariant) => {
   const size = variant === 'row' ? 'h-9 w-9' : 'h-7 w-7';
   return `${size} shrink-0 rounded-full border border-white/15 object-cover`;
 };
-export const creditMemberClasses = (
-  variant: CreditMemberVariant,
-  linked: boolean,
-  ranked: boolean = false
-): string[] => [
+export const creditMemberClasses = (variant: CreditMemberVariant, linked: boolean): string[] => [
   BASE_CLASSES[variant],
-  variant === 'grid' && ranked ? 'border border-white/5 bg-white/[0.02]' : '',
+  variant === 'grid' ? 'border border-white/5 bg-white/[0.02]' : '',
   linked
     ? [
         LINK_HOVER_CLASSES[variant],


### PR DESCRIPTION
## **User description**
## Summary

Makes the **Support Members** and **Nuxt - Closed Beta Testers** sections use the same bounded compact cards as **Open Source Contributors**.

The root cause was that compact grid borders, backgrounds, and wider spacing were conditional on an entry having a contributor rank. Unordered credit groups therefore rendered as loose text cells, and name-only entries could be shorter than avatar entries.

## Changes

- Applies the shared bounded-card presentation to every compact credit grid entry.
- Uses the same 40 px minimum card height and 24 px column / 4 px row spacing across all three compact sections.
- Preserves contributor ranks and counts, alphabetical static-member order, list semantics, and external-link behavior.
- Extends component tests for unordered grid spacing, bounded styling, uniform sizing, and unchanged full-row styling.

## Related Issues

Closes #702

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. Open `/credits` at 1424, 1024, 768, and 390 px.
2. Compare Support Members and Closed Beta Testers directly with Open Source Contributors.
3. Confirm identical card height, width, column count, and spacing at each viewport.
4. Confirm there is no card overlap, clipping, or page-level horizontal overflow.
5. Run focused component tests, changed-file lint/format checks, blank-line lint, fallow, Nuxt typecheck, and precompute TypeScript checks.

### Results

- Focused Vitest: 8/8 passed.
- ESLint, Prettier, blank-line lint, fallow, Nuxt typecheck, precompute TypeScript, and commitlint passed.
- At each tested viewport, all three compact sections produced identical card dimensions:
  - 1424 px: 249.75 x 40 px, 4 columns
  - 1024 px: 207.66/207.67 x 40 px, 3 columns
  - 768 px: 283.5 x 40 px, 2 columns
  - 390 px: 237 x 40 px, 1 column
- No overlap, clipping, or horizontal overflow was detected.

## Screenshots/Videos

- Before: attached to #702.
- After: validated in the local browser and visually approved before publication.

## Documentation impact

- [ ] No behavior changed — no documentation review needed
- [x] Behavior changed — existing documentation remains accurate
- [ ] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [ ] Contributor documentation
- [ ] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [x] Screenshots or diagrams

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [ ] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

Husky's Git Bash environment could not resolve the bundled Windows `pnpm` shim. The exact staged-file hook tasks were run successfully through `pnpm exec lint-staged`, and commitlint was run separately before pushing.

___

## **CodeAnt-AI Description**
Align all compact credit member cards with consistent sizing and spacing

### What Changed
- Support Members and Closed Beta Testers now use the same bounded card layout as ranked contributors
- Compact cards have a uniform minimum height, border, background, and grid spacing
- Unranked member lists now use the same column and row gaps as ranked lists

### Impact
`✅ Consistent credit card sizing`
`✅ Clearer separation between compact members`
`✅ Fewer layout differences across credit sections`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved credit member grid layouts with increased spacing and taller member cards.
  * Applied consistent borders and backgrounds to grid members.
  * Preserved border-free styling for row-based members.
* **Tests**
  * Updated credit component coverage to reflect the revised spacing and visual styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR standardizes compact credit entries so ranked and unranked groups share consistent bounded-card styling and spacing.
- Applies a 40 px minimum height, border, and background to all compact grid cards.
- Uses consistent horizontal and vertical gaps across ordered and unordered compact grids.
- Extends component tests for list semantics, card styling, sizing, and row-style preservation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/features/credits/CreditMember.vue | Removes rank-dependent styling selection so every compact grid member uses the shared presentation. |
| app/features/credits/CreditMemberList.vue | Standardizes compact grid spacing across ordered and unordered member lists. |
| app/features/credits/creditMemberStyles.ts | Gives all grid cards a consistent minimum height, border, and background while preserving row styling. |
| app/features/credits/__tests__/creditsComponents.test.ts | Updates coverage for uniform grid spacing, bounded cards, link rendering, sizing, and unchanged row behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(ui): avoid nullable credit fixture ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/218df57ae6175965968cc222f3fb6e1704daf2c6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52018642)</sub>

<!-- /greptile_comment -->