### PR TITLE
feat(tasks): expand task map panel by default with obvious toggle and fullscreen view

### DIFF
--- a/app/assets/css/tailwind.css
+++ b/app/assets/css/tailwind.css
@@ -857,18 +857,6 @@ summary {
 .leaflet-popup-content {
   margin: 0.75rem;
 }
-.leaflet-control-zoom a {
-  background-color: var(--color-surface-800) !important;
-  color: var(--color-gray-200) !important;
-  border-color: var(--color-surface-700) !important;
-}
-.leaflet-control-zoom a:hover {
-  background-color: var(--color-surface-700) !important;
-}
-.leaflet-control-zoom-reset {
-  border-top: 1px solid var(--color-surface-700) !important;
-  font-size: 18px;
-}
 .map-zone-tooltip {
   background-color: var(--color-surface-900) !important;
   color: var(--color-gray-200) !important;

--- a/app/composables/__tests__/useLeafletMap.test.ts
+++ b/app/composables/__tests__/useLeafletMap.test.ts
@@ -176,6 +176,9 @@ const mountUseLeafletMap = async (
 describe('useLeafletMap', () => {
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockMapInstance.setView.mockReset();
+    mockMapInstance.options.zoomDelta = 1;
+    mockMapInstance.options.zoomSnap = 1;
     vi.useFakeTimers();
     lastSvgElement = null;
     containerRefForTest = ref(document.createElement('div')) as Ref<HTMLElement | null>;

--- a/app/composables/__tests__/useLeafletMap.test.ts
+++ b/app/composables/__tests__/useLeafletMap.test.ts
@@ -273,6 +273,37 @@ describe('useLeafletMap', () => {
       });
       wrapper.unmount();
     });
+    it('disables zoom snapping while restoring a fractional initialView zoom', async () => {
+      const mapData = {
+        id: 'customs',
+        name: 'Customs',
+        normalizedName: 'customs',
+        svg: {
+          file: 'customs.svg',
+          floors: ['ground'],
+          defaultFloor: 'ground',
+          coordinateRotation: 0,
+          bounds: [
+            [0, 0],
+            [100, 100],
+          ],
+        },
+      } as TarkovMap;
+      mockMapInstance.options.zoomSnap = 1;
+      let zoomSnapDuringSetView: number | undefined;
+      mockMapInstance.setView.mockImplementation(() => {
+        zoomSnapDuringSetView = mockMapInstance.options.zoomSnap;
+        return mockMapInstance;
+      });
+      const initialView: { center: [number, number]; zoom: number } = {
+        center: [55.5, 37.6],
+        zoom: 6.4,
+      };
+      const { wrapper } = await mountUseLeafletMap(mapData, undefined, initialView);
+      expect(zoomSnapDuringSetView).toBe(0);
+      expect(mockMapInstance.options.zoomSnap).toBe(1);
+      wrapper.unmount();
+    });
     it('falls back to fitting bounds when initialView is missing', async () => {
       const mapData = {
         id: 'customs',

--- a/app/composables/__tests__/useLeafletMap.test.ts
+++ b/app/composables/__tests__/useLeafletMap.test.ts
@@ -10,6 +10,8 @@ const mockMapInstance = {
   off: vi.fn(),
   remove: vi.fn(),
   fitBounds: vi.fn(),
+  setView: vi.fn(),
+  panTo: vi.fn(),
   invalidateSize: vi.fn(),
   createPane: vi.fn(() => ({ style: {} })),
   options: { zoomDelta: 1, zoomSnap: 1 },
@@ -138,7 +140,8 @@ let useLeafletMapForTest: UseLeafletMapFn;
 let containerRefForTest: Ref<HTMLElement | null>;
 const mountUseLeafletMap = async (
   mapValue: TarkovMap | null,
-  initialFloor?: string
+  initialFloor?: string,
+  initialView?: { center: [number, number]; zoom: number } | null
 ): Promise<{
   result: ReturnType<UseLeafletMapFn>;
   wrapper: ReturnType<typeof mount>;
@@ -154,6 +157,7 @@ const mountUseLeafletMap = async (
           containerRef: containerRefForTest,
           map: mapRef,
           initialFloor,
+          initialView,
           enableIdleDetection: false,
         });
         return () => null;
@@ -240,6 +244,54 @@ describe('useLeafletMap', () => {
       const { result, wrapper } = await mountUseLeafletMap(mapData, 'parking');
       expect(result.floors.value).toEqual(['parking', 'ground', 'second']);
       expect(result.selectedFloor.value).toBe('parking');
+      wrapper.unmount();
+    });
+    it('restores an initialView instead of fitting bounds when provided', async () => {
+      const mapData = {
+        id: 'customs',
+        name: 'Customs',
+        normalizedName: 'customs',
+        svg: {
+          file: 'customs.svg',
+          floors: ['ground'],
+          defaultFloor: 'ground',
+          coordinateRotation: 0,
+          bounds: [
+            [0, 0],
+            [100, 100],
+          ],
+        },
+      } as TarkovMap;
+      const initialView: { center: [number, number]; zoom: number } = {
+        center: [55.5, 37.6],
+        zoom: 6,
+      };
+      const { wrapper } = await mountUseLeafletMap(mapData, undefined, initialView);
+      expect(mockMapInstance.fitBounds).not.toHaveBeenCalled();
+      expect(mockMapInstance.setView).toHaveBeenCalledWith(initialView.center, initialView.zoom, {
+        animate: false,
+      });
+      wrapper.unmount();
+    });
+    it('falls back to fitting bounds when initialView is missing', async () => {
+      const mapData = {
+        id: 'customs',
+        name: 'Customs',
+        normalizedName: 'customs',
+        svg: {
+          file: 'customs.svg',
+          floors: ['ground'],
+          defaultFloor: 'ground',
+          coordinateRotation: 0,
+          bounds: [
+            [0, 0],
+            [100, 100],
+          ],
+        },
+      } as TarkovMap;
+      const { wrapper } = await mountUseLeafletMap(mapData);
+      expect(mockMapInstance.setView).not.toHaveBeenCalled();
+      expect(mockMapInstance.fitBounds).toHaveBeenCalled();
       wrapper.unmount();
     });
     it('ignores stale async init when map becomes unavailable before layer setup', async () => {

--- a/app/composables/__tests__/useLeafletMap.test.ts
+++ b/app/composables/__tests__/useLeafletMap.test.ts
@@ -294,6 +294,31 @@ describe('useLeafletMap', () => {
       expect(mockMapInstance.fitBounds).toHaveBeenCalled();
       wrapper.unmount();
     });
+    it('falls back to fitting bounds when initialView has a non-finite center coordinate', async () => {
+      const mapData = {
+        id: 'customs',
+        name: 'Customs',
+        normalizedName: 'customs',
+        svg: {
+          file: 'customs.svg',
+          floors: ['ground'],
+          defaultFloor: 'ground',
+          coordinateRotation: 0,
+          bounds: [
+            [0, 0],
+            [100, 100],
+          ],
+        },
+      } as TarkovMap;
+      const initialView: { center: [number, number]; zoom: number } = {
+        center: [Number.NaN, 37.6],
+        zoom: 6,
+      };
+      const { wrapper } = await mountUseLeafletMap(mapData, undefined, initialView);
+      expect(mockMapInstance.setView).not.toHaveBeenCalled();
+      expect(mockMapInstance.fitBounds).toHaveBeenCalled();
+      wrapper.unmount();
+    });
     it('ignores stale async init when map becomes unavailable before layer setup', async () => {
       const deferredFetch = createDeferred<{ ok: boolean; text: () => Promise<string> }>();
       const fetchSpy = vi.fn(() => deferredFetch.promise);

--- a/app/composables/useLeafletMap.ts
+++ b/app/composables/useLeafletMap.ts
@@ -750,28 +750,6 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
       // Create map instance with custom CRS
       const mapOptions = getLeafletMapOptions(leaflet.value, renderConfig);
       mapInstance.value = leaflet.value.map(containerRef.value, mapOptions);
-      const ZoomWithReset = leaflet.value.Control.Zoom.extend({
-        onAdd(this: L.Control.Zoom, map: L.Map) {
-          const container = leaflet.value!.Control.Zoom.prototype.onAdd!.call(this, map);
-          const resetBtn = leaflet.value!.DomUtil.create(
-            'a',
-            'leaflet-control-zoom-reset',
-            container
-          );
-          resetBtn.textContent = '\u27F2';
-          resetBtn.href = '#';
-          resetBtn.title = 'Reset view';
-          resetBtn.setAttribute('role', 'button');
-          resetBtn.setAttribute('aria-label', 'Reset view');
-          leaflet.value!.DomEvent.disableClickPropagation(resetBtn);
-          leaflet.value!.DomEvent.on(resetBtn, 'click', (e: Event) => {
-            leaflet.value!.DomEvent.preventDefault(e);
-            refreshView();
-          });
-          return container;
-        },
-      });
-      new ZoomWithReset({ position: 'bottomright' }).addTo(mapInstance.value);
       // Create a custom pane for the map background to ensure it stays behind markers
       const backgroundPane = mapInstance.value.createPane('mapBackground');
       backgroundPane.style.zIndex = '200'; // Below overlayPane (400) and markerPane (600)

--- a/app/composables/useLeafletMap.ts
+++ b/app/composables/useLeafletMap.ts
@@ -25,7 +25,7 @@ export interface UseLeafletMapOptions {
   /** Initial floor selection */
   initialFloor?: string;
   /** Initial view (center + zoom) to apply instead of fitting map bounds */
-  initialView?: { center: [number, number]; zoom: number } | null;
+  initialView?: MapViewState | null;
   /** Enable idle detection for performance */
   enableIdleDetection?: boolean;
   /** Idle timeout in milliseconds */
@@ -157,30 +157,33 @@ function parseSvgContent(content: string): SVGElement | null {
   }
   return doc.documentElement as unknown as SVGElement;
 }
-type MapInitialView = { center: [number, number]; zoom: number };
-function isFiniteLatLng(center: unknown): boolean {
-  return Array.isArray(center) && center.length === 2 && center.every(Number.isFinite);
+export interface MapViewState {
+  center: [number, number];
+  zoom: number;
 }
-function isRestorableMapView(view: MapInitialView | null | undefined): view is MapInitialView {
-  if (!view) return false;
-  return isFiniteLatLng(view.center) && Number.isFinite(view.zoom);
-}
-function applyRestoredMapView(instance: L.Map, view: MapInitialView): void {
+export function withoutZoomSnap(instance: L.Map, apply: () => void): void {
   const originalZoomSnap = instance.options.zoomSnap ?? 0;
   instance.options.zoomSnap = 0;
   try {
-    instance.setView(view.center, view.zoom, { animate: false });
+    apply();
   } finally {
     instance.options.zoomSnap = originalZoomSnap;
   }
 }
+function isFiniteLatLng(center: unknown): boolean {
+  return Array.isArray(center) && center.length === 2 && center.every(Number.isFinite);
+}
+function isRestorableMapView(view: MapViewState | null | undefined): view is MapViewState {
+  if (!view) return false;
+  return isFiniteLatLng(view.center) && Number.isFinite(view.zoom);
+}
 function setInitialMapView(
   instance: L.Map,
-  view: MapInitialView | null | undefined,
+  view: MapViewState | null | undefined,
   bounds: L.LatLngBoundsExpression
 ): void {
   if (isRestorableMapView(view)) {
-    applyRestoredMapView(instance, view);
+    withoutZoomSnap(instance, () => instance.setView(view.center, view.zoom, { animate: false }));
     return;
   }
   instance.fitBounds(bounds);
@@ -208,7 +211,7 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
   const crsKey = ref('');
   const renderKey = ref('');
   let hasAppliedInitialView = false;
-  const consumeInitialView = (): MapInitialView | null => {
+  const consumeInitialView = (): MapViewState | null => {
     if (hasAppliedInitialView) return null;
     hasAppliedInitialView = true;
     return initialView ?? null;

--- a/app/composables/useLeafletMap.ts
+++ b/app/composables/useLeafletMap.ts
@@ -781,6 +781,8 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
         initialView &&
         Array.isArray(initialView.center) &&
         initialView.center.length === 2 &&
+        Number.isFinite(initialView.center[0]) &&
+        Number.isFinite(initialView.center[1]) &&
         Number.isFinite(initialView.zoom)
       ) {
         mapInstance.value.setView(initialView.center, initialView.zoom, { animate: false });

--- a/app/composables/useLeafletMap.ts
+++ b/app/composables/useLeafletMap.ts
@@ -157,6 +157,34 @@ function parseSvgContent(content: string): SVGElement | null {
   }
   return doc.documentElement as unknown as SVGElement;
 }
+type MapInitialView = { center: [number, number]; zoom: number };
+function isFiniteLatLng(center: unknown): boolean {
+  return Array.isArray(center) && center.length === 2 && center.every(Number.isFinite);
+}
+function isRestorableMapView(view: MapInitialView | null | undefined): view is MapInitialView {
+  if (!view) return false;
+  return isFiniteLatLng(view.center) && Number.isFinite(view.zoom);
+}
+function applyRestoredMapView(instance: L.Map, view: MapInitialView): void {
+  const originalZoomSnap = instance.options.zoomSnap ?? 0;
+  instance.options.zoomSnap = 0;
+  try {
+    instance.setView(view.center, view.zoom, { animate: false });
+  } finally {
+    instance.options.zoomSnap = originalZoomSnap;
+  }
+}
+function setInitialMapView(
+  instance: L.Map,
+  view: MapInitialView | null | undefined,
+  bounds: L.LatLngBoundsExpression
+): void {
+  if (isRestorableMapView(view)) {
+    applyRestoredMapView(instance, view);
+    return;
+  }
+  instance.fitBounds(bounds);
+}
 export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapReturn {
   const {
     containerRef,
@@ -179,6 +207,12 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
   const spawnLayer = shallowRef<L.LayerGroup | null>(null);
   const crsKey = ref('');
   const renderKey = ref('');
+  let hasAppliedInitialView = false;
+  const consumeInitialView = (): MapInitialView | null => {
+    if (hasAppliedInitialView) return null;
+    hasAppliedInitialView = true;
+    return initialView ?? null;
+  };
   // Map event handlers
   const onWheel = (e: WheelEvent) => {
     if (!mapInstance.value) return;
@@ -755,18 +789,7 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
       backgroundPane.style.zIndex = '200'; // Below overlayPane (400) and markerPane (600)
       // Set initial view using map bounds, or restore a previous view when provided
       const bounds = getLeafletBounds(renderConfig);
-      if (
-        initialView &&
-        Array.isArray(initialView.center) &&
-        initialView.center.length === 2 &&
-        Number.isFinite(initialView.center[0]) &&
-        Number.isFinite(initialView.center[1]) &&
-        Number.isFinite(initialView.zoom)
-      ) {
-        mapInstance.value.setView(initialView.center, initialView.zoom, { animate: false });
-      } else {
-        mapInstance.value.fitBounds(bounds);
-      }
+      setInitialMapView(mapInstance.value, consumeInitialView(), bounds);
       // Set initial floor
       selectedFloor.value = resolveInitialFloor(svgConfig, tileConfig, initialFloor);
       renderKey.value = getRenderKey() ?? '';

--- a/app/composables/useLeafletMap.ts
+++ b/app/composables/useLeafletMap.ts
@@ -790,7 +790,6 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
       // Create a custom pane for the map background to ensure it stays behind markers
       const backgroundPane = mapInstance.value.createPane('mapBackground');
       backgroundPane.style.zIndex = '200'; // Below overlayPane (400) and markerPane (600)
-      // Set initial view using map bounds, or restore a previous view when provided
       const bounds = getLeafletBounds(renderConfig);
       setInitialMapView(mapInstance.value, consumeInitialView(), bounds);
       // Set initial floor

--- a/app/composables/useLeafletMap.ts
+++ b/app/composables/useLeafletMap.ts
@@ -24,6 +24,8 @@ export interface UseLeafletMapOptions {
   map: Ref<TarkovMap | null>;
   /** Initial floor selection */
   initialFloor?: string;
+  /** Initial view (center + zoom) to apply instead of fitting map bounds */
+  initialView?: { center: [number, number]; zoom: number } | null;
   /** Enable idle detection for performance */
   enableIdleDetection?: boolean;
   /** Idle timeout in milliseconds */
@@ -160,6 +162,7 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
     containerRef,
     map,
     initialFloor,
+    initialView,
     enableIdleDetection = true,
     idleTimeout = 60000, // 1 minute
   } = options;
@@ -772,9 +775,18 @@ export function useLeafletMap(options: UseLeafletMapOptions): UseLeafletMapRetur
       // Create a custom pane for the map background to ensure it stays behind markers
       const backgroundPane = mapInstance.value.createPane('mapBackground');
       backgroundPane.style.zIndex = '200'; // Below overlayPane (400) and markerPane (600)
-      // Set initial view using map bounds
+      // Set initial view using map bounds, or restore a previous view when provided
       const bounds = getLeafletBounds(renderConfig);
-      mapInstance.value.fitBounds(bounds);
+      if (
+        initialView &&
+        Array.isArray(initialView.center) &&
+        initialView.center.length === 2 &&
+        Number.isFinite(initialView.zoom)
+      ) {
+        mapInstance.value.setView(initialView.center, initialView.zoom, { animate: false });
+      } else {
+        mapInstance.value.fitBounds(bounds);
+      }
       // Set initial floor
       selectedFloor.value = resolveInitialFloor(svgConfig, tileConfig, initialFloor);
       renderKey.value = getRenderKey() ?? '';

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -803,9 +803,6 @@
   >;
   let lastUserOpenedPopover: 'colors' | 'settings' | 'help' | null = null;
   const onPopoverOpenChange = (key: 'colors' | 'settings' | 'help', isOpen: boolean) => {
-    if (key === 'help' && isOpen) {
-      helpOpenedThisSession.value = true;
-    }
     if (isOpen) {
       lastUserOpenedPopover = key;
       return;
@@ -814,6 +811,10 @@
     lastUserOpenedPopover = null;
     nextTick(() => popoverTriggers[key]?.focus());
   };
+  watch(mapHelpOpen, (isOpen) => {
+    if (!isOpen) return;
+    helpOpenedThisSession.value = true;
+  });
   watch([mapColorsOpen, mapSettingsOpen, mapHelpOpen], ([colors, settings, help]) => {
     if (colors) {
       mapSettingsOpen.value = false;

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -312,7 +312,7 @@
                 "
               >
                 <span
-                  v-if="!helpOpenedThisSession"
+                  v-if="!mapHelpSeen"
                   data-testid="map-help-unseen-dot"
                   class="bg-primary-400 absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full"
                 />
@@ -641,14 +641,26 @@
   import type { TarkovMap } from '@/types/tarkov';
   import type L from 'leaflet';
   const MAP_CONTROLS_HINT_KEY = 'mapControlsHintSeen';
+  const MAP_HELP_SEEN_KEY = 'mapHelpSeen';
   const mapControlsHintSeen = ref(false);
+  const mapHelpSeen = ref(false);
   onMounted(() => {
     try {
       mapControlsHintSeen.value = window.localStorage.getItem(MAP_CONTROLS_HINT_KEY) === 'true';
+      mapHelpSeen.value = window.localStorage.getItem(MAP_HELP_SEEN_KEY) === 'true';
     } catch (error) {
-      logger.warn('[LeafletMap] Failed to read map controls hint flag:', error);
+      logger.warn('[LeafletMap] Failed to read map hint flags:', error);
     }
   });
+  const markMapHelpSeen = () => {
+    if (mapHelpSeen.value) return;
+    mapHelpSeen.value = true;
+    try {
+      window.localStorage.setItem(MAP_HELP_SEEN_KEY, 'true');
+    } catch (error) {
+      logger.warn('[LeafletMap] Failed to persist map help seen flag:', error);
+    }
+  };
   const dismissMapControlsHint = () => {
     mapControlsHintSeen.value = true;
     try {
@@ -687,6 +699,7 @@
     fill?: boolean;
     height?: number;
     initialView?: MapViewState | null;
+    initialFloor?: string;
   }
   const props = withDefaults(defineProps<Props>(), {
     marks: () => [],
@@ -699,6 +712,7 @@
     fill: false,
     height: undefined,
     initialView: null,
+    initialFloor: undefined,
   });
   const emit = defineEmits<{ 'toggle-fullscreen': [] }>();
   const { t } = useI18n({ useScope: 'global' });
@@ -735,6 +749,7 @@
     containerRef: mapContainer,
     map: toRef(props, 'map'),
     initialView: props.initialView ?? null,
+    initialFloor: props.initialFloor,
   });
   const ZONE_HOVER_DELTA = 0.16;
   const ZONE_HOVER_MAX = 0.6;
@@ -803,7 +818,6 @@
   const mapColorsOpen = ref(false);
   const mapSettingsOpen = ref(false);
   const mapHelpOpen = ref(false);
-  const helpOpenedThisSession = ref(false);
   const popoverTriggers = { colors: null, settings: null, help: null } as Record<
     'colors' | 'settings' | 'help',
     HTMLElement | null
@@ -820,7 +834,7 @@
   };
   watch(mapHelpOpen, (isOpen) => {
     if (!isOpen) return;
-    helpOpenedThisSession.value = true;
+    markMapHelpSeen();
   });
   watch([mapColorsOpen, mapSettingsOpen, mapHelpOpen], ([colors, settings, help]) => {
     if (colors) {
@@ -1881,12 +1895,15 @@
     }
     withoutZoomSnap(instance, () => instance.setView(state.center, state.zoom, { animate: false }));
   };
+  const getFloor = (): string => selectedFloor.value;
   defineExpose({
     activateObjectivePopup,
     closeActivePopup,
     refreshView,
     getViewState,
     setViewState,
+    getFloor,
+    setFloor,
   });
   onUnmounted(() => {
     window.removeEventListener('keydown', onGlobalMapKeydown);

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -302,6 +302,7 @@
               <button
                 :ref="(el) => (popoverTriggers.help = el as HTMLElement | null)"
                 type="button"
+                data-testid="map-help-toggle"
                 :aria-label="t('maps.help.title')"
                 class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-850 relative flex h-8 w-8 items-center justify-center rounded-md border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                 :class="
@@ -312,6 +313,7 @@
               >
                 <span
                   v-if="!helpOpenedThisSession"
+                  data-testid="map-help-unseen-dot"
                   class="bg-primary-400 absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full"
                 />
                 <UIcon name="i-mdi-help-circle-outline" class="h-4 w-4" />
@@ -463,6 +465,7 @@
           <AppTooltip :text="t('maps.tooltips.zoom_in')" :kbds="['E']">
             <button
               type="button"
+              data-testid="map-zoom-in"
               :disabled="!canZoomIn"
               :aria-label="t('maps.tooltips.zoom_in')"
               class="focus-visible:ring-primary-500 text-surface-200 hover:text-surface-50 focus-visible:ring-offset-surface-850 disabled:hover:text-surface-200 flex h-9 w-9 items-center justify-center transition-colors hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
@@ -474,6 +477,7 @@
           <AppTooltip :text="t('maps.tooltips.zoom_out')" :kbds="['Q']">
             <button
               type="button"
+              data-testid="map-zoom-out"
               :disabled="!canZoomOut"
               :aria-label="t('maps.tooltips.zoom_out')"
               class="focus-visible:ring-primary-500 text-surface-200 hover:text-surface-50 focus-visible:ring-offset-surface-850 disabled:hover:text-surface-200 flex h-9 w-9 items-center justify-center transition-colors hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
@@ -486,6 +490,7 @@
           <AppTooltip :text="t('maps.tooltips.reset_view')" :kbds="['R']">
             <button
               type="button"
+              data-testid="map-reset-view"
               :aria-label="t('maps.tooltips.reset_view')"
               class="focus-visible:ring-primary-500 text-surface-200 hover:text-surface-50 focus-visible:ring-offset-surface-850 flex h-9 w-9 items-center justify-center transition-colors hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
               @click="resetMapView"
@@ -525,6 +530,7 @@
             <button
               type="button"
               class="bg-primary-500 hover:bg-primary-400 text-surface-950 rounded px-3 py-1 text-xs font-semibold transition-colors"
+              data-testid="map-hint-dismiss"
               @click="dismissFirstUseHint"
             >
               {{ t('common.got_it') }}
@@ -532,6 +538,7 @@
             <button
               type="button"
               class="text-primary-300 hover:text-primary-200 text-xs font-medium underline-offset-2 transition-colors hover:underline"
+              data-testid="map-hint-all-controls"
               @click="openHelpFromHint"
             >
               {{ t('maps.hint.all_controls') }}
@@ -608,7 +615,7 @@
 <script setup lang="ts">
   import 'leaflet/dist/leaflet.css';
   import { createApp } from 'vue';
-  import { useLeafletMap } from '@/composables/useLeafletMap';
+  import { type MapViewState, useLeafletMap, withoutZoomSnap } from '@/composables/useLeafletMap';
   import {
     MAP_BUTTON_ACTIVE_CLASS,
     MAP_BUTTON_INACTIVE_CLASS,
@@ -679,7 +686,7 @@
     isFullscreen?: boolean;
     fill?: boolean;
     height?: number;
-    initialView?: { center: [number, number]; zoom: number } | null;
+    initialView?: MapViewState | null;
   }
   const props = withDefaults(defineProps<Props>(), {
     marks: () => [],
@@ -840,15 +847,6 @@
   });
   const updateCurrentMapZoom = () => {
     currentMapZoom.value = mapInstance.value?.getZoom() ?? 0;
-  };
-  const withoutZoomSnap = (instance: L.Map, apply: () => void): void => {
-    const originalZoomSnap = instance.options.zoomSnap ?? 0;
-    instance.options.zoomSnap = 0;
-    try {
-      apply();
-    } finally {
-      instance.options.zoomSnap = originalZoomSnap;
-    }
   };
   const zoomMapBy = (direction: 1 | -1) => {
     const instance = mapInstance.value;
@@ -1868,13 +1866,13 @@
     const size = instance.getSize();
     return size.x > 0 && size.y > 0;
   };
-  const getViewState = (): { center: [number, number]; zoom: number } | null => {
+  const getViewState = (): MapViewState | null => {
     const instance = mapInstance.value;
     if (!instance || !hasLaidOutContainer(instance)) return null;
     const center = instance.getCenter();
     return { center: [center.lat, center.lng], zoom: instance.getZoom() };
   };
-  const setViewState = (state: { center: [number, number]; zoom: number }): void => {
+  const setViewState = (state: MapViewState): void => {
     const instance = mapInstance.value;
     if (!instance || !hasLaidOutContainer(instance)) return;
     if (instance.getZoom() === state.zoom) {

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -412,6 +412,7 @@
     showSpawnToggle?: boolean;
     showLegend?: boolean;
     height?: number;
+    initialView?: { center: [number, number]; zoom: number } | null;
   }
   const props = withDefaults(defineProps<Props>(), {
     marks: () => [],
@@ -420,6 +421,7 @@
     showSpawnToggle: true,
     showLegend: true,
     height: undefined,
+    initialView: null,
   });
   const { t } = useI18n({ useScope: 'global' });
   const router = useRouter();
@@ -450,6 +452,7 @@
   } = useLeafletMap({
     containerRef: mapContainer,
     map: toRef(props, 'map'),
+    initialView: props.initialView ?? null,
   });
   const ZONE_HOVER_DELTA = 0.16;
   const ZONE_HOVER_MAX = 0.6;
@@ -1474,10 +1477,27 @@
       activePinnedPopupCleanup();
     }
   };
+  const getViewState = (): { center: [number, number]; zoom: number } | null => {
+    const instance = mapInstance.value;
+    if (!instance) return null;
+    const center = instance.getCenter();
+    return { center: [center.lat, center.lng], zoom: instance.getZoom() };
+  };
+  const setViewState = (state: { center: [number, number]; zoom: number }): void => {
+    const instance = mapInstance.value;
+    if (!instance || !state) return;
+    if (instance.getZoom() !== state.zoom) {
+      instance.setView(state.center, state.zoom, { animate: false });
+      return;
+    }
+    instance.panTo(state.center, { animate: false });
+  };
   defineExpose({
     activateObjectivePopup,
     closeActivePopup,
     refreshView,
+    getViewState,
+    setViewState,
   });
   onUnmounted(() => {
     window.removeEventListener('keydown', onGlobalMapKeydown);

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -3,11 +3,13 @@
     ref="mapSurfaceRef"
     tabindex="0"
     class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-900 relative isolate w-full focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+    :class="{ 'flex h-full min-h-0 flex-col': props.fill }"
     @pointerdown.capture="focusMapSurface"
   >
     <div
       v-if="isMapUnavailable"
-      class="bg-surface-900 flex h-100 w-full flex-col items-center justify-center rounded sm:h-125 lg:h-150"
+      class="bg-surface-900 flex w-full flex-col items-center justify-center rounded"
+      :class="props.fill ? 'min-h-0 flex-1' : 'h-100 sm:h-125 lg:h-150'"
       :style="mapHeightStyle"
     >
       <UIcon name="i-mdi-map-marker-off" class="text-surface-500 mb-4 h-16 w-16" />
@@ -23,30 +25,40 @@
       </p>
     </div>
     <template v-else>
-      <div
+      <AppTooltip
         v-if="hasMultipleFloors"
-        class="bg-surface-800/90 absolute top-2 left-2 z-1000 flex flex-col gap-1 rounded p-1.5"
+        :text="t('maps.tooltips.switch_floor')"
+        :content="{ side: 'right' }"
       >
-        <span class="text-surface-400 px-1 text-[10px] font-medium tracking-wide uppercase">
-          {{ t('maps.floors') }}
-        </span>
-        <div class="flex flex-col-reverse gap-1">
-          <UButton
-            v-for="floor in floors"
-            :key="floor"
-            color="neutral"
-            :variant="floor === selectedFloor ? 'soft' : 'ghost'"
-            size="sm"
-            :class="[
-              'justify-start',
-              floor === selectedFloor ? MAP_BUTTON_ACTIVE_CLASS : MAP_BUTTON_INACTIVE_CLASS,
-            ]"
-            @click="setFloor(floor)"
-          >
-            {{ floor.replace(/_/g, ' ') }}
-          </UButton>
+        <div
+          class="bg-surface-850/95 absolute top-2 left-2 z-1000 flex flex-col gap-1 rounded-lg border border-white/8 p-1.5 shadow-lg"
+        >
+          <span class="text-surface-400 px-1 text-[10px] font-medium tracking-wide uppercase">
+            {{ t('maps.floors') }}
+          </span>
+          <div class="flex flex-col-reverse gap-0.5">
+            <button
+              v-for="floor in floors"
+              :key="floor"
+              type="button"
+              :aria-pressed="floor === selectedFloor"
+              class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-850 relative flex h-8 w-full items-center rounded-md px-2.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              :class="
+                floor === selectedFloor
+                  ? 'bg-primary-500/15 text-surface-50'
+                  : 'text-surface-300/65 hover:text-surface-100 hover:bg-white/5'
+              "
+              @click="setFloor(floor)"
+            >
+              <span
+                v-if="floor === selectedFloor"
+                class="bg-primary-400 absolute top-1/2 left-0 h-4 w-0.5 -translate-y-1/2 rounded-full"
+              />
+              {{ floor.replace(/_/g, ' ') }}
+            </button>
+          </div>
         </div>
-      </div>
+      </AppTooltip>
       <div
         v-if="isLoading"
         class="bg-surface-900/50 absolute inset-0 z-1001 flex items-center justify-center"
@@ -54,198 +66,382 @@
         <UIcon name="i-mdi-loading" class="text-surface-200 h-8 w-8 animate-spin" />
       </div>
       <div
-        class="bg-surface-800/90 absolute top-2 right-2 z-1000 flex flex-wrap items-center gap-2 rounded p-1.5"
+        class="bg-surface-850/95 absolute top-2 right-2 z-1000 flex flex-wrap items-center gap-1 rounded-lg border border-white/8 p-1 shadow-lg"
       >
-        <UButton
-          v-if="props.showExtractToggle"
-          color="neutral"
-          :variant="showPmcExtracts ? 'soft' : 'ghost'"
-          size="sm"
-          icon="i-mdi-exit-run"
-          :class="showPmcExtracts ? MAP_BUTTON_ACTIVE_CLASS : MAP_BUTTON_INACTIVE_CLASS"
-          @click="showPmcExtracts = !showPmcExtracts"
-        >
-          {{ t('maps.factions.pmc') }}
-        </UButton>
-        <UButton
-          v-if="props.showExtractToggle"
-          color="neutral"
-          :variant="showScavExtracts ? 'soft' : 'ghost'"
-          size="sm"
-          icon="i-mdi-exit-run"
-          :class="showScavExtracts ? MAP_BUTTON_ACTIVE_CLASS : MAP_BUTTON_INACTIVE_CLASS"
-          @click="showScavExtracts = !showScavExtracts"
-        >
-          {{ t('common.scav') }}
-        </UButton>
-        <UButton
-          v-if="props.showSpawnToggle && hasPmcSpawns"
-          color="neutral"
-          :variant="showPmcSpawns ? 'soft' : 'ghost'"
-          size="sm"
-          icon="i-mdi-crosshairs-gps"
-          :class="showPmcSpawns ? MAP_BUTTON_ACTIVE_CLASS : MAP_BUTTON_INACTIVE_CLASS"
-          @click="showPmcSpawns = !showPmcSpawns"
-        >
-          {{ t('maps.layers.pmc_spawns') }}
-        </UButton>
-        <UPopover>
-          <UButton
-            color="neutral"
-            variant="soft"
-            size="sm"
-            icon="i-mdi-palette"
-            :class="MAP_BUTTON_ACTIVE_CLASS"
-            :title="t('settings.interface.maps.colors.title')"
-            :aria-label="t('settings.interface.maps.colors.title')"
+        <div class="flex items-center gap-1">
+          <button
+            v-if="props.showExtractToggle"
+            type="button"
+            :aria-pressed="showPmcExtracts"
+            class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-850 flex h-8 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+            :class="showPmcExtracts ? MAP_BUTTON_ACTIVE_CLASS : MAP_BUTTON_INACTIVE_CLASS"
+            @click="showPmcExtracts = !showPmcExtracts"
           >
-            <span class="hidden md:inline">{{ t('settings.interface.maps.colors.title') }}</span>
-          </UButton>
-          <template #content>
-            <div class="w-72 space-y-3 p-3 md:w-80">
-              <div class="flex items-start justify-between gap-3">
-                <div class="space-y-0.5">
+            <UIcon name="i-mdi-shield-account-outline" class="h-4 w-4 shrink-0" />
+            <span class="whitespace-nowrap">{{ t('maps.factions.pmc') }}</span>
+          </button>
+          <button
+            v-if="props.showExtractToggle"
+            type="button"
+            :aria-pressed="showScavExtracts"
+            class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-850 flex h-8 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+            :class="showScavExtracts ? MAP_BUTTON_ACTIVE_CLASS : MAP_BUTTON_INACTIVE_CLASS"
+            @click="showScavExtracts = !showScavExtracts"
+          >
+            <UIcon name="i-mdi-skull-outline" class="h-4 w-4 shrink-0" />
+            <span class="whitespace-nowrap">{{ t('common.scav') }}</span>
+          </button>
+          <button
+            v-if="props.showSpawnToggle && hasPmcSpawns"
+            type="button"
+            :aria-pressed="showPmcSpawns"
+            class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-850 flex h-8 items-center gap-1.5 rounded-md px-2.5 text-xs font-medium transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+            :class="showPmcSpawns ? MAP_BUTTON_ACTIVE_CLASS : MAP_BUTTON_INACTIVE_CLASS"
+            @click="showPmcSpawns = !showPmcSpawns"
+          >
+            <UIcon name="i-mdi-crosshairs-gps" class="h-4 w-4 shrink-0" />
+            <span class="whitespace-nowrap">{{ t('maps.layers.pmc_spawns') }}</span>
+          </button>
+        </div>
+        <div class="mx-1 h-6 w-px bg-white/10" />
+        <div class="flex items-center gap-1">
+          <AppTooltip
+            :text="t('settings.interface.maps.colors.title')"
+            :disabled="mapColorsOpen"
+            :content="{ side: 'bottom' }"
+          >
+            <UPopover
+              v-model:open="mapColorsOpen"
+              arrow
+              :content="{ align: 'end', side: 'bottom', sideOffset: 8 }"
+              @update:open="onPopoverOpenChange('colors', $event)"
+            >
+              <button
+                :ref="(el) => (popoverTriggers.colors = el as HTMLElement | null)"
+                type="button"
+                :aria-label="t('settings.interface.maps.colors.title')"
+                class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-850 flex h-8 w-8 items-center justify-center rounded-md border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                :class="
+                  mapColorsOpen
+                    ? 'border-primary-400/60 bg-primary-500/15 text-primary-100'
+                    : 'text-surface-300 hover:text-surface-100 border-transparent hover:bg-white/5'
+                "
+              >
+                <UIcon name="i-mdi-palette" class="h-4 w-4" />
+              </button>
+              <template #content>
+                <div class="w-80 space-y-3 p-3 md:w-96">
+                  <div class="flex items-start justify-between gap-3">
+                    <div class="space-y-0.5">
+                      <p class="text-surface-200 text-xs font-semibold tracking-wide uppercase">
+                        {{ t('settings.interface.maps.colors.title') }}
+                      </p>
+                      <p class="text-surface-400 text-xs">
+                        {{ t('settings.interface.maps.colors.description') }}
+                      </p>
+                    </div>
+                    <UButton
+                      color="neutral"
+                      size="xs"
+                      variant="ghost"
+                      @click="preferencesStore.resetMapMarkerColors()"
+                    >
+                      {{ t('common.reset') }}
+                    </UButton>
+                  </div>
+                  <div class="grid grid-cols-2 gap-2">
+                    <label
+                      v-for="option in mapColorOptions"
+                      :key="option.key"
+                      class="bg-surface-800/70 border-surface-700 flex items-center justify-between gap-2 rounded-md border px-2 py-1.5"
+                    >
+                      <span class="flex min-w-0 items-center gap-2">
+                        <span
+                          class="h-3.5 w-3.5 shrink-0 rounded-full border border-white/30"
+                          :style="{ backgroundColor: mapColors[option.key] }"
+                        />
+                        <span class="text-surface-200 text-[11px] font-medium">
+                          {{ option.label }}
+                        </span>
+                      </span>
+                      <input
+                        :aria-label="option.label"
+                        :value="mapColors[option.key]"
+                        type="color"
+                        class="bg-surface-900 border-surface-700 h-7 w-9 shrink-0 cursor-pointer rounded border p-1"
+                        @input="onMapColorInput(option.key, $event)"
+                      />
+                    </label>
+                  </div>
+                </div>
+              </template>
+            </UPopover>
+          </AppTooltip>
+          <AppTooltip
+            :text="t('maps.map_settings')"
+            :disabled="mapSettingsOpen"
+            :content="{ side: 'bottom' }"
+          >
+            <UPopover
+              v-model:open="mapSettingsOpen"
+              arrow
+              :content="{ align: 'end', side: 'bottom', sideOffset: 8 }"
+              @update:open="onPopoverOpenChange('settings', $event)"
+            >
+              <button
+                :ref="(el) => (popoverTriggers.settings = el as HTMLElement | null)"
+                type="button"
+                :aria-label="t('maps.map_settings')"
+                class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-850 flex h-8 w-8 items-center justify-center rounded-md border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                :class="
+                  mapSettingsOpen
+                    ? 'border-primary-400/60 bg-primary-500/15 text-primary-100'
+                    : 'text-surface-300 hover:text-surface-100 border-transparent hover:bg-white/5'
+                "
+              >
+                <UIcon name="i-mdi-cog" class="h-4 w-4" />
+              </button>
+              <template #content>
+                <div class="w-56 space-y-2 p-3">
                   <p class="text-surface-200 text-xs font-semibold tracking-wide uppercase">
-                    {{ t('settings.interface.maps.colors.title') }}
+                    {{ t('maps.map_settings') }}
                   </p>
-                  <p class="text-surface-400 text-xs">
-                    {{ t('settings.interface.maps.colors.description') }}
+                  <div class="space-y-2">
+                    <div class="space-y-1">
+                      <div
+                        class="text-surface-400 flex items-center justify-between text-[10px] font-semibold uppercase"
+                      >
+                        <span>{{ t('common.zoom_speed') }}</span>
+                        <span class="text-surface-200 tabular-nums">{{ zoomSpeedLabel }}</span>
+                      </div>
+                      <input
+                        v-model.number="mapZoomSpeed"
+                        type="range"
+                        :min="ZOOM_SPEED_MIN"
+                        :max="ZOOM_SPEED_MAX"
+                        step="0.1"
+                        class="accent-primary-500 h-1.5 w-full cursor-pointer"
+                        :aria-label="t('common.zoom_speed')"
+                      />
+                    </div>
+                    <div class="space-y-1">
+                      <div
+                        class="text-surface-400 flex items-center justify-between text-[10px] font-semibold uppercase"
+                      >
+                        <span>{{ t('common.pan_speed') }}</span>
+                        <span class="text-surface-200 tabular-nums">{{ panSpeedLabel }}</span>
+                      </div>
+                      <input
+                        v-model.number="mapPanSpeed"
+                        type="range"
+                        :min="PAN_SPEED_MIN"
+                        :max="PAN_SPEED_MAX"
+                        step="0.1"
+                        class="accent-primary-500 h-1.5 w-full cursor-pointer"
+                        :aria-label="t('common.pan_speed')"
+                      />
+                    </div>
+                    <div class="space-y-1">
+                      <div
+                        class="text-surface-400 flex items-center justify-between text-[10px] font-semibold uppercase"
+                      >
+                        <span>{{ t('common.zone_opacity') }}</span>
+                        <span class="text-surface-200 tabular-nums">{{ zoneOpacityLabel }}</span>
+                      </div>
+                      <input
+                        v-model.number="mapZoneOpacity"
+                        type="range"
+                        :min="ZONE_OPACITY_MIN"
+                        :max="ZONE_OPACITY_MAX"
+                        step="0.01"
+                        class="accent-primary-500 h-1.5 w-full cursor-pointer"
+                        :aria-label="t('common.zone_opacity')"
+                      />
+                    </div>
+                    <div class="flex items-center justify-between">
+                      <span class="text-surface-400 text-[10px] font-semibold uppercase">
+                        {{ t('maps.tooltip_density') }}
+                      </span>
+                      <button
+                        type="button"
+                        class="rounded px-2 py-0.5 text-[10px] font-medium transition-colors"
+                        :class="
+                          mapTooltipDensity === 'compact'
+                            ? 'bg-surface-600 text-surface-100'
+                            : 'bg-surface-800 text-surface-400 hover:text-surface-200'
+                        "
+                        :aria-label="t('maps.aria.tooltip_density')"
+                        @click="
+                          mapTooltipDensity =
+                            mapTooltipDensity === 'compact' ? 'default' : 'compact'
+                        "
+                      >
+                        {{
+                          mapTooltipDensity === 'compact'
+                            ? t('common.compact')
+                            : t('common.default')
+                        }}
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              </template>
+            </UPopover>
+          </AppTooltip>
+          <AppTooltip
+            :text="t('maps.help.title')"
+            :disabled="mapHelpOpen"
+            :content="{ side: 'bottom' }"
+          >
+            <UPopover
+              v-model:open="mapHelpOpen"
+              arrow
+              :content="{ align: 'end', side: 'bottom', sideOffset: 8 }"
+              @update:open="onPopoverOpenChange('help', $event)"
+            >
+              <button
+                :ref="(el) => (popoverTriggers.help = el as HTMLElement | null)"
+                type="button"
+                :aria-label="t('maps.help.title')"
+                class="focus-visible:ring-primary-500 focus-visible:ring-offset-surface-850 relative flex h-8 w-8 items-center justify-center rounded-md border transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                :class="
+                  mapHelpOpen
+                    ? 'border-primary-400/60 bg-primary-500/15 text-primary-100'
+                    : 'text-surface-300 hover:text-surface-100 border-transparent hover:bg-white/5'
+                "
+              >
+                <span
+                  v-if="!helpOpenedThisSession"
+                  class="bg-primary-400 absolute -top-0.5 -right-0.5 h-2 w-2 rounded-full"
+                />
+                <UIcon name="i-mdi-help-circle-outline" class="h-4 w-4" />
+              </button>
+              <template #content>
+                <div class="w-80 space-y-2.5 p-3">
+                  <p class="text-surface-200 text-xs font-semibold tracking-wide uppercase">
+                    {{ t('maps.help.title') }}
                   </p>
-                </div>
-                <UButton
-                  color="neutral"
-                  size="xs"
-                  variant="ghost"
-                  @click="preferencesStore.resetMapMarkerColors()"
-                >
-                  {{ t('common.reset') }}
-                </UButton>
-              </div>
-              <div class="grid gap-2 sm:grid-cols-2">
-                <label
-                  v-for="option in mapColorOptions"
-                  :key="option.key"
-                  class="bg-surface-800/70 border-surface-700 flex items-center justify-between gap-2 rounded-md border px-2 py-1.5"
-                >
-                  <span class="flex min-w-0 items-center gap-2">
-                    <span
-                      class="h-3.5 w-3.5 shrink-0 rounded-full border border-white/30"
-                      :style="{ backgroundColor: mapColors[option.key] }"
-                    />
-                    <span class="text-surface-200 truncate text-[11px] font-medium">
-                      {{ option.label }}
-                    </span>
-                  </span>
-                  <input
-                    :aria-label="option.label"
-                    :value="mapColors[option.key]"
-                    type="color"
-                    class="bg-surface-900 border-surface-700 h-7 w-10 shrink-0 cursor-pointer rounded border p-1"
-                    @input="onMapColorInput(option.key, $event)"
-                  />
-                </label>
-              </div>
-            </div>
-          </template>
-        </UPopover>
-        <UPopover>
-          <UButton
-            color="neutral"
-            variant="soft"
-            size="sm"
-            icon="i-mdi-cog"
-            :class="MAP_BUTTON_ACTIVE_CLASS"
-            :title="t('maps.map_settings')"
-            :aria-label="t('maps.map_settings')"
-          />
-          <template #content>
-            <div class="w-56 space-y-2 p-3">
-              <p class="text-surface-200 text-xs font-semibold tracking-wide uppercase">
-                {{ t('maps.map_settings') }}
-              </p>
-              <div class="space-y-2">
-                <div class="space-y-1">
-                  <div
-                    class="text-surface-400 flex items-center justify-between text-[10px] font-semibold uppercase"
-                  >
-                    <span>{{ t('common.zoom_speed') }}</span>
-                    <span class="text-surface-200 tabular-nums">{{ zoomSpeedLabel }}</span>
+                  <div class="grid grid-cols-2 gap-x-3 gap-y-2.5">
+                    <div class="space-y-1">
+                      <p class="text-surface-400 text-[10px] font-semibold tracking-wide uppercase">
+                        {{ t('maps.help.groups.navigate') }}
+                      </p>
+                      <p
+                        class="text-surface-300 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px]"
+                      >
+                        <kbd
+                          class="bg-surface-700 text-surface-200 rounded px-1 py-0.5 font-mono text-[10px]"
+                        >
+                          WASD
+                        </kbd>
+                        <span>/</span>
+                        <kbd
+                          class="bg-surface-700 text-surface-200 rounded px-1 py-0.5 font-mono text-[10px]"
+                        >
+                          ←↑↓→
+                        </kbd>
+                        <span>{{ t('maps.controls.help.pan') }}</span>
+                      </p>
+                      <p
+                        class="text-surface-300 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px]"
+                      >
+                        <kbd
+                          class="bg-surface-700 text-surface-200 rounded px-1 py-0.5 font-mono text-[10px]"
+                        >
+                          Shift
+                        </kbd>
+                        <kbd
+                          class="bg-surface-700 text-surface-200 rounded px-1 py-0.5 font-mono text-[10px]"
+                        >
+                          Scroll
+                        </kbd>
+                        <span>/</span>
+                        <kbd
+                          class="bg-surface-700 text-surface-200 rounded px-1 py-0.5 font-mono text-[10px]"
+                        >
+                          Q/E
+                        </kbd>
+                        <span>{{ t('maps.controls.help.zoom') }}</span>
+                      </p>
+                      <p
+                        class="text-surface-300 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px]"
+                      >
+                        <kbd
+                          class="bg-surface-700 text-surface-200 rounded px-1 py-0.5 font-mono text-[10px]"
+                        >
+                          R
+                        </kbd>
+                        <span>{{ t('maps.controls.help.reset') }}</span>
+                      </p>
+                    </div>
+                    <div class="space-y-1">
+                      <div v-if="hasMultipleFloors" class="space-y-1">
+                        <p
+                          class="text-surface-400 text-[10px] font-semibold tracking-wide uppercase"
+                        >
+                          {{ t('maps.help.groups.floors') }}
+                        </p>
+                        <p
+                          class="text-surface-300 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px]"
+                        >
+                          <kbd
+                            class="bg-surface-700 text-surface-200 rounded px-1 py-0.5 font-mono text-[10px]"
+                          >
+                            Ctrl
+                          </kbd>
+                          <kbd
+                            class="bg-surface-700 text-surface-200 rounded px-1 py-0.5 font-mono text-[10px]"
+                          >
+                            Scroll
+                          </kbd>
+                          <span>{{ t('maps.controls.help.cycle_floors') }}</span>
+                        </p>
+                        <p class="text-surface-400 text-[11px]">
+                          {{ t('maps.controls.help.floor_panel') }}
+                        </p>
+                      </div>
+                      <p
+                        class="text-surface-400 pt-1 text-[10px] font-semibold tracking-wide uppercase"
+                      >
+                        {{ t('maps.help.groups.interact') }}
+                      </p>
+                      <p
+                        class="text-surface-300 flex flex-wrap items-center gap-x-1.5 gap-y-1 text-[11px]"
+                      >
+                        <kbd
+                          class="bg-surface-700 text-surface-200 rounded px-1 py-0.5 font-mono text-[10px]"
+                        >
+                          F
+                        </kbd>
+                        <span>{{ t('maps.controls.help.click_at_cursor') }}</span>
+                      </p>
+                      <p class="text-surface-300 text-[11px]">
+                        {{ t('maps.controls.help.click_marker') }}
+                      </p>
+                    </div>
+                    <div class="col-span-2 space-y-1">
+                      <p class="text-surface-400 text-[10px] font-semibold tracking-wide uppercase">
+                        {{ t('maps.help.groups.view') }}
+                      </p>
+                      <p class="text-surface-300 text-[11px]">
+                        {{ t('maps.controls.help.fullscreen') }}
+                      </p>
+                      <p class="text-surface-300 text-[11px]">
+                        {{ t('maps.controls.help.resize') }}
+                      </p>
+                    </div>
                   </div>
-                  <input
-                    v-model.number="mapZoomSpeed"
-                    type="range"
-                    :min="ZOOM_SPEED_MIN"
-                    :max="ZOOM_SPEED_MAX"
-                    step="0.1"
-                    class="accent-surface-200 h-1.5 w-full cursor-pointer"
-                    :aria-label="t('common.zoom_speed')"
-                  />
                 </div>
-                <div class="space-y-1">
-                  <div
-                    class="text-surface-400 flex items-center justify-between text-[10px] font-semibold uppercase"
-                  >
-                    <span>{{ t('common.pan_speed') }}</span>
-                    <span class="text-surface-200 tabular-nums">{{ panSpeedLabel }}</span>
-                  </div>
-                  <input
-                    v-model.number="mapPanSpeed"
-                    type="range"
-                    :min="PAN_SPEED_MIN"
-                    :max="PAN_SPEED_MAX"
-                    step="0.1"
-                    class="accent-surface-200 h-1.5 w-full cursor-pointer"
-                    :aria-label="t('common.pan_speed')"
-                  />
-                </div>
-                <div class="space-y-1">
-                  <div
-                    class="text-surface-400 flex items-center justify-between text-[10px] font-semibold uppercase"
-                  >
-                    <span>{{ t('common.zone_opacity') }}</span>
-                    <span class="text-surface-200 tabular-nums">{{ zoneOpacityLabel }}</span>
-                  </div>
-                  <input
-                    v-model.number="mapZoneOpacity"
-                    type="range"
-                    :min="ZONE_OPACITY_MIN"
-                    :max="ZONE_OPACITY_MAX"
-                    step="0.01"
-                    class="accent-surface-200 h-1.5 w-full cursor-pointer"
-                    :aria-label="t('common.zone_opacity')"
-                  />
-                </div>
-                <div class="flex items-center justify-between">
-                  <span class="text-surface-400 text-[10px] font-semibold uppercase">
-                    {{ t('maps.tooltip_density') }}
-                  </span>
-                  <button
-                    type="button"
-                    class="rounded px-2 py-0.5 text-[10px] font-medium transition-colors"
-                    :class="
-                      mapTooltipDensity === 'compact'
-                        ? 'bg-surface-600 text-surface-100'
-                        : 'bg-surface-800 text-surface-400 hover:text-surface-200'
-                    "
-                    :aria-label="t('maps.aria.tooltip_density')"
-                    @click="
-                      mapTooltipDensity = mapTooltipDensity === 'compact' ? 'default' : 'compact'
-                    "
-                  >
-                    {{
-                      mapTooltipDensity === 'compact' ? t('common.compact') : t('common.default')
-                    }}
-                  </button>
-                </div>
-              </div>
-            </div>
-          </template>
-        </UPopover>
+              </template>
+            </UPopover>
+          </AppTooltip>
+        </div>
       </div>
-      <div class="relative">
+      <div class="relative" :class="{ 'min-h-0 flex-1': props.fill }">
         <div
           ref="mapContainer"
-          class="bg-surface-900 h-100 w-full rounded sm:h-125 lg:h-150"
+          class="bg-surface-900 w-full rounded ring-1 ring-white/10 ring-inset"
+          :class="props.fill ? 'h-full' : 'h-100 sm:h-125 lg:h-150'"
           :style="mapHeightStyle"
         />
         <div
@@ -261,11 +457,92 @@
             />
           </div>
         </div>
+        <div
+          class="bg-surface-850/95 absolute right-2 bottom-2 z-1000 flex flex-col overflow-hidden rounded-md border border-white/10 shadow-lg"
+        >
+          <AppTooltip :text="t('maps.tooltips.zoom_in')" :kbds="['E']">
+            <button
+              type="button"
+              :disabled="!canZoomIn"
+              :aria-label="t('maps.tooltips.zoom_in')"
+              class="focus-visible:ring-primary-500 text-surface-200 hover:text-surface-50 focus-visible:ring-offset-surface-850 disabled:hover:text-surface-200 flex h-9 w-9 items-center justify-center transition-colors hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+              @click="zoomMapIn"
+            >
+              <UIcon name="i-mdi-plus" class="h-4.5 w-4.5" />
+            </button>
+          </AppTooltip>
+          <AppTooltip :text="t('maps.tooltips.zoom_out')" :kbds="['Q']">
+            <button
+              type="button"
+              :disabled="!canZoomOut"
+              :aria-label="t('maps.tooltips.zoom_out')"
+              class="focus-visible:ring-primary-500 text-surface-200 hover:text-surface-50 focus-visible:ring-offset-surface-850 disabled:hover:text-surface-200 flex h-9 w-9 items-center justify-center transition-colors hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-transparent"
+              @click="zoomMapOut"
+            >
+              <UIcon name="i-mdi-minus" class="h-4.5 w-4.5" />
+            </button>
+          </AppTooltip>
+          <div class="mx-1 h-px bg-white/10" />
+          <AppTooltip :text="t('maps.tooltips.reset_view')" :kbds="['R']">
+            <button
+              type="button"
+              :aria-label="t('maps.tooltips.reset_view')"
+              class="focus-visible:ring-primary-500 text-surface-200 hover:text-surface-50 focus-visible:ring-offset-surface-850 flex h-9 w-9 items-center justify-center transition-colors hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+              @click="resetMapView"
+            >
+              <UIcon name="i-mdi-restore" class="h-4.5 w-4.5" />
+            </button>
+          </AppTooltip>
+          <template v-if="props.showFullscreenToggle">
+            <div class="mx-1 h-px bg-white/10" />
+            <AppTooltip :text="fullscreenToggleLabel">
+              <button
+                type="button"
+                data-testid="map-fullscreen-toggle"
+                :aria-label="fullscreenToggleLabel"
+                class="focus-visible:ring-primary-500 text-surface-200 hover:text-surface-50 focus-visible:ring-offset-surface-850 flex h-9 w-9 items-center justify-center transition-colors hover:bg-white/5 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                @click="emit('toggle-fullscreen')"
+              >
+                <UIcon
+                  :name="props.isFullscreen ? 'i-mdi-fullscreen-exit' : 'i-mdi-fullscreen'"
+                  class="h-4.5 w-4.5"
+                />
+              </button>
+            </AppTooltip>
+          </template>
+        </div>
+        <div
+          v-if="showFirstUseHint"
+          data-testid="map-first-use-hint"
+          class="bg-surface-850/95 absolute bottom-3 left-1/2 z-1001 w-max max-w-[calc(100%-1.5rem)] -translate-x-1/2 rounded-lg border border-white/12 p-3 shadow-xl"
+        >
+          <p class="text-surface-100 text-xs font-semibold">{{ t('maps.hint.title') }}</p>
+          <p class="text-surface-300 mt-1 text-xs">
+            {{ t('maps.hint.drag_to_pan') }} · {{ t('maps.hint.shift_scroll_zoom') }} ·
+            {{ t('maps.hint.ctrl_scroll_floors') }}
+          </p>
+          <div class="mt-2.5 flex items-center gap-3">
+            <button
+              type="button"
+              class="bg-primary-500 hover:bg-primary-400 text-surface-950 rounded px-3 py-1 text-xs font-semibold transition-colors"
+              @click="dismissFirstUseHint"
+            >
+              {{ t('common.got_it') }}
+            </button>
+            <button
+              type="button"
+              class="text-primary-300 hover:text-primary-200 text-xs font-medium underline-offset-2 transition-colors hover:underline"
+              @click="openHelpFromHint"
+            >
+              {{ t('maps.hint.all_controls') }}
+            </button>
+          </div>
+        </div>
       </div>
-      <div class="mt-2 flex flex-wrap items-start justify-between gap-x-4 gap-y-4">
+      <div class="mt-2 flex shrink-0 flex-wrap items-start justify-between gap-x-4 gap-y-4">
         <div
           v-if="props.showLegend"
-          class="text-surface-300 flex flex-wrap items-center gap-4 text-xs"
+          class="bg-surface-850/95 text-surface-300 flex flex-wrap items-center gap-4 rounded-lg border border-white/8 px-3 py-2 text-xs shadow-lg"
         >
           <div class="flex items-center gap-1">
             <div
@@ -324,36 +601,6 @@
             <span>{{ t('maps.legend.coop_extract') }}</span>
           </div>
         </div>
-        <div
-          class="text-surface-400 ml-auto flex flex-wrap-reverse items-center justify-end gap-x-4 gap-y-1 text-[10px] font-medium"
-        >
-          <div class="flex items-center gap-1">
-            <kbd class="bg-surface-700 text-surface-300 rounded px-1 py-0.5 font-mono">WASD</kbd>
-            <span>/</span>
-            <kbd class="bg-surface-700 text-surface-300 rounded px-1 py-0.5 font-mono">←↑↓→</kbd>
-            <span>{{ t('maps.controls.keyboard.pan') }}</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <kbd class="bg-surface-700 text-surface-300 rounded px-1 py-0.5 font-mono">Q/E</kbd>
-            <span>{{ t('maps.controls.keyboard.zoom_keys') }}</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <kbd class="bg-surface-700 text-surface-300 rounded px-1 py-0.5 font-mono">F</kbd>
-            <span>{{ t('maps.controls.keyboard.click') }}</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <kbd class="bg-surface-700 text-surface-300 rounded px-1 py-0.5 font-mono">R</kbd>
-            <span>{{ t('maps.controls.keyboard.reset') }}</span>
-          </div>
-          <div v-if="hasMultipleFloors" class="flex items-center gap-1">
-            <kbd class="bg-surface-700 text-surface-300 rounded px-1 py-0.5 font-mono">Ctrl</kbd>
-            <span>{{ t('maps.controls.keyboard.cycle_floors') }}</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <kbd class="bg-surface-700 text-surface-300 rounded px-1 py-0.5 font-mono">Shift</kbd>
-            <span>{{ t('maps.controls.keyboard.zoom') }}</span>
-          </div>
-        </div>
       </div>
     </template>
   </div>
@@ -386,6 +633,23 @@
   } from '@/utils/mapCoordinates';
   import type { TarkovMap } from '@/types/tarkov';
   import type L from 'leaflet';
+  const MAP_CONTROLS_HINT_KEY = 'mapControlsHintSeen';
+  const mapControlsHintSeen = ref(false);
+  onMounted(() => {
+    try {
+      mapControlsHintSeen.value = window.localStorage.getItem(MAP_CONTROLS_HINT_KEY) === 'true';
+    } catch (error) {
+      logger.warn('[LeafletMap] Failed to read map controls hint flag:', error);
+    }
+  });
+  const dismissMapControlsHint = () => {
+    mapControlsHintSeen.value = true;
+    try {
+      window.localStorage.setItem(MAP_CONTROLS_HINT_KEY, 'true');
+    } catch (error) {
+      logger.warn('[LeafletMap] Failed to persist map controls hint flag:', error);
+    }
+  };
   interface MapZone {
     map: { id: string };
     outline: Array<{ x: number; z: number }>;
@@ -411,6 +675,9 @@
     showPmcSpawns?: boolean;
     showSpawnToggle?: boolean;
     showLegend?: boolean;
+    showFullscreenToggle?: boolean;
+    isFullscreen?: boolean;
+    fill?: boolean;
     height?: number;
     initialView?: { center: [number, number]; zoom: number } | null;
   }
@@ -420,15 +687,23 @@
     showExtractToggle: true,
     showSpawnToggle: true,
     showLegend: true,
+    showFullscreenToggle: false,
+    isFullscreen: false,
+    fill: false,
     height: undefined,
     initialView: null,
   });
+  const emit = defineEmits<{ 'toggle-fullscreen': [] }>();
   const { t } = useI18n({ useScope: 'global' });
   const router = useRouter();
   const preferencesStore = usePreferencesStore();
   const mapSurfaceRef = ref<HTMLElement | null>(null);
   const showKeyboardCursor = ref(false);
+  const fullscreenToggleLabel = computed(() =>
+    props.isFullscreen ? t('maps.tooltips.exit_fullscreen') : t('maps.tooltips.open_fullscreen')
+  );
   const mapHeightStyle = computed(() => {
+    if (props.fill) return undefined;
     if (typeof props.height !== 'number' || Number.isNaN(props.height)) return undefined;
     return { height: `${props.height}px` };
   });
@@ -518,6 +793,108 @@
     showScavExtracts: props.showScavExtracts,
     t,
   });
+  const mapColorsOpen = ref(false);
+  const mapSettingsOpen = ref(false);
+  const mapHelpOpen = ref(false);
+  const helpOpenedThisSession = ref(false);
+  const popoverTriggers = { colors: null, settings: null, help: null } as Record<
+    'colors' | 'settings' | 'help',
+    HTMLElement | null
+  >;
+  let lastUserOpenedPopover: 'colors' | 'settings' | 'help' | null = null;
+  const onPopoverOpenChange = (key: 'colors' | 'settings' | 'help', isOpen: boolean) => {
+    if (key === 'help' && isOpen) {
+      helpOpenedThisSession.value = true;
+    }
+    if (isOpen) {
+      lastUserOpenedPopover = key;
+      return;
+    }
+    if (lastUserOpenedPopover !== key) return;
+    lastUserOpenedPopover = null;
+    nextTick(() => popoverTriggers[key]?.focus());
+  };
+  watch([mapColorsOpen, mapSettingsOpen, mapHelpOpen], ([colors, settings, help]) => {
+    if (colors) {
+      mapSettingsOpen.value = false;
+      mapHelpOpen.value = false;
+    } else if (settings) {
+      mapColorsOpen.value = false;
+      mapHelpOpen.value = false;
+    } else if (help) {
+      mapColorsOpen.value = false;
+      mapSettingsOpen.value = false;
+    }
+  });
+  const currentMapZoom = ref(0);
+  const canZoomIn = computed(() => {
+    const instance = mapInstance.value;
+    if (!instance) return false;
+    return currentMapZoom.value < instance.getMaxZoom();
+  });
+  const canZoomOut = computed(() => {
+    const instance = mapInstance.value;
+    if (!instance) return false;
+    return currentMapZoom.value > instance.getMinZoom();
+  });
+  const updateCurrentMapZoom = () => {
+    currentMapZoom.value = mapInstance.value?.getZoom() ?? 0;
+  };
+  const zoomMapBy = (direction: 1 | -1) => {
+    const instance = mapInstance.value;
+    if (!instance) return;
+    const originalZoomSnap = instance.options.zoomSnap ?? 0;
+    instance.options.zoomSnap = 0;
+    try {
+      if (direction > 0) {
+        instance.zoomIn();
+      } else {
+        instance.zoomOut();
+      }
+    } finally {
+      instance.options.zoomSnap = originalZoomSnap;
+    }
+  };
+  const zoomMapIn = () => {
+    zoomMapBy(1);
+  };
+  const zoomMapOut = () => {
+    zoomMapBy(-1);
+  };
+  const resetMapView = () => {
+    refreshView();
+  };
+  const showFirstUseHint = computed(() => {
+    return !mapControlsHintSeen.value && !isLoading.value && Boolean(mapInstance.value);
+  });
+  const dismissFirstUseHint = () => {
+    dismissMapControlsHint();
+  };
+  const openHelpFromHint = () => {
+    dismissMapControlsHint();
+    mapHelpOpen.value = true;
+  };
+  let firstUseHintListeners: { instance: L.Map; dismiss: () => void } | null = null;
+  watch(
+    showFirstUseHint,
+    (visible) => {
+      if (visible) {
+        const instance = mapInstance.value;
+        if (!instance) return;
+        const dismiss = () => dismissMapControlsHint();
+        firstUseHintListeners = { instance, dismiss };
+        instance.on('dragstart', dismiss);
+        instance.on('zoomstart', dismiss);
+        return;
+      }
+      if (firstUseHintListeners) {
+        firstUseHintListeners.instance.off('dragstart', firstUseHintListeners.dismiss);
+        firstUseHintListeners.instance.off('zoomstart', firstUseHintListeners.dismiss);
+        firstUseHintListeners = null;
+      }
+    },
+    { immediate: true }
+  );
   const pressedMapKeys = new Set<'up' | 'down' | 'left' | 'right' | 'zoom-in' | 'zoom-out'>();
   let mapKeyboardFrameId: number | null = null;
   let mapKeyboardLastTick = 0;
@@ -1450,6 +1827,7 @@
       const oldInstance = oldValues?.[4] as L.Map | null | undefined;
       if (oldInstance && oldInstance !== instance) {
         oldInstance.off('zoomend', handleSpawnZoomChange);
+        oldInstance.off('zoomend', updateCurrentMapZoom);
       }
       if (
         loading ||
@@ -1462,6 +1840,9 @@
       lastMarksHash.value = '';
       instance.off('zoomend', handleSpawnZoomChange);
       instance.on('zoomend', handleSpawnZoomChange);
+      instance.off('zoomend', updateCurrentMapZoom);
+      instance.on('zoomend', updateCurrentMapZoom);
+      updateCurrentMapZoom();
       waitForSvgAndUpdateMarkers(instance);
     },
     { immediate: true, flush: 'post' }
@@ -1506,8 +1887,14 @@
     clearKeyboardCursorHover();
     stopMapKeyboardLoop(true);
     teardownSvgReadyWatcher();
+    if (firstUseHintListeners) {
+      firstUseHintListeners.instance.off('dragstart', firstUseHintListeners.dismiss);
+      firstUseHintListeners.instance.off('zoomstart', firstUseHintListeners.dismiss);
+      firstUseHintListeners = null;
+    }
     if (mapInstance.value) {
       mapInstance.value.off('zoomend', handleSpawnZoomChange);
+      mapInstance.value.off('zoomend', updateCurrentMapZoom);
     }
     if (activePinnedPopupCleanup) {
       activePinnedPopupCleanup();

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -642,8 +642,12 @@
   import type L from 'leaflet';
   const MAP_CONTROLS_HINT_KEY = 'mapControlsHintSeen';
   const MAP_HELP_SEEN_KEY = 'mapHelpSeen';
+  const MAP_HELP_SEEN_EVENT = 'map-help-seen';
   const mapControlsHintSeen = ref(false);
   const mapHelpSeen = ref(false);
+  const onMapHelpSeenElsewhere = () => {
+    mapHelpSeen.value = true;
+  };
   onMounted(() => {
     try {
       mapControlsHintSeen.value = window.localStorage.getItem(MAP_CONTROLS_HINT_KEY) === 'true';
@@ -651,6 +655,7 @@
     } catch (error) {
       logger.warn('[LeafletMap] Failed to read map hint flags:', error);
     }
+    window.addEventListener(MAP_HELP_SEEN_EVENT, onMapHelpSeenElsewhere);
   });
   const markMapHelpSeen = () => {
     if (mapHelpSeen.value) return;
@@ -660,6 +665,7 @@
     } catch (error) {
       logger.warn('[LeafletMap] Failed to persist map help seen flag:', error);
     }
+    window.dispatchEvent(new CustomEvent(MAP_HELP_SEEN_EVENT));
   };
   const dismissMapControlsHint = () => {
     mapControlsHintSeen.value = true;
@@ -1909,6 +1915,7 @@
     window.removeEventListener('keydown', onGlobalMapKeydown);
     window.removeEventListener('keyup', onGlobalMapKeyup);
     window.removeEventListener('blur', onMapWindowBlur);
+    window.removeEventListener(MAP_HELP_SEEN_EVENT, onMapHelpSeenElsewhere);
     clearKeyboardCursorHover();
     stopMapKeyboardLoop(true);
     teardownSvgReadyWatcher();

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -840,20 +840,25 @@
   const updateCurrentMapZoom = () => {
     currentMapZoom.value = mapInstance.value?.getZoom() ?? 0;
   };
-  const zoomMapBy = (direction: 1 | -1) => {
-    const instance = mapInstance.value;
-    if (!instance) return;
+  const withoutZoomSnap = (instance: L.Map, apply: () => void): void => {
     const originalZoomSnap = instance.options.zoomSnap ?? 0;
     instance.options.zoomSnap = 0;
     try {
-      if (direction > 0) {
-        instance.zoomIn();
-      } else {
-        instance.zoomOut();
-      }
+      apply();
     } finally {
       instance.options.zoomSnap = originalZoomSnap;
     }
+  };
+  const zoomMapBy = (direction: 1 | -1) => {
+    const instance = mapInstance.value;
+    if (!instance) return;
+    withoutZoomSnap(instance, () => {
+      if (direction > 0) {
+        instance.zoomIn();
+        return;
+      }
+      instance.zoomOut();
+    });
   };
   const zoomMapIn = () => {
     zoomMapBy(1);
@@ -1861,17 +1866,19 @@
   const getViewState = (): { center: [number, number]; zoom: number } | null => {
     const instance = mapInstance.value;
     if (!instance) return null;
+    const size = instance.getSize();
+    if (size.x === 0 || size.y === 0) return null;
     const center = instance.getCenter();
     return { center: [center.lat, center.lng], zoom: instance.getZoom() };
   };
   const setViewState = (state: { center: [number, number]; zoom: number }): void => {
     const instance = mapInstance.value;
     if (!instance || !state) return;
-    if (instance.getZoom() !== state.zoom) {
-      instance.setView(state.center, state.zoom, { animate: false });
+    if (instance.getZoom() === state.zoom) {
+      instance.panTo(state.center, { animate: false });
       return;
     }
-    instance.panTo(state.center, { animate: false });
+    withoutZoomSnap(instance, () => instance.setView(state.center, state.zoom, { animate: false }));
   };
   defineExpose({
     activateObjectivePopup,

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -1864,17 +1864,19 @@
       activePinnedPopupCleanup();
     }
   };
+  const hasLaidOutContainer = (instance: L.Map): boolean => {
+    const size = instance.getSize();
+    return size.x > 0 && size.y > 0;
+  };
   const getViewState = (): { center: [number, number]; zoom: number } | null => {
     const instance = mapInstance.value;
-    if (!instance) return null;
-    const size = instance.getSize();
-    if (size.x === 0 || size.y === 0) return null;
+    if (!instance || !hasLaidOutContainer(instance)) return null;
     const center = instance.getCenter();
     return { center: [center.lat, center.lng], zoom: instance.getZoom() };
   };
   const setViewState = (state: { center: [number, number]; zoom: number }): void => {
     const instance = mapInstance.value;
-    if (!instance || !state) return;
+    if (!instance || !hasLaidOutContainer(instance)) return;
     if (instance.getZoom() === state.zoom) {
       instance.panTo(state.center, { animate: false });
       return;

--- a/app/features/maps/__tests__/LeafletMapControlsComponent.test.ts
+++ b/app/features/maps/__tests__/LeafletMapControlsComponent.test.ts
@@ -45,6 +45,8 @@ const { mapState, mockMapInstance, resetMapMarkerColorsSpy } = vi.hoisted(() => 
   };
 });
 const refreshViewSpy = vi.fn();
+const setFloorSpy = vi.fn();
+const useLeafletMapOptionsSpy = vi.fn();
 vi.mock('@/composables/useLeafletMap', () => ({
   withoutZoomSnap: (instance: { options: { zoomSnap?: number } }, apply: () => void): void => {
     const originalZoomSnap = instance.options.zoomSnap ?? 0;
@@ -55,23 +57,26 @@ vi.mock('@/composables/useLeafletMap', () => ({
       instance.options.zoomSnap = originalZoomSnap;
     }
   },
-  useLeafletMap: () => ({
-    mapInstance: shallowRef(mockMapInstance),
-    leaflet: shallowRef(null),
-    selectedFloor: ref(''),
-    floors: ref([]),
-    hasMultipleFloors: ref(false),
-    isLoading: ref(mapState.isLoading),
-    isIdle: ref(false),
-    svgLayer: shallowRef(null),
-    objectiveLayer: shallowRef(null),
-    extractLayer: shallowRef(null),
-    spawnLayer: shallowRef(null),
-    setFloor: vi.fn(),
-    refreshView: refreshViewSpy,
-    clearMarkers: vi.fn(),
-    destroy: vi.fn(),
-  }),
+  useLeafletMap: (options: unknown) => {
+    useLeafletMapOptionsSpy(options);
+    return {
+      mapInstance: shallowRef(mockMapInstance),
+      leaflet: shallowRef(null),
+      selectedFloor: ref(''),
+      floors: ref([]),
+      hasMultipleFloors: ref(false),
+      isLoading: ref(mapState.isLoading),
+      isIdle: ref(false),
+      svgLayer: shallowRef(null),
+      objectiveLayer: shallowRef(null),
+      extractLayer: shallowRef(null),
+      spawnLayer: shallowRef(null),
+      setFloor: setFloorSpy,
+      refreshView: refreshViewSpy,
+      clearMarkers: vi.fn(),
+      destroy: vi.fn(),
+    };
+  },
 }));
 vi.mock('@/stores/usePreferences', () => ({
   usePreferencesStore: () => ({
@@ -125,6 +130,8 @@ describe('LeafletMap controls', () => {
   beforeEach(() => {
     localStorage.clear();
     refreshViewSpy.mockClear();
+    setFloorSpy.mockClear();
+    useLeafletMapOptionsSpy.mockClear();
     mockMapInstance.options.zoomSnap = 1;
     mockMapInstance.zoomSnapDuringCall = undefined;
     mockMapInstance.size = { x: 800, y: 600 };
@@ -160,6 +167,24 @@ describe('LeafletMap controls', () => {
     expect(refreshViewSpy).toHaveBeenCalled();
     wrapper.unmount();
   });
+  it('passes the initialFloor prop through to useLeafletMap', async () => {
+    const wrapper = await mountMap({ initialFloor: '2nd Floor' });
+    expect(useLeafletMapOptionsSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ initialFloor: '2nd Floor' })
+    );
+    wrapper.unmount();
+  });
+  it('exposes the current floor and the floor setter', async () => {
+    const wrapper = await mountMap();
+    const vm = wrapper.vm as unknown as {
+      getFloor: () => string;
+      setFloor: (floor: string) => void;
+    };
+    expect(vm.getFloor()).toBe('');
+    vm.setFloor('garage');
+    expect(setFloorSpy).toHaveBeenCalledWith('garage');
+    wrapper.unmount();
+  });
   it('clears the help notification dot when help is opened from the first-use hint', async () => {
     const wrapper = await mountMap();
     const hint = wrapper.find('[data-testid="map-first-use-hint"]');
@@ -184,6 +209,18 @@ describe('LeafletMap controls', () => {
     expect(wrapper.find('[data-testid="map-first-use-hint"]').exists()).toBe(false);
     expect(localStorage.getItem('mapControlsHintSeen')).toBe('true');
     wrapper.unmount();
+  });
+  it('persists the help seen flag so the dot stays hidden after remount', async () => {
+    const wrapper = await mountMap();
+    expect(wrapper.find('[data-testid="map-help-unseen-dot"]').exists()).toBe(true);
+    await wrapper.find('[data-testid="map-hint-all-controls"]').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="map-help-unseen-dot"]').exists()).toBe(false);
+    expect(localStorage.getItem('mapHelpSeen')).toBe('true');
+    wrapper.unmount();
+    const remounted = await mountMap();
+    expect(remounted.find('[data-testid="map-help-unseen-dot"]').exists()).toBe(false);
+    remounted.unmount();
   });
   it('exposes the current view state and skips a hidden container', async () => {
     const wrapper = await mountMap();

--- a/app/features/maps/__tests__/LeafletMapControlsComponent.test.ts
+++ b/app/features/maps/__tests__/LeafletMapControlsComponent.test.ts
@@ -1,0 +1,202 @@
+import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TarkovMap } from '@/types/tarkov';
+const { mapState, mockMapInstance, resetMapMarkerColorsSpy } = vi.hoisted(() => {
+  const instance = {
+    size: { x: 800, y: 600 },
+    zoom: 4.25,
+    center: { lat: 12.5, lng: 34.5 },
+    options: { zoomSnap: 1 } as Record<string, unknown>,
+    zoomSnapDuringCall: undefined as number | undefined,
+    on: vi.fn(),
+    off: vi.fn(),
+    hasLayer: vi.fn(() => false),
+    getPane: vi.fn(() => document.createElement('div')),
+    getContainer: vi.fn(() => document.createElement('div')),
+    getMinZoom: vi.fn(() => -2),
+    getMaxZoom: vi.fn(() => 10),
+    panBy: vi.fn(),
+    panTo: vi.fn(),
+    containerPointToLatLng: vi.fn(() => ({ lat: 0, lng: 0 })),
+    setZoomAround: vi.fn(),
+  };
+  const mapInstance = {
+    ...instance,
+    getSize: vi.fn(() => mapInstance.size),
+    getZoom: vi.fn(() => mapInstance.zoom),
+    getCenter: vi.fn(() => mapInstance.center),
+    setView: vi.fn(() => {
+      mapInstance.zoomSnapDuringCall = mapInstance.options.zoomSnap as number;
+      return mapInstance;
+    }),
+    zoomIn: vi.fn(() => {
+      mapInstance.zoomSnapDuringCall = mapInstance.options.zoomSnap as number;
+      return mapInstance;
+    }),
+    zoomOut: vi.fn(() => {
+      mapInstance.zoomSnapDuringCall = mapInstance.options.zoomSnap as number;
+      return mapInstance;
+    }),
+  };
+  return {
+    mockMapInstance: mapInstance,
+    resetMapMarkerColorsSpy: vi.fn(),
+    mapState: { isLoading: false },
+  };
+});
+const refreshViewSpy = vi.fn();
+vi.mock('@/composables/useLeafletMap', () => ({
+  useLeafletMap: () => ({
+    mapInstance: shallowRef(mockMapInstance),
+    leaflet: shallowRef(null),
+    selectedFloor: ref(''),
+    floors: ref([]),
+    hasMultipleFloors: ref(false),
+    isLoading: ref(mapState.isLoading),
+    isIdle: ref(false),
+    svgLayer: shallowRef(null),
+    objectiveLayer: shallowRef(null),
+    extractLayer: shallowRef(null),
+    spawnLayer: shallowRef(null),
+    setFloor: vi.fn(),
+    refreshView: refreshViewSpy,
+    clearMarkers: vi.fn(),
+    destroy: vi.fn(),
+  }),
+}));
+vi.mock('@/stores/usePreferences', () => ({
+  usePreferencesStore: () => ({
+    resetMapMarkerColors: resetMapMarkerColorsSpy,
+    getMapMarkerColors: {
+      SELF_OBJECTIVE: '#111111',
+      TEAM_OBJECTIVE: '#222222',
+      PMC_SPAWN: '#333333',
+      PMC_EXTRACT: '#444444',
+      SCAV_EXTRACT: '#555555',
+      SHARED_EXTRACT: '#666666',
+      COOP_EXTRACT: '#777777',
+    },
+    getMapTooltipDensity: 'comfortable',
+    getMapZoneOpacity: 0.3,
+    getMapZoomSpeed: 1,
+    mapPanSpeed: 1,
+    setMapMarkerColor: vi.fn(),
+    setMapPanSpeed: vi.fn(),
+    setMapTooltipDensity: vi.fn(),
+    setMapZoneOpacity: vi.fn(),
+    setMapZoomSpeed: vi.fn(),
+  }),
+}));
+const mapData = {
+  id: 'customs',
+  name: 'Customs',
+  normalizedName: 'customs',
+} as TarkovMap;
+const mapStubs = {
+  AppTooltip: { template: '<div><slot /></div>' },
+  UPopover: {
+    template: '<div><slot /><slot name="content" /></div>',
+  },
+  UButton: {
+    inheritAttrs: false,
+    emits: ['click'],
+    template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
+  },
+  UIcon: { template: '<span />' },
+};
+const mountMap = async (props: Record<string, unknown> = {}) => {
+  const LeafletMap = (await import('@/features/maps/LeafletMap.vue')).default;
+  return mountSuspended(LeafletMap, {
+    attachTo: document.body,
+    props: { map: mapData, showFullscreenToggle: true, ...props },
+    global: { stubs: mapStubs },
+  });
+};
+describe('LeafletMap controls', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    refreshViewSpy.mockClear();
+    mockMapInstance.options.zoomSnap = 1;
+    mockMapInstance.zoomSnapDuringCall = undefined;
+    mockMapInstance.size = { x: 800, y: 600 };
+    mockMapInstance.zoom = 4.25;
+    mockMapInstance.setView.mockClear();
+    mockMapInstance.panTo.mockClear();
+    mockMapInstance.zoomIn.mockClear();
+    mockMapInstance.zoomOut.mockClear();
+  });
+  it('emits toggle-fullscreen from the fullscreen control', async () => {
+    const wrapper = await mountMap();
+    const toggle = wrapper.find('[data-testid="map-fullscreen-toggle"]');
+    expect(toggle.exists()).toBe(true);
+    await toggle.trigger('click');
+    expect(wrapper.emitted('toggle-fullscreen')).toHaveLength(1);
+    wrapper.unmount();
+  });
+  it('keeps fractional zoom by disabling zoom snapping for zoom controls', async () => {
+    const wrapper = await mountMap();
+    await wrapper.find('button[aria-label="Zoom in"]').trigger('click');
+    expect(mockMapInstance.zoomIn).toHaveBeenCalled();
+    expect(mockMapInstance.zoomSnapDuringCall).toBe(0);
+    expect(mockMapInstance.options.zoomSnap).toBe(1);
+    mockMapInstance.zoomSnapDuringCall = undefined;
+    await wrapper.find('button[aria-label="Zoom out"]').trigger('click');
+    expect(mockMapInstance.zoomOut).toHaveBeenCalled();
+    expect(mockMapInstance.zoomSnapDuringCall).toBe(0);
+    wrapper.unmount();
+  });
+  it('resets the view from the reset control', async () => {
+    const wrapper = await mountMap();
+    await wrapper.find('button[aria-label="Reset view"]').trigger('click');
+    expect(refreshViewSpy).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+  it('clears the help notification dot when help is opened from the first-use hint', async () => {
+    const wrapper = await mountMap();
+    const hint = wrapper.find('[data-testid="map-first-use-hint"]');
+    expect(hint.exists()).toBe(true);
+    const helpTrigger = wrapper.find('button[aria-label="Map controls"]');
+    expect(helpTrigger.find('span.bg-primary-400').exists()).toBe(true);
+    await hint.find('button.text-primary-300').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="map-first-use-hint"]').exists()).toBe(false);
+    expect(
+      wrapper.find('button[aria-label="Map controls"]').find('span.bg-primary-400').exists()
+    ).toBe(false);
+    wrapper.unmount();
+  });
+  it('dismisses the first-use hint and remembers it', async () => {
+    const wrapper = await mountMap();
+    await wrapper.find('[data-testid="map-first-use-hint"] button.bg-primary-500').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="map-first-use-hint"]').exists()).toBe(false);
+    expect(localStorage.getItem('mapControlsHintSeen')).toBe('true');
+    wrapper.unmount();
+  });
+  it('exposes the current view state and skips a hidden container', async () => {
+    const wrapper = await mountMap();
+    const vm = wrapper.vm as unknown as {
+      getViewState: () => { center: [number, number]; zoom: number } | null;
+      setViewState: (state: { center: [number, number]; zoom: number }) => void;
+    };
+    expect(vm.getViewState()).toEqual({ center: [12.5, 34.5], zoom: 4.25 });
+    mockMapInstance.size = { x: 0, y: 0 };
+    expect(vm.getViewState()).toBeNull();
+    wrapper.unmount();
+  });
+  it('restores a fractional zoom without snapping in setViewState', async () => {
+    const wrapper = await mountMap();
+    const vm = wrapper.vm as unknown as {
+      setViewState: (state: { center: [number, number]; zoom: number }) => void;
+    };
+    vm.setViewState({ center: [1.5, 2.5], zoom: 6.4 });
+    expect(mockMapInstance.setView).toHaveBeenCalledWith([1.5, 2.5], 6.4, { animate: false });
+    expect(mockMapInstance.zoomSnapDuringCall).toBe(0);
+    expect(mockMapInstance.options.zoomSnap).toBe(1);
+    mockMapInstance.setView.mockClear();
+    vm.setViewState({ center: [3.5, 4.5], zoom: mockMapInstance.zoom });
+    expect(mockMapInstance.setView).not.toHaveBeenCalled();
+    expect(mockMapInstance.panTo).toHaveBeenCalledWith([3.5, 4.5], { animate: false });
+    wrapper.unmount();
+  });
+});

--- a/app/features/maps/__tests__/LeafletMapControlsComponent.test.ts
+++ b/app/features/maps/__tests__/LeafletMapControlsComponent.test.ts
@@ -222,6 +222,18 @@ describe('LeafletMap controls', () => {
     expect(remounted.find('[data-testid="map-help-unseen-dot"]').exists()).toBe(false);
     remounted.unmount();
   });
+  it('hides the help dot on every mounted map instance when help opens in another one', async () => {
+    const inlineMap = await mountMap();
+    const fullscreenMap = await mountMap();
+    expect(inlineMap.find('[data-testid="map-help-unseen-dot"]').exists()).toBe(true);
+    expect(fullscreenMap.find('[data-testid="map-help-unseen-dot"]').exists()).toBe(true);
+    await fullscreenMap.find('[data-testid="map-hint-all-controls"]').trigger('click');
+    await nextTick();
+    expect(fullscreenMap.find('[data-testid="map-help-unseen-dot"]').exists()).toBe(false);
+    expect(inlineMap.find('[data-testid="map-help-unseen-dot"]').exists()).toBe(false);
+    inlineMap.unmount();
+    fullscreenMap.unmount();
+  });
   it('exposes the current view state and skips a hidden container', async () => {
     const wrapper = await mountMap();
     const vm = wrapper.vm as unknown as {

--- a/app/features/maps/__tests__/LeafletMapControlsComponent.test.ts
+++ b/app/features/maps/__tests__/LeafletMapControlsComponent.test.ts
@@ -46,6 +46,15 @@ const { mapState, mockMapInstance, resetMapMarkerColorsSpy } = vi.hoisted(() => 
 });
 const refreshViewSpy = vi.fn();
 vi.mock('@/composables/useLeafletMap', () => ({
+  withoutZoomSnap: (instance: { options: { zoomSnap?: number } }, apply: () => void): void => {
+    const originalZoomSnap = instance.options.zoomSnap ?? 0;
+    instance.options.zoomSnap = 0;
+    try {
+      apply();
+    } finally {
+      instance.options.zoomSnap = originalZoomSnap;
+    }
+  },
   useLeafletMap: () => ({
     mapInstance: shallowRef(mockMapInstance),
     leaflet: shallowRef(null),
@@ -135,19 +144,19 @@ describe('LeafletMap controls', () => {
   });
   it('keeps fractional zoom by disabling zoom snapping for zoom controls', async () => {
     const wrapper = await mountMap();
-    await wrapper.find('button[aria-label="Zoom in"]').trigger('click');
+    await wrapper.find('[data-testid="map-zoom-in"]').trigger('click');
     expect(mockMapInstance.zoomIn).toHaveBeenCalled();
     expect(mockMapInstance.zoomSnapDuringCall).toBe(0);
     expect(mockMapInstance.options.zoomSnap).toBe(1);
     mockMapInstance.zoomSnapDuringCall = undefined;
-    await wrapper.find('button[aria-label="Zoom out"]').trigger('click');
+    await wrapper.find('[data-testid="map-zoom-out"]').trigger('click');
     expect(mockMapInstance.zoomOut).toHaveBeenCalled();
     expect(mockMapInstance.zoomSnapDuringCall).toBe(0);
     wrapper.unmount();
   });
   it('resets the view from the reset control', async () => {
     const wrapper = await mountMap();
-    await wrapper.find('button[aria-label="Reset view"]').trigger('click');
+    await wrapper.find('[data-testid="map-reset-view"]').trigger('click');
     expect(refreshViewSpy).toHaveBeenCalled();
     wrapper.unmount();
   });
@@ -155,19 +164,22 @@ describe('LeafletMap controls', () => {
     const wrapper = await mountMap();
     const hint = wrapper.find('[data-testid="map-first-use-hint"]');
     expect(hint.exists()).toBe(true);
-    const helpTrigger = wrapper.find('button[aria-label="Map controls"]');
-    expect(helpTrigger.find('span.bg-primary-400').exists()).toBe(true);
-    await hint.find('button.text-primary-300').trigger('click');
+    const helpTrigger = wrapper.find('[data-testid="map-help-toggle"]');
+    expect(helpTrigger.find('[data-testid="map-help-unseen-dot"]').exists()).toBe(true);
+    await hint.find('[data-testid="map-hint-all-controls"]').trigger('click');
     await nextTick();
     expect(wrapper.find('[data-testid="map-first-use-hint"]').exists()).toBe(false);
     expect(
-      wrapper.find('button[aria-label="Map controls"]').find('span.bg-primary-400').exists()
+      wrapper
+        .find('[data-testid="map-help-toggle"]')
+        .find('[data-testid="map-help-unseen-dot"]')
+        .exists()
     ).toBe(false);
     wrapper.unmount();
   });
   it('dismisses the first-use hint and remembers it', async () => {
     const wrapper = await mountMap();
-    await wrapper.find('[data-testid="map-first-use-hint"] button.bg-primary-500').trigger('click');
+    await wrapper.find('[data-testid="map-hint-dismiss"]').trigger('click');
     await nextTick();
     expect(wrapper.find('[data-testid="map-first-use-hint"]').exists()).toBe(false);
     expect(localStorage.getItem('mapControlsHintSeen')).toBe('true');

--- a/app/features/maps/composables/useLeafletMapControls.ts
+++ b/app/features/maps/composables/useLeafletMapControls.ts
@@ -28,8 +28,10 @@ export const PAN_SPEED_MIN = 0.5;
 export const PAN_SPEED_MAX = 3;
 export const ZONE_OPACITY_MIN = 0.05;
 export const ZONE_OPACITY_MAX = 0.5;
-export const MAP_BUTTON_ACTIVE_CLASS = '!bg-surface-700/80 !text-surface-50 !ring-1 !ring-white/30';
-export const MAP_BUTTON_INACTIVE_CLASS = 'text-surface-300 hover:text-surface-100';
+export const MAP_BUTTON_ACTIVE_CLASS =
+  'border border-primary-400/60 bg-primary-500/15 text-primary-100';
+export const MAP_BUTTON_INACTIVE_CLASS =
+  'border border-transparent text-surface-300/60 hover:bg-white/5 hover:text-surface-100';
 export const isCoopExtract = (extract: MapExtract): boolean =>
   /\bco-?op\b/i.test(extract.name || '');
 export function useLeafletMapControls({

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -939,7 +939,6 @@
       "loading": "Loading tasks",
       "map": {
         "resize_handle": "Resize map height",
-        "toggle_panel": "Toggle map panel",
         "show_map": "Show map",
         "hide_map": "Hide map",
         "fullscreen_label": "Full screen",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -911,6 +911,11 @@
       "map": {
         "resize_handle": "Resize map height",
         "toggle_panel": "Toggle map panel",
+        "show_map": "Show map",
+        "hide_map": "Hide map",
+        "open_fullscreen": "Open map full screen",
+        "exit_fullscreen": "Exit full screen",
+        "fullscreen_label": "Full screen",
         "required_items_summary": "Required items for active tasks",
         "required_keys_summary": "Required keys for active tasks",
         "time_period": {

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -318,7 +318,8 @@
     "reset_all_data": "Reset All Data",
     "import_failed": "Import Failed",
     "delete_archived_run": "Delete Archived Run",
-    "validation_error": "Validation Error"
+    "validation_error": "Validation Error",
+    "got_it": "Got it"
   },
   "page_help": {
     "button": "Help",
@@ -503,15 +504,43 @@
       "shared_extract": "Shared Extract (Either Faction)",
       "coop_extract": "Co-op Extract (PMC + Scav)"
     },
+    "tooltips": {
+      "zoom_in": "Zoom in",
+      "zoom_out": "Zoom out",
+      "reset_view": "Reset view",
+      "open_fullscreen": "Open map full screen",
+      "exit_fullscreen": "Exit full screen",
+      "drag_to_resize": "Drag to resize map",
+      "switch_floor": "Switch floor (Ctrl + Scroll)"
+    },
     "controls": {
-      "keyboard": {
-        "pan": "to Pan",
-        "zoom_keys": "to Zoom",
-        "click": "to Click at Cursor",
-        "reset": "to Reset View",
-        "cycle_floors": "+ Scroll to Cycle Floors",
-        "zoom": "+ Scroll to Zoom"
+      "help": {
+        "pan": "or drag to pan",
+        "zoom": "to zoom",
+        "reset": "to reset view",
+        "cycle_floors": "to cycle floors",
+        "floor_panel": "or use the floor panel",
+        "click_at_cursor": "to click at cursor",
+        "click_marker": "Click a marker for details",
+        "fullscreen": "Use the full screen button in the map controls",
+        "resize": "Drag the bottom edge of the map to resize"
       }
+    },
+    "help": {
+      "title": "Map controls",
+      "groups": {
+        "navigate": "Navigate",
+        "floors": "Floors",
+        "interact": "Interact",
+        "view": "View"
+      }
+    },
+    "hint": {
+      "title": "Quick map controls",
+      "drag_to_pan": "Drag to pan",
+      "shift_scroll_zoom": "Shift + Scroll to zoom",
+      "ctrl_scroll_floors": "Ctrl + Scroll to change floors",
+      "all_controls": "All controls"
     },
     "aria": {
       "tooltip_density": "Tooltip density"
@@ -913,8 +942,6 @@
         "toggle_panel": "Toggle map panel",
         "show_map": "Show map",
         "hide_map": "Hide map",
-        "open_fullscreen": "Open map full screen",
-        "exit_fullscreen": "Exit full screen",
         "fullscreen_label": "Full screen",
         "required_items_summary": "Required items for active tasks",
         "required_keys_summary": "Required keys for active tasks",
@@ -928,7 +955,9 @@
         "map_complete_tasks_hidden": "{count} tasks hidden on this map.",
         "map_complete_tasks_showing": "{count} map-complete tasks shown on this map.",
         "map_complete_tasks_toggle_show": "Show hidden",
-        "map_complete_tasks_toggle_hide": "Hide map-complete"
+        "map_complete_tasks_toggle_hide": "Hide map-complete",
+        "map_hidden_hint": "Map hidden — click to show",
+        "raid_time_tooltip": "Current in-game raid time"
       },
       "pinned_tasks_section": "Pinned Tasks",
       "focused_task_section": "Focused Task",

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -214,6 +214,10 @@ vi.mock('vue-router', async (importOriginal) => ({
     push: vi.fn(() => Promise.resolve()),
   }),
 }));
+const { leafletGetViewStateSpy, leafletSetViewStateSpy } = vi.hoisted(() => ({
+  leafletGetViewStateSpy: vi.fn(),
+  leafletSetViewStateSpy: vi.fn(),
+}));
 vi.mock('@/features/maps/LeafletMap.vue', () => ({
   __esModule: true,
   default: defineComponent({
@@ -222,15 +226,22 @@ vi.mock('@/features/maps/LeafletMap.vue', () => ({
         type: Array,
         default: () => [],
       },
+      initialView: {
+        type: Object,
+        default: null,
+      },
     },
     setup(props, { expose }) {
       expose({
         activateObjectivePopup: () => true,
         closeActivePopup: () => undefined,
+        getViewState: leafletGetViewStateSpy,
+        setViewState: leafletSetViewStateSpy,
       });
       return { props };
     },
-    template: '<div data-testid="leaflet-map" :data-marks="JSON.stringify(props.marks ?? [])" />',
+    template:
+      '<div data-testid="leaflet-map" :data-marks="JSON.stringify(props.marks ?? [])" :data-initial-view="JSON.stringify(props.initialView ?? null)" />',
   }),
 }));
 const UButtonStub = {
@@ -276,6 +287,8 @@ describe('tasks page', () => {
     isGlobalTaskMock.mockReset();
     clearPinnedTaskMock.mockClear();
     handleTaskQueryParamMock.mockClear();
+    leafletGetViewStateSpy.mockReset();
+    leafletSetViewStateSpy.mockReset();
     isGlobalTaskMock.mockImplementation((_task: Task) => false);
     preferencesStoreMock.getTaskPrimaryView = 'all';
     preferencesStoreMock.getTaskSecondaryView = 'available';
@@ -412,16 +425,26 @@ describe('tasks page', () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
     metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    const panelViewState = { center: [55.7558, 37.6173] as [number, number], zoom: 12 };
+    leafletGetViewStateSpy.mockReturnValue(panelViewState);
     await mountPage();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
     await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
     await nextTick();
+    await nextTick();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(true);
+    const fullscreenMap = wrapper.find(
+      '[data-testid="map-fullscreen-overlay"] [data-testid="leaflet-map"]'
+    );
+    expect(fullscreenMap.attributes('data-initial-view')).toBe(JSON.stringify(panelViewState));
+    const overlayViewState = { center: [59.939, 30.315] as [number, number], zoom: 14 };
+    leafletGetViewStateSpy.mockReturnValue(overlayViewState);
     const exitButton = wrapper.find('[data-testid="map-fullscreen-exit"]');
     expect(exitButton.exists()).toBe(true);
     await exitButton.trigger('click');
     await nextTick();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
+    expect(leafletSetViewStateSpy).toHaveBeenCalledWith(overlayViewState);
   });
   it('expands the map panel when opening full screen from a collapsed panel', async () => {
     localStorage.setItem(STORAGE_KEYS.tasksMapPanelExpanded, 'false');
@@ -435,6 +458,33 @@ describe('tasks page', () => {
     await nextTick();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(true);
     expect(toggleButton.attributes('aria-expanded')).toBe('true');
+  });
+  it('moves focus into the full screen overlay and restores it on close', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    wrapper = await mountSuspended(TasksPage, {
+      attachTo: document.body,
+      global: { stubs: defaultGlobalStubs },
+    });
+    const fullscreenToggle = wrapper.find('[data-testid="map-fullscreen-toggle"]');
+    fullscreenToggle.element.focus();
+    await fullscreenToggle.trigger('click');
+    await nextTick();
+    await nextTick();
+    const overlay = wrapper.find('[data-testid="map-fullscreen-overlay"]');
+    expect(overlay.exists()).toBe(true);
+    const exitButton = wrapper.find('[data-testid="map-fullscreen-exit"]');
+    expect(document.activeElement).toBe(exitButton.element);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
+    expect(document.activeElement).toBe(exitButton.element);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    expect(document.activeElement).toBe(exitButton.element);
+    await exitButton.trigger('click');
+    await nextTick();
+    await nextTick();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
+    expect(document.activeElement).toBe(fullscreenToggle.element);
   });
   it('shows re-hide footer action in map section when hidden tasks are visible', async () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -304,6 +304,14 @@ describe('tasks page', () => {
     await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
     await nextTick();
   };
+  const isInsideInertSubtree = (element: Element | null): boolean => {
+    let node: HTMLElement | null = element as HTMLElement | null;
+    while (node) {
+      if (node.inert) return true;
+      node = node.parentElement;
+    }
+    return false;
+  };
   beforeEach(async () => {
     visibleTasksRef.value = [defaultTask];
     focusedTaskRef.value = null;
@@ -484,7 +492,7 @@ describe('tasks page', () => {
     await flushTransition();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
   });
-  it('hides the map full screen control while the map panel is collapsed', async () => {
+  it('keeps the map full screen control mounted while the map panel is collapsed', async () => {
     localStorage.setItem(STORAGE_KEYS.tasksMapPanelExpanded, 'false');
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
@@ -518,14 +526,97 @@ describe('tasks page', () => {
     expect(overlay.exists()).toBe(true);
     const exitButton = wrapper.find('[data-testid="map-fullscreen-exit"]');
     expect(document.activeElement).toBe(exitButton.element);
+    const overlayMapToggle = wrapper.find(
+      '[data-testid="map-fullscreen-overlay"] [data-testid="map-fullscreen-toggle"]'
+    );
+    expect(overlayMapToggle.exists()).toBe(true);
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
-    expect(overlay.element.contains(document.activeElement)).toBe(true);
+    expect(document.activeElement).toBe(overlayMapToggle.element);
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
-    expect(overlay.element.contains(document.activeElement)).toBe(true);
+    expect(document.activeElement).toBe(exitButton.element);
     await exitButton.trigger('click');
     await flushTransition();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
     expect(document.activeElement).toBe(fullscreenToggle.element);
+  });
+  it('marks background content inert while the full screen map is open', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    wrapper = await mountSuspended(TasksPage, {
+      attachTo: document.body,
+      global: { stubs: defaultGlobalStubs },
+    });
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await flushTransition();
+    const overlay = wrapper.find('[data-testid="map-fullscreen-overlay"]');
+    expect(overlay.exists()).toBe(true);
+    const panelToggleElement = wrapper.find('[data-testid="map-panel-toggle"]').element;
+    expect(isInsideInertSubtree(panelToggleElement)).toBe(true);
+    expect(isInsideInertSubtree(overlay.element)).toBe(false);
+    await wrapper.find('[data-testid="map-fullscreen-exit"]').trigger('click');
+    await flushTransition();
+    expect(isInsideInertSubtree(panelToggleElement)).toBe(false);
+  });
+  it('leaves focus alone while a portalled popover is open in full screen', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    wrapper = await mountSuspended(TasksPage, {
+      attachTo: document.body,
+      global: { stubs: defaultGlobalStubs },
+    });
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await flushTransition();
+    const popover = document.createElement('div');
+    popover.setAttribute('data-reka-popper-content-wrapper', '');
+    const popoverInput = document.createElement('button');
+    popover.appendChild(popoverInput);
+    document.body.appendChild(popover);
+    popoverInput.focus();
+    expect(document.activeElement).toBe(popoverInput);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
+    expect(document.activeElement).toBe(popoverInput);
+    popover.remove();
+  });
+  it('keeps full screen open when Escape was already handled by a nested control', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    wrapper = await mountSuspended(TasksPage, {
+      attachTo: document.body,
+      global: { stubs: defaultGlobalStubs },
+    });
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await flushTransition();
+    const handledEscape = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true });
+    handledEscape.preventDefault();
+    window.dispatchEvent(handledEscape);
+    await flushTransition();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(true);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
+    await flushTransition();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
+  });
+  it('closes full screen and skips the view restore when the map view is left', async () => {
+    const mapViewRef = ref('map-1');
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = mapViewRef as unknown as string;
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    leafletGetViewStateSpy.mockReturnValue({ center: [1, 2], zoom: 3 });
+    wrapper = await mountSuspended(TasksPage, {
+      attachTo: document.body,
+      global: { stubs: defaultGlobalStubs },
+    });
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await flushTransition();
+    const panelToggleElement = wrapper.find('[data-testid="map-panel-toggle"]').element;
+    expect(isInsideInertSubtree(panelToggleElement)).toBe(true);
+    mapViewRef.value = 'all';
+    await flushTransition();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
+    expect(leafletSetViewStateSpy).not.toHaveBeenCalled();
+    expect(isInsideInertSubtree(panelToggleElement)).toBe(false);
   });
   it('shows re-hide footer action in map section when hidden tasks are visible', async () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -345,6 +345,14 @@ describe('tasks page', () => {
     await toggleButton.trigger('click');
     expect(preferencesStoreMock.setHideCompletedMapObjectives).toHaveBeenCalledWith(false);
   });
+  it('expands the map panel by default on the map view', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    await mountPage();
+    const toggleButton = wrapper.find('[data-testid="map-panel-toggle"]');
+    expect(toggleButton.attributes('aria-expanded')).toBe('true');
+  });
   it('collapses and expands the map panel from the map header toggle', async () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
@@ -352,13 +360,13 @@ describe('tasks page', () => {
     await mountPage();
     const toggleButton = wrapper.find('[data-testid="map-panel-toggle"]');
     expect(toggleButton.exists()).toBe(true);
-    expect(toggleButton.attributes('aria-expanded')).toBe('false');
-    await toggleButton.trigger('click');
-    await nextTick();
     expect(toggleButton.attributes('aria-expanded')).toBe('true');
     await toggleButton.trigger('click');
     await nextTick();
     expect(toggleButton.attributes('aria-expanded')).toBe('false');
+    await toggleButton.trigger('click');
+    await nextTick();
+    expect(toggleButton.attributes('aria-expanded')).toBe('true');
   });
   it('restores the saved map panel expanded state', async () => {
     localStorage.setItem(STORAGE_KEYS.tasksMapPanelExpanded, 'true');
@@ -370,6 +378,7 @@ describe('tasks page', () => {
     expect(toggleButton.attributes('aria-expanded')).toBe('true');
   });
   it('expands the map panel when jumping to a map objective from a collapsed state', async () => {
+    localStorage.setItem(STORAGE_KEYS.tasksMapPanelExpanded, 'false');
     const TaskCardJumpStub = defineComponent({
       setup() {
         const jumpToMapObjective = inject(jumpToMapObjectiveKey, null);
@@ -397,6 +406,34 @@ describe('tasks page', () => {
     expect(jumpButton.exists()).toBe(true);
     await jumpButton.trigger('click');
     await nextTick();
+    expect(toggleButton.attributes('aria-expanded')).toBe('true');
+  });
+  it('opens and closes the map full screen overlay', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    await mountPage();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(true);
+    const exitButton = wrapper.find('[data-testid="map-fullscreen-exit"]');
+    expect(exitButton.exists()).toBe(true);
+    await exitButton.trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
+  });
+  it('expands the map panel when opening full screen from a collapsed panel', async () => {
+    localStorage.setItem(STORAGE_KEYS.tasksMapPanelExpanded, 'false');
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    await mountPage();
+    const toggleButton = wrapper.find('[data-testid="map-panel-toggle"]');
+    expect(toggleButton.attributes('aria-expanded')).toBe('false');
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await nextTick();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(true);
     expect(toggleButton.attributes('aria-expanded')).toBe('true');
   });
   it('shows re-hide footer action in map section when hidden tasks are visible', async () => {

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -214,10 +214,13 @@ vi.mock('vue-router', async (importOriginal) => ({
     push: vi.fn(() => Promise.resolve()),
   }),
 }));
-const { leafletGetViewStateSpy, leafletSetViewStateSpy } = vi.hoisted(() => ({
-  leafletGetViewStateSpy: vi.fn(),
-  leafletSetViewStateSpy: vi.fn(),
-}));
+const { leafletGetViewStateSpy, leafletSetViewStateSpy, leafletGetFloorSpy, leafletSetFloorSpy } =
+  vi.hoisted(() => ({
+    leafletGetViewStateSpy: vi.fn(),
+    leafletSetViewStateSpy: vi.fn(),
+    leafletGetFloorSpy: vi.fn(),
+    leafletSetFloorSpy: vi.fn(),
+  }));
 vi.mock('@/features/maps/LeafletMap.vue', () => ({
   __esModule: true,
   default: defineComponent({
@@ -229,6 +232,10 @@ vi.mock('@/features/maps/LeafletMap.vue', () => ({
       initialView: {
         type: Object,
         default: null,
+      },
+      initialFloor: {
+        type: String,
+        default: undefined,
       },
       showFullscreenToggle: {
         type: Boolean,
@@ -246,10 +253,12 @@ vi.mock('@/features/maps/LeafletMap.vue', () => ({
         closeActivePopup: () => undefined,
         getViewState: leafletGetViewStateSpy,
         setViewState: leafletSetViewStateSpy,
+        getFloor: leafletGetFloorSpy,
+        setFloor: leafletSetFloorSpy,
       });
       return { props };
     },
-    template: `<div data-testid="leaflet-map" :data-marks="JSON.stringify(props.marks ?? [])" :data-initial-view="JSON.stringify(props.initialView ?? null)">
+    template: `<div data-testid="leaflet-map" :data-marks="JSON.stringify(props.marks ?? [])" :data-initial-view="JSON.stringify(props.initialView ?? null)" :data-initial-floor="props.initialFloor ?? ''">
       <button
         v-if="props.showFullscreenToggle"
         type="button"
@@ -328,6 +337,8 @@ describe('tasks page', () => {
     handleTaskQueryParamMock.mockClear();
     leafletGetViewStateSpy.mockReset();
     leafletSetViewStateSpy.mockReset();
+    leafletGetFloorSpy.mockReset();
+    leafletSetFloorSpy.mockReset();
     isGlobalTaskMock.mockImplementation((_task: Task) => false);
     preferencesStoreMock.getTaskPrimaryView = 'all';
     preferencesStoreMock.getTaskSecondaryView = 'available';
@@ -487,6 +498,33 @@ describe('tasks page', () => {
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
     expect(leafletSetViewStateSpy).toHaveBeenCalledWith(overlayViewState);
   });
+  it('carries the inline map floor into the full screen overlay', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    leafletGetFloorSpy.mockReturnValue('3rd Floor');
+    await mountPage();
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await flushTransition();
+    const fullscreenMap = wrapper.find(
+      '[data-testid="map-fullscreen-overlay"] [data-testid="leaflet-map"]'
+    );
+    expect(fullscreenMap.attributes('data-initial-floor')).toBe('3rd Floor');
+  });
+  it('restores the full screen floor onto the inline map on close', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    leafletGetFloorSpy.mockReturnValue('Ground Level');
+    await mountPage();
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await flushTransition();
+    leafletGetFloorSpy.mockReturnValue('2nd Floor');
+    await wrapper.find('[data-testid="map-fullscreen-exit"]').trigger('click');
+    await flushTransition();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
+    expect(leafletSetFloorSpy).toHaveBeenCalledWith('2nd Floor');
+  });
   it('closes the map full screen overlay from the in-map control', async () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
@@ -639,6 +677,7 @@ describe('tasks page', () => {
     preferencesStoreMock.getTaskMapView = mapViewRef as unknown as string;
     metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
     leafletGetViewStateSpy.mockReturnValue({ center: [1, 2], zoom: 3 });
+    leafletGetFloorSpy.mockReturnValue('Ground Level');
     await mountAttachedPage();
     await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
     await flushTransition();
@@ -648,6 +687,7 @@ describe('tasks page', () => {
     await flushTransition();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
     expect(leafletSetViewStateSpy).not.toHaveBeenCalled();
+    expect(leafletSetFloorSpy).not.toHaveBeenCalled();
     expect(isInsideInertSubtree(panelToggleElement)).toBe(false);
   });
   it('shows re-hide footer action in map section when hidden tasks are visible', async () => {

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -598,6 +598,28 @@ describe('tasks page', () => {
     await flushTransition();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
   });
+  it('lets an open popover consume Escape before closing full screen', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    wrapper = await mountSuspended(TasksPage, {
+      attachTo: document.body,
+      global: { stubs: defaultGlobalStubs },
+    });
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await flushTransition();
+    const popover = document.createElement('div');
+    popover.setAttribute('data-reka-popper-content-wrapper', '');
+    popover.innerHTML = '<div role="dialog" data-state="open"></div>';
+    document.body.appendChild(popover);
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
+    await flushTransition();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(true);
+    popover.remove();
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', cancelable: true }));
+    await flushTransition();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
+  });
   it('closes full screen and skips the view restore when the map view is left', async () => {
     const mapViewRef = ref('map-1');
     preferencesStoreMock.getTaskPrimaryView = 'maps';

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -1,5 +1,5 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, inject, isRef, nextTick, ref } from 'vue';
 import { jumpToMapObjectiveKey } from '@/features/tasks/task-context';
 import { STORAGE_KEYS } from '@/utils/storageKeys';
@@ -295,6 +295,13 @@ describe('tasks page', () => {
       global: { stubs: defaultGlobalStubs },
     });
   };
+  const mountAttachedPage = async () => {
+    wrapper?.unmount();
+    wrapper = await mountSuspended(TasksPage, {
+      attachTo: document.body,
+      global: { stubs: defaultGlobalStubs },
+    });
+  };
   const getLeafletMarks = (): MapObjectiveMark[] => {
     const raw = wrapper.find('[data-testid="leaflet-map"]').attributes('data-marks') ?? '[]';
     return JSON.parse(raw) as MapObjectiveMark[];
@@ -346,6 +353,9 @@ describe('tasks page', () => {
     const module = await import('@/pages/tasks.vue');
     TasksPage = module.default;
     await mountPage();
+  });
+  afterEach(() => {
+    wrapper?.unmount();
   });
   it('renders task cards when tasks are available', async () => {
     expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true);
@@ -514,10 +524,7 @@ describe('tasks page', () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
     metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
-    wrapper = await mountSuspended(TasksPage, {
-      attachTo: document.body,
-      global: { stubs: defaultGlobalStubs },
-    });
+    await mountAttachedPage();
     const fullscreenToggle = wrapper.find('[data-testid="map-fullscreen-toggle"]');
     fullscreenToggle.element.focus();
     await fullscreenToggle.trigger('click');
@@ -539,14 +546,29 @@ describe('tasks page', () => {
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
     expect(document.activeElement).toBe(fullscreenToggle.element);
   });
+  it('names the map heading after the map and pairs both disclosure controls', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    await mountPage();
+    const headerToggle = wrapper.find('[data-testid="map-panel-toggle"]');
+    expect(headerToggle.attributes('aria-label')).toBeUndefined();
+    expect(headerToggle.text()).toContain('Map One');
+    const collapseToggle = wrapper.find('[data-testid="map-collapse-toggle"]');
+    expect(collapseToggle.attributes('aria-expanded')).toBe(
+      headerToggle.attributes('aria-expanded')
+    );
+    expect(collapseToggle.attributes('aria-controls')).toBe('tasks-map-panel-content');
+    await collapseToggle.trigger('click');
+    await flushTransition();
+    expect(headerToggle.attributes('aria-expanded')).toBe('false');
+    expect(collapseToggle.attributes('aria-expanded')).toBe('false');
+  });
   it('marks background content inert while the full screen map is open', async () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
     metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
-    wrapper = await mountSuspended(TasksPage, {
-      attachTo: document.body,
-      global: { stubs: defaultGlobalStubs },
-    });
+    await mountAttachedPage();
     await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
     await flushTransition();
     const overlay = wrapper.find('[data-testid="map-fullscreen-overlay"]');
@@ -562,10 +584,7 @@ describe('tasks page', () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
     metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
-    wrapper = await mountSuspended(TasksPage, {
-      attachTo: document.body,
-      global: { stubs: defaultGlobalStubs },
-    });
+    await mountAttachedPage();
     await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
     await flushTransition();
     const popover = document.createElement('div');
@@ -583,10 +602,7 @@ describe('tasks page', () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
     metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
-    wrapper = await mountSuspended(TasksPage, {
-      attachTo: document.body,
-      global: { stubs: defaultGlobalStubs },
-    });
+    await mountAttachedPage();
     await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
     await flushTransition();
     const handledEscape = new KeyboardEvent('keydown', { key: 'Escape', cancelable: true });
@@ -602,10 +618,7 @@ describe('tasks page', () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
     metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
-    wrapper = await mountSuspended(TasksPage, {
-      attachTo: document.body,
-      global: { stubs: defaultGlobalStubs },
-    });
+    await mountAttachedPage();
     await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
     await flushTransition();
     const popover = document.createElement('div');
@@ -626,10 +639,7 @@ describe('tasks page', () => {
     preferencesStoreMock.getTaskMapView = mapViewRef as unknown as string;
     metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
     leafletGetViewStateSpy.mockReturnValue({ center: [1, 2], zoom: 3 });
-    wrapper = await mountSuspended(TasksPage, {
-      attachTo: document.body,
-      global: { stubs: defaultGlobalStubs },
-    });
+    await mountAttachedPage();
     await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
     await flushTransition();
     const panelToggleElement = wrapper.find('[data-testid="map-panel-toggle"]').element;

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -230,7 +230,16 @@ vi.mock('@/features/maps/LeafletMap.vue', () => ({
         type: Object,
         default: null,
       },
+      showFullscreenToggle: {
+        type: Boolean,
+        default: false,
+      },
+      isFullscreen: {
+        type: Boolean,
+        default: false,
+      },
     },
+    emits: ['toggle-fullscreen'],
     setup(props, { expose }) {
       expose({
         activateObjectivePopup: () => true,
@@ -240,15 +249,25 @@ vi.mock('@/features/maps/LeafletMap.vue', () => ({
       });
       return { props };
     },
-    template:
-      '<div data-testid="leaflet-map" :data-marks="JSON.stringify(props.marks ?? [])" :data-initial-view="JSON.stringify(props.initialView ?? null)" />',
+    template: `<div data-testid="leaflet-map" :data-marks="JSON.stringify(props.marks ?? [])" :data-initial-view="JSON.stringify(props.initialView ?? null)">
+      <button
+        v-if="props.showFullscreenToggle"
+        type="button"
+        data-testid="map-fullscreen-toggle"
+        @click="$emit('toggle-fullscreen')"
+      />
+    </div>`,
   }),
 }));
 const UButtonStub = {
   emits: ['click'],
   template: '<button v-bind="$attrs" @click="$emit(\'click\')"><slot /></button>',
 };
+const AppTooltipStub = {
+  template: '<div><slot /></div>',
+};
 const defaultGlobalStubs = {
+  AppTooltip: AppTooltipStub,
   TaskCard: {
     props: ['accentVariant', 'task'],
     template: '<div data-testid="task-card" :data-accent="accentVariant">{{ task.id }}</div>',
@@ -279,6 +298,11 @@ describe('tasks page', () => {
   const getLeafletMarks = (): MapObjectiveMark[] => {
     const raw = wrapper.find('[data-testid="leaflet-map"]').attributes('data-marks') ?? '[]';
     return JSON.parse(raw) as MapObjectiveMark[];
+  };
+  const flushTransition = async () => {
+    await nextTick();
+    await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+    await nextTick();
   };
   beforeEach(async () => {
     visibleTasksRef.value = [defaultTask];
@@ -430,8 +454,7 @@ describe('tasks page', () => {
     await mountPage();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
     await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
-    await nextTick();
-    await nextTick();
+    await flushTransition();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(true);
     const fullscreenMap = wrapper.find(
       '[data-testid="map-fullscreen-overlay"] [data-testid="leaflet-map"]'
@@ -442,11 +465,26 @@ describe('tasks page', () => {
     const exitButton = wrapper.find('[data-testid="map-fullscreen-exit"]');
     expect(exitButton.exists()).toBe(true);
     await exitButton.trigger('click');
-    await nextTick();
+    await flushTransition();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
     expect(leafletSetViewStateSpy).toHaveBeenCalledWith(overlayViewState);
   });
-  it('expands the map panel when opening full screen from a collapsed panel', async () => {
+  it('closes the map full screen overlay from the in-map control', async () => {
+    preferencesStoreMock.getTaskPrimaryView = 'maps';
+    preferencesStoreMock.getTaskMapView = 'map-1';
+    metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    await mountPage();
+    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
+    await flushTransition();
+    const overlayToggle = wrapper.find(
+      '[data-testid="map-fullscreen-overlay"] [data-testid="map-fullscreen-toggle"]'
+    );
+    expect(overlayToggle.exists()).toBe(true);
+    await overlayToggle.trigger('click');
+    await flushTransition();
+    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
+  });
+  it('hides the map full screen control while the map panel is collapsed', async () => {
     localStorage.setItem(STORAGE_KEYS.tasksMapPanelExpanded, 'false');
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
@@ -454,10 +492,15 @@ describe('tasks page', () => {
     await mountPage();
     const toggleButton = wrapper.find('[data-testid="map-panel-toggle"]');
     expect(toggleButton.attributes('aria-expanded')).toBe('false');
-    await wrapper.find('[data-testid="map-fullscreen-toggle"]').trigger('click');
-    await nextTick();
-    expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(true);
+    const panelContent = wrapper.find('#tasks-map-panel-content');
+    expect(panelContent.attributes('style')).toContain('display: none');
+    expect(panelContent.find('[data-testid="map-fullscreen-toggle"]').exists()).toBe(true);
+    await toggleButton.trigger('click');
+    await flushTransition();
     expect(toggleButton.attributes('aria-expanded')).toBe('true');
+    expect(wrapper.find('#tasks-map-panel-content').attributes('style') ?? '').not.toContain(
+      'display: none'
+    );
   });
   it('moves focus into the full screen overlay and restores it on close', async () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
@@ -470,19 +513,17 @@ describe('tasks page', () => {
     const fullscreenToggle = wrapper.find('[data-testid="map-fullscreen-toggle"]');
     fullscreenToggle.element.focus();
     await fullscreenToggle.trigger('click');
-    await nextTick();
-    await nextTick();
+    await flushTransition();
     const overlay = wrapper.find('[data-testid="map-fullscreen-overlay"]');
     expect(overlay.exists()).toBe(true);
     const exitButton = wrapper.find('[data-testid="map-fullscreen-exit"]');
     expect(document.activeElement).toBe(exitButton.element);
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', shiftKey: true }));
-    expect(document.activeElement).toBe(exitButton.element);
+    expect(overlay.element.contains(document.activeElement)).toBe(true);
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab' }));
-    expect(document.activeElement).toBe(exitButton.element);
+    expect(overlay.element.contains(document.activeElement)).toBe(true);
     await exitButton.trigger('click');
-    await nextTick();
-    await nextTick();
+    await flushTransition();
     expect(wrapper.find('[data-testid="map-fullscreen-overlay"]').exists()).toBe(false);
     expect(document.activeElement).toBe(fullscreenToggle.element);
   });

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -467,6 +467,7 @@
               :is-fullscreen="true"
               fill
               :initial-view="fullscreenMapView"
+              :initial-floor="fullscreenInitialFloor"
               @toggle-fullscreen="closeMapFullscreen"
             />
           </div>
@@ -681,6 +682,8 @@
     closeActivePopup: () => void;
     getViewState?: () => MapViewState | null;
     setViewState?: (state: MapViewState) => void;
+    getFloor?: () => string;
+    setFloor?: (floor: string) => void;
   }
   const leafletMapRef = ref<MapComponentRef | null>(null);
   const { jumpToMapObjective, cleanup: cleanupMapPopup } = useMapObjectivePopup({
@@ -689,6 +692,7 @@
   });
   const fullscreenLeafletMapRef = ref<MapComponentRef | null>(null);
   const fullscreenMapView = ref<MapViewState | null>(null);
+  const fullscreenInitialFloor = ref<string | undefined>(undefined);
   const isMapFullscreen = ref(false);
   const FULLSCREEN_OVERLAY_SELECTOR = '[data-testid="map-fullscreen-overlay"]';
   const getFullscreenOverlay = (): HTMLElement | null =>
@@ -743,19 +747,28 @@
     inertBackgroundElements.some((background) => background.contains(element));
   const readFullscreenMapView = (): MapViewState | null =>
     fullscreenLeafletMapRef.value?.getViewState?.() ?? null;
+  const readFullscreenFloor = (): string | undefined => fullscreenLeafletMapRef.value?.getFloor?.();
   const restoreInlineMapView = (view: MapViewState): void => {
     if (fullscreenMapId !== selectedMapId.value) return;
     leafletMapRef.value?.setViewState?.(view);
   };
+  const restoreInlineMapFloor = (floor: string | undefined): void => {
+    if (!floor || fullscreenMapId !== selectedMapId.value) return;
+    leafletMapRef.value?.setFloor?.(floor);
+  };
   const openMapFullscreen = () => {
     fullscreenMapId = selectedMapId.value;
     fullscreenMapView.value = leafletMapRef.value?.getViewState?.() ?? null;
+    fullscreenInitialFloor.value = leafletMapRef.value?.getFloor?.() ?? undefined;
     isMapFullscreen.value = true;
   };
   const closeMapFullscreen = () => {
     const overlayView = readFullscreenMapView();
+    const overlayFloor = readFullscreenFloor();
     isMapFullscreen.value = false;
     fullscreenMapView.value = null;
+    fullscreenInitialFloor.value = undefined;
+    restoreInlineMapFloor(overlayFloor);
     if (overlayView) nextTick(() => restoreInlineMapView(overlayView));
   };
   const PORTALLED_POPOVER_SELECTOR = '[data-reka-popper-content-wrapper]';

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -680,10 +680,10 @@
   interface MapComponentRef {
     activateObjectivePopup: (id: string) => boolean;
     closeActivePopup: () => void;
-    getViewState?: () => MapViewState | null;
-    setViewState?: (state: MapViewState) => void;
-    getFloor?: () => string;
-    setFloor?: (floor: string) => void;
+    getViewState: () => MapViewState | null;
+    setViewState: (state: MapViewState) => void;
+    getFloor: () => string;
+    setFloor: (floor: string) => void;
   }
   const leafletMapRef = ref<MapComponentRef | null>(null);
   const { jumpToMapObjective, cleanup: cleanupMapPopup } = useMapObjectivePopup({
@@ -746,20 +746,23 @@
   const isInInertBackground = (element: HTMLElement): boolean =>
     inertBackgroundElements.some((background) => background.contains(element));
   const readFullscreenMapView = (): MapViewState | null =>
-    fullscreenLeafletMapRef.value?.getViewState?.() ?? null;
-  const readFullscreenFloor = (): string | undefined => fullscreenLeafletMapRef.value?.getFloor?.();
+    fullscreenLeafletMapRef.value?.getViewState() ?? null;
+  const readFullscreenFloor = (): string | undefined => fullscreenLeafletMapRef.value?.getFloor();
   const restoreInlineMapView = (view: MapViewState): void => {
     if (fullscreenMapId !== selectedMapId.value) return;
-    leafletMapRef.value?.setViewState?.(view);
+    leafletMapRef.value?.setViewState(view);
   };
   const restoreInlineMapFloor = (floor: string | undefined): void => {
     if (!floor || fullscreenMapId !== selectedMapId.value) return;
-    leafletMapRef.value?.setFloor?.(floor);
+    leafletMapRef.value?.setFloor(floor);
   };
   const openMapFullscreen = () => {
     fullscreenMapId = selectedMapId.value;
-    fullscreenMapView.value = leafletMapRef.value?.getViewState?.() ?? null;
-    fullscreenInitialFloor.value = leafletMapRef.value?.getFloor?.() ?? undefined;
+    const inlineMap = leafletMapRef.value;
+    if (inlineMap) {
+      fullscreenMapView.value = inlineMap.getViewState();
+      fullscreenInitialFloor.value = inlineMap.getFloor();
+    }
     isMapFullscreen.value = true;
   };
   const closeMapFullscreen = () => {

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -13,83 +13,89 @@
           <template v-else>
             <div v-if="showMapDisplay" ref="mapContainerRef" class="mb-6">
               <div class="bg-surface-800/50 rounded-lg p-4">
-                <div class="mb-3 flex items-start justify-between gap-3">
+                <div class="mb-3 flex items-center justify-between gap-3">
                   <button
                     type="button"
                     data-testid="map-panel-toggle"
                     :aria-expanded="isMapPanelExpanded"
                     aria-controls="tasks-map-panel-content"
                     :aria-label="t('page.tasks.map.toggle_panel')"
-                    class="hover:bg-surface-800/40 focus-visible:ring-primary-500 focus-visible:ring-offset-surface-800 group -m-1.5 flex min-w-0 flex-1 cursor-pointer items-start gap-2.5 rounded-lg p-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                    class="group hover:bg-surface-700/40 focus-visible:ring-primary-500 focus-visible:ring-offset-surface-800 -m-1.5 flex min-w-0 flex-1 cursor-pointer items-center gap-2.5 rounded-lg p-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                     @click="toggleMapPanelVisibility"
                   >
                     <span
-                      class="bg-primary-500/15 border-primary-500/25 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border"
+                      class="bg-primary-500/15 border-primary-500/25 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
                     >
                       <UIcon
                         name="i-mdi-map-marker-radius-outline"
-                        class="text-primary-300 h-4 w-4"
+                        class="text-primary-300 h-4.5 w-4.5"
                       />
                     </span>
-                    <span class="min-w-0 flex-1 space-y-1.5">
-                      <span class="flex min-w-0 items-center gap-2">
-                        <h3 class="text-surface-100 truncate text-lg leading-tight font-semibold">
-                          {{ selectedMapData?.name || t('tasks.view.map') }}
-                        </h3>
+                    <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1.5">
+                      <h3 class="text-surface-100 truncate text-base leading-tight font-semibold">
+                        {{ selectedMapData?.name || t('tasks.view.map') }}
+                      </h3>
+                      <AppTooltip
+                        :text="t('page.tasks.map.raid_time_tooltip')"
+                        :content="{ side: 'bottom' }"
+                      >
                         <span
-                          class="text-surface-400 border-surface-700 bg-surface-800/60 group-hover:text-surface-100 inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-semibold whitespace-nowrap transition-colors"
+                          class="bg-surface-900/50 inline-flex items-center gap-1.5 rounded-full border border-white/8 px-2.5 py-1"
                         >
-                          <UIcon
-                            :name="isMapPanelExpanded ? 'i-mdi-chevron-up' : 'i-mdi-chevron-down'"
-                            class="h-3.5 w-3.5 transition-transform duration-200"
-                          />
-                          {{
-                            isMapPanelExpanded
-                              ? t('page.tasks.map.hide_map')
-                              : t('page.tasks.map.show_map')
-                          }}
+                          <template
+                            v-for="(entry, index) in mapTimeEntries"
+                            :key="`${entry.value}-${index}`"
+                          >
+                            <span v-if="index > 0" class="h-3 w-px bg-white/10" />
+                            <span class="flex items-center gap-1 text-[11px]">
+                              <UIcon
+                                :name="entry.icon"
+                                :class="['h-3.5 w-3.5 shrink-0', clockEntryIconClass(entry.period)]"
+                              />
+                              <span
+                                class="tracking-wide uppercase"
+                                :class="clockEntryLabelClass(entry.period)"
+                              >
+                                {{ getMapTimeLabel(entry.period) }}
+                              </span>
+                              <span
+                                class="tabular-nums"
+                                :class="clockEntryValueClass(entry.period)"
+                              >
+                                {{ entry.value }}
+                              </span>
+                            </span>
+                          </template>
                         </span>
-                      </span>
-                      <span class="flex flex-wrap items-center gap-2">
-                        <span
-                          v-for="(entry, index) in mapTimeEntries"
-                          :key="`${entry.value}-${index}`"
-                          class="inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-semibold"
-                          :class="entry.badgeClass"
-                        >
-                          <UIcon
-                            :name="entry.icon"
-                            :class="['h-4 w-4 shrink-0', entry.iconClass]"
-                          />
-                          <span class="tracking-wide uppercase" :class="entry.labelClass">
-                            {{ getMapTimeLabel(entry.period) }}
-                          </span>
-                          <span class="tabular-nums" :class="entry.valueClass">
-                            {{ entry.value }}
-                          </span>
-                        </span>
+                      </AppTooltip>
+                      <span v-if="!isMapPanelExpanded" class="text-surface-500 text-xs font-medium">
+                        {{ t('page.tasks.map.map_hidden_hint') }}
                       </span>
                     </span>
                   </button>
-                  <UButton
-                    data-testid="map-fullscreen-toggle"
-                    icon="i-mdi-fullscreen"
-                    variant="ghost"
-                    color="neutral"
-                    size="xs"
-                    :aria-label="
-                      isMapFullscreen
-                        ? t('page.tasks.map.exit_fullscreen')
-                        : t('page.tasks.map.open_fullscreen')
+                  <AppTooltip
+                    :text="
+                      isMapPanelExpanded
+                        ? t('page.tasks.map.hide_map')
+                        : t('page.tasks.map.show_map')
                     "
-                    :title="
-                      isMapFullscreen
-                        ? t('page.tasks.map.exit_fullscreen')
-                        : t('page.tasks.map.open_fullscreen')
-                    "
-                    class="mt-0.5 shrink-0"
-                    @click="isMapFullscreen ? closeMapFullscreen() : openMapFullscreen()"
-                  />
+                  >
+                    <UButton
+                      data-testid="map-collapse-toggle"
+                      :icon="isMapPanelExpanded ? 'i-mdi-chevron-up' : 'i-mdi-chevron-down'"
+                      variant="ghost"
+                      color="neutral"
+                      size="sm"
+                      :aria-label="
+                        isMapPanelExpanded
+                          ? t('page.tasks.map.hide_map')
+                          : t('page.tasks.map.show_map')
+                      "
+                      class="h-8 w-8 shrink-0"
+                      :ui="{ leadingIcon: 'transition-transform duration-200' }"
+                      @click="toggleMapPanelVisibility"
+                    />
+                  </AppTooltip>
                 </div>
                 <Transition
                   enter-active-class="transition duration-150 ease-out"
@@ -108,24 +114,34 @@
                         :show-extracts="true"
                         :show-extract-toggle="true"
                         :show-legend="true"
+                        :show-fullscreen-toggle="true"
                         :height="mapHeight"
+                        @toggle-fullscreen="openMapFullscreen"
                       />
-                      <div
-                        ref="resizeHandleRef"
-                        role="separator"
-                        aria-orientation="horizontal"
-                        :aria-label="t('page.tasks.map.resize_handle')"
-                        :aria-valuemin="mapHeightMin"
-                        :aria-valuemax="mapHeightMax"
-                        :aria-valuenow="mapHeight"
-                        tabindex="0"
-                        class="bg-surface-900/60 border-surface-700 text-surface-400 hover:text-surface-200 focus-visible:ring-primary-500 focus-visible:ring-offset-surface-900 mt-3 flex h-8 w-full cursor-row-resize touch-none items-center justify-center rounded-md border transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-                        :class="{ 'ring-primary-500 text-surface-200 ring-1': isResizing }"
-                        @pointerdown="startResize"
-                        @keydown="onResizeKeydown"
+                      <AppTooltip
+                        :text="t('maps.tooltips.drag_to_resize')"
+                        :content="{ side: 'top' }"
                       >
-                        <UIcon name="i-mdi-drag-horizontal-variant" class="h-4 w-4" />
-                      </div>
+                        <div
+                          ref="resizeHandleRef"
+                          role="separator"
+                          aria-orientation="horizontal"
+                          :aria-label="t('page.tasks.map.resize_handle')"
+                          :aria-valuemin="mapHeightMin"
+                          :aria-valuemax="mapHeightMax"
+                          :aria-valuenow="mapHeight"
+                          tabindex="0"
+                          class="group hover:border-primary-500/40 focus-visible:ring-primary-500 focus-visible:ring-offset-surface-900 mt-3 flex h-3.5 w-full cursor-ns-resize touch-none items-center justify-center rounded-md border border-transparent transition focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                          :class="{ 'ring-primary-500 ring-1': isResizing }"
+                          @pointerdown="startResize"
+                          @keydown="onResizeKeydown"
+                        >
+                          <span
+                            class="bg-surface-600 group-hover:bg-primary-400 h-1 w-8 rounded-full transition-colors"
+                            :class="{ 'bg-primary-400': isResizing }"
+                          />
+                        </div>
+                      </AppTooltip>
                     </template>
                     <UAlert
                       v-else
@@ -378,48 +394,66 @@
           <div
             class="bg-surface-900 border-surface-800 flex items-center justify-between gap-3 border-b px-4 py-3"
           >
-            <div class="flex min-w-0 items-center gap-2">
+            <div class="flex min-w-0 items-center gap-2.5">
               <span
-                class="bg-primary-500/15 border-primary-500/25 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border"
+                class="bg-primary-500/15 border-primary-500/25 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
               >
-                <UIcon name="i-mdi-map-marker-radius-outline" class="text-primary-300 h-4 w-4" />
+                <UIcon
+                  name="i-mdi-map-marker-radius-outline"
+                  class="text-primary-300 h-4.5 w-4.5"
+                />
               </span>
-              <h3 class="text-surface-100 truncate text-lg leading-tight font-semibold">
+              <h3 class="text-surface-100 truncate text-base leading-tight font-semibold">
                 {{ selectedMapData?.name || t('tasks.view.map') }}
               </h3>
               <span class="text-surface-500 hidden text-xs font-medium sm:inline">
                 {{ t('page.tasks.map.fullscreen_label') }}
               </span>
-            </div>
-            <div class="flex min-w-0 items-center gap-2">
-              <span
-                v-for="(entry, index) in mapTimeEntries"
-                :key="`fullscreen-${entry.value}-${index}`"
-                class="hidden items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-semibold md:inline-flex"
-                :class="entry.badgeClass"
+              <AppTooltip
+                :text="t('page.tasks.map.raid_time_tooltip')"
+                :content="{ side: 'bottom' }"
               >
-                <UIcon :name="entry.icon" :class="['h-4 w-4 shrink-0', entry.iconClass]" />
-                <span class="tracking-wide uppercase" :class="entry.labelClass">
-                  {{ getMapTimeLabel(entry.period) }}
+                <span
+                  class="bg-surface-950/60 hidden items-center gap-1.5 rounded-full border border-white/8 px-2.5 py-1 md:inline-flex"
+                >
+                  <template
+                    v-for="(entry, index) in mapTimeEntries"
+                    :key="`fullscreen-${entry.value}-${index}`"
+                  >
+                    <span v-if="index > 0" class="h-3 w-px bg-white/10" />
+                    <span class="flex items-center gap-1 text-[11px]">
+                      <UIcon
+                        :name="entry.icon"
+                        :class="['h-3.5 w-3.5 shrink-0', clockEntryIconClass(entry.period)]"
+                      />
+                      <span
+                        class="tracking-wide uppercase"
+                        :class="clockEntryLabelClass(entry.period)"
+                      >
+                        {{ getMapTimeLabel(entry.period) }}
+                      </span>
+                      <span class="tabular-nums" :class="clockEntryValueClass(entry.period)">
+                        {{ entry.value }}
+                      </span>
+                    </span>
+                  </template>
                 </span>
-                <span class="tabular-nums" :class="entry.valueClass">
-                  {{ entry.value }}
-                </span>
-              </span>
+              </AppTooltip>
+            </div>
+            <AppTooltip :text="t('maps.tooltips.exit_fullscreen')">
               <UButton
                 data-testid="map-fullscreen-exit"
                 icon="i-mdi-fullscreen-exit"
                 color="neutral"
                 variant="soft"
                 size="sm"
-                :aria-label="t('page.tasks.map.exit_fullscreen')"
+                class="h-8 w-8"
+                :aria-label="t('maps.tooltips.exit_fullscreen')"
                 @click="closeMapFullscreen"
-              >
-                {{ t('page.tasks.map.exit_fullscreen') }}
-              </UButton>
-            </div>
+              />
+            </AppTooltip>
           </div>
-          <div v-if="selectedMapData" class="min-h-0 flex-1">
+          <div v-if="selectedMapData" class="flex min-h-0 flex-1">
             <LeafletMapComponent
               ref="fullscreenLeafletMapRef"
               :map="selectedMapData"
@@ -427,8 +461,11 @@
               :show-extracts="true"
               :show-extract-toggle="true"
               :show-legend="true"
-              :height="fullscreenMapHeight"
+              :show-fullscreen-toggle="true"
+              :is-fullscreen="true"
+              fill
               :initial-view="fullscreenMapView"
+              @toggle-fullscreen="closeMapFullscreen"
             />
           </div>
         </div>
@@ -437,7 +474,7 @@
   </div>
 </template>
 <script setup lang="ts">
-  import { useScrollLock, useStorage, useWindowSize } from '@vueuse/core';
+  import { useScrollLock, useStorage } from '@vueuse/core';
   import { storeToRefs } from 'pinia';
   import {
     type DashboardFocusProgressInteraction,
@@ -558,6 +595,43 @@
   });
   const selectedMapId = computed(() => selectedMapData.value?.id ?? null);
   const { getMapTimeLabel, mapTimeEntries } = useMapTime(getTaskMapView, tarkovTime);
+  const MAP_CLOCK_ENTRY_STYLES: Record<string, { icon: string; label: string; value: string }> = {
+    dawn: {
+      icon: 'text-primary-300/80',
+      label: 'text-primary-300/70',
+      value: 'text-primary-200/85',
+    },
+    day: {
+      icon: 'text-warning-300/80',
+      label: 'text-warning-300/70',
+      value: 'text-warning-200/85',
+    },
+    dusk: {
+      icon: 'text-warning-300/70',
+      label: 'text-warning-300/60',
+      value: 'text-warning-200/80',
+    },
+    night: {
+      icon: 'text-info-300/80',
+      label: 'text-info-300/70',
+      value: 'text-info-200/85',
+    },
+    default: {
+      icon: 'text-surface-300/80',
+      label: 'text-surface-300/70',
+      value: 'text-surface-200/85',
+    },
+  };
+  const DEFAULT_CLOCK_ENTRY_STYLE: { icon: string; label: string; value: string } = {
+    icon: 'text-surface-300/80',
+    label: 'text-surface-300/70',
+    value: 'text-surface-200/85',
+  };
+  const getClockEntryStyle = (period: string) =>
+    MAP_CLOCK_ENTRY_STYLES[period] ?? DEFAULT_CLOCK_ENTRY_STYLE;
+  const clockEntryIconClass = (period: string) => getClockEntryStyle(period).icon;
+  const clockEntryLabelClass = (period: string) => getClockEntryStyle(period).label;
+  const clockEntryValueClass = (period: string) => getClockEntryStyle(period).value;
   const {
     mapHeight,
     mapHeightMax,
@@ -609,13 +683,6 @@
     leafletMapRef,
     mapContainerRef,
   });
-  const { height: windowHeight } = useWindowSize();
-  const FULLSCREEN_HEADER_HEIGHT = 68;
-  const fullscreenMapHeight = computed(() => {
-    const height = windowHeight.value;
-    if (!height) return undefined;
-    return Math.max(320, Math.round(height - FULLSCREEN_HEADER_HEIGHT));
-  });
   const fullscreenLeafletMapRef = ref<MapComponentRef | null>(null);
   const fullscreenMapView = ref<MapViewState | null>(null);
   const isMapFullscreen = ref(false);
@@ -638,7 +705,6 @@
   let fullscreenOpenerElement: HTMLElement | null = null;
   const openMapFullscreen = () => {
     fullscreenMapView.value = leafletMapRef.value?.getViewState?.() ?? null;
-    isMapPanelExpanded.value = true;
     isMapFullscreen.value = true;
   };
   const closeMapFullscreen = () => {

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -384,13 +384,13 @@
         leave-from-class="opacity-100"
         leave-to-class="opacity-0"
       >
-        <div
+        <dialog
           v-if="isMapFullscreen"
+          open
           data-testid="map-fullscreen-overlay"
-          role="dialog"
           aria-modal="true"
           :aria-label="t('page.tasks.map.fullscreen_label')"
-          class="bg-surface-950 fixed inset-0 z-100 flex flex-col"
+          class="bg-surface-950 text-surface-200 fixed inset-0 z-100 flex h-full max-h-none w-full max-w-none flex-col"
         >
           <div
             class="bg-surface-900 border-surface-800 flex items-center justify-between gap-3 border-b px-4 py-3"
@@ -469,7 +469,7 @@
               @toggle-fullscreen="closeMapFullscreen"
             />
           </div>
-        </div>
+        </dialog>
       </Transition>
     </Teleport>
   </div>
@@ -753,11 +753,18 @@
     fullscreenMapView.value = null;
     if (overlayView) restoreInlineMapView(overlayView);
   };
+  const PORTALLED_POPOVER_SELECTOR = '[data-reka-popper-content-wrapper]';
   const isFocusInsidePortalledPopover = (): boolean => {
     const activeElement = document.activeElement;
     if (!(activeElement instanceof HTMLElement)) return false;
-    return Boolean(activeElement.closest('[data-reka-popper-content-wrapper]'));
+    return Boolean(activeElement.closest(PORTALLED_POPOVER_SELECTOR));
   };
+  const isPopoverLayerOpen = (): boolean =>
+    Boolean(
+      document.querySelector(`${PORTALLED_POPOVER_SELECTOR} [role="dialog"][data-state="open"]`)
+    );
+  const shouldCloseOnEscape = (event: KeyboardEvent): boolean =>
+    !event.defaultPrevented && !isPopoverLayerOpen();
   const resolveFullscreenTabTarget = (
     event: KeyboardEvent,
     overlay: HTMLElement
@@ -778,13 +785,12 @@
     target.focus();
   };
   const handleFullscreenKeydown = (event: KeyboardEvent) => {
-    if (event.key === 'Escape') {
-      if (event.defaultPrevented) return;
-      closeMapFullscreen();
-      return;
-    }
     if (event.key === 'Tab') {
       trapFullscreenTab(event);
+      return;
+    }
+    if (event.key === 'Escape' && shouldCloseOnEscape(event)) {
+      closeMapFullscreen();
     }
   };
   const bodyScrollLock = useScrollLock(document.body);

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -14,49 +14,81 @@
             <div v-if="showMapDisplay" ref="mapContainerRef" class="mb-6">
               <div class="bg-surface-800/50 rounded-lg p-4">
                 <div class="mb-3 flex items-start justify-between gap-3">
-                  <div class="min-w-0 space-y-2">
-                    <div class="flex min-w-0 items-center gap-2">
-                      <span
-                        class="bg-primary-500/15 border-primary-500/25 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border"
-                      >
-                        <UIcon
-                          name="i-mdi-map-marker-radius-outline"
-                          class="text-primary-300 h-4 w-4"
-                        />
-                      </span>
-                      <h3 class="text-surface-100 truncate text-lg leading-tight font-semibold">
-                        {{ selectedMapData?.name || t('tasks.view.map') }}
-                      </h3>
-                    </div>
-                    <div class="flex flex-wrap items-center gap-2">
-                      <span
-                        v-for="(entry, index) in mapTimeEntries"
-                        :key="`${entry.value}-${index}`"
-                        class="inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-semibold"
-                        :class="entry.badgeClass"
-                      >
-                        <UIcon :name="entry.icon" :class="['h-4 w-4 shrink-0', entry.iconClass]" />
-                        <span class="tracking-wide uppercase" :class="entry.labelClass">
-                          {{ getMapTimeLabel(entry.period) }}
-                        </span>
-                        <span class="tabular-nums" :class="entry.valueClass">
-                          {{ entry.value }}
-                        </span>
-                      </span>
-                    </div>
-                  </div>
-                  <UButton
+                  <button
+                    type="button"
                     data-testid="map-panel-toggle"
-                    icon="i-mdi-chevron-down"
+                    :aria-expanded="isMapPanelExpanded"
+                    aria-controls="tasks-map-panel-content"
+                    :aria-label="t('page.tasks.map.toggle_panel')"
+                    class="hover:bg-surface-800/40 focus-visible:ring-primary-500 focus-visible:ring-offset-surface-800 group -m-1.5 flex min-w-0 flex-1 cursor-pointer items-start gap-2.5 rounded-lg p-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                    @click="toggleMapPanelVisibility"
+                  >
+                    <span
+                      class="bg-primary-500/15 border-primary-500/25 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border"
+                    >
+                      <UIcon
+                        name="i-mdi-map-marker-radius-outline"
+                        class="text-primary-300 h-4 w-4"
+                      />
+                    </span>
+                    <span class="min-w-0 flex-1 space-y-1.5">
+                      <span class="flex min-w-0 items-center gap-2">
+                        <h3 class="text-surface-100 truncate text-lg leading-tight font-semibold">
+                          {{ selectedMapData?.name || t('tasks.view.map') }}
+                        </h3>
+                        <span
+                          class="text-surface-400 border-surface-700 bg-surface-800/60 group-hover:text-surface-100 inline-flex shrink-0 items-center gap-1 rounded-md border px-2 py-0.5 text-[11px] font-semibold whitespace-nowrap transition-colors"
+                        >
+                          <UIcon
+                            :name="isMapPanelExpanded ? 'i-mdi-chevron-up' : 'i-mdi-chevron-down'"
+                            class="h-3.5 w-3.5 transition-transform duration-200"
+                          />
+                          {{
+                            isMapPanelExpanded
+                              ? t('page.tasks.map.hide_map')
+                              : t('page.tasks.map.show_map')
+                          }}
+                        </span>
+                      </span>
+                      <span class="flex flex-wrap items-center gap-2">
+                        <span
+                          v-for="(entry, index) in mapTimeEntries"
+                          :key="`${entry.value}-${index}`"
+                          class="inline-flex items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-semibold"
+                          :class="entry.badgeClass"
+                        >
+                          <UIcon
+                            :name="entry.icon"
+                            :class="['h-4 w-4 shrink-0', entry.iconClass]"
+                          />
+                          <span class="tracking-wide uppercase" :class="entry.labelClass">
+                            {{ getMapTimeLabel(entry.period) }}
+                          </span>
+                          <span class="tabular-nums" :class="entry.valueClass">
+                            {{ entry.value }}
+                          </span>
+                        </span>
+                      </span>
+                    </span>
+                  </button>
+                  <UButton
+                    data-testid="map-fullscreen-toggle"
+                    icon="i-mdi-fullscreen"
                     variant="ghost"
                     color="neutral"
                     size="xs"
-                    :aria-label="t('page.tasks.map.toggle_panel')"
-                    :aria-expanded="isMapPanelExpanded"
-                    aria-controls="tasks-map-panel-content"
-                    :class="{ 'rotate-180': isMapPanelExpanded }"
-                    class="mt-0.5 shrink-0 transition-transform duration-200"
-                    @click="toggleMapPanelVisibility"
+                    :aria-label="
+                      isMapFullscreen
+                        ? t('page.tasks.map.exit_fullscreen')
+                        : t('page.tasks.map.open_fullscreen')
+                    "
+                    :title="
+                      isMapFullscreen
+                        ? t('page.tasks.map.exit_fullscreen')
+                        : t('page.tasks.map.open_fullscreen')
+                    "
+                    class="mt-0.5 shrink-0"
+                    @click="isMapFullscreen ? closeMapFullscreen() : openMapFullscreen()"
                   />
                 </div>
                 <Transition
@@ -326,10 +358,86 @@
         </div>
       </Transition>
     </Teleport>
+    <Teleport to="body">
+      <Transition
+        enter-active-class="transition duration-200 ease-out"
+        enter-from-class="opacity-0"
+        enter-to-class="opacity-100"
+        leave-active-class="transition duration-150 ease-in"
+        leave-from-class="opacity-100"
+        leave-to-class="opacity-0"
+      >
+        <div
+          v-if="isMapFullscreen"
+          data-testid="map-fullscreen-overlay"
+          role="dialog"
+          aria-modal="true"
+          :aria-label="t('page.tasks.map.fullscreen_label')"
+          class="bg-surface-950 fixed inset-0 z-[100] flex flex-col"
+        >
+          <div
+            class="bg-surface-900 border-surface-800 flex items-center justify-between gap-3 border-b px-4 py-3"
+          >
+            <div class="flex min-w-0 items-center gap-2">
+              <span
+                class="bg-primary-500/15 border-primary-500/25 inline-flex h-7 w-7 shrink-0 items-center justify-center rounded-md border"
+              >
+                <UIcon name="i-mdi-map-marker-radius-outline" class="text-primary-300 h-4 w-4" />
+              </span>
+              <h3 class="text-surface-100 truncate text-lg leading-tight font-semibold">
+                {{ selectedMapData?.name || t('tasks.view.map') }}
+              </h3>
+              <span class="text-surface-500 hidden text-xs font-medium sm:inline">
+                {{ t('page.tasks.map.fullscreen_label') }}
+              </span>
+            </div>
+            <div class="flex min-w-0 items-center gap-2">
+              <span
+                v-for="(entry, index) in mapTimeEntries"
+                :key="`fullscreen-${entry.value}-${index}`"
+                class="hidden items-center gap-2 rounded-md border px-2.5 py-1 text-xs font-semibold md:inline-flex"
+                :class="entry.badgeClass"
+              >
+                <UIcon :name="entry.icon" :class="['h-4 w-4 shrink-0', entry.iconClass]" />
+                <span class="tracking-wide uppercase" :class="entry.labelClass">
+                  {{ getMapTimeLabel(entry.period) }}
+                </span>
+                <span class="tabular-nums" :class="entry.valueClass">
+                  {{ entry.value }}
+                </span>
+              </span>
+              <UButton
+                data-testid="map-fullscreen-exit"
+                icon="i-mdi-fullscreen-exit"
+                color="neutral"
+                variant="soft"
+                size="sm"
+                :aria-label="t('page.tasks.map.exit_fullscreen')"
+                @click="closeMapFullscreen"
+              >
+                {{ t('page.tasks.map.exit_fullscreen') }}
+              </UButton>
+            </div>
+          </div>
+          <div v-if="selectedMapData" class="min-h-0 flex-1">
+            <LeafletMapComponent
+              ref="fullscreenLeafletMapRef"
+              :map="selectedMapData"
+              :marks="mapObjectiveMarks"
+              :show-extracts="true"
+              :show-extract-toggle="true"
+              :show-legend="true"
+              :height="fullscreenMapHeight"
+              :initial-view="fullscreenMapView"
+            />
+          </div>
+        </div>
+      </Transition>
+    </Teleport>
   </div>
 </template>
 <script setup lang="ts">
-  import { useStorage } from '@vueuse/core';
+  import { useScrollLock, useStorage, useWindowSize } from '@vueuse/core';
   import { storeToRefs } from 'pinia';
   import {
     type DashboardFocusProgressInteraction,
@@ -460,8 +568,12 @@
     stopResize,
     onResizeKeydown,
   } = useMapResize();
-  const isMapPanelExpanded = useStorage<boolean>(STORAGE_KEYS.tasksMapPanelExpanded, false);
+  const isMapPanelExpanded = useStorage<boolean>(STORAGE_KEYS.tasksMapPanelExpanded, true);
   const toggleMapPanelVisibility = () => {
+    if (isMapFullscreen.value) {
+      closeMapFullscreen();
+      return;
+    }
     if (isMapPanelExpanded.value) {
       stopResize();
     }
@@ -485,13 +597,54 @@
     return new Set(filteredTasks.map((task) => task.id));
   });
   const mapContainerRef = ref<HTMLElement | null>(null);
-  const leafletMapRef = ref<{
+  type MapViewState = { center: [number, number]; zoom: number };
+  interface MapComponentRef {
     activateObjectivePopup: (id: string) => boolean;
     closeActivePopup: () => void;
-  } | null>(null);
+    getViewState?: () => MapViewState | null;
+    setViewState?: (state: MapViewState) => void;
+  }
+  const leafletMapRef = ref<MapComponentRef | null>(null);
   const { jumpToMapObjective, cleanup: cleanupMapPopup } = useMapObjectivePopup({
     leafletMapRef,
     mapContainerRef,
+  });
+  const { height: windowHeight } = useWindowSize();
+  const FULLSCREEN_HEADER_HEIGHT = 68;
+  const fullscreenMapHeight = computed(() => {
+    const height = windowHeight.value;
+    if (!height) return undefined;
+    return Math.max(320, Math.round(height - FULLSCREEN_HEADER_HEIGHT));
+  });
+  const fullscreenLeafletMapRef = ref<MapComponentRef | null>(null);
+  const fullscreenMapView = ref<MapViewState | null>(null);
+  const isMapFullscreen = ref(false);
+  const openMapFullscreen = () => {
+    fullscreenMapView.value = leafletMapRef.value?.getViewState?.() ?? null;
+    isMapPanelExpanded.value = true;
+    isMapFullscreen.value = true;
+  };
+  const closeMapFullscreen = () => {
+    const overlayView = fullscreenLeafletMapRef.value?.getViewState?.() ?? null;
+    isMapFullscreen.value = false;
+    fullscreenMapView.value = null;
+    if (overlayView && leafletMapRef.value?.setViewState) {
+      leafletMapRef.value.setViewState(overlayView);
+    }
+  };
+  const handleFullscreenKeydown = (event: KeyboardEvent) => {
+    if (event.key === 'Escape' && isMapFullscreen.value) {
+      closeMapFullscreen();
+    }
+  };
+  const bodyScrollLock = useScrollLock(document.body);
+  watch(isMapFullscreen, (isActive) => {
+    bodyScrollLock.value = isActive;
+    if (isActive) {
+      window.addEventListener('keydown', handleFullscreenKeydown);
+    } else {
+      window.removeEventListener('keydown', handleFullscreenKeydown);
+    }
   });
   const handleJumpToMapObjective = async (objectiveId: string) => {
     isMapPanelExpanded.value = true;
@@ -727,5 +880,8 @@
     cleanupMapPopup();
     cleanupNotification();
     cleanupDeepLink();
+    isMapFullscreen.value = false;
+    bodyScrollLock.value = false;
+    window.removeEventListener('keydown', handleFullscreenKeydown);
   });
 </script>

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -21,7 +21,6 @@
                         data-testid="map-panel-toggle"
                         :aria-expanded="isMapPanelExpanded"
                         aria-controls="tasks-map-panel-content"
-                        :aria-label="t('page.tasks.map.toggle_panel')"
                         class="group hover:bg-surface-700/40 focus-visible:ring-primary-500 focus-visible:ring-offset-surface-800 -m-1.5 flex min-w-0 cursor-pointer items-center gap-2.5 rounded-lg p-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
                         @click="toggleMapPanelVisibility"
                       >
@@ -87,6 +86,8 @@
                       variant="ghost"
                       color="neutral"
                       size="sm"
+                      :aria-expanded="isMapPanelExpanded"
+                      aria-controls="tasks-map-panel-content"
                       :aria-label="
                         isMapPanelExpanded
                           ? t('page.tasks.map.hide_map')
@@ -736,6 +737,8 @@
     });
     inertBackgroundElements = [];
   };
+  const isInInertBackground = (element: HTMLElement): boolean =>
+    inertBackgroundElements.some((background) => background.contains(element));
   const readFullscreenMapView = (): MapViewState | null =>
     fullscreenLeafletMapRef.value?.getViewState?.() ?? null;
   const restoreInlineMapView = (view: MapViewState): void => {
@@ -751,7 +754,7 @@
     const overlayView = readFullscreenMapView();
     isMapFullscreen.value = false;
     fullscreenMapView.value = null;
-    if (overlayView) restoreInlineMapView(overlayView);
+    if (overlayView) nextTick(() => restoreInlineMapView(overlayView));
   };
   const PORTALLED_POPOVER_SELECTOR = '[data-reka-popper-content-wrapper]';
   const isFocusInsidePortalledPopover = (): boolean => {
@@ -759,10 +762,12 @@
     if (!(activeElement instanceof HTMLElement)) return false;
     return Boolean(activeElement.closest(PORTALLED_POPOVER_SELECTOR));
   };
-  const isPopoverLayerOpen = (): boolean =>
-    Boolean(
-      document.querySelector(`${PORTALLED_POPOVER_SELECTOR} [role="dialog"][data-state="open"]`)
+  const isPopoverLayerOpen = (): boolean => {
+    const layers = document.querySelectorAll<HTMLElement>(
+      `${PORTALLED_POPOVER_SELECTOR} [role="dialog"][data-state="open"]`
     );
+    return Array.from(layers).some((layer) => !isInInertBackground(layer));
+  };
   const shouldCloseOnEscape = (event: KeyboardEvent): boolean =>
     !event.defaultPrevented && !isPopoverLayerOpen();
   const resolveFullscreenTabTarget = (

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -619,6 +619,23 @@
   const fullscreenLeafletMapRef = ref<MapComponentRef | null>(null);
   const fullscreenMapView = ref<MapViewState | null>(null);
   const isMapFullscreen = ref(false);
+  const FULLSCREEN_OVERLAY_SELECTOR = '[data-testid="map-fullscreen-overlay"]';
+  const getFullscreenOverlay = (): HTMLElement | null =>
+    document.querySelector<HTMLElement>(FULLSCREEN_OVERLAY_SELECTOR);
+  const FULLSCREEN_FOCUSABLE_SELECTOR = [
+    'a[href]',
+    'button:not([disabled])',
+    'input:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    '[tabindex]:not([tabindex="-1"])',
+  ].join(',');
+  const getFullscreenFocusableElements = (container: HTMLElement): HTMLElement[] => {
+    return Array.from(
+      container.querySelectorAll<HTMLElement>(FULLSCREEN_FOCUSABLE_SELECTOR)
+    ).filter((element) => element.getAttribute('aria-hidden') !== 'true');
+  };
+  let fullscreenOpenerElement: HTMLElement | null = null;
   const openMapFullscreen = () => {
     fullscreenMapView.value = leafletMapRef.value?.getViewState?.() ?? null;
     isMapPanelExpanded.value = true;
@@ -633,17 +650,49 @@
     }
   };
   const handleFullscreenKeydown = (event: KeyboardEvent) => {
-    if (event.key === 'Escape' && isMapFullscreen.value) {
+    if (event.key === 'Escape') {
       closeMapFullscreen();
+      return;
+    }
+    if (event.key !== 'Tab') return;
+    const overlay = getFullscreenOverlay();
+    if (!overlay) return;
+    const focusable = getFullscreenFocusableElements(overlay);
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (!first || !last) {
+      event.preventDefault();
+      return;
+    }
+    const activeElement = document.activeElement;
+    if (event.shiftKey) {
+      if (activeElement === first || !overlay.contains(activeElement)) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (activeElement === last || !overlay.contains(activeElement)) {
+      event.preventDefault();
+      first.focus();
     }
   };
   const bodyScrollLock = useScrollLock(document.body);
   watch(isMapFullscreen, (isActive) => {
     bodyScrollLock.value = isActive;
     if (isActive) {
+      fullscreenOpenerElement =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
       window.addEventListener('keydown', handleFullscreenKeydown);
+      nextTick(() => {
+        getFullscreenOverlay()
+          ?.querySelector<HTMLElement>('[data-testid="map-fullscreen-exit"]')
+          ?.focus();
+      });
     } else {
       window.removeEventListener('keydown', handleFullscreenKeydown);
+      if (fullscreenOpenerElement) {
+        fullscreenOpenerElement.focus();
+        fullscreenOpenerElement = null;
+      }
     }
   });
   const handleJumpToMapObjective = async (objectiveId: string) => {
@@ -882,6 +931,7 @@
     cleanupDeepLink();
     isMapFullscreen.value = false;
     bodyScrollLock.value = false;
+    fullscreenOpenerElement = null;
     window.removeEventListener('keydown', handleFullscreenKeydown);
   });
 </script>

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -515,6 +515,7 @@
   import { STORAGE_KEYS } from '@/utils/storageKeys';
   import { getTaskSecondaryViewForPrimaryView } from '@/utils/taskFilterNormalization';
   import { buildTaskTypeFilterOptions, filterTasksByTypeSettings } from '@/utils/taskTypeFilters';
+  import type { MapViewState } from '@/composables/useLeafletMap';
   import type { TaskActionPayload } from '@/composables/useTaskActions';
   import type { Task } from '@/types/tarkov';
   import type {
@@ -597,7 +598,18 @@
   });
   const selectedMapId = computed(() => selectedMapData.value?.id ?? null);
   const { getMapTimeLabel, mapTimeEntries } = useMapTime(getTaskMapView, tarkovTime);
-  const MAP_CLOCK_ENTRY_STYLES: Record<string, { icon: string; label: string; value: string }> = {
+  type MapClockPeriod = 'dawn' | 'day' | 'dusk' | 'night' | 'default';
+  interface ClockEntryStyle {
+    icon: string;
+    label: string;
+    value: string;
+  }
+  const DEFAULT_CLOCK_ENTRY_STYLE: ClockEntryStyle = {
+    icon: 'text-surface-300/80',
+    label: 'text-surface-300/70',
+    value: 'text-surface-200/85',
+  };
+  const MAP_CLOCK_ENTRY_STYLES: Record<MapClockPeriod, ClockEntryStyle> = {
     dawn: {
       icon: 'text-primary-300/80',
       label: 'text-primary-300/70',
@@ -618,19 +630,10 @@
       label: 'text-info-300/70',
       value: 'text-info-200/85',
     },
-    default: {
-      icon: 'text-surface-300/80',
-      label: 'text-surface-300/70',
-      value: 'text-surface-200/85',
-    },
+    default: DEFAULT_CLOCK_ENTRY_STYLE,
   };
-  const DEFAULT_CLOCK_ENTRY_STYLE: { icon: string; label: string; value: string } = {
-    icon: 'text-surface-300/80',
-    label: 'text-surface-300/70',
-    value: 'text-surface-200/85',
-  };
-  const getClockEntryStyle = (period: string) =>
-    MAP_CLOCK_ENTRY_STYLES[period] ?? DEFAULT_CLOCK_ENTRY_STYLE;
+  const getClockEntryStyle = (period: string): ClockEntryStyle =>
+    MAP_CLOCK_ENTRY_STYLES[period as MapClockPeriod] ?? DEFAULT_CLOCK_ENTRY_STYLE;
   const clockEntryIconClass = (period: string) => getClockEntryStyle(period).icon;
   const clockEntryLabelClass = (period: string) => getClockEntryStyle(period).label;
   const clockEntryValueClass = (period: string) => getClockEntryStyle(period).value;
@@ -673,7 +676,6 @@
     return new Set(filteredTasks.map((task) => task.id));
   });
   const mapContainerRef = ref<HTMLElement | null>(null);
-  type MapViewState = { center: [number, number]; zoom: number };
   interface MapComponentRef {
     activateObjectivePopup: (id: string) => boolean;
     closeActivePopup: () => void;

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -14,65 +14,66 @@
             <div v-if="showMapDisplay" ref="mapContainerRef" class="mb-6">
               <div class="bg-surface-800/50 rounded-lg p-4">
                 <div class="mb-3 flex items-center justify-between gap-3">
-                  <button
-                    type="button"
-                    data-testid="map-panel-toggle"
-                    :aria-expanded="isMapPanelExpanded"
-                    aria-controls="tasks-map-panel-content"
-                    :aria-label="t('page.tasks.map.toggle_panel')"
-                    class="group hover:bg-surface-700/40 focus-visible:ring-primary-500 focus-visible:ring-offset-surface-800 -m-1.5 flex min-w-0 flex-1 cursor-pointer items-center gap-2.5 rounded-lg p-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
-                    @click="toggleMapPanelVisibility"
-                  >
-                    <span
-                      class="bg-primary-500/15 border-primary-500/25 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
-                    >
-                      <UIcon
-                        name="i-mdi-map-marker-radius-outline"
-                        class="text-primary-300 h-4.5 w-4.5"
-                      />
-                    </span>
-                    <span class="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1.5">
-                      <h3 class="text-surface-100 truncate text-base leading-tight font-semibold">
-                        {{ selectedMapData?.name || t('tasks.view.map') }}
-                      </h3>
-                      <AppTooltip
-                        :text="t('page.tasks.map.raid_time_tooltip')"
-                        :content="{ side: 'bottom' }"
+                  <div class="flex min-w-0 flex-1 flex-wrap items-center gap-x-3 gap-y-1.5">
+                    <h3 class="min-w-0 flex-1">
+                      <button
+                        type="button"
+                        data-testid="map-panel-toggle"
+                        :aria-expanded="isMapPanelExpanded"
+                        aria-controls="tasks-map-panel-content"
+                        :aria-label="t('page.tasks.map.toggle_panel')"
+                        class="group hover:bg-surface-700/40 focus-visible:ring-primary-500 focus-visible:ring-offset-surface-800 -m-1.5 flex min-w-0 cursor-pointer items-center gap-2.5 rounded-lg p-1.5 text-left transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+                        @click="toggleMapPanelVisibility"
                       >
                         <span
-                          class="bg-surface-900/50 inline-flex items-center gap-1.5 rounded-full border border-white/8 px-2.5 py-1"
+                          class="bg-primary-500/15 border-primary-500/25 inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-md border"
                         >
-                          <template
-                            v-for="(entry, index) in mapTimeEntries"
-                            :key="`${entry.value}-${index}`"
-                          >
-                            <span v-if="index > 0" class="h-3 w-px bg-white/10" />
-                            <span class="flex items-center gap-1 text-[11px]">
-                              <UIcon
-                                :name="entry.icon"
-                                :class="['h-3.5 w-3.5 shrink-0', clockEntryIconClass(entry.period)]"
-                              />
-                              <span
-                                class="tracking-wide uppercase"
-                                :class="clockEntryLabelClass(entry.period)"
-                              >
-                                {{ getMapTimeLabel(entry.period) }}
-                              </span>
-                              <span
-                                class="tabular-nums"
-                                :class="clockEntryValueClass(entry.period)"
-                              >
-                                {{ entry.value }}
-                              </span>
-                            </span>
-                          </template>
+                          <UIcon
+                            name="i-mdi-map-marker-radius-outline"
+                            class="text-primary-300 h-4.5 w-4.5"
+                          />
                         </span>
-                      </AppTooltip>
-                      <span v-if="!isMapPanelExpanded" class="text-surface-500 text-xs font-medium">
-                        {{ t('page.tasks.map.map_hidden_hint') }}
+                        <span
+                          class="text-surface-100 truncate text-base leading-tight font-semibold"
+                        >
+                          {{ selectedMapData?.name || t('tasks.view.map') }}
+                        </span>
+                      </button>
+                    </h3>
+                    <AppTooltip
+                      :text="t('page.tasks.map.raid_time_tooltip')"
+                      :content="{ side: 'bottom' }"
+                    >
+                      <span
+                        class="bg-surface-900/50 inline-flex items-center gap-1.5 rounded-full border border-white/8 px-2.5 py-1"
+                      >
+                        <template
+                          v-for="(entry, index) in mapTimeEntries"
+                          :key="`${entry.value}-${index}`"
+                        >
+                          <span v-if="index > 0" class="h-3 w-px bg-white/10" />
+                          <span class="flex items-center gap-1 text-[11px]">
+                            <UIcon
+                              :name="entry.icon"
+                              :class="['h-3.5 w-3.5 shrink-0', clockEntryIconClass(entry.period)]"
+                            />
+                            <span
+                              class="tracking-wide uppercase"
+                              :class="clockEntryLabelClass(entry.period)"
+                            >
+                              {{ getMapTimeLabel(entry.period) }}
+                            </span>
+                            <span class="tabular-nums" :class="clockEntryValueClass(entry.period)">
+                              {{ entry.value }}
+                            </span>
+                          </span>
+                        </template>
                       </span>
+                    </AppTooltip>
+                    <span v-if="!isMapPanelExpanded" class="text-surface-500 text-xs font-medium">
+                      {{ t('page.tasks.map.map_hidden_hint') }}
                     </span>
-                  </button>
+                  </div>
                   <AppTooltip
                     :text="
                       isMapPanelExpanded
@@ -389,7 +390,7 @@
           role="dialog"
           aria-modal="true"
           :aria-label="t('page.tasks.map.fullscreen_label')"
-          class="bg-surface-950 fixed inset-0 z-[100] flex flex-col"
+          class="bg-surface-950 fixed inset-0 z-100 flex flex-col"
         >
           <div
             class="bg-surface-900 border-surface-800 flex items-center justify-between gap-3 border-b px-4 py-3"
@@ -703,42 +704,87 @@
     ).filter((element) => element.getAttribute('aria-hidden') !== 'true');
   };
   let fullscreenOpenerElement: HTMLElement | null = null;
+  let fullscreenMapId: string | null = null;
+  let inertBackgroundElements: HTMLElement[] = [];
+  const collectInertSiblings = (element: HTMLElement): HTMLElement[] => {
+    const parent = element.parentElement;
+    if (!parent) return [];
+    return Array.from(parent.children).filter(
+      (child): child is HTMLElement => child !== element && child instanceof HTMLElement
+    );
+  };
+  const collectFullscreenBackgroundElements = (overlay: HTMLElement): HTMLElement[] => {
+    const elements: HTMLElement[] = [];
+    let node: HTMLElement | null = overlay;
+    while (node && node !== document.body) {
+      elements.push(...collectInertSiblings(node));
+      node = node.parentElement;
+    }
+    return elements;
+  };
+  const applyFullscreenBackgroundInert = () => {
+    const overlay = getFullscreenOverlay();
+    if (!overlay) return;
+    inertBackgroundElements = collectFullscreenBackgroundElements(overlay);
+    inertBackgroundElements.forEach((element) => {
+      element.inert = true;
+    });
+  };
+  const clearFullscreenBackgroundInert = () => {
+    inertBackgroundElements.forEach((element) => {
+      element.inert = false;
+    });
+    inertBackgroundElements = [];
+  };
+  const readFullscreenMapView = (): MapViewState | null =>
+    fullscreenLeafletMapRef.value?.getViewState?.() ?? null;
+  const restoreInlineMapView = (view: MapViewState): void => {
+    if (fullscreenMapId !== selectedMapId.value) return;
+    leafletMapRef.value?.setViewState?.(view);
+  };
   const openMapFullscreen = () => {
+    fullscreenMapId = selectedMapId.value;
     fullscreenMapView.value = leafletMapRef.value?.getViewState?.() ?? null;
     isMapFullscreen.value = true;
   };
   const closeMapFullscreen = () => {
-    const overlayView = fullscreenLeafletMapRef.value?.getViewState?.() ?? null;
+    const overlayView = readFullscreenMapView();
     isMapFullscreen.value = false;
     fullscreenMapView.value = null;
-    if (overlayView && leafletMapRef.value?.setViewState) {
-      leafletMapRef.value.setViewState(overlayView);
-    }
+    if (overlayView) restoreInlineMapView(overlayView);
+  };
+  const isFocusInsidePortalledPopover = (): boolean => {
+    const activeElement = document.activeElement;
+    if (!(activeElement instanceof HTMLElement)) return false;
+    return Boolean(activeElement.closest('[data-reka-popper-content-wrapper]'));
+  };
+  const resolveFullscreenTabTarget = (
+    event: KeyboardEvent,
+    overlay: HTMLElement
+  ): HTMLElement | undefined => {
+    const focusable = getFullscreenFocusableElements(overlay);
+    const [edge, wrap] = event.shiftKey
+      ? [focusable[0], focusable[focusable.length - 1]]
+      : [focusable[focusable.length - 1], focusable[0]];
+    if (document.activeElement === edge) return wrap;
+    return overlay.contains(document.activeElement) ? undefined : wrap;
+  };
+  const trapFullscreenTab = (event: KeyboardEvent) => {
+    const overlay = getFullscreenOverlay();
+    if (!overlay || isFocusInsidePortalledPopover()) return;
+    const target = resolveFullscreenTabTarget(event, overlay);
+    if (!target) return;
+    event.preventDefault();
+    target.focus();
   };
   const handleFullscreenKeydown = (event: KeyboardEvent) => {
     if (event.key === 'Escape') {
+      if (event.defaultPrevented) return;
       closeMapFullscreen();
       return;
     }
-    if (event.key !== 'Tab') return;
-    const overlay = getFullscreenOverlay();
-    if (!overlay) return;
-    const focusable = getFullscreenFocusableElements(overlay);
-    const first = focusable[0];
-    const last = focusable[focusable.length - 1];
-    if (!first || !last) {
-      event.preventDefault();
-      return;
-    }
-    const activeElement = document.activeElement;
-    if (event.shiftKey) {
-      if (activeElement === first || !overlay.contains(activeElement)) {
-        event.preventDefault();
-        last.focus();
-      }
-    } else if (activeElement === last || !overlay.contains(activeElement)) {
-      event.preventDefault();
-      first.focus();
+    if (event.key === 'Tab') {
+      trapFullscreenTab(event);
     }
   };
   const bodyScrollLock = useScrollLock(document.body);
@@ -749,17 +795,23 @@
         document.activeElement instanceof HTMLElement ? document.activeElement : null;
       window.addEventListener('keydown', handleFullscreenKeydown);
       nextTick(() => {
+        applyFullscreenBackgroundInert();
         getFullscreenOverlay()
           ?.querySelector<HTMLElement>('[data-testid="map-fullscreen-exit"]')
           ?.focus();
       });
     } else {
+      clearFullscreenBackgroundInert();
       window.removeEventListener('keydown', handleFullscreenKeydown);
       if (fullscreenOpenerElement) {
         fullscreenOpenerElement.focus();
         fullscreenOpenerElement = null;
       }
     }
+  });
+  watch(showMapDisplay, (isMapView) => {
+    if (isMapView || !isMapFullscreen.value) return;
+    closeMapFullscreen();
   });
   const handleJumpToMapObjective = async (objectiveId: string) => {
     isMapPanelExpanded.value = true;
@@ -998,6 +1050,7 @@
     isMapFullscreen.value = false;
     bodyScrollLock.value = false;
     fullscreenOpenerElement = null;
+    clearFullscreenBackgroundInert();
     window.removeEventListener('keydown', handleFullscreenKeydown);
   });
 </script>


### PR DESCRIPTION
## What

Addresses #612 (maps hidden by default, reported by Niv) plus two follow-up UX requests:

1. **Map panel open by default** — `isMapPanelExpanded` default flipped from `false` to `true`, so the map is visible when entering the tasks map view. The user's fold/unfold choice is still persisted in localStorage (`v2_tasks_map_panel_expanded`), so deliberate collapses are remembered.

2. **Obvious, easy fold/unfold control** — the whole map header row (icon, map name, time badges) is now a `<button>` toggle with hover/focus feedback and `aria-expanded`/`aria-controls`, and a visible "Hide map / Show map" chip with a rotating chevron replaces the old tiny arrow button.

3. **Site-level fullscreen map** (not browser F11 fullscreen) — a new fullscreen icon button opens the map in a `Teleport` overlay that covers the entire site viewport (`fixed inset-0`, `role="dialog"`, body scroll-locked) with its own prominent **"Exit full screen"** button and Escape-to-exit. All map controls (floors, extracts/spawns, colors, settings, legend) and time badges are preserved, and the map **center/zoom is carried between the inline and fullscreen instances** (new `initialView` option in `useLeafletMap` + `getViewState`/`setViewState` exposed by `LeafletMap`), so exiting fullscreen leaves you exactly where you were.

## Validation

- `pnpm run typecheck`, `lint`, `lint:blank-lines`, `i18n:check` — all pass (exit 0)
- 54 tests pass across the tasks page, `useLeafletMap`, and maps feature suites; added coverage for:
  - default-expanded panel
  - row-toggle collapse/expand with new default
  - jump-to-objective from a stored collapsed state
  - fullscreen open/close and expand-from-collapsed
  - `initialView` restore vs. fitBounds fallback
- Manually verified in a real browser (dev server + Playwright): panel expanded by default, row click toggles with chip label switching, fullscreen overlay fills the viewport, exit button + Escape both close it, scroll lock engages/releases, view state syncs back on exit, 0 console errors.

## Notes

- Only `app/locales/en.json` edited (new `page.tasks.map.{show_map,hide_map,open_fullscreen,exit_fullscreen,fullscreen_label}` keys); other locales are Crowdin-owned.
- New icons `i-mdi-fullscreen` / `i-mdi-fullscreen-exit` are statically referenced, so they're bundled by the icon client bundle.

## Screenshots

Test on the deploy preview: Tasks → Maps view.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a redesigned map interface with improved floor, layer, color, settings, help, zoom, reset, and fullscreen controls.
  - Added fullscreen map viewing with preserved map position, keyboard navigation, focus management, and background interaction blocking.
  - Added restoration of saved map center and zoom, including support for fractional zoom levels.
  - Added first-use control hints with persistent dismissal.
  - Map panels now open expanded by default.

- **Bug Fixes**
  - Improved map resizing and fallback positioning when saved view data is unavailable or invalid.
  - Added clearer control states, tooltips, and accessibility messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR expands the task map by default and redesigns its controls, including a site-level fullscreen dialog that transfers map view and floor state.
- Adds explicit map-panel disclosure controls and persisted expansion state.
- Adds fullscreen map lifecycle, focus management, background inertness, and scroll locking.
- Adds map navigation controls, help UI, localization, and focused tests.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/pages/tasks.vue | Adds the default-expanded map panel and fullscreen dialog with state transfer, focus restoration, inert background handling, and cleanup. |
| app/features/maps/LeafletMap.vue | Redesigns map controls and exposes view and floor state needed for inline/fullscreen synchronization. |
| app/composables/useLeafletMap.ts | Adds validated initial-view restoration and fractional-zoom preservation while retaining bounds fallback. |
| app/pages/__tests__/tasks.page.test.ts | Covers panel defaults, fullscreen lifecycle, focus behavior, inertness, and map state transfer. |
| app/features/maps/__tests__/LeafletMapControlsComponent.test.ts | Covers the redesigned controls, persisted hints, and exposed map-state operations. |

</details>

<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Inline["Inline task map"] -->|"capture center, zoom, floor"| Fullscreen["Fullscreen map dialog"]
  Fullscreen -->|"restore center, zoom, floor"| Inline
  Fullscreen --> Focus["Focus trap and Escape handling"]
  Fullscreen --> Inert["Background inertness and scroll lock"]
```
</details>

<sub>Reviews (10): Last reviewed commit: ["fix(maps): sync map help seen flag acros..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/33cfcf4e4fe40efade7eaa5d5844c7d5514b1688) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53629695)</sub>

**Context used:**

- Knowledge Base — [Frontend App (Nuxt)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/frontend-app.md)

<!-- /greptile_comment -->