### PR TITLE
docs(tasks): note unlocalized upstream prestige names pending overlay locale work

### DIFF
--- a/app/stores/tarkov/prestige.ts
+++ b/app/stores/tarkov/prestige.ts
@@ -387,6 +387,13 @@ export const buildPrestigeRequirementRows = (
       continue;
     }
     if (condition.type === 'taskStatus' && condition.task?.id) {
+      // Task names here come straight from the raw prestige metadata: the
+      // /api/tarkov/prestige endpoint does not run applyOverlay yet, so locale
+      // corrections are not applied and upstream names stay as tarkov.dev
+      // ships them (e.g. the prestige-1 quest renders as German "Neuanfang"
+      // instead of "New Beginning"). Consuming locale corrections for the
+      // prestige dataset is tracked by the overlay epic (tarkovtracker-org/TarkovTracker#730);
+      // do not normalize names here until that lands.
       const taskName = condition.task.name || 'Task';
       const taskRole: PrestigeRequirementTaskRole =
         taskName === 'Collector'


### PR DESCRIPTION
Refs #615, Refs #730

## Summary

Documents the root cause of #615 (prestige settings menu showing "Neuanfang" instead of "New Beginning (Prestige 1)") directly at the source in `app/stores/tarkov/prestige.ts`:

- The prestige requirement rows take task names from the raw prestige metadata.
- `/api/tarkov/prestige` does not run `applyOverlay` (unlike `tasks-core`, `items`, `hideout`, `tasks-objectives`), so locale corrections are never applied to it and upstream tarkov.dev names (German "Neuanfang") flow through to the UI.
- Fixing the actual consumption gap is tracked by the overlay epic #730 ("wider locale corrections" not fully consumed). No name normalization here, deliberately, to avoid masking the upstream issue.

## Validation

- `pnpm exec eslint app/stores/tarkov/prestige.ts`: clean
- `pnpm exec vitest run app/stores/__tests__/prestigeRequirements.test.ts app/stores/__tests__/useMetadata.prestigeTaskMap.test.ts`: 18/18 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added notes clarifying that prestige task names reflect the original metadata and may not be normalized for localized overlays.
  * Documented that names should remain unchanged until localization overlay support is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This documentation-only PR explains why raw upstream prestige task names can remain unlocalized. The added explanation belongs in the canonical system documentation rather than an inline store comment.

- Documents that `/api/tarkov/prestige` does not yet apply locale overlays.
- Records the intended deferral to the wider overlay work tracked by issue #730.
</details>

<details open><summary><h3>Confidence Score: 4/5</h3></summary>

The PR is safe to merge from a runtime perspective, with a non-blocking documentation-placement issue to address.

The only change is a comment, so runtime behavior is unaffected; however, it duplicates overlay-system behavior in source instead of updating the canonical system specification.

**Files Needing Attention:** app/stores/tarkov/prestige.ts
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/stores/tarkov/prestige.ts | Adds no executable behavior, but introduces a system-level explanatory comment contrary to the repository's documentation-placement rule. |

</details>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
### Issue 1
app/stores/tarkov/prestige.ts:390-396
**System behavior duplicated inline**

This block documents the overlay pipeline directly in the store, contrary to the repository requirement to keep system behavior in `docs/SYSTEMS.md`. Maintaining the contract in two places creates drift when prestige overlay handling changes; move the explanation to the canonical system specification and reserve this location for a genuinely local decision.

---

For each issue above, determine whether it is valid and should be fixed. If so, fix it directly.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["docs(tasks): note unlocalized upstream p..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/dbdd81ee8d9e658c66ba0a37f71bf32dbfe73562) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53626994)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - AGENTS.md ([source](https://github.com/tarkovtracker-org/tarkovtracker/blob/main/AGENTS.md))

<!-- /greptile_comment -->