### PR TITLE
fix(settings): support Seasonal Tarkov.dev profile imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,8 +199,8 @@ Naming:
 - Keep the app's `ACTIVE_SEASON` number and dates synchronized with the database's
   `private.active_season_*()` functions. The Worker resolves the number from the database.
   Advancing the number starts a fresh empty Seasonal progress row without deleting history.
-  Tarkov.dev profile and EFT-log
-  imports must remain unavailable for Seasonal until their Season profile data is verified.
+  Tarkov.dev profile imports support Seasonal through the upstream `pvp-season` profile path.
+  EFT-log imports must remain unavailable for Seasonal until their Season log data is verified.
 - Public progress API clients must send a 5–200 character `User-Agent`; infrastructure routes are exempt. Usage reporting stores the latest normalized value per token/day.
 - API token renames update only `api_tokens.note` through authenticated owner-scoped RLS. They
   must never rotate or replace the token or change its ID, value or hash, permissions, game mode,

--- a/app/composables/__tests__/useTarkovDevImport.test.ts
+++ b/app/composables/__tests__/useTarkovDevImport.test.ts
@@ -14,12 +14,7 @@ const { mockGetImportCooldownRemainingMs, mockRecordImportCompletion, mockUseRun
     mockUseRuntimeConfig: vi.fn(),
   }));
 mockNuxtImport('useRuntimeConfig', () => mockUseRuntimeConfig);
-mockNuxtImport('useI18n', () => () => ({
-  t: (key: string) =>
-    key === 'settings.data_management.seasonal_import_locked'
-      ? 'Seasonal PvP imports are temporarily locked until the source data is verified for Season 1.'
-      : key,
-}));
+mockNuxtImport('useI18n', () => () => ({ t: (key: string) => key }));
 vi.mock('@/utils/tarkovDevImportCooldown', () => ({
   getImportCooldownRemainingMs: mockGetImportCooldownRemainingMs,
   recordImportCompletion: mockRecordImportCompletion,
@@ -315,6 +310,25 @@ describe('useTarkovDevImport', () => {
     await composable.confirmImport('pve');
     expect(mockRecordImportCompletion).toHaveBeenCalledWith(8560316, 'pve', 60 * 60_000);
   });
+  it('fetches and imports a seasonal pvp profile into seasonal progress', async () => {
+    mockFetch.mockResolvedValue({ aid: 8560316 });
+    mockParseTarkovDevProfile.mockReturnValue({
+      data: createImportData({ tarkovUid: 8560316 }),
+      ok: true,
+    });
+    const composable = await loadComposable();
+    await composable.parseProfileUrl('https://tarkov.dev/players/pvp-season/8560316');
+    await composable.confirmImport('seasonal');
+    expect(mockFetch).toHaveBeenCalledWith('/api/tarkov-dev/profile', {
+      query: { url: 'https://players.tarkov.dev/pvp-season/8560316.json' },
+      retry: 0,
+    });
+    expect(tarkovStore.switchGameMode).toHaveBeenNthCalledWith(1, 'seasonal');
+    expect(tarkovStore.setTarkovUid).toHaveBeenCalledWith(8560316);
+    expect(mockRecordImportCompletion).toHaveBeenCalledWith(8560316, 'seasonal', 60 * 60_000);
+    expect(tarkovStore.switchGameMode).toHaveBeenNthCalledWith(2, 'pvp');
+    expect(composable.importState.value).toBe('success');
+  });
   it('does not record a cooldown for file imports', async () => {
     mockParseTarkovDevProfile.mockReturnValue({
       data: createImportData(),
@@ -324,21 +338,6 @@ describe('useTarkovDevImport', () => {
     await composable.parseFile(createFile('{"aid":123}'));
     await composable.confirmImport('pvp');
     expect(mockRecordImportCompletion).not.toHaveBeenCalled();
-  });
-  it('rejects seasonal imports before mutating progress', async () => {
-    mockParseTarkovDevProfile.mockReturnValue({
-      data: createImportData(),
-      ok: true,
-    });
-    const composable = await loadComposable();
-    await composable.parseFile(createFile('{"aid":123}'));
-    await (composable.confirmImport as (mode: string) => Promise<void>)('seasonal');
-    expect(composable.importState.value).toBe('error');
-    expect(composable.importError.value).toBe(
-      'Seasonal PvP imports are temporarily locked until the source data is verified for Season 1.'
-    );
-    expect(tarkovStore.switchGameMode).not.toHaveBeenCalled();
-    expect(tarkovStore.setTarkovUid).not.toHaveBeenCalled();
   });
   it('applies imported profile data and restores the original mode', async () => {
     const parsedData = createImportData({

--- a/app/composables/useTarkovDevImport.ts
+++ b/app/composables/useTarkovDevImport.ts
@@ -2,12 +2,7 @@ import { useSkillCalculation } from '@/composables/useSkillCalculation';
 import { useXpCalculation } from '@/composables/useXpCalculation';
 import { useMetadataStore } from '@/stores/useMetadata';
 import { useTarkovStore } from '@/stores/useTarkov';
-import {
-  GAME_MODES,
-  getGameModeSeasonNumber,
-  isImportableGameMode,
-  type ImportableGameMode,
-} from '@/utils/constants';
+import { isGameMode, type GameMode } from '@/utils/constants';
 import { logger } from '@/utils/logger';
 import {
   getImportCooldownRemainingMs,
@@ -37,7 +32,7 @@ export interface UseTarkovDevImportReturn {
     profileUrl: string,
     options?: TarkovDevProfileFetchOptions
   ) => Promise<TarkovDevProfileSource | null>;
-  confirmImport: (targetMode: ImportableGameMode, editionOverride?: number | null) => Promise<void>;
+  confirmImport: (targetMode: GameMode, editionOverride?: number | null) => Promise<void>;
   setError: (message: string) => void;
   reset: () => void;
 }
@@ -71,7 +66,6 @@ function readNumericField(data: Record<string, unknown> | null, key: string): nu
   return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 export function useTarkovDevImport(): UseTarkovDevImportReturn {
-  const { t } = useI18n({ useScope: 'global' });
   const tarkovStore = useTarkovStore();
   const metadataStore = useMetadataStore();
   const runtimeConfig = useRuntimeConfig();
@@ -229,24 +223,11 @@ export function useTarkovDevImport(): UseTarkovDevImportReturn {
     }
   }
   async function confirmImport(
-    targetMode: ImportableGameMode,
+    targetMode: GameMode,
     editionOverride?: number | null
   ): Promise<void> {
     if (!previewData.value) return;
-    if (!isImportableGameMode(targetMode)) {
-      setCodedError(
-        t(
-          'settings.data_management.seasonal_import_locked',
-          {
-            season: getGameModeSeasonNumber(GAME_MODES.SEASONAL),
-          },
-          'Seasonal PvP imports are temporarily locked until the source data is verified for Season {season}.'
-        ),
-        null,
-        null
-      );
-      return;
-    }
+    if (!isGameMode(targetMode)) return;
     const data = previewData.value;
     const originalMode = tarkovStore.getCurrentGameMode();
     const shouldRestoreMode = targetMode !== originalMode;

--- a/app/features/profile/ProfileProgression.vue
+++ b/app/features/profile/ProfileProgression.vue
@@ -259,12 +259,7 @@
   import { usePreferencesStore } from '@/stores/usePreferences';
   import { useProgressStore } from '@/stores/useProgress';
   import { useTarkovStore } from '@/stores/useTarkov';
-  import {
-    ACTIVE_SEASON_NUMBER,
-    GAME_MODES,
-    isImportableGameMode,
-    type GameMode,
-  } from '@/utils/constants';
+  import { ACTIVE_SEASON_NUMBER, GAME_MODES, type GameMode } from '@/utils/constants';
   import { isTaskAvailableForEdition as checkTaskEdition } from '@/utils/editionHelpers';
   import { calculatePercentageNum, useLocaleNumberFormatter } from '@/utils/formatters';
   import { logger } from '@/utils/logger';
@@ -660,7 +655,6 @@
   const modeFaction = computed(() => modeData.value.pmcFaction ?? 'USEC');
   const tarkovDevProfileUrl = computed(() => {
     if (isViewingSharedProfile.value) return undefined;
-    if (!isImportableGameMode(selectedMode.value)) return undefined;
     return buildTarkovDevProfileUrl(tarkovStore.getTarkovUid(), selectedMode.value);
   });
   const profileLevel = computed(() => {

--- a/app/features/settings/DataManagementCard.vue
+++ b/app/features/settings/DataManagementCard.vue
@@ -46,7 +46,7 @@
                   <span class="text-surface-300 text-xs font-semibold">
                     {{ $t('settings.tarkov_dev_import.refetch_mode_label') }}
                   </span>
-                  <div class="grid grid-cols-3 gap-2">
+                  <div class="grid grid-cols-2 gap-2 sm:grid-cols-4">
                     <UButton
                       v-for="option in tarkovDevRefetchModeOptions"
                       :key="option.value"
@@ -308,19 +308,7 @@
               <label class="text-surface-200 text-sm font-semibold">
                 {{ $t('settings.tarkov_dev_import.import_to_mode') }}
               </label>
-              <GameModeToggle
-                v-model="tarkovDevTargetMode"
-                :disabled-modes="[GAME_MODES.SEASONAL]"
-              />
-              <p class="text-warning-300 text-xs">
-                {{
-                  $t(
-                    'settings.data_management.seasonal_import_locked',
-                    { season: ACTIVE_SEASON_NUMBER },
-                    'Seasonal PvP imports are temporarily locked until the source data is verified for Season {season}.'
-                  )
-                }}
-              </p>
+              <GameModeToggle v-model="tarkovDevTargetMode" />
             </div>
             <div class="flex gap-2">
               <UButton
@@ -967,8 +955,8 @@
   } from '@/stores/useMetadata';
   import { useTarkovStore } from '@/stores/useTarkov';
   import {
-    ACTIVE_SEASON_NUMBER,
     GAME_MODES,
+    getGameModeLabel,
     sortSkillsByGameOrder,
     type GameMode,
     type ImportableGameMode,
@@ -979,7 +967,7 @@
   import type { BackupImportTargetModes } from '@/composables/useDataBackup';
   const TARKOV_DEV_ARENA_MODE = 'arena' as const;
   type DataManagementView = 'all' | 'imports' | 'backup';
-  type TarkovDevRefetchMode = ImportableGameMode | typeof TARKOV_DEV_ARENA_MODE;
+  type TarkovDevRefetchMode = GameMode | typeof TARKOV_DEV_ARENA_MODE;
   type TarkovDevRefetchModeOption = {
     disabled: boolean;
     label: string;
@@ -1114,11 +1102,12 @@
   } = useTurnstileWidget(turnstileContainerRef);
   const tarkovDevProfileUrlInput = ref('');
   const tarkovDevRequestGeneration = ref(0);
+  const currentTarkovDevMode = (): GameMode => tarkovStore.getCurrentGameMode();
   const currentImportableMode = (): ImportableGameMode =>
     tarkovStore.getCurrentGameMode() === GAME_MODES.PVE ? GAME_MODES.PVE : GAME_MODES.PVP;
-  const tarkovDevFixedTargetMode = ref<ImportableGameMode | null>(null);
-  const tarkovDevTargetMode = ref<ImportableGameMode>(currentImportableMode());
-  const tarkovDevRefetchMode = ref<TarkovDevRefetchMode>(currentImportableMode());
+  const tarkovDevFixedTargetMode = ref<GameMode | null>(null);
+  const tarkovDevTargetMode = ref<GameMode>(currentTarkovDevMode());
+  const tarkovDevRefetchMode = ref<TarkovDevRefetchMode>(currentTarkovDevMode());
   const isTarkovDevProfileUrlBlank = computed(
     () => tarkovDevProfileUrlInput.value.trim().length === 0
   );
@@ -1164,19 +1153,24 @@
       value: GAME_MODES.PVE,
     },
     {
+      disabled: false,
+      label: t('common.seasonal_pvp'),
+      value: GAME_MODES.SEASONAL,
+    },
+    {
       disabled: true,
       label: t('settings.tarkov_dev_import.refetch_mode_arena'),
       value: TARKOV_DEV_ARENA_MODE,
     },
   ]);
-  function isTarkovDevImportableMode(mode: unknown): mode is ImportableGameMode {
-    return mode === GAME_MODES.PVP || mode === GAME_MODES.PVE;
+  function isTarkovDevProfileMode(mode: unknown): mode is GameMode {
+    return mode === GAME_MODES.PVP || mode === GAME_MODES.PVE || mode === GAME_MODES.SEASONAL;
   }
   const isTarkovDevRefetchModeSupported = computed(() =>
-    isTarkovDevImportableMode(tarkovDevRefetchMode.value)
+    isTarkovDevProfileMode(tarkovDevRefetchMode.value)
   );
   const tarkovDevProfileUrl = computed(() => {
-    if (!isTarkovDevImportableMode(tarkovDevRefetchMode.value)) return undefined;
+    if (!isTarkovDevProfileMode(tarkovDevRefetchMode.value)) return undefined;
     return buildTarkovDevProfileUrl(tarkovUid.value, tarkovDevRefetchMode.value);
   });
   const previewLevel = computed(() => {
@@ -1258,7 +1252,7 @@
   const tarkovDevRefetchCooldownMinutes = computed(() => {
     const uid = tarkovUid.value;
     const mode = tarkovDevRefetchMode.value;
-    if (uid === null || !isTarkovDevImportableMode(mode)) return 0;
+    if (uid === null || !isTarkovDevProfileMode(mode)) return 0;
     const remainingMs = getImportCooldownRemainingMs(
       uid,
       mode,
@@ -1267,9 +1261,10 @@
     );
     return Math.ceil(remainingMs / 60_000);
   });
-  const tarkovDevFixedTargetModeLabel = computed(() =>
-    tarkovDevFixedTargetMode.value === GAME_MODES.PVE ? t('common.pve') : t('common.pvp')
-  );
+  const tarkovDevFixedTargetModeLabel = computed(() => {
+    const mode = tarkovDevFixedTargetMode.value;
+    return mode ? t(getGameModeLabel(mode)) : t('common.pvp');
+  });
   const tarkovDevImportTargetNotice = computed(() =>
     t('settings.tarkov_dev_import.import_target_notice', {
       mode: tarkovDevFixedTargetModeLabel.value,
@@ -1280,16 +1275,16 @@
   }
   function updateTarkovDevImportTarget(
     sourceMode: GameMode | null | undefined,
-    fallbackMode?: ImportableGameMode
+    fallbackMode?: GameMode
   ) {
-    const targetMode = isTarkovDevImportableMode(sourceMode) ? sourceMode : (fallbackMode ?? null);
+    const targetMode = isTarkovDevProfileMode(sourceMode) ? sourceMode : (fallbackMode ?? null);
     tarkovDevFixedTargetMode.value = targetMode;
     if (!targetMode) return;
     tarkovDevRefetchMode.value = targetMode;
     tarkovDevTargetMode.value = targetMode;
   }
   function selectTarkovDevRefetchMode(mode: TarkovDevRefetchMode) {
-    if (!isTarkovDevImportableMode(mode)) return;
+    if (!isTarkovDevProfileMode(mode)) return;
     tarkovDevRefetchMode.value = mode;
     tarkovDevTargetMode.value = mode;
   }
@@ -1334,7 +1329,7 @@
   async function handleTarkovDevRefetch() {
     try {
       const refetchMode = tarkovDevRefetchMode.value;
-      if (!isTarkovDevImportableMode(refetchMode)) return;
+      if (!isTarkovDevProfileMode(refetchMode)) return;
       const linkedProfileUrl = tarkovDevProfileUrl.value;
       if (!linkedProfileUrl) return;
       const source = await fetchTarkovDevProfile(linkedProfileUrl, true);
@@ -1364,7 +1359,7 @@
   }
   function handleTarkovDevUnlink() {
     tarkovDevFixedTargetMode.value = null;
-    tarkovDevRefetchMode.value = currentImportableMode();
+    tarkovDevRefetchMode.value = currentTarkovDevMode();
     tarkovStore.setTarkovUid(null);
   }
   async function handleTarkovDevConfirm() {

--- a/app/features/settings/__tests__/DataManagementCard.test.ts
+++ b/app/features/settings/__tests__/DataManagementCard.test.ts
@@ -45,7 +45,7 @@ const {
         profileUrl: string,
         options?: { fresh?: boolean; turnstileToken?: string | null }
       ) => Promise<{
-        mode: 'pvp' | 'pve' | null;
+        mode: 'pvp' | 'pve' | 'seasonal' | null;
         profileJsonUrl: string;
         tarkovUid: number;
       } | null>
@@ -89,7 +89,7 @@ const {
     warn: vi.fn(),
   },
   tarkovStoreState: {
-    currentMode: 'pvp' as 'pvp' | 'pve',
+    currentMode: 'pvp' as 'pvp' | 'pve' | 'seasonal',
     setTarkovUid: vi.fn<(uid: number | null) => void>(),
     tarkovUid: null as number | null,
   },
@@ -381,6 +381,24 @@ describe('DataManagementCard', () => {
       { fresh: false, turnstileToken: null }
     );
     expect(vm.tarkovDevTargetMode).toBe('pve');
+  });
+  it('uses a pvp-season profile url as a fixed seasonal import target', async () => {
+    tarkovDevFns.parseProfileUrl.mockResolvedValue({
+      mode: 'seasonal',
+      profileJsonUrl: 'https://players.tarkov.dev/pvp-season/8560316.json',
+      tarkovUid: 8560316,
+    });
+    const wrapper = createWrapper();
+    const vm = asVm<{
+      handleTarkovDevProfileUrlSubmit: () => Promise<void>;
+      tarkovDevFixedTargetMode: 'pvp' | 'pve' | 'seasonal' | null;
+      tarkovDevProfileUrlInput: string;
+      tarkovDevTargetMode: 'pvp' | 'pve' | 'seasonal';
+    }>(wrapper.vm);
+    vm.tarkovDevProfileUrlInput = 'https://tarkov.dev/players/pvp-season/8560316';
+    await vm.handleTarkovDevProfileUrlSubmit();
+    expect(vm.tarkovDevFixedTargetMode).toBe('seasonal');
+    expect(vm.tarkovDevTargetMode).toBe('seasonal');
   });
   it('passes the Turnstile token to the fetch and resets the widget afterwards', async () => {
     turnstileState.enabled = true;

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1844,6 +1844,7 @@
       "import_target_pvp": "PvP Only",
       "import_target_pve": "PvE Only",
       "import_target_all": "All Available",
+      "seasonal_import_locked": "Seasonal PvP imports are temporarily locked until the source data is verified for Season {season}.",
       "import_success_title": "Backup Imported",
       "import_success_description": "Your progress data has been restored successfully.",
       "import_error_title": "Backup Import Failed",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1844,7 +1844,6 @@
       "import_target_pvp": "PvP Only",
       "import_target_pve": "PvE Only",
       "import_target_all": "All Available",
-      "seasonal_import_locked": "Seasonal PvP imports are temporarily locked until the source data is verified for Season {season}.",
       "import_success_title": "Backup Imported",
       "import_success_description": "Your progress data has been restored successfully.",
       "import_error_title": "Backup Import Failed",

--- a/app/utils/__tests__/tarkovDevProfileSource.test.ts
+++ b/app/utils/__tests__/tarkovDevProfileSource.test.ts
@@ -21,6 +21,16 @@ describe('resolveTarkovDevProfileSource', () => {
       tarkovUid: 8560316,
     });
   });
+  it('extracts a seasonal pvp profile id from a Tarkov.dev player url', () => {
+    const result = resolveTarkovDevProfileSource('https://tarkov.dev/players/pvp-season/8560316');
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual({
+      mode: 'seasonal',
+      profileJsonUrl: 'https://players.tarkov.dev/pvp-season/8560316.json',
+      tarkovUid: 8560316,
+    });
+  });
   it('accepts the public pvp profile json url', () => {
     const result = resolveTarkovDevProfileSource('https://players.tarkov.dev/profile/8560316.json');
     expect(result.ok).toBe(true);
@@ -38,6 +48,18 @@ describe('resolveTarkovDevProfileSource', () => {
     expect(result.data).toEqual({
       mode: 'pve',
       profileJsonUrl: 'https://players.tarkov.dev/pve/8560316.json',
+      tarkovUid: 8560316,
+    });
+  });
+  it('accepts the public seasonal pvp profile json url', () => {
+    const result = resolveTarkovDevProfileSource(
+      'https://players.tarkov.dev/pvp-season/8560316.json'
+    );
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.data).toEqual({
+      mode: 'seasonal',
+      profileJsonUrl: 'https://players.tarkov.dev/pvp-season/8560316.json',
       tarkovUid: 8560316,
     });
   });

--- a/app/utils/__tests__/tarkovDevProfileUrl.test.ts
+++ b/app/utils/__tests__/tarkovDevProfileUrl.test.ts
@@ -9,6 +9,11 @@ describe('buildTarkovDevProfileUrl', () => {
   it('builds a pve profile URL for pve mode', () => {
     expect(buildTarkovDevProfileUrl(123456, 'pve')).toBe('https://tarkov.dev/players/pve/123456');
   });
+  it('builds a pvp-season profile URL for seasonal mode', () => {
+    expect(buildTarkovDevProfileUrl(123456, 'seasonal')).toBe(
+      'https://tarkov.dev/players/pvp-season/123456'
+    );
+  });
   it('returns undefined for missing or invalid uid values', () => {
     expect(buildTarkovDevProfileUrl(null, 'pvp')).toBeUndefined();
     expect(buildTarkovDevProfileUrl(-1, 'pve')).toBeUndefined();

--- a/app/utils/tarkovDevProfileSource.ts
+++ b/app/utils/tarkovDevProfileSource.ts
@@ -1,10 +1,15 @@
-import { API_GAME_MODES, GAME_MODES, type ImportableGameMode } from '@/utils/constants';
+import { API_GAME_MODES, GAME_MODES, type GameMode } from '@/utils/constants';
 const PROFILE_JSON_ORIGIN = 'https://players.tarkov.dev';
+const PROFILE_JSON_PATHS = {
+  [GAME_MODES.PVP]: 'profile',
+  [GAME_MODES.PVE]: 'pve',
+  [GAME_MODES.SEASONAL]: 'pvp-season',
+} as const satisfies Record<GameMode, string>;
 const PROFILE_URL_ERROR =
   'Paste a Tarkov.dev player profile URL like https://tarkov.dev/players/regular/8560316.';
 const PROFILE_ID_ERROR = 'Tarkov.dev profile URL must include a valid numeric profile id.';
 export interface TarkovDevProfileSource {
-  mode: ImportableGameMode | null;
+  mode: GameMode | null;
   profileJsonUrl: string;
   tarkovUid: number;
 }
@@ -18,19 +23,18 @@ function parseProfileId(value: string | undefined): number | null {
   if (!Number.isSafeInteger(tarkovUid) || tarkovUid <= 0) return null;
   return tarkovUid;
 }
-function modeFromProfileSlug(value: string | undefined): ImportableGameMode | null {
-  if (value === API_GAME_MODES[GAME_MODES.PVP]) return GAME_MODES.PVP;
-  if (value === API_GAME_MODES[GAME_MODES.PVE]) return GAME_MODES.PVE;
-  return null;
+function modeFromProfileSlug(value: string | undefined): GameMode | null {
+  const entry = Object.entries(API_GAME_MODES).find(([, slug]) => slug === value);
+  return (entry?.[0] as GameMode | undefined) ?? null;
 }
-function buildProfileSource(
-  tarkovUid: number,
-  mode: ImportableGameMode | null
-): TarkovDevProfileSource {
-  const profilePath = mode === GAME_MODES.PVE ? 'pve' : 'profile';
+function modeFromProfileJsonPath(value: string | undefined): GameMode | null {
+  const entry = Object.entries(PROFILE_JSON_PATHS).find(([, path]) => path === value);
+  return (entry?.[0] as GameMode | undefined) ?? null;
+}
+function buildProfileSource(tarkovUid: number, mode: GameMode): TarkovDevProfileSource {
   return {
     mode,
-    profileJsonUrl: `${PROFILE_JSON_ORIGIN}/${profilePath}/${tarkovUid}.json`,
+    profileJsonUrl: `${PROFILE_JSON_ORIGIN}/${PROFILE_JSON_PATHS[mode]}/${tarkovUid}.json`,
     tarkovUid,
   };
 }
@@ -51,15 +55,11 @@ export function resolveTarkovDevProfileSource(input: string): TarkovDevProfileSo
     if (!mode || tarkovUid === null) return { ok: false, error: PROFILE_ID_ERROR };
     return { ok: true, data: buildProfileSource(tarkovUid, mode) };
   }
-  if (host === 'players.tarkov.dev' && parts[0] === 'profile') {
+  if (host === 'players.tarkov.dev') {
+    const mode = modeFromProfileJsonPath(parts[0]);
     const tarkovUid = parseProfileId(parts[1]);
-    if (tarkovUid === null) return { ok: false, error: PROFILE_ID_ERROR };
-    return { ok: true, data: buildProfileSource(tarkovUid, GAME_MODES.PVP) };
-  }
-  if (host === 'players.tarkov.dev' && parts[0] === 'pve') {
-    const tarkovUid = parseProfileId(parts[1]);
-    if (tarkovUid === null) return { ok: false, error: PROFILE_ID_ERROR };
-    return { ok: true, data: buildProfileSource(tarkovUid, GAME_MODES.PVE) };
+    if (!mode || tarkovUid === null) return { ok: false, error: PROFILE_ID_ERROR };
+    return { ok: true, data: buildProfileSource(tarkovUid, mode) };
   }
   return { ok: false, error: PROFILE_URL_ERROR };
 }

--- a/app/utils/tarkovDevProfileSource.ts
+++ b/app/utils/tarkovDevProfileSource.ts
@@ -23,12 +23,11 @@ function parseProfileId(value: string | undefined): number | null {
   if (!Number.isSafeInteger(tarkovUid) || tarkovUid <= 0) return null;
   return tarkovUid;
 }
-function modeFromProfileSlug(value: string | undefined): GameMode | null {
-  const entry = Object.entries(API_GAME_MODES).find(([, slug]) => slug === value);
-  return (entry?.[0] as GameMode | undefined) ?? null;
-}
-function modeFromProfileJsonPath(value: string | undefined): GameMode | null {
-  const entry = Object.entries(PROFILE_JSON_PATHS).find(([, path]) => path === value);
+function modeFromMappedValue(
+  mapping: Record<GameMode, string>,
+  value: string | undefined
+): GameMode | null {
+  const entry = Object.entries(mapping).find(([, mappedValue]) => mappedValue === value);
   return (entry?.[0] as GameMode | undefined) ?? null;
 }
 function buildProfileSource(tarkovUid: number, mode: GameMode): TarkovDevProfileSource {
@@ -50,13 +49,13 @@ export function resolveTarkovDevProfileSource(input: string): TarkovDevProfileSo
   const host = url.hostname.toLowerCase();
   const parts = url.pathname.split('/').filter(Boolean);
   if ((host === 'tarkov.dev' || host === 'www.tarkov.dev') && parts[0] === 'players') {
-    const mode = modeFromProfileSlug(parts[1]);
+    const mode = modeFromMappedValue(API_GAME_MODES, parts[1]);
     const tarkovUid = parseProfileId(parts[2]);
     if (!mode || tarkovUid === null) return { ok: false, error: PROFILE_ID_ERROR };
     return { ok: true, data: buildProfileSource(tarkovUid, mode) };
   }
   if (host === 'players.tarkov.dev') {
-    const mode = modeFromProfileJsonPath(parts[0]);
+    const mode = modeFromMappedValue(PROFILE_JSON_PATHS, parts[0]);
     const tarkovUid = parseProfileId(parts[1]);
     if (!mode || tarkovUid === null) return { ok: false, error: PROFILE_ID_ERROR };
     return { ok: true, data: buildProfileSource(tarkovUid, mode) };

--- a/app/utils/tarkovDevProfileUrl.ts
+++ b/app/utils/tarkovDevProfileUrl.ts
@@ -1,11 +1,10 @@
-import { GAME_MODES, type ImportableGameMode } from '@/utils/constants';
+import { API_GAME_MODES, type GameMode } from '@/utils/constants';
 export const buildTarkovDevProfileUrl = (
   tarkovUid: number | null,
-  mode: ImportableGameMode | null | undefined
+  mode: GameMode | null | undefined
 ): string | undefined => {
-  if (tarkovUid === null || !Number.isFinite(tarkovUid) || tarkovUid <= 0) {
+  if (tarkovUid === null || !Number.isFinite(tarkovUid) || tarkovUid <= 0 || !mode) {
     return undefined;
   }
-  const modeSlug = mode === GAME_MODES.PVE ? 'pve' : 'regular';
-  return `https://tarkov.dev/players/${modeSlug}/${tarkovUid}`;
+  return `https://tarkov.dev/players/${API_GAME_MODES[mode]}/${tarkovUid}`;
 };

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -168,21 +168,19 @@ Manages isolated progress for persistent PvP, persistent PvE, and numbered Seaso
 - The app does **not** persist a long-lived "linked mode" or "imported mode" field.
 - Unlinking a tarkov.dev account clears only the saved `tarkovUid`; it does not roll back imported
   progress, profile, skill, level, edition, or prestige fields.
-- Refetching a linked profile asks for a persistent profile mode because PvP and PvE profile JSON
+- Refetching a linked profile asks for a profile mode because PvP, PvE, and Seasonal profile JSON
   use the same account id but different tarkov.dev mode routes.
-- Tarkov.dev imports always ask which persistent mode to write into and default to the current mode
-  when it is importable. Seasonal is visible but locked until its profile route, parser, and field
-  compatibility are verified for the active season.
-- The import UI accepts a full `tarkov.dev/players/{regular|pve}/{uid}` profile URL, fetches
-  `players.tarkov.dev/profile/{uid}.json` for PvP or `players.tarkov.dev/pve/{uid}.json` for PvE
-  through the public `/api/tarkov-dev/profile` proxy, and parses that JSON with the existing
-  Tarkov.dev profile parser.
+- Tarkov.dev imports default to the current mode when the pasted source does not identify a mode.
+  Mode-specific profile URLs fix the target to prevent cross-mode writes.
+- The import UI accepts a full `tarkov.dev/players/{regular|pve|pvp-season}/{uid}` profile URL,
+  fetches `players.tarkov.dev/{profile|pve|pvp-season}/{uid}.json` through the public
+  `/api/tarkov-dev/profile` proxy, and parses that JSON with the existing Tarkov.dev profile parser.
 - The import preview keeps parsed skill values collapsed by default, but exposes the exact
   skill-id and level pairs that will be applied.
 - Tarkov.dev only refreshes that public JSON after the user opens their profile page on tarkov.dev,
   so the UI asks users to open the profile before importing.
 - Tarkov.dev links use the currently viewed or selected mode only to choose the URL slug:
-  `regular` for PvP, `pve` for PvE.
+  `regular` for PvP, `pve` for PvE, and `pvp-season` for Seasonal.
 - EFT-log imports are also locked for Seasonal until the active-season data source is verified.
 - Legacy embedded `tarkovDevProfile` payloads are sanitized out of stored progress data and should
   not be reintroduced as long-lived state.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -741,8 +741,8 @@ through the Nitro proxy `/api/tarkov-dev/profile`, which layers cost and abuse c
   cost protection, per the design principle in `docs/RATE_LIMITING.md`.
 - Ordinary success responses are browser-cacheable (`private`); explicit `fresh=1` responses and
   error responses never are.
-- The client rejects a Seasonal target before mutating progress. Adding a Seasonal player-profile
-  route alone is not enough to unlock it; parser and field compatibility must be verified first.
+- The client accepts the verified Tarkov.dev `pvp-season` profile source for Seasonal progress and
+  rejects Seasonal EFT-log imports before mutating progress until that source is verified.
 
 ---
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -731,6 +731,8 @@ through the Nitro proxy `/api/tarkov-dev/profile`, which layers cost and abuse c
   entries are treated as misses, and invalid upstream payloads fail without entering shared cache.
 - Cached payloads are re-checked against the freshness gate on every serve, so a stale snapshot can
   never be imported from cache either.
+- Profile page modes use the centralized upstream slugs `regular`, `pve`, and `pvp-season`; the
+  `pvp-season` profile is imported into the stable internal `seasonal` progress mode.
 - A `fresh=1` request bypasses serving from cache but not the cache lookup or rate limits, and
   revalidates with `If-None-Match` when a cached ETag exists — "I just refreshed on tarkov.dev"
   costs at most one conditional upstream request.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -654,7 +654,8 @@ flowchart LR
 - Seasonal PvP has no prestige. `archive_prestige_run_and_reset_progress` rejects any mode outside
   `pvp`/`pve`, `user_prestige_runs` keeps its `mode IN ('pvp','pve')` constraint, and no Seasonal
   progress is written through a prestige.
-- Tarkov.dev profile and EFT-log imports cannot target Seasonal until their source data is verified.
+- Tarkov.dev profile imports can target Seasonal through the verified `pvp-season` source. EFT-log
+  imports cannot target Seasonal until their source data is verified.
 
 ---
 
@@ -662,10 +663,10 @@ flowchart LR
 
 **Summary.** Settings → Data Management lets a user import their in-game profile (level/XP,
 skills, faction, prestige, edition guess) from tarkov.dev's player-profile snapshots on the
-players.tarkov.dev host (the `profile/{aid}` path for PvP and `pve/{aid}` for PvE, each with a
-JSON suffix). Imports can target persistent PvP or PvE. Seasonal is visible but locked until its
-profile source and mapping are verified, preventing persistent PvP data from being written into
-Season 1. The upstream JSON only refreshes when a human views the player page on tarkov.dev
+players.tarkov.dev host (the `profile/{aid}` path for PvP, `pve/{aid}` for PvE, and
+`pvp-season/{aid}` for Seasonal, each with a JSON suffix). Profile URLs fix the target mode, so
+Seasonal snapshots write only into active Seasonal progress. The upstream JSON only refreshes when
+a human views the player page on tarkov.dev
 (Turnstile-guarded
 there); tarkov.dev purges its CDN copy on refresh, so a new snapshot is visible to us immediately.
 The upstream sends no CORS headers, so the browser cannot fetch it directly — everything goes


### PR DESCRIPTION
## **User description**
## Summary

- Parse Tarkov.dev `pvp-season` profile URLs and map them to the stable internal `seasonal` mode.
- Import, refetch, link, and display Seasonal profile data through the upstream `pvp-season` paths.
- Keep EFT-log Seasonal imports locked while updating the profile-import system contract and regression coverage.

## Root cause

The profile source resolver only accepted the `regular` and `pve` slugs, and the profile import confirmation flow deliberately excluded the internal `seasonal` mode. A valid URL such as `https://tarkov.dev/players/pvp-season/8560316` therefore failed before its numeric profile ID could be used.

## Validation

- `pnpm exec vitest run app/utils/__tests__/tarkovDevProfileSource.test.ts app/utils/__tests__/tarkovDevProfileUrl.test.ts app/composables/__tests__/useTarkovDevImport.test.ts app/features/settings/__tests__/DataManagementCard.test.ts app/server/api/tarkov-dev/__tests__/profile.test.ts` — 92 tests passed
- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run i18n:check`
- Prettier check for all changed files

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Support Seasonal Tarkov.dev profile imports

### What Changed
- Seasonal profile URLs using `pvp-season` can now be recognized and imported into Seasonal progress
- Seasonal profiles can be refetched from linked accounts and are assigned to the correct Seasonal target automatically
- Seasonal profile links now use the correct Tarkov.dev URL format
- The Seasonal import lock message and restriction were removed, while EFT-log Seasonal imports remain unavailable

### Impact
`✅ Seasonal Tarkov.dev imports work`
`✅ Correct Seasonal profile targeting`
`✅ Seasonal profiles can be refetched`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for importing Seasonal profiles from Tarkov.dev using seasonal profile links and public JSON URLs.
  * Seasonal mode is now available when selecting import targets, refreshing profiles, and generating profile links.
  * Imports automatically preserve the selected Seasonal progress and restore the active mode after completion.
* **Documentation**
  * Updated import guidance to document Seasonal Tarkov.dev support.
  * Clarified that EFT-log imports remain unavailable for Seasonal mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds Seasonal Tarkov.dev profile import support while keeping Seasonal EFT-log imports unavailable.

- Maps upstream `pvp-season` profile URLs and JSON paths to the internal `seasonal` mode.
- Enables Seasonal import targeting, profile refetching, cooldown tracking, and profile links.
- Updates regression tests and synchronizes the repository’s system documentation.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/utils/tarkovDevProfileSource.ts | Centralizes profile path mappings and resolves `pvp-season` sources to the internal Seasonal mode. |
| app/composables/useTarkovDevImport.ts | Expands confirmed Tarkov.dev imports from persistent modes to all validated game modes, including Seasonal. |
| app/features/settings/DataManagementCard.vue | Enables Seasonal profile selection, refetching, fixed import targeting, and mode-specific labels. |
| app/utils/tarkovDevProfileUrl.ts | Builds profile links from centralized upstream mode slugs, including `pvp-season`. |
| docs/SYSTEMS.md | Now consistently distinguishes supported Seasonal Tarkov.dev imports from locked Seasonal EFT-log imports. |
| docs/ARCHITECTURE.md | Documents Seasonal profile routing, targeting, refetching, and link generation consistently with the implementation. |
| AGENTS.md | Updates the canonical repository contract to permit Seasonal Tarkov.dev imports while retaining the EFT-log restriction. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant U as User
  participant UI as Data Management
  participant R as Profile Source Resolver
  participant API as Tarkov.dev Proxy
  participant S as Progress Store
  U->>UI: Paste pvp-season profile URL
  UI->>R: Resolve profile source
  R-->>UI: seasonal + pvp-season JSON URL
  UI->>API: Fetch profile JSON
  API-->>UI: Seasonal profile snapshot
  U->>UI: Confirm import
  UI->>S: Switch to seasonal and apply progress
  S-->>UI: Import complete
  UI->>S: Restore original active mode
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs: clarify seasonal import invariant"](https://github.com/tarkovtracker-org/tarkovtracker/commit/a85f54c4e7941032acc5ab34e8254d2f0f907ee0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52450340)</sub>

<!-- /greptile_comment -->