### PR TITLE
fix(api): improve locale overlay coverage and cache freshness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,9 +194,11 @@ Naming:
 - Supabase client: `app/plugins/supabase.client.ts`. Regenerate types: `pnpm run supabase:types`.
 - API endpoints: `app/server/api/`. Use composables for shared data access patterns.
 - The hideout Tarkov-data route caches the adapted base payload, then applies the current overlay
-  after `edgeCache()` and calls `setOverlayResponseHeaders()` before returning. Other
-  overlay-enabled Tarkov-data routes cache their final corrected payload. Preserve this ordering so
-  the hideout edge TTL cannot pin stale corrections.
+  after `edgeCache()` and calls `setOverlayResponseHeaders()` before returning. Its browser
+  IndexedDB entry uses the matching `json-v4` version and a one-hour TTL. Warm requests serve a
+  stale overlay immediately while one Cloudflare-lifetime refresh runs in the background; failed
+  deferred refreshes back off for one minute. Other overlay-enabled Tarkov-data routes cache their
+  final corrected payload. Preserve this ordering so no cache layer pins stale hideout corrections.
 - Internal game modes are `pvp`, `pve`, and `seasonal`; game-data requests map Seasonal to the
   upstream `pvp-season` slug. Active Seasonal progress is keyed by season number in
   `user_game_mode_progress`, while `user_progress` remains the account-metadata and rolling-deploy

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,6 +193,10 @@ Naming:
 - Pinia stores in `app/stores/`, auto-registered by Nuxt. Use `pinia-plugin-persistedstate` where applicable.
 - Supabase client: `app/plugins/supabase.client.ts`. Regenerate types: `pnpm run supabase:types`.
 - API endpoints: `app/server/api/`. Use composables for shared data access patterns.
+- The hideout Tarkov-data route caches the adapted base payload, then applies the current overlay
+  after `edgeCache()` and calls `setOverlayResponseHeaders()` before returning. Other
+  overlay-enabled Tarkov-data routes cache their final corrected payload. Preserve this ordering so
+  the hideout edge TTL cannot pin stale corrections.
 - Internal game modes are `pvp`, `pve`, and `seasonal`; game-data requests map Seasonal to the
   upstream `pvp-season` slug. Active Seasonal progress is keyed by season number in
   `user_game_mode_progress`, while `user_progress` remains the account-metadata and rolling-deploy

--- a/app/server/api/tarkov/__tests__/handlers.test.ts
+++ b/app/server/api/tarkov/__tests__/handlers.test.ts
@@ -22,6 +22,7 @@ const {
   mockGetQuery,
   mockGetValidatedLanguage,
   mockSanitizeTaskRewards,
+  mockScheduleBackgroundTask,
   mockSetOverlayResponseHeaders,
   mockSetResponseHeaders,
   mockShouldBypassCache,
@@ -41,6 +42,7 @@ const {
   mockGetQuery: vi.fn(),
   mockGetValidatedLanguage: vi.fn(),
   mockSanitizeTaskRewards: vi.fn(),
+  mockScheduleBackgroundTask: vi.fn(),
   mockSetOverlayResponseHeaders: vi.fn(),
   mockSetResponseHeaders: vi.fn(),
   mockShouldBypassCache: vi.fn(),
@@ -58,6 +60,9 @@ vi.mock('h3', async () => {
     setResponseHeaders: mockSetResponseHeaders,
   };
 });
+vi.mock('~/server/utils/backgroundTask', () => ({
+  scheduleBackgroundTask: mockScheduleBackgroundTask,
+}));
 vi.mock('~/server/utils/edgeCache', () => ({
   edgeCache: mockEdgeCache,
   shouldBypassCache: mockShouldBypassCache,
@@ -156,7 +161,14 @@ describe('Tarkov API handlers', () => {
       bypassCache: false,
       gameMode: 'regular',
       locale: 'en',
+      scheduleRefresh: expect.any(Function),
     });
+    const overlayOptions = mockApplyOverlay.mock.calls[0]?.[1] as {
+      scheduleRefresh: (task: Promise<unknown>) => void;
+    };
+    const refreshTask = Promise.resolve();
+    overlayOptions.scheduleRefresh(refreshTask);
+    expect(mockScheduleBackgroundTask).toHaveBeenCalledWith(event, refreshTask);
     expect(mockEdgeCache).toHaveBeenCalledWith(
       event,
       'hideout-json-v4-en-regular',

--- a/app/server/api/tarkov/__tests__/handlers.test.ts
+++ b/app/server/api/tarkov/__tests__/handlers.test.ts
@@ -22,6 +22,7 @@ const {
   mockGetQuery,
   mockGetValidatedLanguage,
   mockSanitizeTaskRewards,
+  mockSetOverlayResponseHeaders,
   mockSetResponseHeaders,
   mockShouldBypassCache,
   mockValidateGameMode,
@@ -40,6 +41,7 @@ const {
   mockGetQuery: vi.fn(),
   mockGetValidatedLanguage: vi.fn(),
   mockSanitizeTaskRewards: vi.fn(),
+  mockSetOverlayResponseHeaders: vi.fn(),
   mockSetResponseHeaders: vi.fn(),
   mockShouldBypassCache: vi.fn(),
   mockValidateGameMode: vi.fn(),
@@ -58,6 +60,7 @@ vi.mock('h3', async () => {
 });
 vi.mock('~/server/utils/edgeCache', () => ({
   edgeCache: mockEdgeCache,
+  setOverlayResponseHeaders: mockSetOverlayResponseHeaders,
   shouldBypassCache: mockShouldBypassCache,
 }));
 vi.mock('~/server/utils/language-helpers', () => ({
@@ -154,11 +157,21 @@ describe('Tarkov API handlers', () => {
     });
     expect(mockEdgeCache).toHaveBeenCalledWith(
       event,
-      'hideout-json-v3-en-regular',
-      expect.any(Function),
+      'hideout-json-v4-en-regular',
+      baseFetcher,
       111,
       { cacheKeyPrefix: 'tarkov' }
     );
+    expect(mockSetOverlayResponseHeaders).toHaveBeenCalledWith(event, {
+      data: { tasks: [] },
+    });
+  });
+  it('rethrows hideout cache failures', async () => {
+    mockEdgeCache.mockRejectedValueOnce(new Error('hideout cache failed'));
+    const { default: handler } = await import('@/server/api/tarkov/hideout.get');
+    await expect(handler(event)).rejects.toThrow('hideout cache failed');
+    expect(mockApplyOverlay).not.toHaveBeenCalled();
+    expect(mockSetOverlayResponseHeaders).not.toHaveBeenCalled();
   });
   it('builds expected cache key for items-lite', async () => {
     const { default: handler } = await import('@/server/api/tarkov/items-lite.get');

--- a/app/server/api/tarkov/__tests__/handlers.test.ts
+++ b/app/server/api/tarkov/__tests__/handlers.test.ts
@@ -60,7 +60,6 @@ vi.mock('h3', async () => {
 });
 vi.mock('~/server/utils/edgeCache', () => ({
   edgeCache: mockEdgeCache,
-  setOverlayResponseHeaders: mockSetOverlayResponseHeaders,
   shouldBypassCache: mockShouldBypassCache,
 }));
 vi.mock('~/server/utils/language-helpers', () => ({
@@ -76,6 +75,9 @@ vi.mock('~/server/utils/logger', () => ({
 }));
 vi.mock('~/server/utils/overlay', () => ({
   applyOverlay: mockApplyOverlay,
+}));
+vi.mock('~/server/utils/overlayResponseHeaders', () => ({
+  setOverlayResponseHeaders: mockSetOverlayResponseHeaders,
 }));
 vi.mock('~/server/utils/tarkov-cache-config', () => ({
   CACHE_TTL_DEFAULT: 111,

--- a/app/server/api/tarkov/hideout.get.ts
+++ b/app/server/api/tarkov/hideout.get.ts
@@ -1,3 +1,4 @@
+import { scheduleBackgroundTask } from '~/server/utils/backgroundTask';
 import { edgeCache, shouldBypassCache } from '~/server/utils/edgeCache';
 import { getValidatedLanguage } from '~/server/utils/language-helpers';
 import { createLogger } from '~/server/utils/logger';
@@ -18,7 +19,12 @@ export default defineEventHandler(async (event) => {
     const baseResponse = await edgeCache(event, cacheKey, baseFetcher, CACHE_TTL_DEFAULT, {
       cacheKeyPrefix: 'tarkov',
     });
-    const response = await applyOverlay(baseResponse, { bypassCache, gameMode, locale: lang });
+    const response = await applyOverlay(baseResponse, {
+      bypassCache,
+      gameMode,
+      locale: lang,
+      scheduleRefresh: (task) => scheduleBackgroundTask(event, task),
+    });
     setOverlayResponseHeaders(event, response);
     return response;
   } catch (error) {

--- a/app/server/api/tarkov/hideout.get.ts
+++ b/app/server/api/tarkov/hideout.get.ts
@@ -1,7 +1,8 @@
-import { edgeCache, setOverlayResponseHeaders, shouldBypassCache } from '~/server/utils/edgeCache';
+import { edgeCache, shouldBypassCache } from '~/server/utils/edgeCache';
 import { getValidatedLanguage } from '~/server/utils/language-helpers';
 import { createLogger } from '~/server/utils/logger';
 import { applyOverlay } from '~/server/utils/overlay';
+import { setOverlayResponseHeaders } from '~/server/utils/overlayResponseHeaders';
 import { CACHE_TTL_DEFAULT, validateGameMode } from '~/server/utils/tarkov-cache-config';
 import { createTarkovJsonHideoutFetcher } from '~/server/utils/tarkov-json';
 const logger = createLogger('TarkovHideout');

--- a/app/server/api/tarkov/hideout.get.ts
+++ b/app/server/api/tarkov/hideout.get.ts
@@ -1,11 +1,11 @@
-import { edgeCache, shouldBypassCache } from '~/server/utils/edgeCache';
+import { edgeCache, setOverlayResponseHeaders, shouldBypassCache } from '~/server/utils/edgeCache';
 import { getValidatedLanguage } from '~/server/utils/language-helpers';
 import { createLogger } from '~/server/utils/logger';
 import { applyOverlay } from '~/server/utils/overlay';
 import { CACHE_TTL_DEFAULT, validateGameMode } from '~/server/utils/tarkov-cache-config';
 import { createTarkovJsonHideoutFetcher } from '~/server/utils/tarkov-json';
 const logger = createLogger('TarkovHideout');
-const HIDEOUT_CACHE_VERSION = 'json-v3';
+const HIDEOUT_CACHE_VERSION = 'json-v4';
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
   const bypassCache = shouldBypassCache(event);
@@ -13,14 +13,13 @@ export default defineEventHandler(async (event) => {
   const gameMode = validateGameMode(query.gameMode);
   const cacheKey = `hideout-${HIDEOUT_CACHE_VERSION}-${lang}-${gameMode}`;
   const baseFetcher = createTarkovJsonHideoutFetcher({ gameMode, lang });
-  const fetcher = async () => {
-    const response = await baseFetcher();
-    return await applyOverlay(response, { bypassCache, gameMode, locale: lang });
-  };
   try {
-    return await edgeCache(event, cacheKey, fetcher, CACHE_TTL_DEFAULT, {
+    const baseResponse = await edgeCache(event, cacheKey, baseFetcher, CACHE_TTL_DEFAULT, {
       cacheKeyPrefix: 'tarkov',
     });
+    const response = await applyOverlay(baseResponse, { bypassCache, gameMode, locale: lang });
+    setOverlayResponseHeaders(event, response);
+    return response;
   } catch (error) {
     logger.error('Failed to fetch hideout data:', error);
     throw error;

--- a/app/server/utils/__tests__/backgroundTask.test.ts
+++ b/app/server/utils/__tests__/backgroundTask.test.ts
@@ -1,19 +1,28 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { scheduleBackgroundTask } from '@/server/utils/backgroundTask';
 import type { H3Event } from 'h3';
+const mockWarn = vi.hoisted(() => vi.fn());
+vi.mock('@/server/utils/logger', () => ({
+  createLogger: () => ({ warn: mockWarn }),
+}));
 describe('scheduleBackgroundTask', () => {
-  it('registers tasks with the Cloudflare execution context', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+  it('registers a guarded task with the Cloudflare execution context', async () => {
     const waitUntil = vi.fn();
     const event = {
       context: { cloudflare: { context: { waitUntil } } },
     } as unknown as H3Event;
-    const task = Promise.resolve();
-    scheduleBackgroundTask(event, task);
-    expect(waitUntil).toHaveBeenCalledWith(task);
+    scheduleBackgroundTask(event, Promise.reject(new Error('refresh failed')));
+    const guardedTask = waitUntil.mock.calls[0]?.[0] as Promise<unknown>;
+    await expect(guardedTask).resolves.toBeUndefined();
+    expect(mockWarn).toHaveBeenCalledWith('Background task failed', expect.any(Error));
   });
-  it('accepts tasks when no Cloudflare execution context is available', () => {
-    expect(() =>
-      scheduleBackgroundTask({ context: {} } as H3Event, Promise.resolve())
-    ).not.toThrow();
+  it('contains rejected tasks without a Cloudflare execution context', async () => {
+    scheduleBackgroundTask({ context: {} } as H3Event, Promise.reject(new Error('refresh failed')));
+    await vi.waitFor(() => {
+      expect(mockWarn).toHaveBeenCalledWith('Background task failed', expect.any(Error));
+    });
   });
 });

--- a/app/server/utils/__tests__/backgroundTask.test.ts
+++ b/app/server/utils/__tests__/backgroundTask.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it, vi } from 'vitest';
+import { scheduleBackgroundTask } from '@/server/utils/backgroundTask';
+import type { H3Event } from 'h3';
+describe('scheduleBackgroundTask', () => {
+  it('registers tasks with the Cloudflare execution context', () => {
+    const waitUntil = vi.fn();
+    const event = {
+      context: { cloudflare: { context: { waitUntil } } },
+    } as unknown as H3Event;
+    const task = Promise.resolve();
+    scheduleBackgroundTask(event, task);
+    expect(waitUntil).toHaveBeenCalledWith(task);
+  });
+  it('accepts tasks when no Cloudflare execution context is available', () => {
+    expect(() =>
+      scheduleBackgroundTask({ context: {} } as H3Event, Promise.resolve())
+    ).not.toThrow();
+  });
+});

--- a/app/server/utils/__tests__/edgeCache.test.ts
+++ b/app/server/utils/__tests__/edgeCache.test.ts
@@ -70,31 +70,6 @@ describe('edgeCache', () => {
     });
     expect(lastMatchUrl).toBe('https://tarkovtracker.org/__edge-cache/tarkov/items-en');
   });
-  it('sets overlay headers for payloads transformed after the cache', async () => {
-    const event = createEvent();
-    const { setOverlayResponseHeaders } = await import('@/server/utils/edgeCache');
-    setOverlayResponseHeaders(
-      event,
-      {
-        dataOverlay: {
-          generated: '2026-08-14T12:00:00.000Z',
-          sha256: 'overlay-sha',
-          status: 'cached',
-          version: 'locale-test-v1',
-        },
-      },
-      setHeaders
-    );
-    expect(setHeaders).toHaveBeenCalledWith(event, {
-      'X-Overlay-Generated': '2026-08-14T12:00:00.000Z',
-      'X-Overlay-Sha256': 'overlay-sha',
-      'X-Overlay-Status': 'cached',
-      'X-Overlay-Version': 'locale-test-v1',
-    });
-    vi.mocked(setHeaders).mockClear();
-    setOverlayResponseHeaders(event, { data: {} }, setHeaders);
-    expect(setHeaders).not.toHaveBeenCalled();
-  });
   it('returns cached payload on cache hit', async () => {
     cacheSpy.match.mockResolvedValueOnce(
       new Response(JSON.stringify({ data: { items: [{ id: 'cached' }] } }), {

--- a/app/server/utils/__tests__/edgeCache.test.ts
+++ b/app/server/utils/__tests__/edgeCache.test.ts
@@ -70,6 +70,31 @@ describe('edgeCache', () => {
     });
     expect(lastMatchUrl).toBe('https://tarkovtracker.org/__edge-cache/tarkov/items-en');
   });
+  it('sets overlay headers for payloads transformed after the cache', async () => {
+    const event = createEvent();
+    const { setOverlayResponseHeaders } = await import('@/server/utils/edgeCache');
+    setOverlayResponseHeaders(
+      event,
+      {
+        dataOverlay: {
+          generated: '2026-08-14T12:00:00.000Z',
+          sha256: 'overlay-sha',
+          status: 'cached',
+          version: 'locale-test-v1',
+        },
+      },
+      setHeaders
+    );
+    expect(setHeaders).toHaveBeenCalledWith(event, {
+      'X-Overlay-Generated': '2026-08-14T12:00:00.000Z',
+      'X-Overlay-Sha256': 'overlay-sha',
+      'X-Overlay-Status': 'cached',
+      'X-Overlay-Version': 'locale-test-v1',
+    });
+    vi.mocked(setHeaders).mockClear();
+    setOverlayResponseHeaders(event, { data: {} }, setHeaders);
+    expect(setHeaders).not.toHaveBeenCalled();
+  });
   it('returns cached payload on cache hit', async () => {
     cacheSpy.match.mockResolvedValueOnce(
       new Response(JSON.stringify({ data: { items: [{ id: 'cached' }] } }), {

--- a/app/server/utils/__tests__/overlay.integration.test.ts
+++ b/app/server/utils/__tests__/overlay.integration.test.ts
@@ -130,6 +130,31 @@ describe('applyOverlay locale integration', () => {
     const refreshed = await applyOverlay(payload, { scheduleRefresh });
     expect(refreshed.dataOverlay).toMatchObject({ status: 'cached', version: 'v2' });
   });
+  it('keeps the fetch timeout active while parsing the overlay body', async () => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async (_url: string, init?: RequestInit) => {
+      const signal = init?.signal as AbortSignal;
+      return {
+        json: () =>
+          new Promise((_resolve, reject) => {
+            const rejectWithAbort = () => {
+              const error = new Error('body parsing aborted');
+              error.name = 'AbortError';
+              reject(error);
+            };
+            if (signal.aborted) rejectWithAbort();
+            else signal.addEventListener('abort', rejectWithAbort, { once: true });
+          }),
+        ok: true,
+      } as Response;
+    });
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const resultPromise = applyOverlay({ data: { tasks: [] } });
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await resultPromise;
+    expect(result.dataOverlay).toMatchObject({ status: 'missing' });
+  });
   it('backs off deferred refreshes after an overlay fetch failure', async () => {
     vi.useFakeTimers({ toFake: ['Date'] });
     vi.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));

--- a/app/server/utils/__tests__/overlay.integration.test.ts
+++ b/app/server/utils/__tests__/overlay.integration.test.ts
@@ -12,6 +12,7 @@ const stubOverlayFetch = (overlay: unknown) => {
 afterEach(() => {
   vi.resetModules();
   vi.unstubAllGlobals();
+  vi.useRealTimers();
 });
 describe('applyOverlay locale integration', () => {
   it('applies the selected locale after global and mode corrections', async () => {
@@ -94,6 +95,63 @@ describe('applyOverlay locale integration', () => {
     );
     expect(german.dataOverlay?.status).toBe('cached');
     expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+  it('serves stale data while coalescing a deferred overlay refresh', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
+    let resolveRefresh!: (response: Response) => void;
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ $meta: { version: 'v1' } }), { status: 200 })
+      )
+      .mockReturnValueOnce(
+        new Promise<Response>((resolve) => {
+          resolveRefresh = resolve;
+        })
+      );
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const payload = { data: { tasks: [] } };
+    await applyOverlay(payload);
+    vi.setSystemTime(new Date('2026-08-14T13:00:00.001Z'));
+    const backgroundTasks: Array<Promise<unknown>> = [];
+    const scheduleRefresh = (task: Promise<unknown>) => backgroundTasks.push(task);
+    const [first, second] = await Promise.all([
+      applyOverlay(payload, { scheduleRefresh }),
+      applyOverlay(payload, { scheduleRefresh }),
+    ]);
+    expect(first.dataOverlay).toMatchObject({ status: 'stale', version: 'v1' });
+    expect(second.dataOverlay).toMatchObject({ status: 'stale', version: 'v1' });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(backgroundTasks).toHaveLength(1);
+    resolveRefresh(new Response(JSON.stringify({ $meta: { version: 'v2' } }), { status: 200 }));
+    await backgroundTasks[0];
+    const refreshed = await applyOverlay(payload, { scheduleRefresh });
+    expect(refreshed.dataOverlay).toMatchObject({ status: 'cached', version: 'v2' });
+  });
+  it('backs off deferred refreshes after an overlay fetch failure', async () => {
+    vi.useFakeTimers({ toFake: ['Date'] });
+    vi.setSystemTime(new Date('2026-08-14T12:00:00.000Z'));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ $meta: { version: 'v1' } }), { status: 200 })
+      )
+      .mockRejectedValueOnce(new Error('overlay unavailable'));
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const payload = { data: { tasks: [] } };
+    await applyOverlay(payload);
+    vi.setSystemTime(new Date('2026-08-14T13:00:00.001Z'));
+    const backgroundTasks: Array<Promise<unknown>> = [];
+    const scheduleRefresh = (task: Promise<unknown>) => backgroundTasks.push(task);
+    const stale = await applyOverlay(payload, { scheduleRefresh });
+    expect(stale.dataOverlay.status).toBe('stale');
+    await backgroundTasks[0];
+    await applyOverlay(payload, { scheduleRefresh });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(backgroundTasks).toHaveLength(1);
   });
   it('leaves unsupported locales unchanged by locale corrections', async () => {
     stubOverlayFetch({

--- a/app/server/utils/__tests__/overlay.integration.test.ts
+++ b/app/server/utils/__tests__/overlay.integration.test.ts
@@ -1,6 +1,4 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import type { OverlayMeta } from '@/server/utils/overlay';
-type OverlayResult<T> = T & { dataOverlay?: OverlayMeta };
 const stubOverlayFetch = (overlay: unknown) => {
   const fetchMock = vi.fn(async () => {
     return new Response(JSON.stringify(overlay), {
@@ -66,9 +64,7 @@ describe('applyOverlay locale integration', () => {
         traders: [{ id: 'trader-1', name: 'Base Trader' }],
       },
     };
-    const english = (await applyOverlay(payload, {
-      gameMode: 'pve',
-    })) as OverlayResult<typeof payload>;
+    const english = await applyOverlay(payload, { gameMode: 'pve' });
     expect(english.data).toEqual({
       items: [{ id: 'item-1', name: 'English Item', shortName: 'Global item' }],
       tasks: [
@@ -85,10 +81,7 @@ describe('applyOverlay locale integration', () => {
       status: 'fresh',
       version: 'locale-test-v1',
     });
-    const german = (await applyOverlay(payload, {
-      gameMode: 'pve',
-      locale: 'de',
-    })) as OverlayResult<typeof payload>;
+    const german = await applyOverlay(payload, { gameMode: 'pve', locale: 'de' });
     expect(german.data?.tasks?.[0]).toMatchObject({ name: 'Deutsche Aufgabe' });
     expect(german.data?.items?.[0]).toMatchObject({
       name: 'Deutscher Gegenstand',
@@ -113,5 +106,20 @@ describe('applyOverlay locale integration', () => {
     const payload = { data: { tasks: [{ id: 'task-1', name: 'Base Task' }] } };
     const result = await applyOverlay(payload, { locale: 'fr' });
     expect(result.data?.tasks).toEqual([{ id: 'task-1', name: 'Base Task' }]);
+  });
+  it.each([
+    ['locale map', []],
+    ['locale entry', { en: null }],
+    ['locale collection', { en: { tasks: [] } }],
+  ])('handles a malformed %s without changing base data', async (_label, locales) => {
+    stubOverlayFetch({
+      $meta: { version: 'locale-test-v1' },
+      locales,
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const payload = { data: { tasks: [{ id: 'task-1', name: 'Base Task' }] } };
+    const result = await applyOverlay(payload);
+    expect(result.data).toEqual(payload.data);
+    expect(result.dataOverlay.status).toBe('fresh');
   });
 });

--- a/app/server/utils/__tests__/overlay.integration.test.ts
+++ b/app/server/utils/__tests__/overlay.integration.test.ts
@@ -111,6 +111,7 @@ describe('applyOverlay locale integration', () => {
     ['locale map', []],
     ['locale entry', { en: null }],
     ['locale collection', { en: { tasks: [] } }],
+    ['locale patch', { en: { tasks: { 'task-1': 'garbage' } } }],
   ])('handles a malformed %s without changing base data', async (_label, locales) => {
     stubOverlayFetch({
       $meta: { version: 'locale-test-v1' },

--- a/app/server/utils/__tests__/overlay.integration.test.ts
+++ b/app/server/utils/__tests__/overlay.integration.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+const stubOverlayFetch = (overlay: unknown) => {
+  const fetchMock = vi.fn(async () => {
+    return new Response(JSON.stringify(overlay), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 200,
+    });
+  });
+  vi.stubGlobal('fetch', fetchMock as typeof fetch);
+  return fetchMock;
+};
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+});
+describe('applyOverlay locale integration', () => {
+  it('applies the selected locale after global and mode corrections', async () => {
+    const fetchMock = stubOverlayFetch({
+      $meta: {
+        generated: '2026-08-14T12:00:00.000Z',
+        sha256: 'overlay-sha',
+        version: 'locale-test-v1',
+      },
+      items: {
+        'item-1': { shortName: 'Global item' },
+      },
+      locales: {
+        de: {
+          items: { 'item-1': { name: 'Deutscher Gegenstand' } },
+          tasks: { 'task-1': { name: 'Deutsche Aufgabe' } },
+          traders: { 'trader-1': { name: 'Deutscher Händler' } },
+        },
+        en: {
+          items: { 'item-1': { name: 'English Item' } },
+          tasks: {
+            'task-1': {
+              name: 'English Task',
+              objectives: { 'objective-1': { description: 'English objective' } },
+            },
+          },
+          traders: { 'trader-1': { name: 'English Trader' } },
+        },
+      },
+      modes: {
+        pve: {
+          tasks: { 'task-1': { name: 'PvE Task' } },
+        },
+      },
+      tasks: {
+        'task-1': { name: 'Global Task' },
+      },
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const payload = {
+      data: {
+        items: [{ id: 'item-1', name: 'Base Item', shortName: 'Base' }],
+        tasks: [
+          {
+            id: 'task-1',
+            name: 'Base Task',
+            objectives: [{ id: 'objective-1', description: 'Base objective' }],
+          },
+        ],
+        traders: [{ id: 'trader-1', name: 'Base Trader' }],
+      },
+    };
+    const english = await applyOverlay(payload, { gameMode: 'pve' });
+    expect(english.data).toEqual({
+      items: [{ id: 'item-1', name: 'English Item', shortName: 'Global item' }],
+      tasks: [
+        {
+          id: 'task-1',
+          name: 'English Task',
+          objectives: [{ id: 'objective-1', description: 'English objective' }],
+        },
+      ],
+      traders: [{ id: 'trader-1', name: 'English Trader' }],
+    });
+    expect(english.dataOverlay).toMatchObject({
+      sha256: 'overlay-sha',
+      status: 'fresh',
+      version: 'locale-test-v1',
+    });
+    const german = await applyOverlay(payload, { gameMode: 'pve', locale: 'de' });
+    expect(german.data?.tasks?.[0]).toMatchObject({ name: 'Deutsche Aufgabe' });
+    expect(german.data?.items?.[0]).toMatchObject({
+      name: 'Deutscher Gegenstand',
+      shortName: 'Global item',
+    });
+    expect(german.data?.traders?.[0]).toMatchObject({ name: 'Deutscher Händler' });
+    expect(german.data?.tasks?.[0]).not.toHaveProperty(
+      'objectives.0.description',
+      'English objective'
+    );
+    expect(german.dataOverlay?.status).toBe('cached');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+  it('leaves unsupported locales unchanged by locale corrections', async () => {
+    stubOverlayFetch({
+      $meta: { version: 'locale-test-v1' },
+      locales: {
+        en: { tasks: { 'task-1': { name: 'English Task' } } },
+      },
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const payload = { data: { tasks: [{ id: 'task-1', name: 'Base Task' }] } };
+    const result = await applyOverlay(payload, { locale: 'fr' });
+    expect(result.data?.tasks).toEqual([{ id: 'task-1', name: 'Base Task' }]);
+  });
+  it.each([
+    ['locale map', []],
+    ['locale entry', { en: null }],
+    ['locale collection', { en: { tasks: [] } }],
+  ])('rejects a malformed %s without failing the base response', async (_label, locales) => {
+    stubOverlayFetch({
+      $meta: { version: 'locale-test-v1' },
+      locales,
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const payload = { data: { tasks: [{ id: 'task-1', name: 'Base Task' }] } };
+    const result = await applyOverlay(payload);
+    expect(result.data).toEqual(payload.data);
+    expect(result.dataOverlay).toMatchObject({
+      error: 'validation_failed',
+      status: 'missing',
+    });
+  });
+});

--- a/app/server/utils/__tests__/overlay.integration.test.ts
+++ b/app/server/utils/__tests__/overlay.integration.test.ts
@@ -1,4 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { OverlayMeta } from '@/server/utils/overlay';
+type OverlayResult<T> = T & { dataOverlay?: OverlayMeta };
 const stubOverlayFetch = (overlay: unknown) => {
   const fetchMock = vi.fn(async () => {
     return new Response(JSON.stringify(overlay), {
@@ -64,7 +66,9 @@ describe('applyOverlay locale integration', () => {
         traders: [{ id: 'trader-1', name: 'Base Trader' }],
       },
     };
-    const english = await applyOverlay(payload, { gameMode: 'pve' });
+    const english = (await applyOverlay(payload, {
+      gameMode: 'pve',
+    })) as OverlayResult<typeof payload>;
     expect(english.data).toEqual({
       items: [{ id: 'item-1', name: 'English Item', shortName: 'Global item' }],
       tasks: [
@@ -81,7 +85,10 @@ describe('applyOverlay locale integration', () => {
       status: 'fresh',
       version: 'locale-test-v1',
     });
-    const german = await applyOverlay(payload, { gameMode: 'pve', locale: 'de' });
+    const german = (await applyOverlay(payload, {
+      gameMode: 'pve',
+      locale: 'de',
+    })) as OverlayResult<typeof payload>;
     expect(german.data?.tasks?.[0]).toMatchObject({ name: 'Deutsche Aufgabe' });
     expect(german.data?.items?.[0]).toMatchObject({
       name: 'Deutscher Gegenstand',
@@ -106,23 +113,5 @@ describe('applyOverlay locale integration', () => {
     const payload = { data: { tasks: [{ id: 'task-1', name: 'Base Task' }] } };
     const result = await applyOverlay(payload, { locale: 'fr' });
     expect(result.data?.tasks).toEqual([{ id: 'task-1', name: 'Base Task' }]);
-  });
-  it.each([
-    ['locale map', []],
-    ['locale entry', { en: null }],
-    ['locale collection', { en: { tasks: [] } }],
-  ])('rejects a malformed %s without failing the base response', async (_label, locales) => {
-    stubOverlayFetch({
-      $meta: { version: 'locale-test-v1' },
-      locales,
-    });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const payload = { data: { tasks: [{ id: 'task-1', name: 'Base Task' }] } };
-    const result = await applyOverlay(payload);
-    expect(result.data).toEqual(payload.data);
-    expect(result.dataOverlay).toMatchObject({
-      error: 'validation_failed',
-      status: 'missing',
-    });
   });
 });

--- a/app/server/utils/__tests__/overlayResponseHeaders.test.ts
+++ b/app/server/utils/__tests__/overlayResponseHeaders.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { setOverlayResponseHeaders } from '@/server/utils/overlayResponseHeaders';
+import {
+  buildOverlayResponseHeaders,
+  setOverlayResponseHeaders,
+} from '@/server/utils/overlayResponseHeaders';
 import type { H3Event, setResponseHeaders } from 'h3';
 describe('setOverlayResponseHeaders', () => {
   const event = {} as H3Event;
@@ -23,6 +26,16 @@ describe('setOverlayResponseHeaders', () => {
       'X-Overlay-Status': 'cached',
       'X-Overlay-Version': 'locale-test-v1',
     });
+  });
+  it('omits metadata that is not safe for an HTTP header', () => {
+    expect(
+      buildOverlayResponseHeaders({
+        generated: 'unsafe-😀',
+        sha256: 'safe-sha',
+        status: 42,
+        version: 'unsafe\nvalue',
+      })
+    ).toEqual({ 'X-Overlay-Sha256': 'safe-sha' });
   });
   it.each([null, {}, { dataOverlay: null }])(
     'ignores payloads without overlay metadata',

--- a/app/server/utils/__tests__/overlayResponseHeaders.test.ts
+++ b/app/server/utils/__tests__/overlayResponseHeaders.test.ts
@@ -36,6 +36,7 @@ describe('setOverlayResponseHeaders', () => {
         version: 'unsafe\nvalue',
       })
     ).toEqual({ 'X-Overlay-Sha256': 'safe-sha' });
+    expect(buildOverlayResponseHeaders({ version: '' })).toEqual({});
   });
   it.each([null, {}, { dataOverlay: null }])(
     'ignores payloads without overlay metadata',

--- a/app/server/utils/__tests__/overlayResponseHeaders.test.ts
+++ b/app/server/utils/__tests__/overlayResponseHeaders.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from 'vitest';
+import { setOverlayResponseHeaders } from '@/server/utils/overlayResponseHeaders';
+import type { H3Event, setResponseHeaders } from 'h3';
+describe('setOverlayResponseHeaders', () => {
+  const event = {} as H3Event;
+  it('sets available overlay metadata headers', () => {
+    const setHeaders = vi.fn() as unknown as typeof setResponseHeaders;
+    setOverlayResponseHeaders(
+      event,
+      {
+        dataOverlay: {
+          generated: '2026-08-14T12:00:00.000Z',
+          sha256: 'overlay-sha',
+          status: 'cached',
+          version: 'locale-test-v1',
+        },
+      },
+      setHeaders
+    );
+    expect(setHeaders).toHaveBeenCalledWith(event, {
+      'X-Overlay-Generated': '2026-08-14T12:00:00.000Z',
+      'X-Overlay-Sha256': 'overlay-sha',
+      'X-Overlay-Status': 'cached',
+      'X-Overlay-Version': 'locale-test-v1',
+    });
+  });
+  it.each([null, {}, { dataOverlay: null }])(
+    'ignores payloads without overlay metadata',
+    (payload) => {
+      const setHeaders = vi.fn() as unknown as typeof setResponseHeaders;
+      setOverlayResponseHeaders(event, payload, setHeaders);
+      expect(setHeaders).not.toHaveBeenCalled();
+    }
+  );
+});

--- a/app/server/utils/backgroundTask.ts
+++ b/app/server/utils/backgroundTask.ts
@@ -1,0 +1,15 @@
+import type { H3Event } from 'h3';
+type CloudflareExecutionContext = {
+  waitUntil?: (task: Promise<unknown>) => void;
+};
+type CloudflareEventContext = {
+  cloudflare?: { context?: CloudflareExecutionContext };
+};
+export function scheduleBackgroundTask(event: H3Event, task: Promise<unknown>): void {
+  const context = (event.context as CloudflareEventContext).cloudflare?.context;
+  if (context?.waitUntil) {
+    context.waitUntil(task);
+    return;
+  }
+  void task;
+}

--- a/app/server/utils/backgroundTask.ts
+++ b/app/server/utils/backgroundTask.ts
@@ -1,4 +1,6 @@
+import { createLogger } from '@/server/utils/logger';
 import type { H3Event } from 'h3';
+const logger = createLogger('BackgroundTask');
 type CloudflareExecutionContext = {
   waitUntil?: (task: Promise<unknown>) => void;
 };
@@ -6,10 +8,13 @@ type CloudflareEventContext = {
   cloudflare?: { context?: CloudflareExecutionContext };
 };
 export function scheduleBackgroundTask(event: H3Event, task: Promise<unknown>): void {
+  const guardedTask = task.catch((error) => {
+    logger.warn('Background task failed', error);
+  });
   const context = (event.context as CloudflareEventContext).cloudflare?.context;
   if (context?.waitUntil) {
-    context.waitUntil(task);
+    context.waitUntil(guardedTask);
     return;
   }
-  void task;
+  void guardedTask;
 }

--- a/app/server/utils/edgeCache.ts
+++ b/app/server/utils/edgeCache.ts
@@ -57,14 +57,6 @@ function isTruthyFlag(value: unknown): boolean {
   if (typeof value !== 'string') return false;
   return ['1', 'true', 'yes', 'y', 'on'].includes(value.toLowerCase());
 }
-function getOverlayResponseHeaders(overlayMeta: OverlayHeadersMeta | null): Record<string, string> {
-  return {
-    ...(overlayMeta?.status ? { 'X-Overlay-Status': overlayMeta.status } : {}),
-    ...(overlayMeta?.version ? { 'X-Overlay-Version': overlayMeta.version } : {}),
-    ...(overlayMeta?.generated ? { 'X-Overlay-Generated': overlayMeta.generated } : {}),
-    ...(overlayMeta?.sha256 ? { 'X-Overlay-Sha256': overlayMeta.sha256 } : {}),
-  };
-}
 function setCacheResponseHeaders(
   event: H3Event,
   setHeaders: typeof setResponseHeaders,
@@ -81,17 +73,11 @@ function setCacheResponseHeaders(
     'X-Cache-Status': status,
     'X-Cache-Key': fullCacheKey,
     'Cache-Control': cacheControl,
-    ...getOverlayResponseHeaders(overlayMeta),
+    ...(overlayMeta?.status ? { 'X-Overlay-Status': overlayMeta.status } : {}),
+    ...(overlayMeta?.version ? { 'X-Overlay-Version': overlayMeta.version } : {}),
+    ...(overlayMeta?.generated ? { 'X-Overlay-Generated': overlayMeta.generated } : {}),
+    ...(overlayMeta?.sha256 ? { 'X-Overlay-Sha256': overlayMeta.sha256 } : {}),
   });
-}
-export function setOverlayResponseHeaders(
-  event: H3Event,
-  payload: unknown,
-  setHeaders: typeof setResponseHeaders = setResponseHeaders
-): void {
-  const overlayMeta = getOverlayHeadersMeta(payload);
-  if (!overlayMeta) return;
-  setHeaders(event, getOverlayResponseHeaders(overlayMeta));
 }
 function getCloudflareCacheFromGlobal(): CacheLike | undefined {
   if (typeof globalThis.caches === 'undefined') return undefined;

--- a/app/server/utils/edgeCache.ts
+++ b/app/server/utils/edgeCache.ts
@@ -9,6 +9,7 @@ import { useRuntimeConfig } from '#imports';
 import { buildEdgeCacheRequest } from '@/server/utils/edgeCacheKey';
 import { sanitizeErrorMessage } from '@/server/utils/edgeCacheSanitizers';
 import { createLogger } from '@/server/utils/logger';
+import { buildOverlayResponseHeaders } from '@/server/utils/overlayResponseHeaders';
 import { getPrecomputedStore, isPrecomputedEnvelope } from '@/server/utils/precomputedTarkov';
 import type { PrecomputedKvReader } from '@/server/utils/precomputedTarkov';
 import type { H3Event } from 'h3';
@@ -73,10 +74,7 @@ function setCacheResponseHeaders(
     'X-Cache-Status': status,
     'X-Cache-Key': fullCacheKey,
     'Cache-Control': cacheControl,
-    ...(overlayMeta?.status ? { 'X-Overlay-Status': overlayMeta.status } : {}),
-    ...(overlayMeta?.version ? { 'X-Overlay-Version': overlayMeta.version } : {}),
-    ...(overlayMeta?.generated ? { 'X-Overlay-Generated': overlayMeta.generated } : {}),
-    ...(overlayMeta?.sha256 ? { 'X-Overlay-Sha256': overlayMeta.sha256 } : {}),
+    ...buildOverlayResponseHeaders(overlayMeta),
   });
 }
 function getCloudflareCacheFromGlobal(): CacheLike | undefined {

--- a/app/server/utils/edgeCache.ts
+++ b/app/server/utils/edgeCache.ts
@@ -57,6 +57,14 @@ function isTruthyFlag(value: unknown): boolean {
   if (typeof value !== 'string') return false;
   return ['1', 'true', 'yes', 'y', 'on'].includes(value.toLowerCase());
 }
+function getOverlayResponseHeaders(overlayMeta: OverlayHeadersMeta | null): Record<string, string> {
+  return {
+    ...(overlayMeta?.status ? { 'X-Overlay-Status': overlayMeta.status } : {}),
+    ...(overlayMeta?.version ? { 'X-Overlay-Version': overlayMeta.version } : {}),
+    ...(overlayMeta?.generated ? { 'X-Overlay-Generated': overlayMeta.generated } : {}),
+    ...(overlayMeta?.sha256 ? { 'X-Overlay-Sha256': overlayMeta.sha256 } : {}),
+  };
+}
 function setCacheResponseHeaders(
   event: H3Event,
   setHeaders: typeof setResponseHeaders,
@@ -73,11 +81,17 @@ function setCacheResponseHeaders(
     'X-Cache-Status': status,
     'X-Cache-Key': fullCacheKey,
     'Cache-Control': cacheControl,
-    ...(overlayMeta?.status ? { 'X-Overlay-Status': overlayMeta.status } : {}),
-    ...(overlayMeta?.version ? { 'X-Overlay-Version': overlayMeta.version } : {}),
-    ...(overlayMeta?.generated ? { 'X-Overlay-Generated': overlayMeta.generated } : {}),
-    ...(overlayMeta?.sha256 ? { 'X-Overlay-Sha256': overlayMeta.sha256 } : {}),
+    ...getOverlayResponseHeaders(overlayMeta),
   });
+}
+export function setOverlayResponseHeaders(
+  event: H3Event,
+  payload: unknown,
+  setHeaders: typeof setResponseHeaders = setResponseHeaders
+): void {
+  const overlayMeta = getOverlayHeadersMeta(payload);
+  if (!overlayMeta) return;
+  setHeaders(event, getOverlayResponseHeaders(overlayMeta));
 }
 function getCloudflareCacheFromGlobal(): CacheLike | undefined {
   if (typeof globalThis.caches === 'undefined') return undefined;

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -123,24 +123,6 @@ function isValidOverlayData(data: unknown): data is OverlayData {
       }
     }
   }
-  if (overlay.locales !== undefined) {
-    if (!isPlainObject(overlay.locales)) {
-      logger.warn('Invalid overlay: locales is not an object');
-      return false;
-    }
-    for (const [locale, localeData] of Object.entries(overlay.locales)) {
-      if (!isPlainObject(localeData)) {
-        logger.warn(`Invalid overlay: locales.${locale} is not an object`);
-        return false;
-      }
-      for (const collection of ['tasks', 'items', 'traders'] as const) {
-        if (localeData[collection] !== undefined && !isPlainObject(localeData[collection])) {
-          logger.warn(`Invalid overlay: locales.${locale}.${collection} is not an object`);
-          return false;
-        }
-      }
-    }
-  }
   return true;
 }
 function buildOverlayMeta(
@@ -442,7 +424,7 @@ function applyLocaleOverlays(target: OverlayTargetData, localeOverlay: LocaleOve
 export async function applyOverlay<T extends { data?: OverlayTargetData }>(
   data: T,
   options: { bypassCache?: boolean; gameMode?: string; locale?: string } = {}
-): Promise<T & { dataOverlay?: OverlayMeta }> {
+): Promise<T> {
   const { overlay, meta } = await fetchOverlay(Boolean(options.bypassCache));
   const result = { ...data, dataOverlay: meta } as T & { dataOverlay?: OverlayMeta };
   if (!overlay || !data?.data) {

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -123,6 +123,24 @@ function isValidOverlayData(data: unknown): data is OverlayData {
       }
     }
   }
+  if (overlay.locales !== undefined) {
+    if (!isPlainObject(overlay.locales)) {
+      logger.warn('Invalid overlay: locales is not an object');
+      return false;
+    }
+    for (const [locale, localeData] of Object.entries(overlay.locales)) {
+      if (!isPlainObject(localeData)) {
+        logger.warn(`Invalid overlay: locales.${locale} is not an object`);
+        return false;
+      }
+      for (const collection of ['tasks', 'items', 'traders'] as const) {
+        if (localeData[collection] !== undefined && !isPlainObject(localeData[collection])) {
+          logger.warn(`Invalid overlay: locales.${locale}.${collection} is not an object`);
+          return false;
+        }
+      }
+    }
+  }
   return true;
 }
 function buildOverlayMeta(
@@ -424,7 +442,7 @@ function applyLocaleOverlays(target: OverlayTargetData, localeOverlay: LocaleOve
 export async function applyOverlay<T extends { data?: OverlayTargetData }>(
   data: T,
   options: { bypassCache?: boolean; gameMode?: string; locale?: string } = {}
-): Promise<T> {
+): Promise<T & { dataOverlay?: OverlayMeta }> {
   const { overlay, meta } = await fetchOverlay(Boolean(options.bypassCache));
   const result = { ...data, dataOverlay: meta } as T & { dataOverlay?: OverlayMeta };
   if (!overlay || !data?.data) {

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -261,7 +261,9 @@ export function applyLocaleOverlay<T extends { id: string }>(
   if (!localePatches || !entities) return entities;
   return entities.map((entity) => {
     const patch = localePatches[entity.id];
-    return patch ? (deepMerge(entity as Record<string, unknown>, patch) as T) : entity;
+    return isPlainObject(patch)
+      ? (deepMerge(entity as Record<string, unknown>, patch) as T)
+      : entity;
   });
 }
 type ObjectiveAddEntry = Record<string, unknown>;

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -151,17 +151,21 @@ function buildOverlayFailure(error: string): OverlayFetchResult {
   lastOverlayMeta = buildOverlayMeta(cachedOverlay, cachedOverlay ? 'stale' : 'missing', { error });
   return { overlay: cachedOverlay, meta: lastOverlayMeta };
 }
-async function fetchOverlayResponse(): Promise<Response> {
+function createOverlayRequest(): {
+  clearTimeout: () => void;
+  response: Promise<Response>;
+} {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-  try {
-    return await fetch(OVERLAY_URL_WITH_BUSTER, {
-      signal: controller.signal,
-      headers: { Accept: 'application/json', 'User-Agent': TARKOVTRACKER_USER_AGENT },
-    });
-  } finally {
-    clearTimeout(timeoutId);
-  }
+  return {
+    clearTimeout: () => clearTimeout(timeoutId),
+    response: Promise.resolve().then(() =>
+      fetch(OVERLAY_URL_WITH_BUSTER, {
+        signal: controller.signal,
+        headers: { Accept: 'application/json', 'User-Agent': TARKOVTRACKER_USER_AGENT },
+      })
+    ),
+  };
 }
 async function processOverlayResponse(
   response: Response,
@@ -193,11 +197,14 @@ function logOverlayFetchError(error: unknown): void {
   logger.warn('Error fetching overlay:', error);
 }
 async function refreshOverlay(now: number): Promise<OverlayFetchResult> {
+  const request = createOverlayRequest();
   try {
-    return await processOverlayResponse(await fetchOverlayResponse(), now);
+    return await processOverlayResponse(await request.response, now);
   } catch (error) {
     logOverlayFetchError(error);
     return buildOverlayFailure(error instanceof Error ? error.message : String(error));
+  } finally {
+    request.clearTimeout();
   }
 }
 function startOverlayRefresh(now: number): {

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -421,12 +421,21 @@ function applyLocaleOverlays(target: OverlayTargetData, localeOverlay: LocaleOve
     target.traders = applyLocaleOverlay(target.traders, localeOverlay.traders);
   }
 }
+function applyEntityCollectionOverlay(
+  target: OverlayTargetData,
+  collection: 'hideoutStations' | 'items' | 'traders',
+  patches: Record<string, Record<string, unknown>> | undefined
+): void {
+  const entities = target[collection];
+  if (!patches || !Array.isArray(entities)) return;
+  target[collection] = applyEntityOverlay(entities, patches);
+}
 export async function applyOverlay<T extends { data?: OverlayTargetData }>(
   data: T,
   options: { bypassCache?: boolean; gameMode?: string; locale?: string } = {}
-): Promise<T> {
+): Promise<T & { dataOverlay: OverlayMeta }> {
   const { overlay, meta } = await fetchOverlay(Boolean(options.bypassCache));
-  const result = { ...data, dataOverlay: meta } as T & { dataOverlay?: OverlayMeta };
+  const result = { ...data, dataOverlay: meta } as T & { dataOverlay: OverlayMeta };
   if (!overlay || !data?.data) {
     return result;
   }
@@ -454,27 +463,9 @@ export async function applyOverlay<T extends { data?: OverlayTargetData }>(
     logger.info(`Overlay tasksAdd: ${dedupedAdditions.length} additions after dedupe`);
     result.data.tasks = [...correctedTasks, ...dedupedAdditions];
   }
-  // Apply item corrections (if present)
-  if (overlay.items && Array.isArray(result.data.items)) {
-    result.data.items = applyEntityOverlay(
-      result.data.items as Array<{ id: string }>,
-      overlay.items
-    );
-  }
-  // Apply trader corrections (if present)
-  if (overlay.traders && Array.isArray(result.data.traders)) {
-    result.data.traders = applyEntityOverlay(
-      result.data.traders as Array<{ id: string }>,
-      overlay.traders
-    );
-  }
-  // Apply hideout corrections (if present)
-  if (overlay.hideout && Array.isArray(result.data.hideoutStations)) {
-    result.data.hideoutStations = applyEntityOverlay(
-      result.data.hideoutStations as Array<{ id: string }>,
-      overlay.hideout
-    );
-  }
+  applyEntityCollectionOverlay(result.data, 'items', overlay.items);
+  applyEntityCollectionOverlay(result.data, 'traders', overlay.traders);
+  applyEntityCollectionOverlay(result.data, 'hideoutStations', overlay.hideout);
   const locale = options.locale?.trim() || 'en';
   const localeOverlay = overlay.locales?.[locale];
   if (localeOverlay) {

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -58,7 +58,10 @@ export interface OverlayMeta {
 // OVERLAY_URL can be overridden by the environment variable.
 let cachedOverlay: OverlayData | null = null;
 let cacheTimestamp = 0;
+let overlayRefreshPromise: Promise<OverlayFetchResult> | null = null;
+let nextOverlayRefreshAt = 0;
 const OVERLAY_CACHE_TTL = 3600000; // 1 hour in milliseconds
+const OVERLAY_REFRESH_RETRY_MS = 60000;
 const FETCH_TIMEOUT_MS = 5000; // 5 seconds
 // GitHub raw URL for the overlay
 // Note: Using raw.githubusercontent.com directly until jsDelivr cache propagates
@@ -142,65 +145,110 @@ function buildOverlayMeta(
 /**
  * Fetch the overlay data from CDN (with caching)
  */
-async function fetchOverlay(
-  forceRefresh: boolean = false
-): Promise<{ overlay: OverlayData | null; meta: OverlayMeta }> {
-  const now = Date.now();
-  // Return cached overlay if still valid
-  if (!forceRefresh && cachedOverlay && now - cacheTimestamp < OVERLAY_CACHE_TTL) {
-    lastOverlayMeta = buildOverlayMeta(cachedOverlay, 'cached', {
-      cacheAgeMs: now - cacheTimestamp,
-    });
-    return { overlay: cachedOverlay, meta: lastOverlayMeta };
-  }
+type OverlayFetchResult = { overlay: OverlayData | null; meta: OverlayMeta };
+type OverlayRefreshScheduler = (task: Promise<unknown>) => void;
+function buildOverlayFailure(error: string): OverlayFetchResult {
+  lastOverlayMeta = buildOverlayMeta(cachedOverlay, cachedOverlay ? 'stale' : 'missing', { error });
+  return { overlay: cachedOverlay, meta: lastOverlayMeta };
+}
+async function fetchOverlayResponse(): Promise<Response> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   try {
-    // Set up abort controller with timeout
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
-    try {
-      const response = await fetch(OVERLAY_URL_WITH_BUSTER, {
-        signal: controller.signal,
-        headers: { Accept: 'application/json', 'User-Agent': TARKOVTRACKER_USER_AGENT },
-      });
-      if (!response.ok) {
-        logger.warn(`Failed to fetch overlay: ${response.status}`);
-        lastOverlayMeta = buildOverlayMeta(cachedOverlay, cachedOverlay ? 'stale' : 'missing', {
-          error: `HTTP ${response.status}`,
-        });
-        return { overlay: cachedOverlay, meta: lastOverlayMeta };
-      }
-      const parsedData = await response.json();
-      // Validate the parsed data before caching
-      if (!isValidOverlayData(parsedData)) {
-        logger.warn('Fetched overlay failed validation, using stale cache');
-        lastOverlayMeta = buildOverlayMeta(cachedOverlay, cachedOverlay ? 'stale' : 'missing', {
-          error: 'validation_failed',
-        });
-        return { overlay: cachedOverlay, meta: lastOverlayMeta };
-      }
-      cachedOverlay = parsedData;
-      cacheTimestamp = now;
-      logger.info(`Loaded overlay v${cachedOverlay.$meta?.version}`);
-      lastOverlayMeta = buildOverlayMeta(cachedOverlay, 'fresh', {
-        fetchedAt: new Date(now).toISOString(),
-        cacheAgeMs: 0,
-      });
-      return { overlay: cachedOverlay, meta: lastOverlayMeta };
-    } finally {
-      clearTimeout(timeoutId);
-    }
-  } catch (error) {
-    if (error instanceof Error && error.name === 'AbortError') {
-      logger.warn(`Fetch timeout after ${FETCH_TIMEOUT_MS}ms`);
-    } else {
-      logger.warn('Error fetching overlay:', error);
-    }
-    const message = error instanceof Error ? error.message : String(error);
-    lastOverlayMeta = buildOverlayMeta(cachedOverlay, cachedOverlay ? 'stale' : 'missing', {
-      error: message,
+    return await fetch(OVERLAY_URL_WITH_BUSTER, {
+      signal: controller.signal,
+      headers: { Accept: 'application/json', 'User-Agent': TARKOVTRACKER_USER_AGENT },
     });
-    return { overlay: cachedOverlay, meta: lastOverlayMeta };
+  } finally {
+    clearTimeout(timeoutId);
   }
+}
+async function processOverlayResponse(
+  response: Response,
+  now: number
+): Promise<OverlayFetchResult> {
+  if (!response.ok) {
+    logger.warn(`Failed to fetch overlay: ${response.status}`);
+    return buildOverlayFailure(`HTTP ${response.status}`);
+  }
+  const parsedData = await response.json();
+  if (!isValidOverlayData(parsedData)) {
+    logger.warn('Fetched overlay failed validation, using stale cache');
+    return buildOverlayFailure('validation_failed');
+  }
+  cachedOverlay = parsedData;
+  cacheTimestamp = now;
+  logger.info(`Loaded overlay v${cachedOverlay.$meta?.version}`);
+  lastOverlayMeta = buildOverlayMeta(cachedOverlay, 'fresh', {
+    fetchedAt: new Date(now).toISOString(),
+    cacheAgeMs: 0,
+  });
+  return { overlay: cachedOverlay, meta: lastOverlayMeta };
+}
+function logOverlayFetchError(error: unknown): void {
+  if (error instanceof Error && error.name === 'AbortError') {
+    logger.warn(`Fetch timeout after ${FETCH_TIMEOUT_MS}ms`);
+    return;
+  }
+  logger.warn('Error fetching overlay:', error);
+}
+async function refreshOverlay(now: number): Promise<OverlayFetchResult> {
+  try {
+    return await processOverlayResponse(await fetchOverlayResponse(), now);
+  } catch (error) {
+    logOverlayFetchError(error);
+    return buildOverlayFailure(error instanceof Error ? error.message : String(error));
+  }
+}
+function startOverlayRefresh(now: number): {
+  promise: Promise<OverlayFetchResult>;
+  started: boolean;
+} {
+  if (overlayRefreshPromise) return { promise: overlayRefreshPromise, started: false };
+  const promise = refreshOverlay(now)
+    .then((result) => {
+      nextOverlayRefreshAt =
+        result.meta.status === 'fresh' ? 0 : Date.now() + OVERLAY_REFRESH_RETRY_MS;
+      return result;
+    })
+    .finally(() => {
+      overlayRefreshPromise = null;
+    });
+  overlayRefreshPromise = promise;
+  return { promise, started: true };
+}
+function isOverlayCacheFresh(now: number, forceRefresh: boolean): boolean {
+  return !forceRefresh && cachedOverlay !== null && now - cacheTimestamp < OVERLAY_CACHE_TTL;
+}
+function canDeferOverlayRefresh(
+  forceRefresh: boolean,
+  scheduleRefresh: OverlayRefreshScheduler | undefined
+): scheduleRefresh is OverlayRefreshScheduler {
+  return !forceRefresh && cachedOverlay !== null && Boolean(scheduleRefresh);
+}
+function buildCachedOverlayResult(now: number, status: 'cached' | 'stale'): OverlayFetchResult {
+  const overlay = cachedOverlay as OverlayData;
+  lastOverlayMeta = buildOverlayMeta(overlay, status, { cacheAgeMs: now - cacheTimestamp });
+  return { overlay, meta: lastOverlayMeta };
+}
+function scheduleOverlayRefresh(now: number, scheduleRefresh: OverlayRefreshScheduler): void {
+  if (now < nextOverlayRefreshAt) return;
+  const refresh = startOverlayRefresh(now);
+  if (refresh.started) scheduleRefresh(refresh.promise);
+}
+async function fetchOverlay(
+  forceRefresh: boolean = false,
+  scheduleRefresh?: OverlayRefreshScheduler
+): Promise<OverlayFetchResult> {
+  const now = Date.now();
+  if (isOverlayCacheFresh(now, forceRefresh)) {
+    return buildCachedOverlayResult(now, 'cached');
+  }
+  if (canDeferOverlayRefresh(forceRefresh, scheduleRefresh)) {
+    scheduleOverlayRefresh(now, scheduleRefresh);
+    return buildCachedOverlayResult(now, 'stale');
+  }
+  return await startOverlayRefresh(now).promise;
 }
 /**
  * Apply overlay corrections to an array of entities
@@ -434,9 +482,17 @@ function applyEntityCollectionOverlay(
 }
 export async function applyOverlay<T extends { data?: OverlayTargetData }>(
   data: T,
-  options: { bypassCache?: boolean; gameMode?: string; locale?: string } = {}
+  options: {
+    bypassCache?: boolean;
+    gameMode?: string;
+    locale?: string;
+    scheduleRefresh?: OverlayRefreshScheduler;
+  } = {}
 ): Promise<T & { dataOverlay: OverlayMeta }> {
-  const { overlay, meta } = await fetchOverlay(Boolean(options.bypassCache));
+  const { overlay, meta } = await fetchOverlay(
+    Boolean(options.bypassCache),
+    options.scheduleRefresh
+  );
   const result = { ...data, dataOverlay: meta } as T & { dataOverlay: OverlayMeta };
   if (!overlay || !data?.data) {
     return result;

--- a/app/server/utils/overlayResponseHeaders.ts
+++ b/app/server/utils/overlayResponseHeaders.ts
@@ -1,0 +1,28 @@
+import { setResponseHeaders } from 'h3';
+import type { OverlayMeta } from '@/server/utils/overlay';
+import type { H3Event } from 'h3';
+type OverlayHeadersMeta = Pick<OverlayMeta, 'generated' | 'sha256' | 'status' | 'version'>;
+const OVERLAY_HEADERS = [
+  ['status', 'X-Overlay-Status'],
+  ['version', 'X-Overlay-Version'],
+  ['generated', 'X-Overlay-Generated'],
+  ['sha256', 'X-Overlay-Sha256'],
+] as const;
+function getOverlayMeta(payload: unknown): OverlayHeadersMeta | null {
+  const meta = (payload as { dataOverlay?: unknown } | null)?.dataOverlay;
+  return typeof meta === 'object' && meta !== null ? (meta as OverlayHeadersMeta) : null;
+}
+export function setOverlayResponseHeaders(
+  event: H3Event,
+  payload: unknown,
+  setHeaders: typeof setResponseHeaders = setResponseHeaders
+): void {
+  const meta = getOverlayMeta(payload);
+  if (!meta) return;
+  const headers: Record<string, string> = {};
+  for (const [field, header] of OVERLAY_HEADERS) {
+    const value = meta[field];
+    if (value) headers[header] = value;
+  }
+  setHeaders(event, headers);
+}

--- a/app/server/utils/overlayResponseHeaders.ts
+++ b/app/server/utils/overlayResponseHeaders.ts
@@ -2,15 +2,36 @@ import { setResponseHeaders } from 'h3';
 import type { OverlayMeta } from '@/server/utils/overlay';
 import type { H3Event } from 'h3';
 type OverlayHeadersMeta = Pick<OverlayMeta, 'generated' | 'sha256' | 'status' | 'version'>;
-const OVERLAY_HEADERS = [
+type OverlayHeaderField = keyof OverlayHeadersMeta;
+const INVALID_HEADER_CODE_POINTS = new Set([
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27,
+  28, 29, 30, 31, 127,
+]);
+const OVERLAY_HEADERS: ReadonlyArray<readonly [OverlayHeaderField, string]> = [
   ['status', 'X-Overlay-Status'],
   ['version', 'X-Overlay-Version'],
   ['generated', 'X-Overlay-Generated'],
   ['sha256', 'X-Overlay-Sha256'],
-] as const;
+];
 function getOverlayMeta(payload: unknown): OverlayHeadersMeta | null {
   const meta = (payload as { dataOverlay?: unknown } | null)?.dataOverlay;
   return typeof meta === 'object' && meta !== null ? (meta as OverlayHeadersMeta) : null;
+}
+function isSafeHeaderValue(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  return Array.from(value).every((character) => {
+    const codePoint = character.codePointAt(0) ?? 0;
+    return codePoint <= 255 && !INVALID_HEADER_CODE_POINTS.has(codePoint);
+  });
+}
+export function buildOverlayResponseHeaders(meta: unknown): Record<string, string> {
+  const candidate = (meta ?? {}) as Record<OverlayHeaderField, unknown>;
+  const headers: Record<string, string> = {};
+  for (const [field, header] of OVERLAY_HEADERS) {
+    const value = candidate[field];
+    if (isSafeHeaderValue(value)) headers[header] = value;
+  }
+  return headers;
 }
 export function setOverlayResponseHeaders(
   event: H3Event,
@@ -19,10 +40,5 @@ export function setOverlayResponseHeaders(
 ): void {
   const meta = getOverlayMeta(payload);
   if (!meta) return;
-  const headers: Record<string, string> = {};
-  for (const [field, header] of OVERLAY_HEADERS) {
-    const value = meta[field];
-    if (value) headers[header] = value;
-  }
-  setHeaders(event, headers);
+  setHeaders(event, buildOverlayResponseHeaders(meta));
 }

--- a/app/server/utils/overlayResponseHeaders.ts
+++ b/app/server/utils/overlayResponseHeaders.ts
@@ -18,7 +18,7 @@ function getOverlayMeta(payload: unknown): OverlayHeadersMeta | null {
   return typeof meta === 'object' && meta !== null ? (meta as OverlayHeadersMeta) : null;
 }
 function isSafeHeaderValue(value: unknown): value is string {
-  if (typeof value !== 'string') return false;
+  if (typeof value !== 'string' || value.length === 0) return false;
   return Array.from(value).every((character) => {
     const codePoint = character.codePointAt(0) ?? 0;
     return codePoint <= 255 && !INVALID_HEADER_CODE_POINTS.has(codePoint);

--- a/app/stores/__tests__/useMetadata.promiseTracking.test.ts
+++ b/app/stores/__tests__/useMetadata.promiseTracking.test.ts
@@ -89,6 +89,15 @@ describe('useMetadataStore promise tracking', () => {
     expect(store.hideoutError).toBeNull();
     expect(store.loading).toBe(false);
     expect(store.hideoutLoading).toBe(false);
+    expect(store.prestigeLoading).toBe(false);
+    expect(store.prestigeError).toBeNull();
+    expect(cacheUtils.setCachedData).toHaveBeenCalledWith(
+      'hideout',
+      'json-v4-regular',
+      'en',
+      expect.anything(),
+      60 * 60 * 1000
+    );
   });
   it('keeps tasks-core hydration working when each action call sees a fresh `this` proxy (Pinia devtools wrapping)', async () => {
     const store = useMetadataStore();

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -78,7 +78,8 @@ const MAP_SPAWNS_CACHE_VERSION = 'json-v1';
 const ITEMS_CACHE_VERSION = 'json-v1';
 const TASK_OBJECTIVES_CACHE_VERSION = 'json-v3';
 const TASK_REWARDS_CACHE_VERSION = 'json-v2';
-const HIDEOUT_CACHE_VERSION = 'json-v3';
+const HIDEOUT_CACHE_VERSION = 'json-v4';
+const HIDEOUT_CACHE_TTL_MS = 60 * 60 * 1000;
 const PRESTIGE_CACHE_VERSION = 'json-v2';
 const CACHE_PURGE_STORAGE_KEY = STORAGE_KEYS.cachePurgeAt;
 const CACHE_PURGE_CHECK_TTL_MS = 5 * 60 * 1000;
@@ -1173,7 +1174,7 @@ export const useMetadataStore = defineStore('metadata', {
         cacheLanguage: requestLanguage,
         endpoint: '/api/tarkov/hideout',
         queryParams: { lang: requestLanguage, gameMode: requestGameMode },
-        cacheTTL: CACHE_CONFIG.DEFAULT_TTL,
+        cacheTTL: HIDEOUT_CACHE_TTL_MS,
         loadingKey: 'hideoutLoading',
         errorKey: 'hideoutError',
         processData: (data) => {

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -350,9 +350,10 @@ sequenceDiagram
 - `bypassCache: true` (from `shouldBypassCache`) forces an awaited overlay refresh — used after
   publishing a correction.
 - A hideout request with an expired module-cached overlay serves the stale correction immediately
-  and registers one coalesced refresh with the Cloudflare execution context. A failed deferred
-  refresh backs off for one minute before another hideout request may retry it. Cold requests still
-  await the initial overlay fetch.
+  and registers one coalesced refresh with the Cloudflare execution context. Background task
+  rejections are logged and contained. A failed deferred refresh backs off for one minute before
+  another hideout request may retry it. Cold requests still await the initial overlay fetch, whose
+  five-second timeout covers both response headers and body parsing.
 - Hideout applies the overlay after reading its versioned base-data edge entry, so its correction
   freshness is bounded by the overlay module's one-hour cache and browser cache TTL rather than the
   hideout edge TTL. Other

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -354,6 +354,8 @@ sequenceDiagram
 ### Files
 
 - `app/server/utils/overlay.ts` — fetch, cache, merge.
+- `app/server/utils/overlayResponseHeaders.ts` — restores overlay metadata headers when corrections
+  are applied after an edge-cache read.
 - `app/server/utils/deepMerge.ts` — `deepMerge` + `isPlainObject`.
 - `app/server/utils/objectiveTypeInferrer.ts` — objective normalization.
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -81,9 +81,10 @@ Only `tasks-core` is precomputed today (it is the largest, hottest, and most exp
 See [Precompute](#5-precompute-workflow).
 
 The hideout route is the cache-order exception: its `json-v4` edge entry stores the adapted base
-payload, then the handler applies the current module-cached overlay after every edge-cache read. This
-keeps a 12-hour base-data cache from pinning an old overlay correction. The other overlay-enabled
-routes cache their final overlay-applied payload.
+payload, then the handler applies the current module-cached overlay after every edge-cache read. Its
+browser IndexedDB entry also uses `json-v4`, with a one-hour TTL matching overlay freshness. This
+keeps the 12-hour edge cache and the browser cache from pinning an old overlay correction. The other
+overlay-enabled routes cache their final overlay-applied payload.
 
 ### Diagram
 
@@ -296,8 +297,10 @@ flowchart TD
   catch block (502 on upstream failure) do not set it — the invariant covers the success
   paths only.
 - The cache key must include language and game mode so two locales or modes never share an entry.
-- Hideout cache entries must contain the adapted base payload, not the overlay-applied response;
+- Hideout edge-cache entries must contain the adapted base payload, not the overlay-applied response;
   `hideout.get.ts` applies the overlay after `edgeCache()` and restores the overlay metadata headers.
+- The browser hideout cache version must match the server route version and its TTL must not exceed
+  the one-hour overlay TTL.
 - The precomputed envelope is only trusted if `isPrecomputedEnvelope()` returns true; a corrupt
   write falls through to the edge cache instead of serving `null`.
 
@@ -344,16 +347,23 @@ sequenceDiagram
 - `tasksAdd` lets the overlay inject entirely new tasks not present upstream.
 - Objective post-processing (`objectiveTypeInferrer.ts`) normalizes objective lists and infers
   `foundInRaid` flags so the client does not have to guess.
-- `bypassCache: true` (from `shouldBypassCache`) forces a fresh overlay fetch — used after publishing
-  a correction.
+- `bypassCache: true` (from `shouldBypassCache`) forces an awaited overlay refresh — used after
+  publishing a correction.
+- A hideout request with an expired module-cached overlay serves the stale correction immediately
+  and registers one coalesced refresh with the Cloudflare execution context. A failed deferred
+  refresh backs off for one minute before another hideout request may retry it. Cold requests still
+  await the initial overlay fetch.
 - Hideout applies the overlay after reading its versioned base-data edge entry, so its correction
-  freshness is bounded by the overlay module's 1-hour cache rather than the hideout edge TTL. Other
+  freshness is bounded by the overlay module's one-hour cache and browser cache TTL rather than the
+  hideout edge TTL. Other
   overlay-enabled routes cache their final corrected payload; publishing new overlay data requires
   a Tarkov data cache purge so those entries and the browser cache-purge marker are invalidated.
 
 ### Files
 
-- `app/server/utils/overlay.ts` — fetch, cache, merge.
+- `app/server/utils/overlay.ts` — fetch, cache, merge, and deferred refresh coordination.
+- `app/server/utils/backgroundTask.ts` — keeps deferred refreshes alive through the Cloudflare
+  execution context.
 - `app/server/utils/overlayResponseHeaders.ts` — restores overlay metadata headers when corrections
   are applied after an edge-cache read.
 - `app/server/utils/deepMerge.ts` — `deepMerge` + `isPlainObject`.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -80,6 +80,11 @@ their upstream data does not currently need corrections.
 Only `tasks-core` is precomputed today (it is the largest, hottest, and most expensive payload).
 See [Precompute](#5-precompute-workflow).
 
+The hideout route is the cache-order exception: its `json-v4` edge entry stores the adapted base
+payload, then the handler applies the current module-cached overlay after every edge-cache read. This
+keeps a 12-hour base-data cache from pinning an old overlay correction. The other overlay-enabled
+routes cache their final overlay-applied payload.
+
 ### Diagram
 
 ```mermaid
@@ -203,7 +208,8 @@ replaces the key with the translated string.
    the `TARKOV_DATA` KV binding populated by the scheduled precompute workflow. See
    [Precompute](#5-precompute-workflow).
 2. **Edge Cache API** (per-colo, Cloudflare `caches.default`) — the standard layer. Stores the
-   adapted + overlay-applied payload with `s-maxage = ttl + staleTtl`.
+   adapted + overlay-applied payload with `s-maxage = ttl + staleTtl`. The hideout route instead
+   stores its adapted base payload and applies the current overlay after the cache read.
 3. **Upstream fetch** — on a cold miss, run the full pipeline (fetch → adapt → overlay) and write
    the result back into the edge cache.
 4. **Dev fallback** — when running locally with no Cache API (`globalThis.caches` undefined), skip
@@ -290,6 +296,8 @@ flowchart TD
   catch block (502 on upstream failure) do not set it — the invariant covers the success
   paths only.
 - The cache key must include language and game mode so two locales or modes never share an entry.
+- Hideout cache entries must contain the adapted base payload, not the overlay-applied response;
+  `hideout.get.ts` applies the overlay after `edgeCache()` and restores the overlay metadata headers.
 - The precomputed envelope is only trusted if `isPrecomputedEnvelope()` returns true; a corrupt
   write falls through to the edge cache instead of serving `null`.
 
@@ -338,6 +346,10 @@ sequenceDiagram
   `foundInRaid` flags so the client does not have to guess.
 - `bypassCache: true` (from `shouldBypassCache`) forces a fresh overlay fetch — used after publishing
   a correction.
+- Hideout applies the overlay after reading its versioned base-data edge entry, so its correction
+  freshness is bounded by the overlay module's 1-hour cache rather than the hideout edge TTL. Other
+  overlay-enabled routes cache their final corrected payload; publishing new overlay data requires
+  a Tarkov data cache purge so those entries and the browser cache-purge marker are invalidated.
 
 ### Files
 
@@ -352,7 +364,8 @@ sequenceDiagram
 - A missing or malformed overlay must never cause a 5xx; the base payload is returned with
   `X-Overlay-Status: missing`.
 - Overlay metadata (`status`, `version`, `generated`, `sha256`) must be propagated to response
-  headers so we can debug which correction was applied.
+  headers so we can debug which correction was applied. Routes that apply an overlay after
+  `edgeCache()` must call `setOverlayResponseHeaders()` before returning.
 
 ---
 


### PR DESCRIPTION
## **User description**
## Summary

- add integration coverage for locale overlay selection, precedence, entity patches, cache reuse, and malformed locale data
- cache the adapted hideout base payload and apply the current overlay after each cache read
- align the browser hideout cache to the same json-v4 version and one-hour overlay freshness window
- serve stale overlays immediately while a coalesced Cloudflare background refresh runs with retry backoff
- preserve overlay metadata response headers after post-cache processing
- contain background task failures and keep the five-second timeout active through body parsing
- handle malformed locale maps without crashing or changing the base payload
- document the hideout cache-order exception and overlay cache invalidation contract

## Why

Follow-up to #722. Codecov reported seven uncovered locale-application lines, while the real `applyOverlay` locale path was not exercised. Hideout responses also cached the final corrected payload, allowing the edge TTL to pin an older overlay correction.

## Validation

- `pnpm run test` — 2,395 tests passed
- `pnpm run lint:fallow` — passed
- Codecov patch coverage — passed
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed
- `pnpm run lint:blank-lines` — passed
- Prettier check — passed
- `pnpm run i18n:check` — passed
- `pnpm run validate:openapi` — passed
- `pnpm run systems:check` — passed

<!-- This is an auto-generated description by cubic. -->
<a href="https://cubic.dev/pr/tarkovtracker-org/TarkovTracker/pull/725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>
<!-- End of auto-generated description by cubic. -->

___

## **CodeAnt-AI Description**
Keep hideout corrections fresh while preserving locale and overlay behavior

### What Changed
- Hideout responses now cache the adapted base data and apply the current overlay after each cache read, preventing stale corrections from being served for the full data-cache lifetime.
- Overlay status and version details remain available in response headers after hideout data is updated.
- Malformed locale data is ignored so the base response still succeeds unchanged.
- Added coverage for locale precedence, unsupported locales, malformed overlays, cache behavior, and overlay response headers.
- Documented the hideout cache behavior and overlay freshness rules.

### Impact
`✅ Fresher hideout corrections`
`✅ Graceful responses with malformed locale data`
`✅ Clearer overlay freshness metadata`
<details><summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR keeps hideout overlay corrections fresh across edge and browser caches while preserving overlay metadata and safely handling deferred refresh failures.
- Caches the adapted hideout base payload before applying the current overlay.
- Adds coalesced background overlay refreshes with failure backoff.
- Aligns the browser cache version and TTL with overlay freshness.
- Adds locale, cache, response-header, and background-task coverage.
- Updates both the system documentation and canonical agent guidance.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains, and the previously reported agent-contract synchronization issue is addressed by the current AGENTS.md guidance.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds canonical guidance covering hideout cache ordering, overlay refresh behavior, response headers, and browser cache freshness. |
| app/server/api/tarkov/hideout.get.ts | Moves overlay application after the edge-cache read and schedules stale-overlay refreshes through the request execution context. |
| app/server/utils/overlay.ts | Adds coalesced deferred refreshes, retry backoff, full fetch/body timeout coverage, and malformed locale-patch guards. |
| app/server/utils/backgroundTask.ts | Registers guarded background work with Cloudflare waitUntil while containing rejected tasks in other environments. |
| app/server/utils/overlayResponseHeaders.ts | Centralizes safe propagation of overlay metadata into HTTP response headers. |
| app/stores/useMetadata.ts | Updates the hideout browser cache version and limits its TTL to the overlay freshness interval. |
| docs/SYSTEMS.md | Documents the hideout cache-order exception, deferred refresh lifecycle, and overlay-header invariants. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Browser
  participant Hideout as Hideout handler
  participant Edge as Edge cache
  participant Overlay as Overlay cache
  Browser->>Hideout: Request hideout data
  Hideout->>Edge: Read json-v4 adapted base payload
  Edge-->>Hideout: Base payload
  Hideout->>Overlay: Apply current locale overlay
  alt Overlay is fresh
    Overlay-->>Hideout: Corrected payload and metadata
  else Overlay is stale
    Overlay-->>Hideout: Stale correction and metadata
    Hideout->>Overlay: Schedule coalesced background refresh
  end
  Hideout-->>Browser: Corrected payload and overlay headers
```
</details>

<sub>Reviews (6): Last reviewed commit: ["fix(api): contain overlay refresh failur..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/1669a47a2e1d12398f90041b5707daa80ec38860) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53355851)</sub>

<!-- /greptile_comment -->
