### PR TITLE
fix(api): stop leaking internal error messages in gateway 500 responses

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -452,6 +452,10 @@ All endpoints return errors in this format:
 }
 ```
 
+Unexpected gateway failures always return the fixed body `Internal server error` with status `500`.
+The underlying exception is logged server-side only, so clients must not parse `500` bodies for
+diagnostic detail. Client-correctable problems keep their specific `4xx` messages.
+
 ---
 
 ## Caching Behavior

--- a/docs/API.md
+++ b/docs/API.md
@@ -452,9 +452,10 @@ All endpoints return errors in this format:
 }
 ```
 
-Unexpected gateway failures always return the fixed body `Internal server error` with status `500`.
-The underlying exception is logged server-side only, so clients must not parse `500` bodies for
-diagnostic detail. Client-correctable problems keep their specific `4xx` messages.
+Unexpected gateway failures always return `500` with the fixed body
+`{"success": false, "error": "Internal server error"}`. The underlying exception is logged
+server-side only, so clients must not parse `500` bodies for diagnostic detail. Client-correctable
+problems keep their specific `4xx` messages, in the same `{"success": false, "error": ... }` shape.
 
 ---
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -442,7 +442,7 @@ Legacy `tt_` tokens are no longer accepted; they fail with `401 Invalid token fo
 
 ## Error Responses
 
-All endpoints return errors in this format:
+Nuxt/Pages `/api/*` routes return errors in this format:
 
 ```json
 {
@@ -452,10 +452,11 @@ All endpoints return errors in this format:
 }
 ```
 
-Unexpected gateway failures always return `500` with the fixed body
-`{"success": false, "error": "Internal server error"}`. The underlying exception is logged
+The public API gateway (`api.tarkovtracker.org`) uses its own envelope,
+`{"success": false, "error": "..."}`. Unexpected gateway failures always return `500` with the fixed
+body `{"success": false, "error": "Internal server error"}`; the underlying exception is logged
 server-side only, so clients must not parse `500` bodies for diagnostic detail. Client-correctable
-problems keep their specific `4xx` messages, in the same `{"success": false, "error": ... }` shape.
+problems keep their specific `4xx` messages in the same envelope.
 
 ---
 

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -704,7 +704,7 @@ describe('api-gateway', () => {
       })
     );
     const res = await worker.fetch(postTaskRequest('task-main', { state: 'completed' }), BASE_ENV);
-    await expectErrorResponse(res, 500, 'Progress row not found for user');
+    await expectErrorResponse(res, 500, 'Internal server error');
   });
   it('does not lose unrelated keys when two writers merge concurrently', async () => {
     // Both writers read the same stale snapshot (GET always returns the
@@ -1486,7 +1486,7 @@ describe('api-gateway', () => {
       expect(res.headers.get('Access-Control-Allow-Origin')).toBeTruthy();
       const body = (await res.json()) as { success: boolean; error: string };
       expect(body.success).toBe(false);
-      expect(body.error).toBe('digest unavailable');
+      expect(body.error).toBe('Internal server error');
     } finally {
       digest.mockRestore();
     }

--- a/workers/api-gateway/src/router.ts
+++ b/workers/api-gateway/src/router.ts
@@ -411,11 +411,6 @@ export async function handleGatewayRequest(
     });
   } catch (error) {
     console.error('API error:', error);
-    return errorResponse(
-      error instanceof Error ? error.message : 'Internal server error',
-      500,
-      origin,
-      reqOrigin
-    );
+    return errorResponse('Internal server error', 500, origin, reqOrigin);
   }
 }


### PR DESCRIPTION
Fixes #723

## Summary

The gateway's top-level error handler returned the raw `error.message` in 500 response bodies, which could leak internal Supabase/binding/upstream details to clients.

## Changes

- `workers/api-gateway/src/router.ts`: always return the fixed generic body `'Internal server error'` from the `handleGatewayRequest` catch block; the thrown error is still logged server-side via `console.error`.
- `workers/api-gateway/src/__tests__/gateway.test.ts`: updated the two 500-envelope assertions (merge-RPC failure, conditional-read digest failure) to expect `'Internal server error'` rather than the thrown message.

## Validation

- `pnpm run test:api-gateway`: 9 files, 175 tests passed
- `pnpm exec eslint workers/api-gateway/src/router.ts workers/api-gateway/src/__tests__/gateway.test.ts`: clean
- `pnpm run typecheck`: passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents unexpected API gateway failures from exposing internal exception messages while retaining server-side logging.
- Replaces raw 500 error messages with a fixed `Internal server error` response.
- Updates gateway tests to assert the sanitized error envelope.
- Documents the distinction between Nuxt/Pages and public gateway error formats.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workers/api-gateway/src/router.ts | Sanitizes the gateway’s top-level 500 response without changing its status, envelope, CORS handling, or server-side logging. |
| workers/api-gateway/src/__tests__/gateway.test.ts | Updates two unexpected-failure cases to verify that internal exception messages are no longer returned. |
| docs/API.md | Documents the gateway-specific error envelope and fixed message used for unexpected 500 responses. |

</details>

<sub>Reviews (4): Last reviewed commit: ["docs(api): scope each error envelope to ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/2eb922ef3f8e903c5f8bf77210517f67cfe92ad3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53597639)</sub>

**Context used:**

- Knowledge Base — [API Gateway (Cloudflare Worker)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/api-gateway.md)

<!-- /greptile_comment -->