### PR TITLE
fix(ui): track layout content scroll container in BackToTop

### DIFF
--- a/app/components/ui/BackToTop.vue
+++ b/app/components/ui/BackToTop.vue
@@ -16,23 +16,37 @@
   const visible = ref(false);
   const SCROLL_THRESHOLD = 300;
   let rafId: number | null = null;
+  let scrollContainer: HTMLElement | null = null;
+  const getScrollTop = () => {
+    const containerTop = scrollContainer ? scrollContainer.scrollTop : 0;
+    return Math.max(window.scrollY, containerTop);
+  };
   const onScroll = () => {
     if (rafId === null) {
       rafId = requestAnimationFrame(() => {
-        visible.value = window.scrollY > SCROLL_THRESHOLD;
+        visible.value = getScrollTop() > SCROLL_THRESHOLD;
         rafId = null;
       });
     }
   };
   const scrollToTop = () => {
     window.scrollTo({ top: 0, behavior: 'smooth' });
+    scrollContainer?.scrollTo({ top: 0, behavior: 'smooth' });
   };
   onMounted(() => {
+    const containerCandidate = document.getElementById('main-content')?.firstElementChild;
+    scrollContainer = containerCandidate instanceof HTMLElement ? containerCandidate : null;
     window.addEventListener('scroll', onScroll, { passive: true });
+    if (scrollContainer) {
+      scrollContainer.addEventListener('scroll', onScroll, { passive: true });
+    }
     onScroll();
   });
   onUnmounted(() => {
     window.removeEventListener('scroll', onScroll);
+    if (scrollContainer) {
+      scrollContainer.removeEventListener('scroll', onScroll);
+    }
     if (rafId !== null) {
       cancelAnimationFrame(rafId);
       rafId = null;

--- a/app/components/ui/BackToTop.vue
+++ b/app/components/ui/BackToTop.vue
@@ -12,14 +12,13 @@
   </Transition>
 </template>
 <script setup lang="ts">
-  import { useMainScrollContainer } from '@/composables/useMainScrollContainer';
+  import { useScrollRoot } from '@/composables/useScrollRoot';
   const { t } = useI18n({ useScope: 'global' });
-  const route = useRoute();
+  const { getScrollContainer, usesWindowScroll } = useScrollRoot();
   const visible = ref(false);
   const SCROLL_THRESHOLD = 300;
   let rafId: number | null = null;
   let scrollContainer: HTMLElement | null = null;
-  const usesWindowScroll = computed(() => Boolean(route.meta?.usesWindowScroll));
   const getScrollTop = () => {
     return usesWindowScroll.value ? window.scrollY : (scrollContainer?.scrollTop ?? window.scrollY);
   };
@@ -39,7 +38,7 @@
     scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
   };
   onMounted(() => {
-    scrollContainer = useMainScrollContainer();
+    scrollContainer = getScrollContainer();
     window.addEventListener('scroll', onScroll, { passive: true });
     if (scrollContainer) {
       scrollContainer.addEventListener('scroll', onScroll, { passive: true });

--- a/app/components/ui/BackToTop.vue
+++ b/app/components/ui/BackToTop.vue
@@ -12,6 +12,7 @@
   </Transition>
 </template>
 <script setup lang="ts">
+  import { useMainScrollContainer } from '@/composables/useMainScrollContainer';
   const { t } = useI18n({ useScope: 'global' });
   const visible = ref(false);
   const SCROLL_THRESHOLD = 300;
@@ -34,8 +35,7 @@
     scrollContainer?.scrollTo({ top: 0, behavior: 'smooth' });
   };
   onMounted(() => {
-    const containerCandidate = document.getElementById('main-content')?.firstElementChild;
-    scrollContainer = containerCandidate instanceof HTMLElement ? containerCandidate : null;
+    scrollContainer = useMainScrollContainer();
     window.addEventListener('scroll', onScroll, { passive: true });
     if (scrollContainer) {
       scrollContainer.addEventListener('scroll', onScroll, { passive: true });

--- a/app/components/ui/BackToTop.vue
+++ b/app/components/ui/BackToTop.vue
@@ -14,13 +14,14 @@
 <script setup lang="ts">
   import { useMainScrollContainer } from '@/composables/useMainScrollContainer';
   const { t } = useI18n({ useScope: 'global' });
+  const route = useRoute();
   const visible = ref(false);
   const SCROLL_THRESHOLD = 300;
   let rafId: number | null = null;
   let scrollContainer: HTMLElement | null = null;
+  const usesWindowScroll = computed(() => Boolean(route.meta?.usesWindowScroll));
   const getScrollTop = () => {
-    const containerTop = scrollContainer ? scrollContainer.scrollTop : 0;
-    return Math.max(window.scrollY, containerTop);
+    return usesWindowScroll.value ? window.scrollY : (scrollContainer?.scrollTop ?? window.scrollY);
   };
   const onScroll = () => {
     if (rafId === null) {
@@ -31,8 +32,11 @@
     }
   };
   const scrollToTop = () => {
-    window.scrollTo({ top: 0, behavior: 'smooth' });
-    scrollContainer?.scrollTo({ top: 0, behavior: 'smooth' });
+    if (usesWindowScroll.value || !scrollContainer) {
+      window.scrollTo({ top: 0, behavior: 'smooth' });
+      return;
+    }
+    scrollContainer.scrollTo({ top: 0, behavior: 'smooth' });
   };
   onMounted(() => {
     scrollContainer = useMainScrollContainer();

--- a/app/components/ui/__tests__/BackToTop.test.ts
+++ b/app/components/ui/__tests__/BackToTop.test.ts
@@ -1,9 +1,9 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { ref } from 'vue';
+import { reactive, ref } from 'vue';
 import BackToTop from '@/components/ui/BackToTop.vue';
-const routeState = { meta: { usesWindowScroll: false } };
+const routeState = reactive({ meta: { usesWindowScroll: false } });
 mockNuxtImport('useRoute', () => () => routeState);
 vi.mock('vue-i18n', async (importOriginal) => ({
   ...(await importOriginal<typeof import('vue-i18n')>()),
@@ -146,6 +146,25 @@ describe('BackToTop', () => {
       mounted.get('button').trigger('click');
       expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
       expect(wrapperScrollTo).not.toHaveBeenCalled();
+    });
+  });
+  it('updates the active scroll root after route metadata changes', async () => {
+    await withMainContent(async (wrapperEl) => {
+      const mounted = mountComponent();
+      rafCallback!(performance.now());
+      await mounted.vm.$nextTick();
+      routeState.meta.usesWindowScroll = true;
+      await mounted.vm.$nextTick();
+      Object.defineProperty(wrapperEl, 'scrollTop', { value: 500, configurable: true });
+      wrapperEl.dispatchEvent(new Event('scroll'));
+      rafCallback!(performance.now());
+      await mounted.vm.$nextTick();
+      expect(mounted.get('button').attributes('style')).toContain('display: none');
+      Object.defineProperty(window, 'scrollY', { value: 400, configurable: true });
+      window.dispatchEvent(new Event('scroll'));
+      rafCallback!(performance.now());
+      await mounted.vm.$nextTick();
+      expect(mounted.get('button').attributes('style')).toBeUndefined();
     });
   });
 });

--- a/app/components/ui/__tests__/BackToTop.test.ts
+++ b/app/components/ui/__tests__/BackToTop.test.ts
@@ -74,4 +74,54 @@ describe('BackToTop', () => {
     wrapper = null;
     expect(window.cancelAnimationFrame).not.toHaveBeenCalled();
   });
+  const withMainContent = async (
+    fn: (wrapperEl: HTMLElement) => void | Promise<void>
+  ): Promise<void> => {
+    const main = document.createElement('main');
+    main.id = 'main-content';
+    const wrapperEl = document.createElement('div');
+    main.appendChild(wrapperEl);
+    document.body.appendChild(main);
+    try {
+      await fn(wrapperEl);
+    } finally {
+      main.remove();
+    }
+  };
+  it('tracks scroll on the layout content wrapper when it is the scroll container', async () => {
+    await withMainContent(async (wrapperEl) => {
+      Object.defineProperty(wrapperEl, 'scrollTop', {
+        value: 0,
+        writable: true,
+        configurable: true,
+      });
+      const mounted = mountComponent();
+      rafCallback!(performance.now());
+      await mounted.vm.$nextTick();
+      Object.defineProperty(wrapperEl, 'scrollTop', { value: 500, configurable: true });
+      wrapperEl.dispatchEvent(new Event('scroll'));
+      rafCallback!(performance.now());
+      await mounted.vm.$nextTick();
+      expect(mounted.get('button').attributes('style')).toBeUndefined();
+    });
+  });
+  it('removes the content wrapper scroll listener on unmount', async () => {
+    await withMainContent((wrapperEl) => {
+      const removeSpy = vi.spyOn(wrapperEl, 'removeEventListener');
+      const mounted = mountComponent();
+      mounted.unmount();
+      wrapper = null;
+      expect(removeSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
+    });
+  });
+  it('scrolls the content wrapper and window to top on click', async () => {
+    await withMainContent((wrapperEl) => {
+      const wrapperScrollTo = vi.fn();
+      wrapperEl.scrollTo = wrapperScrollTo;
+      const mounted = mountComponent();
+      mounted.get('button').trigger('click');
+      expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+      expect(wrapperScrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    });
+  });
 });

--- a/app/components/ui/__tests__/BackToTop.test.ts
+++ b/app/components/ui/__tests__/BackToTop.test.ts
@@ -1,7 +1,10 @@
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { mount, type VueWrapper } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ref } from 'vue';
 import BackToTop from '@/components/ui/BackToTop.vue';
+const routeState = { meta: { usesWindowScroll: false } };
+mockNuxtImport('useRoute', () => () => routeState);
 vi.mock('vue-i18n', async (importOriginal) => ({
   ...(await importOriginal<typeof import('vue-i18n')>()),
   useI18n: () => ({
@@ -22,6 +25,7 @@ describe('BackToTop', () => {
     return wrapper;
   };
   beforeEach(() => {
+    routeState.meta.usesWindowScroll = false;
     rafCallback = null;
     rafId = 1;
     vi.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
@@ -114,14 +118,34 @@ describe('BackToTop', () => {
       expect(removeSpy).toHaveBeenCalledWith('scroll', expect.any(Function));
     });
   });
-  it('scrolls the content wrapper and window to top on click', async () => {
+  it('scrolls the active content wrapper to top on click', async () => {
     await withMainContent((wrapperEl) => {
       const wrapperScrollTo = vi.fn();
       wrapperEl.scrollTo = wrapperScrollTo;
       const mounted = mountComponent();
       mounted.get('button').trigger('click');
-      expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+      expect(window.scrollTo).not.toHaveBeenCalled();
       expect(wrapperScrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    });
+  });
+  it('uses the window as the active scroll root for window-scroll routes', async () => {
+    routeState.meta.usesWindowScroll = true;
+    await withMainContent(async (wrapperEl) => {
+      const wrapperScrollTo = vi.fn();
+      wrapperEl.scrollTo = wrapperScrollTo;
+      Object.defineProperty(wrapperEl, 'scrollTop', { value: 500, configurable: true });
+      const mounted = mountComponent();
+      rafCallback!(performance.now());
+      await mounted.vm.$nextTick();
+      expect(mounted.get('button').attributes('style')).toContain('display: none');
+      Object.defineProperty(window, 'scrollY', { value: 400, configurable: true });
+      window.dispatchEvent(new Event('scroll'));
+      rafCallback!(performance.now());
+      await mounted.vm.$nextTick();
+      expect(mounted.get('button').attributes('style')).toBeUndefined();
+      mounted.get('button').trigger('click');
+      expect(window.scrollTo).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+      expect(wrapperScrollTo).not.toHaveBeenCalled();
     });
   });
 });

--- a/app/composables/useMainScrollContainer.ts
+++ b/app/composables/useMainScrollContainer.ts
@@ -1,0 +1,4 @@
+export const useMainScrollContainer = (): HTMLElement | null => {
+  const containerCandidate = document.getElementById('main-content')?.firstElementChild;
+  return containerCandidate instanceof HTMLElement ? containerCandidate : null;
+};

--- a/app/composables/useMainScrollContainer.ts
+++ b/app/composables/useMainScrollContainer.ts
@@ -1,4 +1,0 @@
-export const useMainScrollContainer = (): HTMLElement | null => {
-  const containerCandidate = document.getElementById('main-content')?.firstElementChild;
-  return containerCandidate instanceof HTMLElement ? containerCandidate : null;
-};

--- a/app/composables/useScrollRoot.ts
+++ b/app/composables/useScrollRoot.ts
@@ -1,0 +1,9 @@
+export const useScrollRoot = () => {
+  const route = useRoute();
+  const usesWindowScroll = computed(() => Boolean(route.meta?.usesWindowScroll));
+  const getScrollContainer = (): HTMLElement | null => {
+    const containerCandidate = document.getElementById('main-content')?.firstElementChild;
+    return containerCandidate instanceof HTMLElement ? containerCandidate : null;
+  };
+  return { getScrollContainer, usesWindowScroll };
+};

--- a/app/layouts/default.vue
+++ b/app/layouts/default.vue
@@ -49,6 +49,7 @@
   </div>
 </template>
 <script setup lang="ts">
+  import { useScrollRoot } from '@/composables/useScrollRoot';
   import { useSharedBreakpoints } from '@/composables/useSharedBreakpoints';
   import AppBar from '@/shell/AppBar.vue';
   import AppFooter from '@/shell/AppFooter.vue';
@@ -64,8 +65,8 @@
     });
   }
   const appStore = useAppStore();
-  const route = useRoute();
   const { belowMd } = useSharedBreakpoints();
+  const { usesWindowScroll } = useScrollRoot();
   const mainMarginLeft = computed(() => {
     if (belowMd.value) {
       return appStore.mobileDrawerExpanded
@@ -73,9 +74,6 @@
         : SHELL_DRAWER_COLLAPSED_WIDTH;
     }
     return appStore.drawerRail ? SHELL_DRAWER_COLLAPSED_WIDTH : SHELL_DRAWER_EXPANDED_WIDTH;
-  });
-  const usesWindowScroll = computed(() => {
-    return Boolean(route.meta?.usesWindowScroll);
   });
   useHead(
     computed(() => ({

--- a/app/pages/terms-of-service.vue
+++ b/app/pages/terms-of-service.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-  import { useMainScrollContainer } from '@/composables/useMainScrollContainer';
+  import { useScrollRoot } from '@/composables/useScrollRoot';
   const { t } = useI18n({ useScope: 'global' });
+  const { getScrollContainer } = useScrollRoot();
   useSeoMeta({
     title: 'Terms of Service',
     description: 'TarkovTracker terms of service and usage guidelines.',
@@ -62,7 +63,7 @@
     activeId.value = id;
   };
   onMounted(() => {
-    scrollRoot = useMainScrollContainer();
+    scrollRoot = getScrollContainer();
     updateActiveId();
     if (scrollRoot) {
       scrollRoot.addEventListener('scroll', scheduleUpdateActiveId, { passive: true });

--- a/app/pages/terms-of-service.vue
+++ b/app/pages/terms-of-service.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+  import { useMainScrollContainer } from '@/composables/useMainScrollContainer';
   const { t } = useI18n({ useScope: 'global' });
   useSeoMeta({
     title: 'Terms of Service',
@@ -61,8 +62,7 @@
     activeId.value = id;
   };
   onMounted(() => {
-    const rootCandidate = document.getElementById('main-content')?.firstElementChild;
-    scrollRoot = rootCandidate instanceof HTMLElement ? rootCandidate : null;
+    scrollRoot = useMainScrollContainer();
     updateActiveId();
     if (scrollRoot) {
       scrollRoot.addEventListener('scroll', scheduleUpdateActiveId, { passive: true });


### PR DESCRIPTION
## **User description**
## Summary

Fixes an issue where the `BackToTop` button failed to detect scrolling or perform smooth scroll-to-top actions when operating inside the app layout's default scroll container (`#main-content > div` with `overflow-y-auto`).

## Changes

- **`app/components/ui/BackToTop.vue`**:
  - Dynamically inspects `#main-content`'s child container.
  - Adds passive scroll event listeners to both `window` and `scrollContainer`.
  - Calculates scroll distance as `Math.max(window.scrollY, containerTop)`.
  - On click, triggers smooth scrolling on both targets.
  - Cleanly removes event listeners on unmount.
- **`app/components/ui/__tests__/BackToTop.test.ts`**:
  - Added unit test cases verifying layout container scroll tracking, listener cleanup, and click action handlers.

## Validation

- `pnpm exec vitest run app/components/ui/__tests__/BackToTop.test.ts` ✅ (7/7 passed)
- `pnpm run typecheck` ✅
- `pnpm run lint` ✅

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Fix Back to Top scrolling and reduce layout shifts during app startup

### What Changed
- Back to Top now detects scrolling inside the app’s content area as well as the browser window
- Clicking Back to Top smoothly scrolls both the content area and page to the top
- Scroll updates are grouped to keep the interface responsive, and pending updates are cleared when leaving the page
- The app reserves space for the sidebar and top bar before loading, using the saved sidebar state to prevent visible layout shifts
- Shell components load immediately, while the consent banner is preloaded without breaking the page if loading fails

### Impact
`✅ Back to Top works inside app content panels`
`✅ Fewer layout shifts during startup`
`✅ Smoother scrolling under frequent scroll events`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Back-to-top controls now detect scrolling in either the page or the main content area.
  * Selecting the control smoothly scrolls the active content area to the top.

* **Bug Fixes**
  * Improved back-to-top visibility and scrolling behavior on content-focused pages, including the terms-of-service page.
  * Improved event cleanup when navigating away, preventing stale listeners and duplicate scroll handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR centralizes selection of the active scroll root and updates BackToTop to follow either the layout container or window according to route metadata.
- Adds a shared `useScrollRoot` composable.
- Tracks and controls scrolling through the active root with listener cleanup on unmount.
- Reuses the scroll-root helper in the default layout and terms-of-service page.
- Expands BackToTop coverage for container scrolling, route metadata changes, click handling, and cleanup.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/components/ui/BackToTop.vue | BackToTop now reads, observes, and scrolls the route-selected scroll root while cleaning up listeners and queued animation frames. |
| app/components/ui/__tests__/BackToTop.test.ts | Tests cover layout-container scrolling, window-scroll routes, metadata changes, click behavior, and listener cleanup. |
| app/composables/useScrollRoot.ts | Introduces the shared route-aware scroll-root lookup used by layout-related components. |
| app/layouts/default.vue | Replaces duplicated route metadata handling with the shared scroll-root composable. |
| app/pages/terms-of-service.vue | Reuses the shared helper to select the element observed for section-position updates. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix(ui): centralize scroll root route st..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/49564ae1a37bfb4f512312fbd03ad977d2bd5453) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52135231)</sub>

**Context used:**

- Knowledge Base — [Frontend App (Nuxt)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/frontend-app.md)

<!-- /greptile_comment -->