### PR TITLE
feat(tasks): add buildWeapon containsAll mods to needed items

### DIFF
--- a/app/composables/__tests__/useGraphBuilder.test.ts
+++ b/app/composables/__tests__/useGraphBuilder.test.ts
@@ -231,3 +231,34 @@ describe('useGraphBuilder needed item accepted items', () => {
     expect(need?.acceptedItems).toBeUndefined();
   });
 });
+describe('useGraphBuilder buildWeapon containsAll needs', () => {
+  it('emits a need per explicit mod alongside the base weapon', () => {
+    const task: Task = {
+      id: 'gunsmith-11',
+      name: 'Gunsmith - Part 11',
+      failConditions: [],
+      objectives: [
+        {
+          id: 'obj-build',
+          type: 'buildWeapon',
+          count: 1,
+          item: { id: 'vector', name: 'KRISS Vector' },
+          containsAll: [
+            { id: 'rail', name: 'Vector modular rail' },
+            { name: 'Missing id mod' },
+            { id: 'foregrip', name: 'Skeletonized foregrip' },
+          ],
+        },
+      ],
+      taskRequirements: [],
+    } as unknown as Task;
+    const { processTaskData } = useGraphBuilder();
+    const needs = processTaskData([task]).neededItemTaskObjectives;
+    expect(needs.map((need) => [need.id, need.item?.id])).toEqual([
+      ['obj-build', 'vector'],
+      ['obj-build:rail', 'rail'],
+      ['obj-build:foregrip', 'foregrip'],
+    ]);
+    expect(needs.every((need) => need.taskId === 'gunsmith-11' && need.count === 1)).toBe(true);
+  });
+});

--- a/app/composables/__tests__/useGraphBuilder.test.ts
+++ b/app/composables/__tests__/useGraphBuilder.test.ts
@@ -232,8 +232,8 @@ describe('useGraphBuilder needed item accepted items', () => {
   });
 });
 describe('useGraphBuilder buildWeapon containsAll needs', () => {
-  it('emits a need per explicit mod alongside the base weapon', () => {
-    const task: Task = {
+  const buildTask = (foundInRaid?: boolean): Task =>
+    ({
       id: 'gunsmith-11',
       name: 'Gunsmith - Part 11',
       failConditions: [],
@@ -242,6 +242,7 @@ describe('useGraphBuilder buildWeapon containsAll needs', () => {
           id: 'obj-build',
           type: 'buildWeapon',
           count: 1,
+          ...(foundInRaid === undefined ? {} : { foundInRaid }),
           item: { id: 'vector', name: 'KRISS Vector' },
           containsAll: [
             { id: 'rail', name: 'Vector modular rail' },
@@ -251,14 +252,28 @@ describe('useGraphBuilder buildWeapon containsAll needs', () => {
         },
       ],
       taskRequirements: [],
-    } as unknown as Task;
+    }) as unknown as Task;
+  it('emits a need per explicit mod alongside the base weapon', () => {
     const { processTaskData } = useGraphBuilder();
-    const needs = processTaskData([task]).neededItemTaskObjectives;
-    expect(needs.map((need) => [need.id, need.item?.id])).toEqual([
+    const needs = processTaskData([buildTask()]).neededItemTaskObjectives;
+    const byId = [...needs].sort((a, b) => a.id.localeCompare(b.id));
+    expect(byId.map((need) => [need.id, need.item?.id])).toEqual([
       ['obj-build', 'vector'],
-      ['obj-build:rail', 'rail'],
       ['obj-build:foregrip', 'foregrip'],
+      ['obj-build:rail', 'rail'],
     ]);
     expect(needs.every((need) => need.taskId === 'gunsmith-11' && need.count === 1)).toBe(true);
+  });
+  it('keeps mod progress separate from the objective while pointing back to it', () => {
+    const { processTaskData } = useGraphBuilder();
+    const needs = processTaskData([buildTask()]).neededItemTaskObjectives;
+    const mods = needs.filter((need) => need.id !== 'obj-build');
+    expect(mods.map((need) => need.sourceObjectiveId)).toEqual(['obj-build', 'obj-build']);
+    expect(needs.find((need) => need.id === 'obj-build')?.sourceObjectiveId).toBeUndefined();
+  });
+  it('mirrors the objective found-in-raid flag onto its mods', () => {
+    const { processTaskData } = useGraphBuilder();
+    const needs = processTaskData([buildTask(true)]).neededItemTaskObjectives;
+    expect(needs.every((need) => need.foundInRaid === true)).toBe(true);
   });
 });

--- a/app/composables/__tests__/useNeededItems.test.ts
+++ b/app/composables/__tests__/useNeededItems.test.ts
@@ -278,6 +278,37 @@ describe('useNeededItems', () => {
       const { neededItems } = await setup();
       expect(neededItems.allItems.value.length).toBe(6);
     });
+    it('preserves separate progress keys for objectives that need the same item', async () => {
+      const sharedMod = createItem('560d657b4bdc2da74d8b4572', 'Shared weapon mod');
+      const firstObjectiveId = '676529af9c90953d090882ea';
+      const secondObjectiveId = '67652a2f4f75e1a9543289ed';
+      const taskId = '676529af9c90953d090882e7';
+      const taskObjectives: NeededItemTaskObjective[] = [
+        {
+          ...createTaskObjective(`${firstObjectiveId}:${sharedMod.id}`, taskId, sharedMod, 1),
+          sourceObjectiveId: firstObjectiveId,
+        },
+        {
+          ...createTaskObjective(`${secondObjectiveId}:${sharedMod.id}`, taskId, sharedMod, 1),
+          sourceObjectiveId: secondObjectiveId,
+        },
+      ];
+      const { neededItems } = await setup({
+        metadataStore: { neededItemTaskObjectives: taskObjectives },
+        preferencesStore: { getNeededItemsHideOwned: true },
+        tarkovStore: {
+          getObjectiveCount: (id: string) => (id === taskObjectives[1]?.id ? 1 : 0),
+        },
+      });
+      const allTaskItems = neededItems.allItems.value.filter(
+        (item): item is NeededItemTaskObjective => item.needType === 'taskObjective'
+      );
+      const filteredTaskItems = neededItems.filteredItems.value.filter(
+        (item): item is NeededItemTaskObjective => item.needType === 'taskObjective'
+      );
+      expect(allTaskItems).toEqual(taskObjectives);
+      expect(filteredTaskItems).toEqual([taskObjectives[0]]);
+    });
     it('excludes task objectives for invalid tasks', async () => {
       const { neededItems } = await setup({
         progressStore: {

--- a/app/composables/useGraphBuilder.ts
+++ b/app/composables/useGraphBuilder.ts
@@ -23,6 +23,27 @@ import type {
   TaskRequirement,
 } from '@/types/tarkov';
 /**
+ * Explicit `containsAll` mods (e.g. Gunsmith weapon builds) are required items in
+ * their own right. Each gets a synthetic progress id so counting one mod does not
+ * count the others or the objective's base item.
+ */
+function buildContainsAllNeeds(
+  taskId: string,
+  objective: TaskObjective
+): NeededItemTaskObjective[] {
+  return (objective.containsAll ?? [])
+    .filter((part) => Boolean(part?.id))
+    .map((part) => ({
+      id: `${objective.id}:${part.id}`,
+      needType: 'taskObjective' as const,
+      taskId,
+      type: objective.type,
+      item: part,
+      count: 1,
+      foundInRaid: false,
+    }));
+}
+/**
  * Composable for building task and hideout dependency graphs
  * Extracts complex graph algorithms from the metadata store
  */
@@ -190,6 +211,7 @@ export function useGraphBuilder() {
             foundInRaid: objective.foundInRaid ?? false,
             ...(acceptedItems ? { acceptedItems } : {}),
           });
+          tempNeededObjectives.push(...buildContainsAllNeeds(task.id, objective));
         }
       });
       // Process fail conditions for alternative tasks (complete-status triggers)

--- a/app/composables/useGraphBuilder.ts
+++ b/app/composables/useGraphBuilder.ts
@@ -22,11 +22,6 @@ import type {
   TaskObjective,
   TaskRequirement,
 } from '@/types/tarkov';
-/**
- * Explicit `containsAll` mods (e.g. Gunsmith weapon builds) are required items in
- * their own right. Each gets a synthetic progress id so counting one mod does not
- * count the others or the objective's base item.
- */
 function buildContainsAllNeeds(
   taskId: string,
   objective: TaskObjective
@@ -37,10 +32,11 @@ function buildContainsAllNeeds(
       id: `${objective.id}:${part.id}`,
       needType: 'taskObjective' as const,
       taskId,
+      sourceObjectiveId: objective.id,
       type: objective.type,
       item: part,
       count: 1,
-      foundInRaid: false,
+      foundInRaid: objective.foundInRaid ?? false,
     }));
 }
 /**

--- a/app/composables/useGraphBuilder.ts
+++ b/app/composables/useGraphBuilder.ts
@@ -196,18 +196,20 @@ export function useGraphBuilder() {
           // item; never a sparse/id-less array entry that would break grouping.
           const primaryItem = objective.item ?? validItems[0];
           const acceptedItems = validItems.length > 1 ? validItems : undefined;
-          tempNeededObjectives.push({
-            id: objective.id,
-            needType: 'taskObjective',
-            taskId: task.id,
-            type: objective.type,
-            item: primaryItem ?? objective.markerItem!,
-            markerItem: objective.markerItem,
-            count: objective.count ?? 1,
-            foundInRaid: objective.foundInRaid ?? false,
-            ...(acceptedItems ? { acceptedItems } : {}),
-          });
-          tempNeededObjectives.push(...buildContainsAllNeeds(task.id, objective));
+          tempNeededObjectives.push(
+            {
+              id: objective.id,
+              needType: 'taskObjective',
+              taskId: task.id,
+              type: objective.type,
+              item: primaryItem ?? objective.markerItem!,
+              markerItem: objective.markerItem,
+              count: objective.count ?? 1,
+              foundInRaid: objective.foundInRaid ?? false,
+              ...(acceptedItems ? { acceptedItems } : {}),
+            },
+            ...buildContainsAllNeeds(task.id, objective)
+          );
         }
       });
       // Process fail conditions for alternative tasks (complete-status triggers)

--- a/app/composables/useNeededItems.ts
+++ b/app/composables/useNeededItems.ts
@@ -307,7 +307,7 @@ export function useNeededItems(options: UseNeededItemsOptions = {}): UseNeededIt
           logger.warn('[NeededItems] Skipping objective without item/markerItem:', need);
           continue;
         }
-        key = `task:${need.taskId}:${itemId}`;
+        key = `task:${need.taskId}:${itemId}:${need.id}`;
       } else {
         itemId = getNeededItemId(need);
         if (!itemId) {

--- a/app/features/neededitems/NeededItem.vue
+++ b/app/features/neededitems/NeededItem.vue
@@ -294,7 +294,8 @@
     }
     if (props.need.needType == 'taskObjective') {
       // Safely get completions, defaulting to empty object
-      const objectiveCompletions = progressStore.objectiveCompletions?.[props.need.id] || {};
+      const objectiveCompletions =
+        progressStore.objectiveCompletions?.[props.need.sourceObjectiveId ?? props.need.id] || {};
       const taskCompletions = progressStore.tasksCompletions?.[props.need.taskId] || {};
       // Find all teammates (not self) that need this objective
       Object.entries(objectiveCompletions).forEach(([user, completed]) => {

--- a/app/types/tarkov.ts
+++ b/app/types/tarkov.ts
@@ -440,6 +440,13 @@ export interface NeededItemTaskObjective extends NeededItemBase {
    * the UI can show that alternatives are allowed.
    */
   acceptedItems?: TarkovItem[];
+  /**
+   * Objective this need was derived from, when `id` is synthetic rather than a
+   * real objective id (e.g. one need per `containsAll` weapon-build mod). Set
+   * only on derived needs; use it for lookups keyed by real objective ids, such
+   * as `objectiveCompletions`, while `id` stays the progress key.
+   */
+  sourceObjectiveId?: string;
 }
 export interface NeededItemHideoutModule extends NeededItemBase {
   needType: 'hideoutModule';


### PR DESCRIPTION
## **User description**
# Pull Request

## Summary

Explicit `containsAll` mods on weapon-build objectives (Gunsmith rails, foregrips, pistol grips, etc.) are now emitted as needed-for-task items, so they show up in Needed Items with their own progress.

## Changes

- `useGraphBuilder` pushes one `NeededItemTaskObjective` per valid `objective.containsAll` entry, keyed `{objectiveId}:{itemId}` so counting one mod does not count the other mods or the objective's base weapon
- Unit test covering derivation and skipping of id-less entries

This is intentionally the minimum viable change: no UI, type, or store changes. Existing Needed Items grouping, filtering, and count controls handle the new entries because they key on `taskId` + item id and read progress by need id.

## Related Issues

Fixes tarkovtracker-org/TarkovTracker#587

Supersedes #664, which reached the same goal with a ~550-line diff (task-card rendering, new helper modules, refactors).

## Scope note

Only explicitly named items are derivable. Gunsmith - Part 11's Glock "Big Stick" magazine is not in upstream `containsAll`: the build is expressed as `buildAttributes.magazineCapacity >= 31` plus `containsCategory`, so any qualifying magazine satisfies it. Category- and attribute-based requirements remain out of scope; the wiki naming one specific magazine is a wiki convention, not an upstream item requirement.

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. `pnpm exec vitest run app/composables/__tests__/useGraphBuilder.test.ts`
2. Open Needed Items and search "modular rail" -> "KRISS Vector Mk.5 modular rail" listed under Gunsmith - Part 11
3. Search "Skeletonized" -> "Tactical Dynamics Skeletonized Foregrip" (Part 11) and "AR-15 Tactical Dynamics Skeletonized pistol grip" (Part 12)
4. Adjust the count on one mod row and confirm the sibling mods and the base weapon row are unaffected

Verified in the dev server against live tarkov.dev data.

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Documentation impact

- [x] Behavior changed - existing documentation remains accurate

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Show explicit weapon-build parts in Needed Items

### What Changed
- Weapon-build objectives now list each explicitly required mod as its own needed item alongside the base weapon
- Progress for one mod is tracked separately from other mods and the weapon
- Entries without an item ID are skipped
- Added coverage for multiple mods, separate progress entries, and invalid item data

### Impact
`✅ Explicit weapon mods appear in Needed Items`
`✅ Separate progress for each required mod`
`✅ No invalid entries for unidentified parts`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved weapon task tracking when objectives include multiple required modifications.
  - Each valid modification is now tracked as a separate required item with its own progress identifier and required count.
  - Base weapons continue to be tracked independently, while invalid modification entries are safely ignored.
  - Task associations, completion counts, and raid-found status are preserved for more accurate progress reporting.
  - Team-needs tracking now correctly links item progress to the original task objective.
  - Distinct task objectives requiring the same item are no longer incorrectly merged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds individually tracked Needed Items entries for explicit `containsAll` weapon-build mods and correctly links their team-completion lookup back to the source objective.
- Generates deterministic per-mod progress IDs while skipping entries without item IDs.
- Preserves separate same-item objective progress during Needed Items aggregation.
- Uses the real source objective for team membership and the synthetic ID for per-mod counts.
- Adds tests covering derivation, filtering, progress isolation, and found-in-raid propagation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/composables/useGraphBuilder.ts | Derives valid `containsAll` weapon parts as independent needs with stable progress IDs and source-objective references. |
| app/composables/useNeededItems.ts | Extends task-item aggregation keys with the need ID so independent objective progress is not collapsed. |
| app/features/neededitems/NeededItem.vue | Correctly uses the source objective for teammate completion membership while retaining synthetic IDs for per-mod counts. |
| app/types/tarkov.ts | Adds the optional source-objective relationship needed to distinguish metadata lookup keys from derived progress keys. |
| app/composables/__tests__/useGraphBuilder.test.ts | Covers mod derivation, invalid entries, source-objective linkage, and found-in-raid propagation. |
| app/composables/__tests__/useNeededItems.test.ts | Verifies separate progress and filtering for same-item needs from distinct objectives. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(tasks): preserve needed-item source ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/82806757eaf482a0965b3a43ca45e38e35d58d00) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52042299)</sub>

<!-- /greptile_comment -->