### PR TITLE
test: cover Cultist Circle level one

### DIFF
--- a/app/features/hideout/__tests__/HideoutCard.test.ts
+++ b/app/features/hideout/__tests__/HideoutCard.test.ts
@@ -236,6 +236,9 @@ describe('HideoutCard', () => {
         },
       },
       global: {
+        mocks: {
+          $t: (key: string) => translations[key] ?? key,
+        },
         stubs: {
           GenericCard: GenericCardStub,
           HideoutRequirement: true,
@@ -248,7 +251,7 @@ describe('HideoutCard', () => {
         },
       },
     });
-    expect(wrapper.text()).toContain('Max station level reached');
+    expect(wrapper.text()).toContain('Max level');
     expect(wrapper.findAll('button')).toHaveLength(1);
   });
 });

--- a/app/features/hideout/__tests__/HideoutCard.test.ts
+++ b/app/features/hideout/__tests__/HideoutCard.test.ts
@@ -4,6 +4,16 @@ import HideoutCard from '@/features/hideout/HideoutCard.vue';
 const trackEventMock = vi.fn();
 const toastAddMock = vi.fn();
 let arePrereqsMetResult = true;
+let gameEdition = 1;
+let gameEditionData: Array<{
+  defaultCultistCircleLevel: number;
+  defaultStashLevel: number;
+  value: number;
+}> = [];
+let hideoutLevels: Record<string, { self: number }> = {
+  generator: { self: 0 },
+  workbench: { self: 0 },
+};
 let stationReqMetResult = true;
 let skillReqMetResult = true;
 let traderReqMetResult = true;
@@ -43,17 +53,14 @@ vi.mock('@/stores/useMetadata', () => ({
 }));
 vi.mock('@/stores/useProgress', () => ({
   useProgressStore: () => ({
-    gameEditionData: [],
-    hideoutLevels: {
-      generator: { self: 0 },
-      workbench: { self: 0 },
-    },
+    gameEditionData,
+    hideoutLevels,
   }),
 }));
 vi.mock('@/stores/useTarkov', () => ({
   useTarkovStore: () => ({
     getCurrentGameMode: () => 'pvp',
-    getGameEdition: () => 'standard',
+    getGameEdition: () => gameEdition,
     setHideoutModuleComplete: vi.fn(),
     setHideoutModuleUncomplete: vi.fn(),
     setHideoutPartComplete: vi.fn(),
@@ -97,6 +104,12 @@ const NuxtLinkStub = {
 describe('HideoutCard', () => {
   beforeEach(() => {
     arePrereqsMetResult = true;
+    gameEdition = 1;
+    gameEditionData = [];
+    hideoutLevels = {
+      generator: { self: 0 },
+      workbench: { self: 0 },
+    };
     stationReqMetResult = true;
     skillReqMetResult = true;
     traderReqMetResult = true;
@@ -188,5 +201,54 @@ describe('HideoutCard', () => {
     expect(wrapper.text()).not.toContain('Not ready');
     expect(wrapper.html()).toContain('text-success-400');
     expect(wrapper.html()).not.toContain('text-error-400');
+  });
+  it('shows the Unheard Cultist Circle at its only level as maxed', async () => {
+    gameEdition = 5;
+    gameEditionData = [
+      {
+        defaultCultistCircleLevel: 1,
+        defaultStashLevel: 5,
+        value: 5,
+      },
+    ];
+    hideoutLevels = {
+      'cultist-circle': { self: 1 },
+    };
+    const wrapper = await mountSuspended(HideoutCard, {
+      props: {
+        station: {
+          id: 'cultist-circle',
+          imageLink: '/cultist-circle.png',
+          levels: [
+            {
+              constructionTime: 0,
+              crafts: [],
+              id: 'cultist-circle-level-1',
+              itemRequirements: [],
+              level: 1,
+              skillRequirements: [],
+              stationLevelRequirements: [],
+              traderRequirements: [],
+            },
+          ],
+          name: 'Cultist Circle',
+          normalizedName: 'cultist-circle',
+        },
+      },
+      global: {
+        stubs: {
+          GenericCard: GenericCardStub,
+          HideoutRequirement: true,
+          NuxtLink: NuxtLinkStub,
+          UButton: UButtonStub,
+          UIcon: true,
+          'i18n-t': {
+            template: '<span><slot name="level" /></span>',
+          },
+        },
+      },
+    });
+    expect(wrapper.text()).toContain('Max station level reached');
+    expect(wrapper.findAll('button')).toHaveLength(1);
   });
 });

--- a/app/features/profile/__tests__/profileStats.test.ts
+++ b/app/features/profile/__tests__/profileStats.test.ts
@@ -45,10 +45,7 @@ describe('profileStats', () => {
       {
         id: 'cultist-circle-station',
         normalizedName: 'cultist-circle',
-        levels: [
-          { id: 'cultist-1', level: 1 },
-          { id: 'cultist-2', level: 2 },
-        ],
+        levels: [{ id: 'cultist-1', level: 1 }],
       },
       {
         id: 'workbench-station',
@@ -73,7 +70,6 @@ describe('profileStats', () => {
       'stash-2': true,
       'stash-3': true,
       'cultist-1': true,
-      'cultist-2': false,
       'workbench-1': false,
       'workbench-2': true,
     });


### PR DESCRIPTION
## Summary

- Add regression coverage for automatic completion of the one-level Cultist Circle.
- Verify the Unheard Cultist Circle renders as maxed at level 1 with no upgrade action.

## Validation

- Focused Vitest suite — 4 tests passed
- Focused ESLint for the changed tests
- pnpm run typecheck

The production logic already uses an equality-inclusive completion check: a module is complete when its level is less than or equal to the edition grant.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds regression coverage for the one-level Cultist Circle granted by the Unheard edition.
- Verifies that the Cultist Circle is displayed as maxed at level 1 without an upgrade or downgrade action.
- Aligns the profile-statistics fixture with the station’s one-level definition.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/features/hideout/__tests__/HideoutCard.test.ts | Adds deterministic edition and hideout-level mocks plus focused coverage of the max-level Cultist Circle state. |
| app/features/profile/__tests__/profileStats.test.ts | Updates the Cultist Circle fixture and expected completion map to model its single level. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: stabilize cultist circle assertion"](https://github.com/tarkovtracker-org/tarkovtracker/commit/86d49e8b0285610bf13c767d57e73eb2152e0de5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52427757)</sub>

<!-- /greptile_comment -->