### PR TITLE
fix(ui): clarify analytics consent status

### DIFF
--- a/app/components/analytics/AnalyticsConsentBanner.vue
+++ b/app/components/analytics/AnalyticsConsentBanner.vue
@@ -22,7 +22,7 @@
                 data-testid="analytics-consent-status"
                 role="status"
                 aria-live="polite"
-                :color="analyticsEnabled ? 'success' : 'neutral'"
+                :color="isAccepted ? 'success' : 'neutral'"
                 variant="soft"
                 size="sm"
                 class="shrink-0"
@@ -98,7 +98,7 @@
 <script setup lang="ts">
   import { shouldEnableAnalyticsIntegrations } from '@/utils/runtimeConfig';
   const { t } = useI18n({ useScope: 'global' });
-  const { accept, closePreferences, decline, hasAnswered, isPromptOpen, state } =
+  const { accept, closePreferences, decline, hasAnswered, isAccepted, isPromptOpen, state } =
     useAnalyticsConsent();
   const runtimeConfig = useRuntimeConfig();
   const consentDescriptionId = 'analytics-consent-description';
@@ -114,9 +114,8 @@
       runtimeConfig.public.microsoftClarityProjectId,
     ].some((value) => String(value || '').trim().length > 0);
   const isVisible = computed(() => analyticsConfigured && isPromptOpen.value);
-  const analyticsEnabled = computed(() => state.value.status === 'accepted');
   const analyticsStatusLabel = computed(() =>
-    analyticsEnabled.value
+    isAccepted.value
       ? t('analytics_consent.status_enabled', 'Analytics Status: Enabled')
       : t('analytics_consent.status_disabled', 'Analytics Status: Disabled')
   );

--- a/app/components/analytics/AnalyticsConsentBanner.vue
+++ b/app/components/analytics/AnalyticsConsentBanner.vue
@@ -11,9 +11,25 @@
       <UCard class="border-surface-700/80 bg-surface-900/95 border shadow-xl backdrop-blur">
         <div class="grid gap-4 lg:grid-cols-[minmax(0,1fr)_220px] lg:items-center">
           <div class="space-y-3">
-            <p class="text-primary-300 text-xs font-semibold tracking-[0.25em] uppercase">
-              {{ t('analytics_consent.eyebrow') }}
-            </p>
+            <div
+              data-testid="analytics-consent-eyebrow-row"
+              class="flex flex-wrap items-center gap-2"
+            >
+              <p class="text-primary-300 text-xs font-semibold tracking-[0.25em] uppercase">
+                {{ t('analytics_consent.eyebrow') }}
+              </p>
+              <UBadge
+                data-testid="analytics-consent-status"
+                role="status"
+                aria-live="polite"
+                :color="analyticsEnabled ? 'success' : 'neutral'"
+                variant="soft"
+                size="sm"
+                class="shrink-0"
+              >
+                {{ analyticsStatusLabel }}
+              </UBadge>
+            </div>
             <div class="space-y-1">
               <h2 :id="consentTitleId" class="text-lg font-semibold text-white">
                 {{ consentTitle }}
@@ -98,6 +114,12 @@
       runtimeConfig.public.microsoftClarityProjectId,
     ].some((value) => String(value || '').trim().length > 0);
   const isVisible = computed(() => analyticsConfigured && isPromptOpen.value);
+  const analyticsEnabled = computed(() => state.value.status === 'accepted');
+  const analyticsStatusLabel = computed(() =>
+    analyticsEnabled.value
+      ? t('analytics_consent.status_enabled', 'Analytics Status: Enabled')
+      : t('analytics_consent.status_disabled', 'Analytics Status: Disabled')
+  );
   const consentTitle = computed(() => {
     if (state.value.status === 'unknown') {
       return t('analytics_consent.title');

--- a/app/components/analytics/__tests__/AnalyticsConsentBanner.test.ts
+++ b/app/components/analytics/__tests__/AnalyticsConsentBanner.test.ts
@@ -18,6 +18,7 @@ const { accept, closePreferences, decline, runtimeConfig } = vi.hoisted(() => ({
 const state = ref<AnalyticsConsentState>({ status: 'unknown', updatedAt: null });
 const isPromptOpen = ref(true);
 const hasAnswered = computed(() => state.value.status !== 'unknown');
+const isAccepted = computed(() => state.value.status === 'accepted');
 const translations: Record<string, string> = {
   'analytics_consent.accepted': 'Analytics accepted',
   'analytics_consent.allow': 'Help us improve',
@@ -35,6 +36,7 @@ mockNuxtImport('useAnalyticsConsent', () => () => ({
   closePreferences,
   decline,
   hasAnswered,
+  isAccepted,
   isPromptOpen,
   state,
 }));

--- a/app/components/analytics/__tests__/AnalyticsConsentBanner.test.ts
+++ b/app/components/analytics/__tests__/AnalyticsConsentBanner.test.ts
@@ -1,0 +1,111 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, ref } from 'vue';
+import type { AnalyticsConsentState } from '@/composables/useAnalyticsConsent';
+const { accept, closePreferences, decline, runtimeConfig } = vi.hoisted(() => ({
+  accept: vi.fn(),
+  closePreferences: vi.fn(),
+  decline: vi.fn(),
+  runtimeConfig: {
+    public: {
+      appUrl: 'https://tarkovtracker.org',
+      googleAnalyticsMeasurementId: 'G-TEST',
+      microsoftClarityProjectId: '',
+    },
+  },
+}));
+const state = ref<AnalyticsConsentState>({ status: 'unknown', updatedAt: null });
+const isPromptOpen = ref(true);
+const hasAnswered = computed(() => state.value.status !== 'unknown');
+const translations: Record<string, string> = {
+  'analytics_consent.accepted': 'Analytics accepted',
+  'analytics_consent.allow': 'Help us improve',
+  'analytics_consent.decline': 'Keep analytics off',
+  'analytics_consent.declined': 'Analytics declined',
+  'analytics_consent.description': 'Analytics description',
+  'analytics_consent.eyebrow': 'Analytics',
+  'analytics_consent.status_disabled': 'Analytics Status: Disabled',
+  'analytics_consent.status_enabled': 'Analytics Status: Enabled',
+  'analytics_consent.title': 'Initial title',
+  'analytics_consent.title_answered': 'Answered title',
+};
+mockNuxtImport('useAnalyticsConsent', () => () => ({
+  accept,
+  closePreferences,
+  decline,
+  hasAnswered,
+  isPromptOpen,
+  state,
+}));
+mockNuxtImport('useI18n', () => () => ({
+  t: (key: string, fallback?: string) => translations[key] ?? fallback ?? key,
+}));
+mockNuxtImport('useRuntimeConfig', () => () => runtimeConfig);
+vi.mock('@/utils/runtimeConfig', () => ({
+  shouldEnableAnalyticsIntegrations: () => true,
+}));
+const UBadgeStub = {
+  inheritAttrs: false,
+  props: ['color', 'size', 'variant'],
+  template: '<span v-bind="$attrs" :data-color="color"><slot /></span>',
+};
+const UButtonStub = {
+  inheritAttrs: false,
+  emits: ['click'],
+  template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
+};
+const mountBanner = async () => {
+  const { default: AnalyticsConsentBanner } =
+    await import('@/components/analytics/AnalyticsConsentBanner.vue');
+  return mount(AnalyticsConsentBanner, {
+    global: {
+      stubs: {
+        RouterLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
+        UBadge: UBadgeStub,
+        UButton: UButtonStub,
+        UCard: { template: '<section><slot /></section>' },
+      },
+    },
+  });
+};
+describe('AnalyticsConsentBanner', () => {
+  beforeEach(() => {
+    state.value = { status: 'unknown', updatedAt: null };
+    isPromptOpen.value = true;
+    accept.mockReset();
+    accept.mockImplementation(() => {
+      state.value = { status: 'accepted', updatedAt: '2026-08-10T00:00:00.000Z' };
+    });
+    closePreferences.mockReset();
+    decline.mockReset();
+    decline.mockImplementation(() => {
+      state.value = { status: 'declined', updatedAt: '2026-08-10T00:00:00.000Z' };
+    });
+  });
+  it('shows the status beside the analytics eyebrow and updates for both choices', async () => {
+    const wrapper = await mountBanner();
+    const eyebrowRow = wrapper.get('[data-testid="analytics-consent-eyebrow-row"]');
+    const getStatus = () => eyebrowRow.get('[data-testid="analytics-consent-status"]');
+    expect(eyebrowRow.get('p').text()).toBe('Analytics');
+    expect(wrapper.get('h2').text()).toBe('Initial title');
+    expect(eyebrowRow.classes()).toEqual(expect.arrayContaining(['flex', 'items-center', 'gap-2']));
+    expect(getStatus().text()).toBe('Analytics Status: Disabled');
+    expect(getStatus().attributes('data-color')).toBe('neutral');
+    const allowButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Help us improve');
+    expect(allowButton).toBeDefined();
+    await allowButton?.trigger('click');
+    expect(getStatus().text()).toBe('Analytics Status: Enabled');
+    expect(getStatus().attributes('data-color')).toBe('success');
+    const declineButton = wrapper
+      .findAll('button')
+      .find((button) => button.text() === 'Keep analytics off');
+    expect(declineButton).toBeDefined();
+    await declineButton?.trigger('click');
+    expect(getStatus().text()).toBe('Analytics Status: Disabled');
+    expect(getStatus().attributes('data-color')).toBe('neutral');
+  });
+});

--- a/app/components/analytics/__tests__/AnalyticsConsentBanner.test.ts
+++ b/app/components/analytics/__tests__/AnalyticsConsentBanner.test.ts
@@ -2,7 +2,6 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { computed, ref } from 'vue';
 import type { AnalyticsConsentState } from '@/composables/useAnalyticsConsent';
 const { accept, closePreferences, decline, runtimeConfig } = vi.hoisted(() => ({
   accept: vi.fn(),

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -2276,6 +2276,8 @@
     "badge_default_off": "Off by default",
     "badge_usage_stats": "Usage stats",
     "badge_analytics_only": "Analytics only",
+    "status_enabled": "Analytics Status: Enabled",
+    "status_disabled": "Analytics Status: Disabled",
     "change_anytime": "Change this anytime from the footer.",
     "review_details": "Review details in Privacy Policy",
     "allow": "Help us improve",


### PR DESCRIPTION
## **User description**
# Pull Request

## Summary

Adds an explicit analytics status badge directly beside the `ANALYTICS` heading so the current consent choice is immediately visible instead of being communicated only through changing descriptive text.

## Changes

- Shows `Analytics Status: Enabled` in a success badge when usage analytics are accepted.
- Shows `Analytics Status: Disabled` in a neutral badge when analytics are declined or have not been enabled.
- Matches the existing consent badges by using the same `UBadge`, soft variant, and small size.
- Adds focused coverage for badge placement and Enabled/Disabled state transitions.

## Related Issues

None.

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. Open Analytics Preferences and verify the status badge appears directly beside the `ANALYTICS` heading.
2. Select `Help us improve` and verify the badge changes to `Analytics Status: Enabled`.
3. Select `Keep analytics off` and verify the badge changes to `Analytics Status: Disabled`.
4. Confirm the badge matches the existing consent badges' size and soft visual treatment.

## Screenshots/Videos

Rendered locally and visually approved before publication.

## Documentation impact

Select one:

- [ ] No behavior changed - no documentation review needed
- [x] Behavior changed - existing documentation remains accurate
- [ ] Behavior changed - documentation was updated in this PR
- [ ] Behavior changed - follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [ ] Contributor documentation
- [ ] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [x] Screenshots or diagrams

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [ ] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [ ] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

Focused tests and all required changed-file gates passed: TypeScript, Vitest, ESLint, Prettier, i18n, blank-line lint, fallow, staged-file checks, and commitlint. The full suite was not run. Fallow reports the inherited eyebrow tracking token because its existing line moved into the new title row; the styling value is unchanged.

___

## **CodeAnt-AI Description**
Show the current analytics consent status beside the Analytics heading

### What Changed
- Displays an “Analytics Status: Enabled” badge after users allow analytics.
- Displays an “Analytics Status: Disabled” badge when analytics are declined or no choice has been made.
- Updates the badge immediately when users switch between allowing and declining analytics.
- Added coverage for badge placement, wording, and status changes.

### Impact
`✅ Clearer analytics consent status`
`✅ Immediate feedback after changing preferences`
`✅ Fewer ambiguous analytics settings`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an analytics status badge to the consent banner.
  * The badge clearly indicates whether analytics is enabled or disabled.
  * Added localized labels for both analytics status states.

* **Tests**
  * Added coverage to verify the banner layout, status text, and badge color for accepted and declined choices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds a localized badge beside the Analytics heading that reflects the existing consent state.
- Displays a neutral Disabled badge until analytics is accepted.
- Switches the badge to success-colored Enabled when consent is accepted.
- Adds focused component coverage for placement and reactive state transitions.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/components/analytics/AnalyticsConsentBanner.vue | Adds a reactive analytics-status badge derived from the existing consent state. |
| app/components/analytics/__tests__/AnalyticsConsentBanner.test.ts | Verifies badge placement, wording, color, and accepted/declined transitions. |
| app/locales/en.json | Adds English labels for enabled and disabled analytics states. |

</details>

<sub>Reviews (3): Last reviewed commit: ["refactor(ui): reuse consent acceptance s..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/c24d0357d20d75ef522a920dc32f08d19575af15) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52038938)</sub>

<!-- /greptile_comment -->