### PR TITLE
test(i18n): warn when enabled locales are largely untranslated

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -179,7 +179,7 @@ Naming:
 
 - Non-English files (`cs`, `de`, `es`, `fr`, `it`, `ko`, `pl`, `pt`, `ru`, `uk`, `zh`) are Crowdin-owned exports.
 - vue-i18n fallback locale is `en` (`app/i18n.config.ts`). Missing non-English keys render English automatically.
-- `pnpm run i18n:check` is fatal only for snake_case naming violations in `en.json`. Missing/orphaned keys in non-English files are informational.
+- `pnpm run i18n:check` is fatal only for snake_case naming violations in `en.json`. Missing/orphaned keys in non-English files are informational. It also emits non-fatal drift warnings comparing flattened parsed values (missing keys count as English fallback): an enabled locale with >90% of values identical to the English source, or a locale file <30% identical that is missing from `SUPPORTED_LOCALES`.
 - Locale keys must be snake_case. Provide fallback strings in `t('key', 'Fallback')` calls.
 - When adding user-facing copy: add key to `en.json` only, run `pnpm run i18n:check`. Crowdin handles propagation.
 - Crowdin-only PRs that change only non-English exports are excluded from repository-owned CI, PR metadata, security, and Dependabot workflows via their `paths-ignore` filters. Changes to source code or `en.json` still run normal checks.

--- a/scripts/lint-i18n.mjs
+++ b/scripts/lint-i18n.mjs
@@ -2,9 +2,22 @@
 import { readFileSync, readdirSync } from 'fs';
 import { join } from 'path';
 const LOCALES_DIR = join(process.cwd(), 'app', 'locales');
+const LOCALES_UTILS_PATH = join(process.cwd(), 'app', 'utils', 'locales.ts');
 const SOURCE_LOCALE = 'en';
 const LOCALE_EXTENSION = '.json';
 const SNAKE_CASE_RE = /^[a-z][a-z0-9]*(_[a-z0-9]+)*$/;
+const ENABLED_UNTRANSLATED_PERCENT = 90;
+const DISABLED_TRANSLATED_PERCENT = 30;
+function loadEnabledLocales() {
+  const raw = readFileSync(LOCALES_UTILS_PATH, 'utf-8');
+  const match = raw.match(/SUPPORTED_LOCALES\s*=\s*\[([\s\S]*?)\]/);
+  const codes = match ? [...match[1].matchAll(/'([a-z0-9-]+)'/gi)].map((m) => m[1]) : [];
+  if (!match || codes.length === 0) {
+    console.warn(`i18n check: could not parse SUPPORTED_LOCALES in ${LOCALES_UTILS_PATH}`);
+    return null;
+  }
+  return new Set(codes);
+}
 function flatten(obj, prefix = '') {
   const result = {};
   for (const [key, value] of Object.entries(obj)) {
@@ -35,7 +48,7 @@ function checkSnakeCase(keys) {
   }
   return violations;
 }
-function main() {
+function readLocaleFiles() {
   const files = readdirSync(LOCALES_DIR).filter((f) => f.endsWith(LOCALE_EXTENSION));
   const localeCodes = files.map((f) => f.replace(LOCALE_EXTENSION, ''));
   if (!localeCodes.includes(SOURCE_LOCALE)) {
@@ -48,65 +61,156 @@ function main() {
   for (const code of localeCodes) {
     locales[code] = loadLocale(code);
   }
-  const sourceKeys = new Set(Object.keys(locales[SOURCE_LOCALE]));
-  const targetCodes = localeCodes.filter((c) => c !== SOURCE_LOCALE).sort();
-  let totalMissing = 0;
-  let totalExtra = 0;
-  const caseViolations = checkSnakeCase([...sourceKeys]);
-  if (caseViolations.length > 0) {
+  return { locales, targetCodes: localeCodes.filter((c) => c !== SOURCE_LOCALE).sort() };
+}
+function reportCaseViolations(keys) {
+  const violations = checkSnakeCase(keys);
+  if (violations.length > 0) {
     console.log(
       `\nKey naming violations in ${SOURCE_LOCALE}${LOCALE_EXTENSION} (expected snake_case):\n`
     );
-    for (const { key, segment } of caseViolations) {
+    for (const { key, segment } of violations) {
       console.log(`  ${key}  (segment: "${segment}")`);
     }
   }
-  for (const code of targetCodes) {
-    const targetKeys = new Set(Object.keys(locales[code]));
-    const missing = [...sourceKeys].filter((k) => !targetKeys.has(k)).sort();
-    const extra = [...targetKeys].filter((k) => !sourceKeys.has(k)).sort();
-    if (missing.length === 0 && extra.length === 0) {
-      continue;
-    }
+  return violations.length;
+}
+function keySyncFor(locales, sourceKeys, code) {
+  const targetKeys = new Set(Object.keys(locales[code]));
+  const missing = [...sourceKeys].filter((k) => !targetKeys.has(k)).sort();
+  const extra = [...targetKeys].filter((k) => !sourceKeys.has(k)).sort();
+  return { missing, extra };
+}
+function printMissing(code, missing) {
+  if (missing.length === 0) {
+    return;
+  }
+  console.log(`\n${code}${LOCALE_EXTENSION}:`);
+  console.log(
+    `  Missing ${missing.length} key(s) (will fall back to ${SOURCE_LOCALE} at runtime):`
+  );
+  for (const k of missing) {
+    console.log(`    - ${k}`);
+  }
+}
+function printExtra(code, extra, withHeader) {
+  if (extra.length === 0) {
+    return;
+  }
+  if (withHeader) {
     console.log(`\n${code}${LOCALE_EXTENSION}:`);
-    if (missing.length > 0) {
-      totalMissing += missing.length;
-      console.log(
-        `  Missing ${missing.length} key(s) (will fall back to ${SOURCE_LOCALE} at runtime):`
-      );
-      for (const k of missing) {
-        console.log(`    - ${k}`);
-      }
-    }
-    if (extra.length > 0) {
-      totalExtra += extra.length;
-      console.log(`  Extra ${extra.length} key(s) not in ${SOURCE_LOCALE}:`);
-      for (const k of extra) {
-        console.log(`    + ${k}`);
-      }
+  }
+  console.log(`  Extra ${extra.length} key(s) not in ${SOURCE_LOCALE}:`);
+  for (const k of extra) {
+    console.log(`    + ${k}`);
+  }
+}
+function reportKeySync(locales, sourceKeys, targetCodes) {
+  let totalMissing = 0;
+  let totalExtra = 0;
+  for (const code of targetCodes) {
+    const { missing, extra } = keySyncFor(locales, sourceKeys, code);
+    printMissing(code, missing);
+    printExtra(code, extra, missing.length === 0);
+    totalMissing += missing.length;
+    totalExtra += extra.length;
+  }
+  return { totalMissing, totalExtra };
+}
+function englishIdentityPercent(sourceValues, targetValues, sourceKeys) {
+  const merged = { ...sourceValues, ...targetValues };
+  let identical = 0;
+  for (const key of sourceKeys) {
+    if (merged[key] === sourceValues[key]) {
+      identical += 1;
     }
   }
+  return sourceKeys.size === 0 ? 0 : (identical / sourceKeys.size) * 100;
+}
+function enabledDriftWarning(code, percent) {
+  if (percent > ENABLED_UNTRANSLATED_PERCENT) {
+    return (
+      `${code}: enabled but ${percent.toFixed(1)}% of values identical to ${SOURCE_LOCALE} ` +
+      `(warn threshold ${ENABLED_UNTRANSLATED_PERCENT}%)`
+    );
+  }
+  return null;
+}
+function disabledDriftWarning(code, percent) {
+  if (percent < DISABLED_TRANSLATED_PERCENT) {
+    return (
+      `${code}: translated (only ${percent.toFixed(1)}% identical to ${SOURCE_LOCALE}) ` +
+      `but not in SUPPORTED_LOCALES`
+    );
+  }
+  return null;
+}
+function driftWarningFor(code, percent, enabled) {
+  return enabled ? enabledDriftWarning(code, percent) : disabledDriftWarning(code, percent);
+}
+function localeDriftWarnings(locales, sourceValues, sourceKeys, targetCodes, enabledLocales) {
+  if (!enabledLocales) {
+    return [];
+  }
+  return targetCodes
+    .map((code) => {
+      const percent = englishIdentityPercent(sourceValues, locales[code], sourceKeys);
+      return driftWarningFor(code, percent, enabledLocales.has(code));
+    })
+    .filter((warning) => warning !== null);
+}
+function printDriftWarnings(warnings) {
+  if (warnings.length === 0) {
+    return;
+  }
+  console.log(`\nLocale drift warnings (non-fatal):`);
+  for (const warning of warnings) {
+    console.log(`  - ${warning}`);
+  }
+}
+function buildSummaryParts(totalMissing, totalExtra, warningCount) {
+  const parts = [];
+  if (totalMissing > 0) {
+    parts.push(`${totalMissing} missing (fallback to ${SOURCE_LOCALE} at runtime)`);
+  }
+  if (totalExtra > 0) {
+    parts.push(`${totalExtra} extra (Crowdin will reconcile on next sync)`);
+  }
+  if (warningCount > 0) {
+    parts.push(`${warningCount} locale drift warning(s)`);
+  }
+  return parts;
+}
+function summarize(parts, targetCount) {
   console.log('');
-  if (caseViolations.length > 0) {
+  if (parts.length > 0) {
+    console.log(`i18n check: ${parts.join(', ')} — non-fatal`);
+    return;
+  }
+  console.log(`All ${targetCount} locale(s) are in sync with ${SOURCE_LOCALE}${LOCALE_EXTENSION}`);
+}
+function main() {
+  const { locales, targetCodes } = readLocaleFiles();
+  const sourceKeys = new Set(Object.keys(locales[SOURCE_LOCALE]));
+  const sourceValues = locales[SOURCE_LOCALE];
+  const enabledLocales = loadEnabledLocales();
+  const caseViolationCount = reportCaseViolations([...sourceKeys]);
+  if (caseViolationCount > 0) {
     console.log(
-      `i18n check: ${caseViolations.length} naming violation(s) in ${SOURCE_LOCALE}${LOCALE_EXTENSION}`
+      `i18n check: ${caseViolationCount} naming violation(s) in ${SOURCE_LOCALE}${LOCALE_EXTENSION}`
     );
     process.exit(1);
   }
-  const informational = [];
-  if (totalMissing > 0) {
-    informational.push(`${totalMissing} missing (fallback to ${SOURCE_LOCALE} at runtime)`);
-  }
-  if (totalExtra > 0) {
-    informational.push(`${totalExtra} extra (Crowdin will reconcile on next sync)`);
-  }
-  if (informational.length > 0) {
-    console.log(`i18n check: ${informational.join(', ')} — non-fatal`);
-  } else {
-    console.log(
-      `All ${targetCodes.length} locale(s) are in sync with ${SOURCE_LOCALE}${LOCALE_EXTENSION}`
-    );
-  }
+  const { totalMissing, totalExtra } = reportKeySync(locales, sourceKeys, targetCodes);
+  const warnings = localeDriftWarnings(
+    locales,
+    sourceValues,
+    sourceKeys,
+    targetCodes,
+    enabledLocales
+  );
+  printDriftWarnings(warnings);
+  summarize(buildSummaryParts(totalMissing, totalExtra, warnings.length), targetCodes.length);
   process.exit(0);
 }
 main();


### PR DESCRIPTION
Closes #584.

Adds the drift guard proposed in the issue: `pnpm run i18n:check` now parses `SUPPORTED_LOCALES` from `app/utils/locales.ts` and emits **non-fatal** warnings when:
- an enabled locale's values are >90% byte-identical to `en.json` (English-only UI), or
- a locale file that is <30% identical to `en.json` (i.e. largely translated) is missing from `SUPPORTED_LOCALES` (translated but never shown in the switcher).

Current output on main: `ko: enabled but 97.2% of values identical to en (warn threshold 90%)` — the exact drift this guard exists to surface. Fatal behavior is unchanged (snake_case violations in `en.json` only).

Decision recorded from #584: **`ko` stays enabled.** Korean Crowdin PRs are actively flowing (latest Aug 14) and Korean is a significant part of the playerbase; the drift warning now tracks it until coverage lands.

Also updates the Localization section of `AGENTS.md` for the new check behavior.

Validation: `pnpm run i18n:check` (exit 0, drift warning fires), `prettier --check`, `lint-blank-lines --check` on the changed script.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR extends the i18n checker with non-fatal translation-drift warnings and documents the behavior in the repository guidance.
- Loads enabled locale codes from `SUPPORTED_LOCALES`.
- Measures translated locale values against English fallback values.
- Reports enabled-but-untranslated and disabled-but-translated locales without changing fatal checks.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/lint-i18n.mjs | Refactors existing i18n reporting and adds non-fatal enabled/disabled locale drift detection. |
| AGENTS.md | Documents the new drift thresholds and fallback-aware comparison behavior. |

</details>

<sub>Reviews (3): Last reviewed commit: ["test(i18n): warn when enabled locales ar..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/668936f5079bc257d5b8cde1cad20f416560e643) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53588422)</sub>

**Context used:**

- Knowledge Base — [Dev Tooling Scripts](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/dev-tooling-scripts.md)

<!-- /greptile_comment -->