### PR TITLE
fix(api): authenticate before decoding URL params in gateway write routes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -212,7 +212,8 @@ Naming:
 - API gateway routes must call `authorize()` before validating or decoding request input (URL params
   and body). Authentication and daily-quota enforcement come first so a malformed request from an
   unauthenticated or over-quota client answers `401`/`429`, never `400`. Pass `auth.rlHeaders` into
-  the resulting `400` responses so validation errors still carry `X-RateLimit-*`.
+  the resulting `400` responses so validation errors carry the same `X-RateLimit-*` headers as
+  successful ones (empty on the fail-open path, where no quota decision exists).
 - API token renames update only `api_tokens.note` through authenticated owner-scoped RLS. They
   must never rotate or replace the token or change its ID, value or hash, permissions, game mode,
   or usage data.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -209,6 +209,10 @@ Naming:
   Tarkov.dev profile imports support Seasonal through the upstream `pvp-season` profile path.
   EFT-log imports must remain unavailable for Seasonal until their Season log data is verified.
 - Public progress API clients must send a 5–200 character `User-Agent`; infrastructure routes are exempt. Usage reporting stores the latest normalized value per token/day.
+- API gateway routes must call `authorize()` before validating or decoding request input (URL params
+  and body). Authentication and daily-quota enforcement come first so a malformed request from an
+  unauthenticated or over-quota client answers `401`/`429`, never `400`. Pass `auth.rlHeaders` into
+  the resulting `400` responses so validation errors still carry `X-RateLimit-*`.
 - API token renames update only `api_tokens.note` through authenticated owner-scoped RLS. They
   must never rotate or replace the token or change its ID, value or hash, permissions, game mode,
   or usage data.

--- a/docs/API.md
+++ b/docs/API.md
@@ -404,6 +404,11 @@ A pre-authentication IP-based abuse gate (Cloudflare Workers Rate Limiting bindi
 the token validation step from floods. It is deliberately coarse — infrastructure protection,
 not a customer quota — and is not advertised as a per-IP entitlement.
 
+Authentication and the daily-quota check run before request-input validation, so a malformed request
+from an unauthenticated or over-quota client returns `401`/`429` rather than `400`. Once a request is
+authorized, validation `400` responses (malformed URL params, invalid JSON body) carry the same
+`X-RateLimit-*` headers as successful responses.
+
 Responses for which the daily-quota service returns a quota decision include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix seconds). When that decision denies the request, the gateway responds with `429` and `Retry-After`. Pre-authentication abuse-gate `429` responses include only `Retry-After`, and fail-open responses (daily-quota service temporarily unavailable) omit the `X-RateLimit-*` headers. When a free-tier user exhausts a daily quota, the `429` body includes an upgrade link. Admins can inspect the top consumers via `GET /api/admin/api-usage`; usage is bucketed by UTC day, so the report covers the current and previous UTC day (the `since` field gives the exact starting day).
 
 ### Conditional Requests & Polling

--- a/docs/API.md
+++ b/docs/API.md
@@ -407,7 +407,8 @@ not a customer quota — and is not advertised as a per-IP entitlement.
 Authentication and the daily-quota check run before request-input validation, so a malformed request
 from an unauthenticated or over-quota client returns `401`/`429` rather than `400`. Once a request is
 authorized, validation `400` responses (malformed URL params, invalid JSON body) carry the same
-`X-RateLimit-*` headers as successful responses.
+`X-RateLimit-*` headers as successful responses — and, like them, omit those headers on the fail-open
+path when no quota decision is available.
 
 Responses for which the daily-quota service returns a quota decision include `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset` (Unix seconds). When that decision denies the request, the gateway responds with `429` and `Retry-After`. Pre-authentication abuse-gate `429` responses include only `Retry-After`, and fail-open responses (daily-quota service temporarily unavailable) omit the `X-RateLimit-*` headers. When a free-tier user exhausts a daily quota, the `429` body includes an upgrade link. Admins can inspect the top consumers via `GET /api/admin/api-usage`; usage is bucketed by UTC day, so the report covers the current and previous UTC day (the `since` field gives the exact starting day).
 

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -852,6 +852,9 @@ describe('api-gateway', () => {
     vi.stubGlobal('fetch', createBaseFetchMock());
     const res = await worker.fetch(postTaskRequest('%E0%A4%A', { state: 'completed' }), BASE_ENV);
     await expectErrorResponse(res, 400, 'Invalid task ID in URL');
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('100');
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('10');
+    expect(res.headers.get('X-RateLimit-Reset')).toMatch(/^\d+$/);
   });
   it('rejects POST /progress/task with malformed JSON body', async () => {
     vi.stubGlobal('fetch', createBaseFetchMock());
@@ -928,6 +931,43 @@ describe('api-gateway', () => {
       BASE_ENV
     );
     await expectErrorResponse(res, 400, 'Invalid objective ID in URL');
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('100');
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('10');
+    expect(res.headers.get('X-RateLimit-Reset')).toMatch(/^\d+$/);
+  });
+  it('authenticates before decoding malformed-URL task writes', async () => {
+    vi.stubGlobal('fetch', createBaseFetchMock());
+    const res = await worker.fetch(
+      buildRequest('/progress/task/%E0%A4%A', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer tt_abc123', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ state: 'completed' }),
+      }),
+      BASE_ENV
+    );
+    await expectErrorResponse(res, 401, 'Invalid token format');
+  });
+  it('authenticates before decoding malformed-URL objective writes', async () => {
+    vi.stubGlobal('fetch', createBaseFetchMock());
+    const res = await worker.fetch(
+      buildRequest('/progress/task/objective/%E0%A4%A', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer tt_abc123', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ state: 'completed' }),
+      }),
+      BASE_ENV
+    );
+    await expectErrorResponse(res, 401, 'Invalid token format');
+  });
+  it('returns 429 (not 400) on malformed-URL writes when the daily quota is exceeded', async () => {
+    const env: Env = {
+      ...BASE_ENV,
+      API_GATEWAY_LIMITER: makeLimiter({ allowed: false, remaining: 0 }),
+    };
+    vi.stubGlobal('fetch', createBaseFetchMock());
+    const res = await worker.fetch(postTaskRequest('%E0%A4%A', { state: 'completed' }), env);
+    expect(res.status).toBe(429);
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('0');
   });
   it('rejects POST /progress/task/objective with malformed JSON body', async () => {
     vi.stubGlobal('fetch', createBaseFetchMock());

--- a/workers/api-gateway/src/responses.ts
+++ b/workers/api-gateway/src/responses.ts
@@ -268,16 +268,17 @@ export function decodeUrlParam(
   raw: string,
   label: string,
   envOrigin?: string,
-  requestOrigin?: string
+  requestOrigin?: string,
+  extraHeaders?: Record<string, string>
 ): string | Response {
   let decoded: string;
   try {
     decoded = decodeURIComponent(raw).trim();
   } catch {
-    return errorResponse(`Invalid ${label} in URL`, 400, envOrigin, requestOrigin);
+    return errorResponse(`Invalid ${label} in URL`, 400, envOrigin, requestOrigin, extraHeaders);
   }
   if (!decoded) {
-    return errorResponse(`Missing ${label} in URL`, 400, envOrigin, requestOrigin);
+    return errorResponse(`Missing ${label} in URL`, 400, envOrigin, requestOrigin, extraHeaders);
   }
   return decoded;
 }

--- a/workers/api-gateway/src/router.ts
+++ b/workers/api-gateway/src/router.ts
@@ -259,10 +259,16 @@ async function routeLevel(context: RouteContext): Promise<Response | null> {
 async function routeObjective(context: RouteContext): Promise<Response | null> {
   const match = context.apiPath.match(/^\/progress\/task\/objective\/([^/]+)$/);
   if (!match || context.request.method !== 'POST') return null;
-  const objectiveId = decodeUrlParam(match[1], 'objective ID', context.origin, context.reqOrigin);
-  if (objectiveId instanceof Response) return objectiveId;
   const auth = await authorize(context, 'WP', 'progress-write');
   if (auth instanceof Response) return auth;
+  const objectiveId = decodeUrlParam(
+    match[1],
+    'objective ID',
+    context.origin,
+    context.reqOrigin,
+    auth.rlHeaders
+  );
+  if (objectiveId instanceof Response) return objectiveId;
   const body = await parseJsonObjectBody(
     context.request,
     context.origin,
@@ -286,10 +292,16 @@ async function routeObjective(context: RouteContext): Promise<Response | null> {
 async function routeTask(context: RouteContext): Promise<Response | null> {
   const match = context.apiPath.match(/^\/progress\/task\/([^/]+)$/);
   if (!match || context.request.method !== 'POST') return null;
-  const taskId = decodeUrlParam(match[1], 'task ID', context.origin, context.reqOrigin);
-  if (taskId instanceof Response) return taskId;
   const auth = await authorize(context, 'WP', 'progress-write');
   if (auth instanceof Response) return auth;
+  const taskId = decodeUrlParam(
+    match[1],
+    'task ID',
+    context.origin,
+    context.reqOrigin,
+    auth.rlHeaders
+  );
+  if (taskId instanceof Response) return taskId;
   const body = await parseJsonObjectBody(
     context.request,
     context.origin,


### PR DESCRIPTION
Fixes #724

## Summary

Deferred from #719: `routeObjective` and `routeTask` called `decodeUrlParam` before `authorize`, so a malformed-URL unauthenticated request returned 400 without passing the pre-auth abuse gate or `validateToken`.

## Changes

- `workers/api-gateway/src/router.ts`: moved `authorize(context, 'WP', 'progress-write')` above `decodeUrlParam` in both `routeObjective` and `routeTask`, and passed `auth.rlHeaders` to the decode 400 responses so malformed-URL errors still carry rate-limit headers.
- `workers/api-gateway/src/responses.ts`: `decodeUrlParam` now accepts an optional `extraHeaders` param (matching `parseJsonObjectBody`).
- `workers/api-gateway/src/__tests__/gateway.test.ts`:
  - malformed-URL task/objective writes with an invalid token now return 401 (not 400)
  - malformed-URL writes when the daily write quota is exceeded return 429 (not 400)
  - valid-token malformed-URL writes still return 400 and now carry `X-RateLimit-*` headers (write tier: 100/day)

## Validation

- `pnpm run test:api-gateway`: 9 files, 178 tests passed
- `pnpm --filter api-gateway run typecheck`: passed
- `pnpm exec eslint` on the three touched files: clean

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR fixes authentication and quota precedence for malformed task and objective write URLs and brings the repository documentation in sync.
- Moves authorization ahead of URL-parameter decoding for task and objective writes.
- Propagates rate-limit headers to authorized malformed-URL responses.
- Adds regression coverage for invalid tokens, exhausted quotas, and authorized validation failures.
- Documents the resulting gateway ordering and response contract.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| workers/api-gateway/src/router.ts | Reorders task and objective write processing so authorization and quota enforcement precede URL decoding, while forwarding quota headers to validation responses. |
| workers/api-gateway/src/responses.ts | Extends URL-parameter decoding errors to accept and propagate optional response headers. |
| workers/api-gateway/src/__tests__/gateway.test.ts | Adds regression coverage for authentication, quota, and rate-limit-header precedence on malformed write URLs. |
| AGENTS.md | Records the gateway authorization-before-validation invariant required by the repository maintenance contract. |
| docs/API.md | Documents the public status-code precedence and rate-limit-header behavior for malformed authenticated requests. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant C as Client
  participant G as API Gateway
  participant A as Auth and quota
  participant V as Input validation
  C->>G: Task/objective write
  G->>A: authorize()
  alt Invalid token
    A-->>C: 401
  else Quota exhausted
    A-->>C: 429 + rate-limit headers
  else Authorized
    A-->>G: auth + rlHeaders
    G->>V: Decode URL and validate body
    alt Malformed input
      V-->>C: 400 + rlHeaders
    else Valid input
      V-->>G: Validated request
      G-->>C: Write response + rlHeaders
    end
  end
```
</details>

<sub>Reviews (3): Last reviewed commit: ["docs(api): note fail-open omits rate-lim..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/6fab8b34687a36fa111b4753a56665dd1f03a693) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53618144)</sub>

**Context used:**

- Knowledge Base — [API Gateway (Cloudflare Worker)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/api-gateway.md)

<!-- /greptile_comment -->