### PR TITLE
fix(admin): edge-cache promoted Twitch config with tag purge

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -221,7 +221,10 @@ Naming:
   `NUXT_PUBLIC_PROMOTED_TWITCH_ENABLED=true` directly enables the build-time fallback without an
   admin write. `public.app_settings` is service-role-only; `/api/twitch/config` resolves the
   admin-managed `promoted_twitch` override over that fallback, and `/api/admin/twitch-config` is the
-  only writer. See the Promoted Twitch configuration section of `docs/SYSTEMS.md`.
+  only writer. `/api/twitch/config` is edge-cached with the `promoted-twitch-config` tag and is
+  invalidated by the `admin-cache-purge` edge function (`twitch-config` purge type, tag purge with a
+  purge-by-URL fallback) after a committed admin update. See the Promoted Twitch configuration
+  section of `docs/SYSTEMS.md`.
 - Mock Supabase/network calls in tests. Keep tests deterministic.
 
 ## Error Handling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -223,8 +223,10 @@ Naming:
   admin-managed `promoted_twitch` override over that fallback, and `/api/admin/twitch-config` is the
   only writer. `/api/twitch/config` is edge-cached with the `promoted-twitch-config` tag and is
   invalidated by the `admin-cache-purge` edge function (`twitch-config` purge type, tag purge with a
-  purge-by-URL fallback) after a committed admin update. See the Promoted Twitch configuration
-  section of `docs/SYSTEMS.md`.
+  purge-by-URL fallback) after a committed admin update. Purge failures return the committed config
+  with an explicit warning flag so clients reconcile without repeating the write. Config responses
+  carry the settings version so stale browser cache entries cannot overwrite a newer admin save. See
+  the Promoted Twitch configuration section of `docs/SYSTEMS.md`.
 - Mock Supabase/network calls in tests. Keep tests deterministic.
 
 ## Error Handling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -224,8 +224,9 @@ Naming:
   only writer. `/api/twitch/config` is edge-cached with the `promoted-twitch-config` tag and is
   invalidated by the `admin-cache-purge` edge function after a committed admin update. A successful
   immediate tag purge (with purge-by-URL fallback) schedules the same purge six seconds later to
-  clear stale in-flight fills. Purge failures return the committed config with an explicit warning
-  flag so clients reconcile without repeating the write. Config responses carry the settings version
+  clear stale in-flight fills. Twitch-only purges use a distinct audit action so game-data cache
+  metadata never interprets them as Tarkov-data invalidations. Purge failures return the committed
+  config with an explicit warning flag so clients reconcile without repeating the write. Config responses carry the settings version
   so stale browser cache entries cannot overwrite a newer admin save. Mounted embeds refresh the
   config every five minutes while visible and on tab focus; those requests are served by the edge
   cache between fills. The admin form disables browser caching when loading config so it cannot

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,8 +225,9 @@ Naming:
   invalidated by the `admin-cache-purge` edge function (`twitch-config` purge type, tag purge with a
   purge-by-URL fallback) after a committed admin update. Purge failures return the committed config
   with an explicit warning flag so clients reconcile without repeating the write. Config responses
-  carry the settings version so stale browser cache entries cannot overwrite a newer admin save. See
-  the Promoted Twitch configuration section of `docs/SYSTEMS.md`.
+  carry the settings version so stale browser cache entries cannot overwrite a newer admin save. The
+  admin form disables browser caching when loading config so it cannot submit stale settings. See the
+  Promoted Twitch configuration section of `docs/SYSTEMS.md`.
 - Mock Supabase/network calls in tests. Keep tests deterministic.
 
 ## Error Handling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -225,10 +225,11 @@ Naming:
   invalidated by the `admin-cache-purge` edge function after a committed admin update. A successful
   immediate tag purge (with purge-by-URL fallback) schedules the same purge six seconds later to
   clear stale in-flight fills. Purge failures return the committed config with an explicit warning
-  flag so clients reconcile without repeating the write. Config responses
-  carry the settings version so stale browser cache entries cannot overwrite a newer admin save. The
-  admin form disables browser caching when loading config so it cannot submit stale settings. See the
-  Promoted Twitch configuration section of `docs/SYSTEMS.md`.
+  flag so clients reconcile without repeating the write. Config responses carry the settings version
+  so stale browser cache entries cannot overwrite a newer admin save. Mounted embeds refresh the
+  config every five minutes while visible and on tab focus; those requests are served by the edge
+  cache between fills. The admin form disables browser caching when loading config so it cannot
+  submit stale settings. See the Promoted Twitch configuration section of `docs/SYSTEMS.md`.
 - Mock Supabase/network calls in tests. Keep tests deterministic.
 
 ## Error Handling

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -222,9 +222,10 @@ Naming:
   admin write. `public.app_settings` is service-role-only; `/api/twitch/config` resolves the
   admin-managed `promoted_twitch` override over that fallback, and `/api/admin/twitch-config` is the
   only writer. `/api/twitch/config` is edge-cached with the `promoted-twitch-config` tag and is
-  invalidated by the `admin-cache-purge` edge function (`twitch-config` purge type, tag purge with a
-  purge-by-URL fallback) after a committed admin update. Purge failures return the committed config
-  with an explicit warning flag so clients reconcile without repeating the write. Config responses
+  invalidated by the `admin-cache-purge` edge function after a committed admin update. A successful
+  immediate tag purge (with purge-by-URL fallback) schedules the same purge six seconds later to
+  clear stale in-flight fills. Purge failures return the committed config with an explicit warning
+  flag so clients reconcile without repeating the write. Config responses
   carry the settings version so stale browser cache entries cannot overwrite a newer admin save. The
   admin form disables browser caching when loading config so it cannot submit stale settings. See the
   Promoted Twitch configuration section of `docs/SYSTEMS.md`.

--- a/app/components/PromotedTwitchEmbed.vue
+++ b/app/components/PromotedTwitchEmbed.vue
@@ -95,10 +95,10 @@
   const isExpanded = ref(true);
   const playerUrl = ref('');
   let pollTimer: ReturnType<typeof setInterval> | null = null;
-  let liveInFlight: Promise<void> | null = null;
+  let liveInFlight: { channel: string; promise: Promise<void> } | null = null;
   let configInFlight: Promise<void> | null = null;
   let hasResolvedConfig = false;
-  const { config: sharedConfig, applyConfig: applySharedConfig } = usePromotedTwitch();
+  const { config: sharedConfig } = usePromotedTwitch();
   const buildPlayerUrl = (): string => {
     const params = new URLSearchParams({
       channel: channel.value,
@@ -148,15 +148,11 @@
     const nextChannel = normalizeChannel(data.channel) || channel.value;
     if (nextChannel !== channel.value) {
       adoptChannel(nextChannel);
-      if (enabled.value) void checkLive();
+      if (data.enabled) void checkLive();
     }
     displayName.value = resolveDisplayName(data.displayName);
     enabled.value = data.enabled;
     hasResolvedConfig = true;
-  };
-  const applyConfig = (data: TwitchConfigResponse): void => {
-    applyLocalConfig(data);
-    applySharedConfig(data);
   };
   watch(sharedConfig, (config) => {
     if (config) applyLocalConfig(config);
@@ -164,7 +160,7 @@
   const refreshConfig = (): Promise<void> => {
     configInFlight ??= (async () => {
       try {
-        applyConfig(await $fetch<TwitchConfigResponse>('/api/twitch/config'));
+        applyLocalConfig(await $fetch<TwitchConfigResponse>('/api/twitch/config'));
       } catch (error) {
         logger.warn('[PromotedTwitchEmbed] Failed to refresh promoted stream config', error);
       }
@@ -183,26 +179,35 @@
       isVisible.value = true;
     }
   };
-  const applyLiveResult = (live: boolean): void => {
+  const applyLiveResult = (requestedChannel: string, live: boolean): void => {
+    if (requestedChannel !== channel.value || !enabled.value) return;
     isLive.value = live;
-    if (dismissed.value || !enabled.value) return;
+    if (dismissed.value) return;
     updatePlayerVisibility(live);
   };
+  const discardLiveResult = (requestedChannel: string): void => {
+    if (requestedChannel !== channel.value) return;
+    isLive.value = false;
+    isVisible.value = false;
+  };
   const checkLive = (): Promise<void> => {
-    liveInFlight ??= (async () => {
+    const requestedChannel = channel.value;
+    if (liveInFlight?.channel === requestedChannel) return liveInFlight.promise;
+    const request = (async () => {
       try {
         const data = await $fetch<{ isLive: boolean }>('/api/twitch/live', {
-          query: { channel: channel.value },
+          query: { channel: requestedChannel },
         });
-        applyLiveResult(data.isLive);
+        applyLiveResult(requestedChannel, data.isLive);
       } catch {
-        isLive.value = false;
-        isVisible.value = false;
+        discardLiveResult(requestedChannel);
       }
-    })().finally(() => {
-      liveInFlight = null;
+    })();
+    liveInFlight = { channel: requestedChannel, promise: request };
+    void request.finally(() => {
+      if (liveInFlight?.promise === request) liveInFlight = null;
     });
-    return liveInFlight;
+    return request;
   };
   const stopPolling = (): void => {
     if (pollTimer) {

--- a/app/components/PromotedTwitchEmbed.vue
+++ b/app/components/PromotedTwitchEmbed.vue
@@ -69,8 +69,10 @@
   </ClientOnly>
 </template>
 <script setup lang="ts">
+  import { usePromotedTwitch } from '@/composables/usePromotedTwitch';
   import { logger } from '@/utils/logger';
   const DISMISS_KEY = 'tt-twitch-dismissed';
+  const POLL_INTERVAL_MS = 60_000;
   const { t } = useI18n({ useScope: 'global' });
   const runtimeConfig = useRuntimeConfig();
   const fallback = runtimeConfig.public.promotedTwitch as {
@@ -93,8 +95,10 @@
   const isExpanded = ref(true);
   const playerUrl = ref('');
   let pollTimer: ReturnType<typeof setInterval> | null = null;
-  let refreshInFlight: Promise<void> | null = null;
+  let liveInFlight: Promise<void> | null = null;
+  let configInFlight: Promise<void> | null = null;
   let hasResolvedConfig = false;
+  const { config: sharedConfig, applyConfig: applySharedConfig } = usePromotedTwitch();
   const buildPlayerUrl = (): string => {
     const params = new URLSearchParams({
       channel: channel.value,
@@ -140,60 +144,104 @@
     channel.value = next;
   };
   const resolveDisplayName = (value: string | undefined): string => value?.trim() || channel.value;
-  const applyConfig = (data: TwitchConfigResponse): void => {
+  const applyLocalConfig = (data: TwitchConfigResponse): void => {
     const nextChannel = normalizeChannel(data.channel) || channel.value;
-    if (nextChannel !== channel.value) adoptChannel(nextChannel);
+    if (nextChannel !== channel.value) {
+      adoptChannel(nextChannel);
+      if (enabled.value) void checkLive();
+    }
     displayName.value = resolveDisplayName(data.displayName);
     enabled.value = data.enabled;
     hasResolvedConfig = true;
   };
-  const loadConfig = async (): Promise<void> => {
-    try {
-      applyConfig(await $fetch<TwitchConfigResponse>('/api/twitch/config'));
-    } catch (error) {
-      logger.warn('[PromotedTwitchEmbed] Failed to refresh promoted stream config', error);
-    }
+  const applyConfig = (data: TwitchConfigResponse): void => {
+    applyLocalConfig(data);
+    applySharedConfig(data);
   };
-  const checkLive = async (): Promise<void> => {
-    try {
-      const data = await $fetch<{ isLive: boolean }>('/api/twitch/live', {
-        query: { channel: channel.value },
-      });
-      isLive.value = data.isLive;
-      if (dismissed.value) return;
-      if (data.isLive && !isVisible.value) {
-        playerUrl.value = buildPlayerUrl();
-        isVisible.value = true;
-      } else if (!data.isLive) {
+  watch(sharedConfig, (config) => {
+    if (config) applyLocalConfig(config);
+  });
+  const refreshConfig = (): Promise<void> => {
+    configInFlight ??= (async () => {
+      try {
+        applyConfig(await $fetch<TwitchConfigResponse>('/api/twitch/config'));
+      } catch (error) {
+        logger.warn('[PromotedTwitchEmbed] Failed to refresh promoted stream config', error);
+      }
+    })().finally(() => {
+      configInFlight = null;
+    });
+    return configInFlight;
+  };
+  const checkLive = (): Promise<void> => {
+    liveInFlight ??= (async () => {
+      try {
+        const data = await $fetch<{ isLive: boolean }>('/api/twitch/live', {
+          query: { channel: channel.value },
+        });
+        isLive.value = data.isLive;
+        if (dismissed.value || !enabled.value) return;
+        if (data.isLive && !isVisible.value) {
+          playerUrl.value = buildPlayerUrl();
+          isVisible.value = true;
+        } else if (!data.isLive) {
+          isVisible.value = false;
+        }
+      } catch {
+        isLive.value = false;
         isVisible.value = false;
       }
-    } catch {
-      isLive.value = false;
-      isVisible.value = false;
+    })().finally(() => {
+      liveInFlight = null;
+    });
+    return liveInFlight;
+  };
+  const stopPolling = (): void => {
+    if (pollTimer) {
+      clearInterval(pollTimer);
+      pollTimer = null;
     }
   };
-  const runRefresh = async (): Promise<void> => {
-    await loadConfig();
-    if (!enabled.value) {
+  const startPolling = (): void => {
+    stopPolling();
+    if (!enabled.value || document.hidden) return;
+    pollTimer = setInterval(() => {
+      void checkLive();
+    }, POLL_INTERVAL_MS);
+  };
+  watch(enabled, (next) => {
+    if (next) {
+      startPolling();
+      void checkLive();
+    } else {
+      stopPolling();
       hidePlayer();
+    }
+  });
+  const handleVisibility = (): void => {
+    if (document.hidden) {
+      stopPolling();
       return;
     }
-    await checkLive();
-  };
-  const refresh = (): Promise<void> => {
-    refreshInFlight ??= runRefresh().finally(() => {
-      refreshInFlight = null;
-    });
-    return refreshInFlight;
+    void refreshConfig();
+    if (enabled.value) {
+      void checkLive();
+      startPolling();
+    }
   };
   onMounted(async () => {
     try {
       dismissed.value = sessionStorage.getItem(DISMISS_KEY) === '1';
     } catch {}
-    await refresh();
-    pollTimer = setInterval(refresh, 60_000);
+    document.addEventListener('visibilitychange', handleVisibility);
+    await refreshConfig();
+    if (enabled.value) {
+      await checkLive();
+      startPolling();
+    }
   });
   onUnmounted(() => {
-    if (pollTimer) clearInterval(pollTimer);
+    document.removeEventListener('visibilitychange', handleVisibility);
+    stopPolling();
   });
 </script>

--- a/app/components/PromotedTwitchEmbed.vue
+++ b/app/components/PromotedTwitchEmbed.vue
@@ -147,17 +147,26 @@
     channel.value = next;
   };
   const resolveDisplayName = (value: string | undefined): string => value?.trim() || channel.value;
+  const applyConfigChannel = (value: string): boolean => {
+    const nextChannel = normalizeChannel(value) || channel.value;
+    if (nextChannel === channel.value) return false;
+    adoptChannel(nextChannel);
+    return true;
+  };
+  const shouldCheckChangedChannel = (
+    channelChanged: boolean,
+    nextEnabled: boolean,
+    enabledChanged: boolean
+  ): boolean => channelChanged && nextEnabled && !enabledChanged;
   const applyLocalConfig = (data: TwitchConfigResponse): void => {
     if (data.version < configVersion) return;
     configVersion = data.version;
     const enabledChanged = data.enabled !== enabled.value;
-    const nextChannel = normalizeChannel(data.channel) || channel.value;
-    const channelChanged = nextChannel !== channel.value;
-    if (channelChanged) adoptChannel(nextChannel);
+    const channelChanged = applyConfigChannel(data.channel);
     displayName.value = resolveDisplayName(data.displayName);
     enabled.value = data.enabled;
     hasResolvedConfig = true;
-    if (channelChanged && data.enabled && !enabledChanged) void checkLive();
+    if (shouldCheckChangedChannel(channelChanged, data.enabled, enabledChanged)) void checkLive();
   };
   const refreshConfig = (): Promise<void> => {
     configInFlight ??= (async () => {
@@ -181,18 +190,14 @@
       isVisible.value = true;
     }
   };
+  const isCurrentLiveRequest = (requestedChannel: string, requestedGeneration: number): boolean =>
+    requestedChannel === channel.value && requestedGeneration === liveGeneration && enabled.value;
   const applyLiveResult = (
     requestedChannel: string,
     requestedGeneration: number,
     live: boolean
   ): void => {
-    if (
-      requestedChannel !== channel.value ||
-      requestedGeneration !== liveGeneration ||
-      !enabled.value
-    ) {
-      return;
-    }
+    if (!isCurrentLiveRequest(requestedChannel, requestedGeneration)) return;
     isLive.value = live;
     if (dismissed.value) return;
     updatePlayerVisibility(live);

--- a/app/components/PromotedTwitchEmbed.vue
+++ b/app/components/PromotedTwitchEmbed.vue
@@ -72,6 +72,7 @@
   import { usePromotedTwitch, type PromotedTwitchConfig } from '@/composables/usePromotedTwitch';
   import { logger } from '@/utils/logger';
   const DISMISS_KEY = 'tt-twitch-dismissed';
+  const CONFIG_REFRESH_INTERVAL_MS = 300_000;
   const POLL_INTERVAL_MS = 60_000;
   const { t } = useI18n({ useScope: 'global' });
   const runtimeConfig = useRuntimeConfig();
@@ -90,6 +91,7 @@
   const dismissed = ref(false);
   const isExpanded = ref(true);
   const playerUrl = ref('');
+  let configTimer: ReturnType<typeof setInterval> | null = null;
   let pollTimer: ReturnType<typeof setInterval> | null = null;
   let liveInFlight: {
     channel: string;
@@ -222,7 +224,12 @@
           query: { channel: requestedChannel },
         });
         applyLiveResult(requestedChannel, requestedGeneration, data.isLive);
-      } catch {
+      } catch (error) {
+        logger.warn('[PromotedTwitchEmbed] Failed to check promoted stream status', {
+          action: 'check_promoted_twitch_live',
+          channel: requestedChannel,
+          error,
+        });
         discardLiveResult(requestedChannel, requestedGeneration);
       }
     })();
@@ -243,6 +250,19 @@
     },
     { immediate: true }
   );
+  const stopConfigPolling = (): void => {
+    if (configTimer) {
+      clearInterval(configTimer);
+      configTimer = null;
+    }
+  };
+  const startConfigPolling = (): void => {
+    stopConfigPolling();
+    if (document.hidden) return;
+    configTimer = setInterval(() => {
+      void refreshConfig();
+    }, CONFIG_REFRESH_INTERVAL_MS);
+  };
   const stopPolling = (): void => {
     if (pollTimer) {
       clearInterval(pollTimer);
@@ -268,10 +288,12 @@
   });
   const handleVisibility = (): void => {
     if (document.hidden) {
+      stopConfigPolling();
       stopPolling();
       return;
     }
     void refreshConfig();
+    startConfigPolling();
     if (enabled.value) {
       void checkLive();
       startPolling();
@@ -283,6 +305,7 @@
     } catch {}
     document.addEventListener('visibilitychange', handleVisibility);
     await refreshConfig();
+    startConfigPolling();
     if (enabled.value) {
       await checkLive();
       startPolling();
@@ -290,6 +313,7 @@
   });
   onUnmounted(() => {
     document.removeEventListener('visibilitychange', handleVisibility);
+    stopConfigPolling();
     stopPolling();
   });
 </script>

--- a/app/components/PromotedTwitchEmbed.vue
+++ b/app/components/PromotedTwitchEmbed.vue
@@ -69,7 +69,7 @@
   </ClientOnly>
 </template>
 <script setup lang="ts">
-  import { usePromotedTwitch } from '@/composables/usePromotedTwitch';
+  import { usePromotedTwitch, type PromotedTwitchConfig } from '@/composables/usePromotedTwitch';
   import { logger } from '@/utils/logger';
   const DISMISS_KEY = 'tt-twitch-dismissed';
   const POLL_INTERVAL_MS = 60_000;
@@ -80,11 +80,7 @@
     displayName?: string;
     enabled?: boolean;
   };
-  interface TwitchConfigResponse {
-    channel: string;
-    displayName: string;
-    enabled: boolean;
-  }
+  type TwitchConfigResponse = PromotedTwitchConfig;
   const normalizeChannel = (value: string | undefined): string => value?.trim().toLowerCase() || '';
   const channel = ref(normalizeChannel(fallback.channel) || 'honeyxxo');
   const displayName = ref(fallback.displayName?.trim() || channel.value);
@@ -95,9 +91,15 @@
   const isExpanded = ref(true);
   const playerUrl = ref('');
   let pollTimer: ReturnType<typeof setInterval> | null = null;
-  let liveInFlight: { channel: string; promise: Promise<void> } | null = null;
+  let liveInFlight: {
+    channel: string;
+    generation: number;
+    promise: Promise<void>;
+  } | null = null;
   let configInFlight: Promise<void> | null = null;
+  let configVersion = 0;
   let hasResolvedConfig = false;
+  let liveGeneration = 0;
   const { config: sharedConfig } = usePromotedTwitch();
   const buildPlayerUrl = (): string => {
     const params = new URLSearchParams({
@@ -139,24 +141,24 @@
     }
   };
   const adoptChannel = (next: string): void => {
+    liveGeneration += 1;
     hidePlayer();
     if (hasResolvedConfig) clearDismissal();
     channel.value = next;
   };
   const resolveDisplayName = (value: string | undefined): string => value?.trim() || channel.value;
   const applyLocalConfig = (data: TwitchConfigResponse): void => {
+    if (data.version < configVersion) return;
+    configVersion = data.version;
+    const enabledChanged = data.enabled !== enabled.value;
     const nextChannel = normalizeChannel(data.channel) || channel.value;
-    if (nextChannel !== channel.value) {
-      adoptChannel(nextChannel);
-      if (data.enabled) void checkLive();
-    }
+    const channelChanged = nextChannel !== channel.value;
+    if (channelChanged) adoptChannel(nextChannel);
     displayName.value = resolveDisplayName(data.displayName);
     enabled.value = data.enabled;
     hasResolvedConfig = true;
+    if (channelChanged && data.enabled && !enabledChanged) void checkLive();
   };
-  watch(sharedConfig, (config) => {
-    if (config) applyLocalConfig(config);
-  });
   const refreshConfig = (): Promise<void> => {
     configInFlight ??= (async () => {
       try {
@@ -179,36 +181,63 @@
       isVisible.value = true;
     }
   };
-  const applyLiveResult = (requestedChannel: string, live: boolean): void => {
-    if (requestedChannel !== channel.value || !enabled.value) return;
+  const applyLiveResult = (
+    requestedChannel: string,
+    requestedGeneration: number,
+    live: boolean
+  ): void => {
+    if (
+      requestedChannel !== channel.value ||
+      requestedGeneration !== liveGeneration ||
+      !enabled.value
+    ) {
+      return;
+    }
     isLive.value = live;
     if (dismissed.value) return;
     updatePlayerVisibility(live);
   };
-  const discardLiveResult = (requestedChannel: string): void => {
-    if (requestedChannel !== channel.value) return;
+  const discardLiveResult = (requestedChannel: string, requestedGeneration: number): void => {
+    if (requestedChannel !== channel.value || requestedGeneration !== liveGeneration) return;
     isLive.value = false;
     isVisible.value = false;
   };
   const checkLive = (): Promise<void> => {
     const requestedChannel = channel.value;
-    if (liveInFlight?.channel === requestedChannel) return liveInFlight.promise;
+    const requestedGeneration = liveGeneration;
+    if (
+      liveInFlight?.channel === requestedChannel &&
+      liveInFlight.generation === requestedGeneration
+    ) {
+      return liveInFlight.promise;
+    }
     const request = (async () => {
       try {
         const data = await $fetch<{ isLive: boolean }>('/api/twitch/live', {
           query: { channel: requestedChannel },
         });
-        applyLiveResult(requestedChannel, data.isLive);
+        applyLiveResult(requestedChannel, requestedGeneration, data.isLive);
       } catch {
-        discardLiveResult(requestedChannel);
+        discardLiveResult(requestedChannel, requestedGeneration);
       }
     })();
-    liveInFlight = { channel: requestedChannel, promise: request };
+    liveInFlight = {
+      channel: requestedChannel,
+      generation: requestedGeneration,
+      promise: request,
+    };
     void request.finally(() => {
       if (liveInFlight?.promise === request) liveInFlight = null;
     });
     return request;
   };
+  watch(
+    sharedConfig,
+    (config) => {
+      if (config) applyLocalConfig(config);
+    },
+    { immediate: true }
+  );
   const stopPolling = (): void => {
     if (pollTimer) {
       clearInterval(pollTimer);
@@ -223,6 +252,7 @@
     }, POLL_INTERVAL_MS);
   };
   watch(enabled, (next) => {
+    liveGeneration += 1;
     if (next) {
       startPolling();
       void checkLive();

--- a/app/components/PromotedTwitchEmbed.vue
+++ b/app/components/PromotedTwitchEmbed.vue
@@ -173,20 +173,28 @@
     });
     return configInFlight;
   };
+  const updatePlayerVisibility = (live: boolean): void => {
+    if (!live) {
+      isVisible.value = false;
+      return;
+    }
+    if (!isVisible.value) {
+      playerUrl.value = buildPlayerUrl();
+      isVisible.value = true;
+    }
+  };
+  const applyLiveResult = (live: boolean): void => {
+    isLive.value = live;
+    if (dismissed.value || !enabled.value) return;
+    updatePlayerVisibility(live);
+  };
   const checkLive = (): Promise<void> => {
     liveInFlight ??= (async () => {
       try {
         const data = await $fetch<{ isLive: boolean }>('/api/twitch/live', {
           query: { channel: channel.value },
         });
-        isLive.value = data.isLive;
-        if (dismissed.value || !enabled.value) return;
-        if (data.isLive && !isVisible.value) {
-          playerUrl.value = buildPlayerUrl();
-          isVisible.value = true;
-        } else if (!data.isLive) {
-          isVisible.value = false;
-        }
+        applyLiveResult(data.isLive);
       } catch {
         isLive.value = false;
         isVisible.value = false;

--- a/app/components/PromotedTwitchEmbed.vue
+++ b/app/components/PromotedTwitchEmbed.vue
@@ -101,8 +101,10 @@
   let configInFlight: Promise<void> | null = null;
   let configVersion = 0;
   let hasResolvedConfig = false;
+  let isMounted = false;
   let liveGeneration = 0;
   const { config: sharedConfig } = usePromotedTwitch();
+  const canRunVisibleWork = (): boolean => isMounted && !document.hidden;
   const buildPlayerUrl = (): string => {
     const params = new URLSearchParams({
       channel: channel.value,
@@ -168,7 +170,12 @@
     displayName.value = resolveDisplayName(data.displayName);
     enabled.value = data.enabled;
     hasResolvedConfig = true;
-    if (shouldCheckChangedChannel(channelChanged, data.enabled, enabledChanged)) void checkLive();
+    if (
+      canRunVisibleWork() &&
+      shouldCheckChangedChannel(channelChanged, data.enabled, enabledChanged)
+    ) {
+      void checkLive();
+    }
   };
   const refreshConfig = (): Promise<void> => {
     configInFlight ??= (async () => {
@@ -258,7 +265,7 @@
   };
   const startConfigPolling = (): void => {
     stopConfigPolling();
-    if (document.hidden) return;
+    if (!canRunVisibleWork()) return;
     configTimer = setInterval(() => {
       void refreshConfig();
     }, CONFIG_REFRESH_INTERVAL_MS);
@@ -271,20 +278,24 @@
   };
   const startPolling = (): void => {
     stopPolling();
-    if (!enabled.value || document.hidden) return;
+    if (!enabled.value || !canRunVisibleWork()) return;
     pollTimer = setInterval(() => {
       void checkLive();
     }, POLL_INTERVAL_MS);
   };
   watch(enabled, (next) => {
     liveGeneration += 1;
-    if (next) {
-      startPolling();
-      void checkLive();
-    } else {
+    if (!next) {
       stopPolling();
       hidePlayer();
+      return;
     }
+    if (!canRunVisibleWork()) {
+      stopPolling();
+      return;
+    }
+    startPolling();
+    void checkLive();
   });
   const handleVisibility = (): void => {
     if (document.hidden) {
@@ -300,11 +311,13 @@
     }
   };
   onMounted(async () => {
+    isMounted = true;
     try {
       dismissed.value = sessionStorage.getItem(DISMISS_KEY) === '1';
     } catch {}
     document.addEventListener('visibilitychange', handleVisibility);
     await refreshConfig();
+    if (!canRunVisibleWork()) return;
     startConfigPolling();
     if (enabled.value) {
       await checkLive();
@@ -312,6 +325,7 @@
     }
   });
   onUnmounted(() => {
+    isMounted = false;
     document.removeEventListener('visibilitychange', handleVisibility);
     stopConfigPolling();
     stopPolling();

--- a/app/components/__tests__/PromotedTwitchEmbed.test.ts
+++ b/app/components/__tests__/PromotedTwitchEmbed.test.ts
@@ -22,7 +22,7 @@ mockNuxtImport('useI18n', () => () => ({
     typeof fallbackOrParams === 'string' ? fallbackOrParams : key,
 }));
 vi.stubGlobal('$fetch', fetchMock);
-let twitchConfig: { channel: string; displayName: string; enabled: boolean };
+let twitchConfig: { channel: string; displayName: string; enabled: boolean; version: number };
 let liveResult: { isLive: boolean };
 const UButtonStub = {
   inheritAttrs: false,
@@ -52,7 +52,12 @@ describe('PromotedTwitchEmbed', () => {
     fetchMock.mockImplementation((url: string) =>
       Promise.resolve(url === '/api/twitch/config' ? twitchConfig : liveResult)
     );
-    twitchConfig = { channel: 'teststreamer', displayName: 'TestStreamer', enabled: true };
+    twitchConfig = {
+      channel: 'teststreamer',
+      displayName: 'TestStreamer',
+      enabled: true,
+      version: 1,
+    };
     liveResult = { isLive: true };
     sessionStorage.clear();
     usePromotedTwitch().resetConfig();
@@ -133,6 +138,7 @@ describe('PromotedTwitchEmbed', () => {
       channel: 'replacement',
       displayName: 'Replacement',
       enabled: true,
+      version: 2,
     });
     await flushPromises();
     await nextTick();
@@ -142,12 +148,38 @@ describe('PromotedTwitchEmbed', () => {
     expect(wrapper.find('iframe').attributes('src')).toContain('channel=replacement');
     wrapper.unmount();
   });
+  it('does not let an older focus response overwrite an admin save', async () => {
+    const wrapper = await mountEmbed();
+    let resolveConfig: ((value: typeof twitchConfig) => void) | undefined;
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/api/twitch/config') {
+        return new Promise((resolve) => {
+          resolveConfig = resolve;
+        });
+      }
+      return Promise.resolve(liveResult);
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    usePromotedTwitch().applyConfig({
+      channel: 'replacement',
+      displayName: 'Replacement',
+      enabled: true,
+      version: 2,
+    });
+    await nextTick();
+    resolveConfig?.(twitchConfig);
+    await flushPromises();
+    await nextTick();
+    expect(wrapper.find('iframe').attributes('src')).toContain('channel=replacement');
+    wrapper.unmount();
+  });
   it('hides an active player and stops polling when the shared config disables the stream', async () => {
     const wrapper = await mountEmbed();
     usePromotedTwitch().applyConfig({
       channel: 'teststreamer',
       displayName: 'TestStreamer',
       enabled: false,
+      version: 2,
     });
     await flushPromises();
     await nextTick();
@@ -157,7 +189,12 @@ describe('PromotedTwitchEmbed', () => {
   });
   it('keeps a stored dismissal when the first resolved channel differs from the fallback', async () => {
     sessionStorage.setItem('tt-twitch-dismissed', '1');
-    twitchConfig = { channel: 'dbstreamer', displayName: 'DB Streamer', enabled: true };
+    twitchConfig = {
+      channel: 'dbstreamer',
+      displayName: 'DB Streamer',
+      enabled: true,
+      version: 1,
+    };
     const wrapper = await mountEmbed();
     expect(sessionStorage.getItem('tt-twitch-dismissed')).toBe('1');
     expect(wrapper.find('iframe').exists()).toBe(false);
@@ -172,6 +209,7 @@ describe('PromotedTwitchEmbed', () => {
       channel: 'replacement',
       displayName: 'Replacement',
       enabled: true,
+      version: 2,
     });
     await flushPromises();
     await nextTick();
@@ -219,6 +257,7 @@ describe('PromotedTwitchEmbed', () => {
       channel: 'replacement',
       displayName: 'Replacement',
       enabled: true,
+      version: 2,
     });
     await flushPromises();
     await nextTick();
@@ -226,6 +265,44 @@ describe('PromotedTwitchEmbed', () => {
     await flushPromises();
     await nextTick();
     expect(wrapper.find('iframe').exists()).toBe(false);
+    wrapper.unmount();
+  });
+  it('discards a stale A to B to A live result', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const wrapper = await mountEmbed();
+    const liveResolvers: Array<(value: { isLive: boolean }) => void> = [];
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/api/twitch/live') {
+        return new Promise((resolve) => {
+          liveResolvers.push(resolve);
+        });
+      }
+      return Promise.resolve(twitchConfig);
+    });
+    const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
+    pollCallback();
+    usePromotedTwitch().applyConfig({
+      channel: 'replacement',
+      displayName: 'Replacement',
+      enabled: true,
+      version: 2,
+    });
+    await nextTick();
+    usePromotedTwitch().applyConfig({
+      channel: 'teststreamer',
+      displayName: 'TestStreamer',
+      enabled: true,
+      version: 3,
+    });
+    await flushPromises();
+    await nextTick();
+    liveResolvers[0]?.({ isLive: true });
+    await flushPromises();
+    expect(wrapper.find('iframe').exists()).toBe(false);
+    liveResolvers[2]?.({ isLive: true });
+    await flushPromises();
+    await nextTick();
+    expect(wrapper.find('iframe').attributes('src')).toContain('channel=teststreamer');
     wrapper.unmount();
   });
   it('logs a warning when clearing a stored dismissal fails', async () => {

--- a/app/components/__tests__/PromotedTwitchEmbed.test.ts
+++ b/app/components/__tests__/PromotedTwitchEmbed.test.ts
@@ -201,6 +201,33 @@ describe('PromotedTwitchEmbed', () => {
     expect(fetchMock).toHaveBeenCalledTimes(3);
     wrapper.unmount();
   });
+  it('discards a stale live result when the channel changes mid-flight', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const wrapper = await mountEmbed();
+    const liveResolvers: Array<(value: { isLive: boolean }) => void> = [];
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/api/twitch/live') {
+        return new Promise((resolve) => {
+          liveResolvers.push(resolve);
+        });
+      }
+      return Promise.resolve(twitchConfig);
+    });
+    const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
+    pollCallback();
+    usePromotedTwitch().applyConfig({
+      channel: 'replacement',
+      displayName: 'Replacement',
+      enabled: true,
+    });
+    await flushPromises();
+    await nextTick();
+    liveResolvers[0]?.({ isLive: true });
+    await flushPromises();
+    await nextTick();
+    expect(wrapper.find('iframe').exists()).toBe(false);
+    wrapper.unmount();
+  });
   it('logs a warning when clearing a stored dismissal fails', async () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
     const removeItemSpy = vi.spyOn(sessionStorage, 'removeItem').mockImplementation(() => {
@@ -239,23 +266,26 @@ describe('PromotedTwitchEmbed', () => {
     let hidden = false;
     const originalDescriptor = Object.getOwnPropertyDescriptor(document, 'hidden');
     Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
-    hidden = true;
-    document.dispatchEvent(new Event('visibilitychange'));
-    await flushPromises();
-    expect(clearIntervalSpy).toHaveBeenCalled();
-    const callsWhileHidden = fetchMock.mock.calls.length;
-    hidden = false;
-    document.dispatchEvent(new Event('visibilitychange'));
-    await flushPromises();
-    await nextTick();
-    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsWhileHidden);
-    expect(fetchMock.mock.calls[callsWhileHidden]?.[0]).toBe('/api/twitch/config');
-    expect(fetchMock).toHaveBeenLastCalledWith('/api/twitch/live', expect.anything());
-    expect(setIntervalSpy).toHaveBeenCalledTimes(2);
-    if (originalDescriptor) {
-      Object.defineProperty(document, 'hidden', originalDescriptor);
-    } else {
-      delete (document as { hidden?: boolean }).hidden;
+    try {
+      hidden = true;
+      document.dispatchEvent(new Event('visibilitychange'));
+      await flushPromises();
+      expect(clearIntervalSpy).toHaveBeenCalled();
+      const callsWhileHidden = fetchMock.mock.calls.length;
+      hidden = false;
+      document.dispatchEvent(new Event('visibilitychange'));
+      await flushPromises();
+      await nextTick();
+      expect(fetchMock.mock.calls.length).toBeGreaterThan(callsWhileHidden);
+      expect(fetchMock.mock.calls[callsWhileHidden]?.[0]).toBe('/api/twitch/config');
+      expect(fetchMock).toHaveBeenLastCalledWith('/api/twitch/live', expect.anything());
+      expect(setIntervalSpy).toHaveBeenCalledTimes(2);
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(document, 'hidden', originalDescriptor);
+      } else {
+        delete (document as { hidden?: boolean }).hidden;
+      }
     }
     wrapper.unmount();
   });

--- a/app/components/__tests__/PromotedTwitchEmbed.test.ts
+++ b/app/components/__tests__/PromotedTwitchEmbed.test.ts
@@ -65,15 +65,38 @@ describe('PromotedTwitchEmbed', () => {
   afterEach(() => {
     vi.restoreAllMocks();
   });
-  it('fetches the config once and does not check live status or poll when disabled', async () => {
+  it('fetches config without checking or polling live status when disabled', async () => {
     twitchConfig.enabled = false;
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const wrapper = await mountEmbed();
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('/api/twitch/config');
     expect(fetchMock).not.toHaveBeenCalledWith('/api/twitch/live', expect.anything());
-    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 300_000);
+    expect(setIntervalSpy).not.toHaveBeenCalledWith(expect.any(Function), 60_000);
     expect(wrapper.find('iframe').exists()).toBe(false);
+    wrapper.unmount();
+  });
+  it('refreshes config for a continuously visible tab while the stream is disabled', async () => {
+    twitchConfig.enabled = false;
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const wrapper = await mountEmbed();
+    twitchConfig = {
+      channel: 'replacement',
+      displayName: 'Replacement',
+      enabled: true,
+      version: 2,
+    };
+    const configCallback = setIntervalSpy.mock.calls.find((call) => call[1] === 300_000)?.[0] as
+      (() => void) | undefined;
+    configCallback?.();
+    await flushPromises();
+    await nextTick();
+    expect(fetchMock.mock.calls.filter((call) => call[0] === '/api/twitch/config')).toHaveLength(2);
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/twitch/live', {
+      query: { channel: 'replacement' },
+    });
+    expect(wrapper.find('iframe').attributes('src')).toContain('channel=replacement');
     wrapper.unmount();
   });
   it('renders the player iframe when the channel is live', async () => {
@@ -119,13 +142,15 @@ describe('PromotedTwitchEmbed', () => {
     expect(sessionStorage.getItem('tt-twitch-dismissed')).toBeNull();
     wrapper.unmount();
   });
-  it('polls only live status on an interval and never re-fetches config', async () => {
+  it('polls live status independently from the slower config refresh', async () => {
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const wrapper = await mountEmbed();
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(fetchMock.mock.calls.filter((call) => call[0] === '/api/twitch/config')).toHaveLength(1);
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
-    const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
+    const pollCallback = setIntervalSpy.mock.calls.find(
+      (call) => call[1] === 60_000
+    )?.[0] as () => void;
     pollCallback();
     await flushPromises();
     expect(fetchMock).toHaveBeenCalledTimes(3);
@@ -229,7 +254,9 @@ describe('PromotedTwitchEmbed', () => {
       }
       return Promise.resolve(twitchConfig);
     });
-    const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
+    const pollCallback = setIntervalSpy.mock.calls.find(
+      (call) => call[1] === 60_000
+    )?.[0] as () => void;
     pollCallback();
     pollCallback();
     await flushPromises();
@@ -251,7 +278,9 @@ describe('PromotedTwitchEmbed', () => {
       }
       return Promise.resolve(twitchConfig);
     });
-    const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
+    const pollCallback = setIntervalSpy.mock.calls.find(
+      (call) => call[1] === 60_000
+    )?.[0] as () => void;
     pollCallback();
     usePromotedTwitch().applyConfig({
       channel: 'replacement',
@@ -279,7 +308,9 @@ describe('PromotedTwitchEmbed', () => {
       }
       return Promise.resolve(twitchConfig);
     });
-    const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
+    const pollCallback = setIntervalSpy.mock.calls.find(
+      (call) => call[1] === 60_000
+    )?.[0] as () => void;
     pollCallback();
     usePromotedTwitch().applyConfig({
       channel: 'replacement',
@@ -335,6 +366,23 @@ describe('PromotedTwitchEmbed', () => {
     );
     wrapper.unmount();
   });
+  it('logs live-status failures with action and channel context', async () => {
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const error = new Error('offline');
+    fetchMock.mockImplementation((url: string) =>
+      url === '/api/twitch/config' ? Promise.resolve(twitchConfig) : Promise.reject(error)
+    );
+    const wrapper = await mountEmbed();
+    expect(warnSpy).toHaveBeenCalledWith(
+      '[PromotedTwitchEmbed] Failed to check promoted stream status',
+      {
+        action: 'check_promoted_twitch_live',
+        channel: 'teststreamer',
+        error,
+      }
+    );
+    wrapper.unmount();
+  });
   it('stops polling while the tab is hidden and resumes with a refresh on focus', async () => {
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
@@ -356,7 +404,8 @@ describe('PromotedTwitchEmbed', () => {
       expect(fetchMock.mock.calls.length).toBeGreaterThan(callsWhileHidden);
       expect(fetchMock.mock.calls[callsWhileHidden]?.[0]).toBe('/api/twitch/config');
       expect(fetchMock).toHaveBeenLastCalledWith('/api/twitch/live', expect.anything());
-      expect(setIntervalSpy).toHaveBeenCalledTimes(2);
+      expect(setIntervalSpy.mock.calls.filter((call) => call[1] === 300_000)).toHaveLength(2);
+      expect(setIntervalSpy.mock.calls.filter((call) => call[1] === 60_000)).toHaveLength(2);
     } finally {
       if (originalDescriptor) {
         Object.defineProperty(document, 'hidden', originalDescriptor);

--- a/app/components/__tests__/PromotedTwitchEmbed.test.ts
+++ b/app/components/__tests__/PromotedTwitchEmbed.test.ts
@@ -77,6 +77,40 @@ describe('PromotedTwitchEmbed', () => {
     expect(wrapper.find('iframe').exists()).toBe(false);
     wrapper.unmount();
   });
+  it('does not start polling after unmount while the initial config is pending', async () => {
+    let resolveConfig: ((value: typeof twitchConfig) => void) | undefined;
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/api/twitch/config') {
+        return new Promise((resolve) => {
+          resolveConfig = resolve;
+        });
+      }
+      return Promise.resolve(liveResult);
+    });
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const { default: PromotedTwitchEmbed } = await import('@/components/PromotedTwitchEmbed.vue');
+    const wrapper = mount(PromotedTwitchEmbed, {
+      global: {
+        stubs: {
+          ClientOnly: { template: '<div><slot /></div>' },
+          UButton: UButtonStub,
+          UIcon: UIconStub,
+        },
+      },
+    });
+    await nextTick();
+    expect(fetchMock).toHaveBeenCalledWith('/api/twitch/config');
+    wrapper.unmount();
+    resolveConfig?.({
+      channel: 'replacement',
+      displayName: 'Replacement',
+      enabled: true,
+      version: 2,
+    });
+    await flushPromises();
+    expect(setIntervalSpy).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalledWith('/api/twitch/live', expect.anything());
+  });
   it('refreshes config for a continuously visible tab while the stream is disabled', async () => {
     twitchConfig.enabled = false;
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
@@ -382,6 +416,70 @@ describe('PromotedTwitchEmbed', () => {
       }
     );
     wrapper.unmount();
+  });
+  it('defers a shared enable until a hidden tab regains focus', async () => {
+    twitchConfig.enabled = false;
+    const wrapper = await mountEmbed();
+    let hidden = true;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(document, 'hidden');
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+    try {
+      document.dispatchEvent(new Event('visibilitychange'));
+      usePromotedTwitch().applyConfig({
+        channel: 'teststreamer',
+        displayName: 'TestStreamer',
+        enabled: true,
+        version: 2,
+      });
+      await flushPromises();
+      await nextTick();
+      expect(fetchMock).not.toHaveBeenCalledWith('/api/twitch/live', expect.anything());
+      hidden = false;
+      document.dispatchEvent(new Event('visibilitychange'));
+      await flushPromises();
+      expect(fetchMock).toHaveBeenLastCalledWith('/api/twitch/live', {
+        query: { channel: 'teststreamer' },
+      });
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(document, 'hidden', originalDescriptor);
+      } else {
+        delete (document as { hidden?: boolean }).hidden;
+      }
+      wrapper.unmount();
+    }
+  });
+  it('defers a shared channel change until a hidden tab regains focus', async () => {
+    const wrapper = await mountEmbed();
+    let hidden = true;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(document, 'hidden');
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+    try {
+      document.dispatchEvent(new Event('visibilitychange'));
+      const callsWhileHidden = fetchMock.mock.calls.length;
+      usePromotedTwitch().applyConfig({
+        channel: 'replacement',
+        displayName: 'Replacement',
+        enabled: true,
+        version: 2,
+      });
+      await flushPromises();
+      await nextTick();
+      expect(fetchMock).toHaveBeenCalledTimes(callsWhileHidden);
+      hidden = false;
+      document.dispatchEvent(new Event('visibilitychange'));
+      await flushPromises();
+      expect(fetchMock).toHaveBeenLastCalledWith('/api/twitch/live', {
+        query: { channel: 'replacement' },
+      });
+    } finally {
+      if (originalDescriptor) {
+        Object.defineProperty(document, 'hidden', originalDescriptor);
+      } else {
+        delete (document as { hidden?: boolean }).hidden;
+      }
+      wrapper.unmount();
+    }
   });
   it('stops polling while the tab is hidden and resumes with a refresh on focus', async () => {
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');

--- a/app/components/__tests__/PromotedTwitchEmbed.test.ts
+++ b/app/components/__tests__/PromotedTwitchEmbed.test.ts
@@ -3,6 +3,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { flushPromises, mount } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { nextTick } from 'vue';
+import { usePromotedTwitch } from '@/composables/usePromotedTwitch';
 import { logger } from '@/utils/logger';
 const { fetchMock } = vi.hoisted(() => ({
   fetchMock: vi.fn(),
@@ -54,16 +55,21 @@ describe('PromotedTwitchEmbed', () => {
     twitchConfig = { channel: 'teststreamer', displayName: 'TestStreamer', enabled: true };
     liveResult = { isLive: true };
     sessionStorage.clear();
+    usePromotedTwitch().resetConfig();
   });
   afterEach(() => {
     vi.restoreAllMocks();
   });
-  it('does not check live status or render when disabled', async () => {
+  it('fetches the config once and does not check live status or poll when disabled', async () => {
     twitchConfig.enabled = false;
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const wrapper = await mountEmbed();
+    expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('/api/twitch/config');
     expect(fetchMock).not.toHaveBeenCalledWith('/api/twitch/live', expect.anything());
+    expect(setIntervalSpy).not.toHaveBeenCalled();
     expect(wrapper.find('iframe').exists()).toBe(false);
+    wrapper.unmount();
   });
   it('renders the player iframe when the channel is live', async () => {
     const wrapper = await mountEmbed();
@@ -76,11 +82,13 @@ describe('PromotedTwitchEmbed', () => {
     expect(iframe.attributes('src')).toContain('player.twitch.tv');
     expect(iframe.attributes('src')).toContain('channel=teststreamer');
     expect(iframe.attributes('src')).toContain('muted=true');
+    wrapper.unmount();
   });
   it('stays hidden when the channel is offline', async () => {
     liveResult = { isLive: false };
     const wrapper = await mountEmbed();
     expect(wrapper.find('iframe').exists()).toBe(false);
+    wrapper.unmount();
   });
   it('hides the player and persists dismissal when closed', async () => {
     const wrapper = await mountEmbed();
@@ -88,12 +96,14 @@ describe('PromotedTwitchEmbed', () => {
     expect(wrapper.find('iframe').exists()).toBe(false);
     expect(sessionStorage.getItem('tt-twitch-dismissed')).toBe('1');
     expect(wrapper.find('button[aria-label="Reopen stream"]').exists()).toBe(true);
+    wrapper.unmount();
   });
   it('does not auto-show when a prior dismissal is stored', async () => {
     sessionStorage.setItem('tt-twitch-dismissed', '1');
     const wrapper = await mountEmbed();
     expect(wrapper.find('iframe').exists()).toBe(false);
     expect(wrapper.find('button[aria-label="Reopen stream"]').exists()).toBe(true);
+    wrapper.unmount();
   });
   it('reopens the player after being dismissed', async () => {
     sessionStorage.setItem('tt-twitch-dismissed', '1');
@@ -102,24 +112,28 @@ describe('PromotedTwitchEmbed', () => {
     await nextTick();
     expect(wrapper.find('iframe').exists()).toBe(true);
     expect(sessionStorage.getItem('tt-twitch-dismissed')).toBeNull();
+    wrapper.unmount();
   });
-  it('polls live status on an interval', async () => {
+  it('polls only live status on an interval and never re-fetches config', async () => {
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const wrapper = await mountEmbed();
     expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock.mock.calls.filter((call) => call[0] === '/api/twitch/config')).toHaveLength(1);
     expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 60_000);
     const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
     pollCallback();
     await flushPromises();
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[2]?.[0]).toBe('/api/twitch/live');
     wrapper.unmount();
   });
-  it('applies config changes on the next poll', async () => {
-    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+  it('applies an admin save immediately through the shared state', async () => {
     const wrapper = await mountEmbed();
-    twitchConfig = { channel: 'replacement', displayName: 'Replacement', enabled: true };
-    const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
-    pollCallback();
+    usePromotedTwitch().applyConfig({
+      channel: 'replacement',
+      displayName: 'Replacement',
+      enabled: true,
+    });
     await flushPromises();
     await nextTick();
     expect(fetchMock).toHaveBeenLastCalledWith('/api/twitch/live', {
@@ -128,16 +142,17 @@ describe('PromotedTwitchEmbed', () => {
     expect(wrapper.find('iframe').attributes('src')).toContain('channel=replacement');
     wrapper.unmount();
   });
-  it('hides an active player when config is disabled on the next poll', async () => {
-    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+  it('hides an active player and stops polling when the shared config disables the stream', async () => {
     const wrapper = await mountEmbed();
-    twitchConfig.enabled = false;
-    const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
-    pollCallback();
+    usePromotedTwitch().applyConfig({
+      channel: 'teststreamer',
+      displayName: 'TestStreamer',
+      enabled: false,
+    });
     await flushPromises();
     await nextTick();
     expect(wrapper.find('iframe').exists()).toBe(false);
-    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     wrapper.unmount();
   });
   it('keeps a stored dismissal when the first resolved channel differs from the fallback', async () => {
@@ -149,40 +164,41 @@ describe('PromotedTwitchEmbed', () => {
     expect(wrapper.find('button[aria-label="Reopen stream"]').exists()).toBe(true);
     wrapper.unmount();
   });
-  it('clears a stored dismissal when the promoted channel changes', async () => {
+  it('clears a stored dismissal when the promoted channel changes via shared state', async () => {
     sessionStorage.setItem('tt-twitch-dismissed', '1');
-    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const wrapper = await mountEmbed();
     expect(wrapper.find('iframe').exists()).toBe(false);
-    twitchConfig = { channel: 'replacement', displayName: 'Replacement', enabled: true };
-    const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
-    pollCallback();
+    usePromotedTwitch().applyConfig({
+      channel: 'replacement',
+      displayName: 'Replacement',
+      enabled: true,
+    });
     await flushPromises();
     await nextTick();
     expect(sessionStorage.getItem('tt-twitch-dismissed')).toBeNull();
     expect(wrapper.find('iframe').attributes('src')).toContain('channel=replacement');
     wrapper.unmount();
   });
-  it('keeps one refresh in flight when polls overlap', async () => {
+  it('keeps one live check in flight when polls overlap', async () => {
     const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
     const wrapper = await mountEmbed();
-    let releaseConfig: (() => void) | undefined;
+    let releaseLive: (() => void) | undefined;
     fetchMock.mockImplementation((url: string) => {
-      if (url === '/api/twitch/config') {
+      if (url === '/api/twitch/live') {
         return new Promise((resolve) => {
-          releaseConfig = () => resolve(twitchConfig);
+          releaseLive = () => resolve(liveResult);
         });
       }
-      return Promise.resolve(liveResult);
+      return Promise.resolve(twitchConfig);
     });
     const pollCallback = setIntervalSpy.mock.calls[0]?.[0] as () => void;
     pollCallback();
     pollCallback();
     await flushPromises();
     expect(fetchMock).toHaveBeenCalledTimes(3);
-    releaseConfig?.();
+    releaseLive?.();
     await flushPromises();
-    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
     wrapper.unmount();
   });
   it('logs a warning when clearing a stored dismissal fails', async () => {
@@ -201,7 +217,7 @@ describe('PromotedTwitchEmbed', () => {
     removeItemSpy.mockRestore();
     wrapper.unmount();
   });
-  it('logs a warning when the config refresh fails', async () => {
+  it('logs a warning when the config fetch fails', async () => {
     const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
     fetchMock.mockImplementation((url: string) =>
       url === '/api/twitch/config'
@@ -213,6 +229,34 @@ describe('PromotedTwitchEmbed', () => {
       '[PromotedTwitchEmbed] Failed to refresh promoted stream config',
       expect.any(Error)
     );
+    wrapper.unmount();
+  });
+  it('stops polling while the tab is hidden and resumes with a refresh on focus', async () => {
+    const setIntervalSpy = vi.spyOn(globalThis, 'setInterval');
+    const clearIntervalSpy = vi.spyOn(globalThis, 'clearInterval');
+    const wrapper = await mountEmbed();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    let hidden = false;
+    const originalDescriptor = Object.getOwnPropertyDescriptor(document, 'hidden');
+    Object.defineProperty(document, 'hidden', { configurable: true, get: () => hidden });
+    hidden = true;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flushPromises();
+    expect(clearIntervalSpy).toHaveBeenCalled();
+    const callsWhileHidden = fetchMock.mock.calls.length;
+    hidden = false;
+    document.dispatchEvent(new Event('visibilitychange'));
+    await flushPromises();
+    await nextTick();
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsWhileHidden);
+    expect(fetchMock.mock.calls[callsWhileHidden]?.[0]).toBe('/api/twitch/config');
+    expect(fetchMock).toHaveBeenLastCalledWith('/api/twitch/live', expect.anything());
+    expect(setIntervalSpy).toHaveBeenCalledTimes(2);
+    if (originalDescriptor) {
+      Object.defineProperty(document, 'hidden', originalDescriptor);
+    } else {
+      delete (document as { hidden?: boolean }).hidden;
+    }
     wrapper.unmount();
   });
 });

--- a/app/composables/usePromotedTwitch.ts
+++ b/app/composables/usePromotedTwitch.ts
@@ -2,6 +2,7 @@ export interface PromotedTwitchConfig {
   channel: string;
   displayName: string;
   enabled: boolean;
+  version: number;
 }
 const sharedConfig = ref<PromotedTwitchConfig | null>(null);
 export const usePromotedTwitch = () => {

--- a/app/composables/usePromotedTwitch.ts
+++ b/app/composables/usePromotedTwitch.ts
@@ -1,0 +1,15 @@
+export interface PromotedTwitchConfig {
+  channel: string;
+  displayName: string;
+  enabled: boolean;
+}
+const sharedConfig = ref<PromotedTwitchConfig | null>(null);
+export const usePromotedTwitch = () => {
+  const applyConfig = (config: PromotedTwitchConfig): void => {
+    sharedConfig.value = config;
+  };
+  const resetConfig = (): void => {
+    sharedConfig.value = null;
+  };
+  return { config: readonly(sharedConfig), applyConfig, resetConfig };
+};

--- a/app/features/admin/AdminTwitchConfigCard.vue
+++ b/app/features/admin/AdminTwitchConfigCard.vue
@@ -84,7 +84,7 @@
       title: t('admin.twitch_config_saved_with_warning_title', 'Twitch config saved'),
       description: t(
         'admin.twitch_config_saved_with_warning_description',
-        'The config was saved, but cached visitors may see the previous value until cache invalidation recovers.'
+        'The config was saved, but cached visitors may still see the previous value. Retry the save to attempt cache invalidation again.'
       ),
       color: 'warning',
       icon: 'i-mdi-alert',

--- a/app/features/admin/AdminTwitchConfigCard.vue
+++ b/app/features/admin/AdminTwitchConfigCard.vue
@@ -84,7 +84,7 @@
       title: t('admin.twitch_config_saved_with_warning_title', 'Twitch config saved'),
       description: t(
         'admin.twitch_config_saved_with_warning_description',
-        'The config was saved, but cached visitors may still see the previous value. Retry the save to attempt cache invalidation again.'
+        'The config was saved, but cached visitors may still see the previous value.'
       ),
       color: 'warning',
       icon: 'i-mdi-alert',

--- a/app/features/admin/AdminTwitchConfigCard.vue
+++ b/app/features/admin/AdminTwitchConfigCard.vue
@@ -66,6 +66,30 @@
     if (error instanceof Error) return serverMessage(error) ?? error.message;
     return t('admin.twitch_config_failed_description', 'Could not update Twitch config.');
   };
+  const showSaveResult = (saved: TwitchConfigSaveResult): void => {
+    if (saved.cacheInvalidated) {
+      toast.add({
+        title: t('admin.twitch_config_saved_title', 'Twitch config updated'),
+        description: t(
+          'admin.twitch_config_saved_description',
+          { channel: channel.value },
+          'Promoted stream is now {channel}.'
+        ),
+        color: 'success',
+        icon: 'i-mdi-check-circle',
+      });
+      return;
+    }
+    toast.add({
+      title: t('admin.twitch_config_saved_with_warning_title', 'Twitch config saved'),
+      description: t(
+        'admin.twitch_config_saved_with_warning_description',
+        'The config was saved, but cached visitors may see the previous value until cache invalidation recovers.'
+      ),
+      color: 'warning',
+      icon: 'i-mdi-alert',
+    });
+  };
   const saveConfig = async () => {
     if (!canSave.value) return;
     isSaving.value = true;
@@ -87,28 +111,7 @@
       });
       applyConfig(saved.config);
       applySharedConfig({ ...saved.config, version: saved.version });
-      if (saved.cacheInvalidated) {
-        toast.add({
-          title: t('admin.twitch_config_saved_title', 'Twitch config updated'),
-          description: t(
-            'admin.twitch_config_saved_description',
-            { channel: channel.value },
-            'Promoted stream is now {channel}.'
-          ),
-          color: 'success',
-          icon: 'i-mdi-check-circle',
-        });
-      } else {
-        toast.add({
-          title: t('admin.twitch_config_saved_with_warning_title', 'Twitch config saved'),
-          description: t(
-            'admin.twitch_config_saved_with_warning_description',
-            'The config was saved, but cached visitors may see the previous value until cache invalidation recovers.'
-          ),
-          color: 'warning',
-          icon: 'i-mdi-alert',
-        });
-      }
+      showSaveResult(saved);
     } catch (error) {
       logger.warn('[AdminTwitchConfigCard] Failed to save Twitch config', error);
       toast.add({

--- a/app/features/admin/AdminTwitchConfigCard.vue
+++ b/app/features/admin/AdminTwitchConfigCard.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+  import { usePromotedTwitch } from '@/composables/usePromotedTwitch';
   import { useSystemStoreWithSupabase } from '@/stores/useSystemStore';
   import { logger } from '@/utils/logger';
   const { $supabase } = useNuxtApp();
   const { t } = useI18n({ useScope: 'global' });
   const toast = useToast();
   const { systemStore } = useSystemStoreWithSupabase();
+  const { applyConfig: applySharedConfig } = usePromotedTwitch();
   const CHANNEL_MAX_LENGTH = 25;
   const DISPLAY_NAME_MAX_LENGTH = 50;
   interface TwitchConfig {
@@ -83,6 +85,7 @@
         },
       });
       applyConfig(saved.config);
+      applySharedConfig(saved.config);
       toast.add({
         title: t('admin.twitch_config_saved_title', 'Twitch config updated'),
         description: t(

--- a/app/features/admin/AdminTwitchConfigCard.vue
+++ b/app/features/admin/AdminTwitchConfigCard.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-  import { usePromotedTwitch } from '@/composables/usePromotedTwitch';
+  import { usePromotedTwitch, type PromotedTwitchConfig } from '@/composables/usePromotedTwitch';
   import { useSystemStoreWithSupabase } from '@/stores/useSystemStore';
   import { logger } from '@/utils/logger';
   const { $supabase } = useNuxtApp();
@@ -9,10 +9,11 @@
   const { applyConfig: applySharedConfig } = usePromotedTwitch();
   const CHANNEL_MAX_LENGTH = 25;
   const DISPLAY_NAME_MAX_LENGTH = 50;
-  interface TwitchConfig {
-    channel: string;
-    displayName: string;
-    enabled: boolean;
+  type TwitchConfig = Omit<PromotedTwitchConfig, 'version'>;
+  interface TwitchConfigSaveResult {
+    cacheInvalidated: boolean;
+    config: TwitchConfig;
+    version: number;
   }
   const channel = ref('');
   const displayName = ref('');
@@ -75,7 +76,7 @@
           t('admin.twitch_config_login_required', 'You must be signed in to update Twitch config.')
         );
       }
-      const saved = await $fetch<{ config: TwitchConfig }>('/api/admin/twitch-config', {
+      const saved = await $fetch<TwitchConfigSaveResult>('/api/admin/twitch-config', {
         method: 'POST',
         headers: { Authorization: `Bearer ${token}` },
         body: {
@@ -85,17 +86,29 @@
         },
       });
       applyConfig(saved.config);
-      applySharedConfig(saved.config);
-      toast.add({
-        title: t('admin.twitch_config_saved_title', 'Twitch config updated'),
-        description: t(
-          'admin.twitch_config_saved_description',
-          { channel: channel.value },
-          'Promoted stream is now {channel}.'
-        ),
-        color: 'success',
-        icon: 'i-mdi-check-circle',
-      });
+      applySharedConfig({ ...saved.config, version: saved.version });
+      if (saved.cacheInvalidated) {
+        toast.add({
+          title: t('admin.twitch_config_saved_title', 'Twitch config updated'),
+          description: t(
+            'admin.twitch_config_saved_description',
+            { channel: channel.value },
+            'Promoted stream is now {channel}.'
+          ),
+          color: 'success',
+          icon: 'i-mdi-check-circle',
+        });
+      } else {
+        toast.add({
+          title: t('admin.twitch_config_saved_with_warning_title', 'Twitch config saved'),
+          description: t(
+            'admin.twitch_config_saved_with_warning_description',
+            'The config was saved, but cached visitors may see the previous value until cache invalidation recovers.'
+          ),
+          color: 'warning',
+          icon: 'i-mdi-alert',
+        });
+      }
     } catch (error) {
       logger.warn('[AdminTwitchConfigCard] Failed to save Twitch config', error);
       toast.add({

--- a/app/features/admin/AdminTwitchConfigCard.vue
+++ b/app/features/admin/AdminTwitchConfigCard.vue
@@ -31,7 +31,7 @@
   const loadConfig = async () => {
     isLoading.value = true;
     try {
-      applyConfig(await $fetch<TwitchConfig>('/api/twitch/config'));
+      applyConfig(await $fetch<TwitchConfig>('/api/twitch/config', { cache: 'no-store' }));
     } catch (error) {
       logger.warn('[AdminTwitchConfigCard] Failed to load Twitch config', error);
       toast.add({

--- a/app/features/admin/AdminTwitchConfigCard.vue
+++ b/app/features/admin/AdminTwitchConfigCard.vue
@@ -141,7 +141,7 @@
           {{
             t(
               'admin.twitch_config_description',
-              'Set the Twitch channel promoted in the corner of the site. Visitors pick up the change within a couple of minutes.'
+              'Set the Twitch channel promoted in the corner of the site. Visitors pick up the change within five minutes.'
             )
           }}
         </p>

--- a/app/features/admin/__tests__/AdminTwitchConfigCard.test.ts
+++ b/app/features/admin/__tests__/AdminTwitchConfigCard.test.ts
@@ -76,7 +76,7 @@ describe('AdminTwitchConfigCard', () => {
   it('loads the effective Twitch configuration', async () => {
     const wrapper = mountCard();
     await flushPromises();
-    expect(fetchMock).toHaveBeenCalledWith('/api/twitch/config', undefined);
+    expect(fetchMock).toHaveBeenCalledWith('/api/twitch/config', { cache: 'no-store' });
     expect(wrapper.findAll('input')[0]!.attributes('value')).toBe('streamer');
     expect(wrapper.findAll('input')[1]!.attributes('value')).toBe('Streamer');
     expect(wrapper.find('button').attributes('disabled')).toBeUndefined();

--- a/app/features/admin/__tests__/AdminTwitchConfigCard.test.ts
+++ b/app/features/admin/__tests__/AdminTwitchConfigCard.test.ts
@@ -70,7 +70,7 @@ describe('AdminTwitchConfigCard', () => {
       if (url === '/api/twitch/config') {
         return Promise.resolve({ channel: 'streamer', displayName: 'Streamer', enabled: true });
       }
-      return Promise.resolve({ config: {} });
+      return Promise.resolve({ cacheInvalidated: true, config: {}, version: 1 });
     });
   });
   it('loads the effective Twitch configuration', async () => {
@@ -96,7 +96,9 @@ describe('AdminTwitchConfigCard', () => {
         return Promise.resolve({ channel: 'streamer', displayName: 'Streamer', enabled: true });
       }
       return Promise.resolve({
+        cacheInvalidated: true,
         config: { channel: 'streamer', displayName: 'streamer', enabled: true },
+        version: 2,
       });
     });
     const wrapper = mountCard();
@@ -113,6 +115,28 @@ describe('AdminTwitchConfigCard', () => {
       })
     );
     expect(wrapper.findAll('input')[1]!.attributes('value')).toBe('streamer');
+  });
+  it('warns when the config was saved but cache invalidation failed', async () => {
+    fetchMock.mockImplementation((url: string) => {
+      if (url === '/api/twitch/config') {
+        return Promise.resolve({ channel: 'streamer', displayName: 'Streamer', enabled: true });
+      }
+      return Promise.resolve({
+        cacheInvalidated: false,
+        config: { channel: 'streamer', displayName: 'Streamer', enabled: true },
+        version: 2,
+      });
+    });
+    const wrapper = mountCard();
+    await flushPromises();
+    await wrapper.find('button').trigger('click');
+    await flushPromises();
+    expect(toastAddMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        color: 'warning',
+        title: 'admin.twitch_config_saved_with_warning_title',
+      })
+    );
   });
   it('surfaces the server validation message on failure', async () => {
     vi.spyOn(logger, 'warn').mockImplementation(() => undefined);

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -57,6 +57,8 @@
     "twitch_display_name_placeholder": "Channel display name",
     "twitch_config_saved_title": "Twitch config updated",
     "twitch_config_saved_description": "Promoted stream is now {channel}.",
+    "twitch_config_saved_with_warning_title": "Twitch config saved",
+    "twitch_config_saved_with_warning_description": "The config was saved, but cached visitors may see the previous value until cache invalidation recovers.",
     "twitch_config_failed_description": "Could not update Twitch config.",
     "twitch_config_load_failed_title": "Twitch config unavailable",
     "twitch_config_load_failed_description": "Could not load the current Twitch config.",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -50,7 +50,7 @@
     "supporter_override_disabled_description": "Disabled active supporter access.",
     "supporter_override_failed_description": "Could not update supporter access.",
     "twitch_config_title": "Twitch Stream",
-    "twitch_config_description": "Set the Twitch channel promoted in the corner of the site. Visitors pick up the change within a couple of minutes.",
+    "twitch_config_description": "Set the Twitch channel promoted in the corner of the site. Visitors pick up the change within five minutes.",
     "twitch_channel_label": "Channel",
     "twitch_channel_placeholder": "Twitch channel name",
     "twitch_display_name_label": "Display name",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -58,7 +58,7 @@
     "twitch_config_saved_title": "Twitch config updated",
     "twitch_config_saved_description": "Promoted stream is now {channel}.",
     "twitch_config_saved_with_warning_title": "Twitch config saved",
-    "twitch_config_saved_with_warning_description": "The config was saved, but cached visitors may see the previous value until cache invalidation recovers.",
+    "twitch_config_saved_with_warning_description": "The config was saved, but cached visitors may still see the previous value. Retry the save to attempt cache invalidation again.",
     "twitch_config_failed_description": "Could not update Twitch config.",
     "twitch_config_load_failed_title": "Twitch config unavailable",
     "twitch_config_load_failed_description": "Could not load the current Twitch config.",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -58,7 +58,7 @@
     "twitch_config_saved_title": "Twitch config updated",
     "twitch_config_saved_description": "Promoted stream is now {channel}.",
     "twitch_config_saved_with_warning_title": "Twitch config saved",
-    "twitch_config_saved_with_warning_description": "The config was saved, but cached visitors may still see the previous value. Retry the save to attempt cache invalidation again.",
+    "twitch_config_saved_with_warning_description": "The config was saved, but cached visitors may still see the previous value.",
     "twitch_config_failed_description": "Could not update Twitch config.",
     "twitch_config_load_failed_title": "Twitch config unavailable",
     "twitch_config_load_failed_description": "Could not load the current Twitch config.",

--- a/app/server/api/admin/__tests__/twitch-config.test.ts
+++ b/app/server/api/admin/__tests__/twitch-config.test.ts
@@ -28,6 +28,11 @@ mockNuxtImport('useRuntimeConfig', () => () => runtimeConfig);
 function makeEvent(authUser: { id?: string; email?: string } | null): H3Event {
   return {
     context: authUser ? { auth: { user: authUser } } : ({} as H3EventContext),
+    node: {
+      req: {
+        headers: authUser ? { authorization: 'Bearer admin-token' } : {},
+      },
+    },
   } as unknown as H3Event;
 }
 function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
@@ -80,20 +85,23 @@ describe('POST /api/admin/twitch-config', () => {
       statusCode: 403,
     });
   });
-  it('upserts the Twitch config and writes an audit log', async () => {
+  it('upserts the Twitch config, writes an audit log, and purges the cache tag', async () => {
     mockReadBody.mockResolvedValue({
       channel: 'NewStreamer',
       displayName: 'New Streamer',
       enabled: false,
     });
-    mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }])).mockResolvedValueOnce(
-      jsonResponse([
-        {
-          value: { channel: 'newstreamer', displayName: 'New Streamer', enabled: false },
-          version: 4,
-        },
-      ])
-    );
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse([{ is_admin: true }]))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            value: { channel: 'newstreamer', displayName: 'New Streamer', enabled: false },
+            version: 4,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: true }));
     const { default: handler } = await import('@/server/api/admin/twitch-config.post');
     const result = await handler(makeEvent({ id: 'admin-1', email: 'admin@example.com' }));
     expect(result).toEqual({
@@ -107,6 +115,52 @@ describe('POST /api/admin/twitch-config', () => {
       p_admin_user_id: 'admin-1',
       p_admin_email: 'admin@example.com',
     });
+    const purgeCall = mockFetch.mock.calls[2] as [string, RequestInit];
+    expect(purgeCall[0]).toBe('https://test.supabase.co/functions/v1/admin-cache-purge');
+    expect(purgeCall[1].headers).toMatchObject({ Authorization: 'Bearer admin-token' });
+    expect(JSON.parse(purgeCall[1].body as string)).toEqual({ purgeType: 'twitch-config' });
+  });
+  it('does not purge the cache when the database update fails', async () => {
+    mockReadBody.mockResolvedValue({ channel: 'validchannel', enabled: true });
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse([{ is_admin: true }]))
+      .mockResolvedValueOnce(jsonResponse({}, { ok: false, status: 500 }));
+    const { default: handler } = await import('@/server/api/admin/twitch-config.post');
+    await expect(handler(makeEvent({ id: 'admin-1' }))).rejects.toMatchObject({ statusCode: 502 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+  it('fails the update when the cache purge fails', async () => {
+    mockReadBody.mockResolvedValue({ channel: 'validchannel', enabled: true });
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse([{ is_admin: true }]))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            value: { channel: 'validchannel', displayName: 'validchannel', enabled: true },
+            version: 2,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: false }, { ok: false, status: 502 }));
+    const { default: handler } = await import('@/server/api/admin/twitch-config.post');
+    await expect(handler(makeEvent({ id: 'admin-1' }))).rejects.toMatchObject({ statusCode: 502 });
+  });
+  it('fails the update when the purge authorization header is missing', async () => {
+    mockReadBody.mockResolvedValue({ channel: 'validchannel', enabled: true });
+    mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }])).mockResolvedValueOnce(
+      jsonResponse([
+        {
+          value: { channel: 'validchannel', displayName: 'validchannel', enabled: true },
+          version: 2,
+        },
+      ])
+    );
+    const { default: handler } = await import('@/server/api/admin/twitch-config.post');
+    const event = makeEvent({ id: 'admin-1' });
+    (event as unknown as { node: { req: { headers: Record<string, string> } } }).node.req.headers =
+      {};
+    await expect(handler(event)).rejects.toMatchObject({ statusCode: 500 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
   });
   it('logs and propagates a transactional update failure', async () => {
     mockReadBody.mockResolvedValue({ channel: 'validchannel', enabled: true });
@@ -126,14 +180,17 @@ describe('POST /api/admin/twitch-config', () => {
   });
   it('defaults the display name to the channel when omitted', async () => {
     mockReadBody.mockResolvedValue({ channel: 'OnlyChannel', enabled: true });
-    mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }])).mockResolvedValueOnce(
-      jsonResponse([
-        {
-          value: { channel: 'onlychannel', displayName: 'onlychannel', enabled: true },
-          version: 1,
-        },
-      ])
-    );
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse([{ is_admin: true }]))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            value: { channel: 'onlychannel', displayName: 'onlychannel', enabled: true },
+            version: 1,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: true }));
     const { default: handler } = await import('@/server/api/admin/twitch-config.post');
     await handler(makeEvent({ id: 'admin-1' }));
     const upsertCall = mockFetch.mock.calls[1] as [string, RequestInit];
@@ -189,14 +246,17 @@ describe('POST /api/admin/twitch-config', () => {
   it('normalizes a Supabase URL that carries a query string', async () => {
     runtimeConfig.supabaseUrl = 'https://test.supabase.co/?apikey=leaked';
     mockReadBody.mockResolvedValue({ channel: 'validchannel', enabled: true });
-    mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }])).mockResolvedValueOnce(
-      jsonResponse([
-        {
-          value: { channel: 'validchannel', displayName: 'validchannel', enabled: true },
-          version: 1,
-        },
-      ])
-    );
+    mockFetch
+      .mockResolvedValueOnce(jsonResponse([{ is_admin: true }]))
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            value: { channel: 'validchannel', displayName: 'validchannel', enabled: true },
+            version: 1,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ success: true }));
     const { default: handler } = await import('@/server/api/admin/twitch-config.post');
     await handler(makeEvent({ id: 'admin-1' }));
     expect(mockFetch.mock.calls[0]?.[0]).toBe(

--- a/app/server/api/admin/__tests__/twitch-config.test.ts
+++ b/app/server/api/admin/__tests__/twitch-config.test.ts
@@ -159,7 +159,7 @@ describe('POST /api/admin/twitch-config', () => {
     const event = makeEvent({ id: 'admin-1' });
     (event as unknown as { node: { req: { headers: Record<string, string> } } }).node.req.headers =
       {};
-    await expect(handler(event)).rejects.toMatchObject({ statusCode: 500 });
+    await expect(handler(event)).rejects.toMatchObject({ statusCode: 502 });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
   it('logs and propagates a transactional update failure', async () => {

--- a/app/server/api/admin/__tests__/twitch-config.test.ts
+++ b/app/server/api/admin/__tests__/twitch-config.test.ts
@@ -105,6 +105,7 @@ describe('POST /api/admin/twitch-config', () => {
     const { default: handler } = await import('@/server/api/admin/twitch-config.post');
     const result = await handler(makeEvent({ id: 'admin-1', email: 'admin@example.com' }));
     expect(result).toEqual({
+      cacheInvalidated: true,
       config: { channel: 'newstreamer', displayName: 'New Streamer', enabled: false },
       version: 4,
     });
@@ -129,7 +130,7 @@ describe('POST /api/admin/twitch-config', () => {
     await expect(handler(makeEvent({ id: 'admin-1' }))).rejects.toMatchObject({ statusCode: 502 });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
-  it('fails the update when the cache purge fails', async () => {
+  it('returns the committed config with a warning when the cache purge fails', async () => {
     mockReadBody.mockResolvedValue({ channel: 'validchannel', enabled: true });
     mockFetch
       .mockResolvedValueOnce(jsonResponse([{ is_admin: true }]))
@@ -143,9 +144,20 @@ describe('POST /api/admin/twitch-config', () => {
       )
       .mockResolvedValueOnce(jsonResponse({ success: false }, { ok: false, status: 502 }));
     const { default: handler } = await import('@/server/api/admin/twitch-config.post');
-    await expect(handler(makeEvent({ id: 'admin-1' }))).rejects.toMatchObject({ statusCode: 502 });
+    await expect(handler(makeEvent({ id: 'admin-1' }))).resolves.toEqual({
+      cacheInvalidated: false,
+      config: { channel: 'validchannel', displayName: 'validchannel', enabled: true },
+      version: 2,
+    });
+    expect(loggerErrorMock).toHaveBeenCalledWith(
+      '[AdminTwitchConfig] Failed to purge Twitch config cache',
+      expect.objectContaining({
+        action: 'purge_promoted_twitch_config',
+        adminUserId: 'admin-1',
+      })
+    );
   });
-  it('fails the update when the purge authorization header is missing', async () => {
+  it('returns the committed config with a warning when purge authorization is missing', async () => {
     mockReadBody.mockResolvedValue({ channel: 'validchannel', enabled: true });
     mockFetch.mockResolvedValueOnce(jsonResponse([{ is_admin: true }])).mockResolvedValueOnce(
       jsonResponse([
@@ -159,7 +171,11 @@ describe('POST /api/admin/twitch-config', () => {
     const event = makeEvent({ id: 'admin-1' });
     (event as unknown as { node: { req: { headers: Record<string, string> } } }).node.req.headers =
       {};
-    await expect(handler(event)).rejects.toMatchObject({ statusCode: 502 });
+    await expect(handler(event)).resolves.toEqual({
+      cacheInvalidated: false,
+      config: { channel: 'validchannel', displayName: 'validchannel', enabled: true },
+      version: 2,
+    });
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
   it('logs and propagates a transactional update failure', async () => {

--- a/app/server/api/admin/twitch-config.post.ts
+++ b/app/server/api/admin/twitch-config.post.ts
@@ -25,21 +25,24 @@ interface AdminAuthUser {
   id?: string;
   email?: string;
 }
-export default defineEventHandler(
-  async (event): Promise<{ config: TwitchConfig; version: number }> => {
-    try {
-      return await handleUpdate(event);
-    } catch (error) {
-      logger.error('[AdminTwitchConfig] Failed to update Twitch config', {
-        action: 'update_promoted_twitch_config',
-        adminUserId: readAdminUserIdForLog(event),
-        error,
-      });
-      throw error;
-    }
+interface UpdateResult {
+  cacheInvalidated: boolean;
+  config: TwitchConfig;
+  version: number;
+}
+export default defineEventHandler(async (event): Promise<UpdateResult> => {
+  try {
+    return await handleUpdate(event);
+  } catch (error) {
+    logger.error('[AdminTwitchConfig] Failed to update Twitch config', {
+      action: 'update_promoted_twitch_config',
+      adminUserId: readAdminUserIdForLog(event),
+      error,
+    });
+    throw error;
   }
-);
-async function handleUpdate(event: H3Event): Promise<{ config: TwitchConfig; version: number }> {
+});
+async function handleUpdate(event: H3Event): Promise<UpdateResult> {
   const runtime = useRuntimeConfig(event) as Record<string, unknown>;
   const supabaseUrl = readSupabaseUrl(runtime);
   const serviceKey = readServiceKey(runtime);
@@ -56,28 +59,25 @@ async function handleUpdate(event: H3Event): Promise<{ config: TwitchConfig; ver
     readAdminEmail(event),
     input
   );
-  await purgeConfigCache(runtime, event);
-  return { config: saved.value, version: saved.version };
+  const cacheInvalidated = await purgeConfigCache(runtime, event);
+  return { cacheInvalidated, config: saved.value, version: saved.version };
 }
-async function purgeConfigCache(runtime: Record<string, unknown>, event: H3Event): Promise<void> {
-  const supabaseUrl = readSupabaseUrl(runtime);
-  const authHeader = readAuthHeader(event);
-  if (!supabaseUrl) {
-    throw createError({ statusCode: 502, message: 'Cache purge config missing' });
-  }
+async function purgeConfigCache(
+  runtime: Record<string, unknown>,
+  event: H3Event
+): Promise<boolean> {
   try {
-    await invokeCachePurge(supabaseUrl, readAnonKey(runtime), authHeader);
+    const supabaseUrl = readSupabaseUrl(runtime);
+    if (!supabaseUrl) throw new Error('Cache purge config missing');
+    await invokeCachePurge(supabaseUrl, readAnonKey(runtime), readAuthHeader(event));
+    return true;
   } catch (error) {
-    if (isHttpError(error)) throw error;
     logger.error('[AdminTwitchConfig] Failed to purge Twitch config cache', {
       action: 'purge_promoted_twitch_config',
       adminUserId: readAdminUserIdForLog(event),
       error,
     });
-    throw createError({
-      statusCode: 502,
-      message: 'Twitch config saved but cache purge failed',
-    });
+    return false;
   }
 }
 function readAnonKey(runtime: Record<string, unknown>): string {
@@ -85,13 +85,8 @@ function readAnonKey(runtime: Record<string, unknown>): string {
 }
 function readAuthHeader(event: H3Event): string {
   const authHeader = getRequestHeader(event, 'authorization');
-  if (!authHeader) {
-    throw createError({ statusCode: 502, message: 'Cache purge config missing' });
-  }
+  if (!authHeader) throw new Error('Cache purge authorization missing');
   return authHeader;
-}
-function isHttpError(error: unknown): boolean {
-  return typeof error === 'object' && error !== null && 'statusCode' in error;
 }
 async function invokeCachePurge(
   supabaseUrl: string,
@@ -120,8 +115,7 @@ async function invokeCachePurge(
 async function buildPurgeFailureError(response: Response): Promise<Error> {
   const detail = await response.text().catch(() => '');
   const suffix = detail ? `: ${detail}` : '';
-  const message = `Twitch config saved but cache purge failed (${response.status})${suffix}`;
-  return createError({ statusCode: 502, message });
+  return new Error(`Cache purge failed (${response.status})${suffix}`);
 }
 async function updateConfig(
   supabaseUrl: string,

--- a/app/server/api/admin/twitch-config.post.ts
+++ b/app/server/api/admin/twitch-config.post.ts
@@ -60,32 +60,14 @@ async function handleUpdate(event: H3Event): Promise<{ config: TwitchConfig; ver
 }
 async function purgeConfigCache(runtime: Record<string, unknown>, event: H3Event): Promise<void> {
   const supabaseUrl = readSupabaseUrl(runtime);
-  const anonKey = runtime.supabaseAnonKey;
-  const authHeader = getRequestHeader(event, 'authorization');
-  if (!supabaseUrl || !authHeader) {
+  const authHeader = readAuthHeader(event);
+  if (!supabaseUrl) {
     throw createError({ statusCode: 500, message: 'Cache purge config missing' });
   }
   try {
-    const response = await fetch(`${supabaseUrl}${EDGE_FUNCTION_PATH}`, {
-      method: 'POST',
-      headers: {
-        Authorization: authHeader,
-        apikey: typeof anonKey === 'string' ? anonKey : '',
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ purgeType: 'twitch-config' }),
-    });
-    if (!response.ok) {
-      const detail = await response.text().catch(() => '');
-      throw createError({
-        statusCode: 502,
-        message: `Twitch config saved but cache purge failed (${response.status})${detail ? `: ${detail}` : ''}`,
-      });
-    }
+    await invokeCachePurge(supabaseUrl, readAnonKey(runtime), authHeader);
   } catch (error) {
-    if (error && typeof error === 'object' && 'statusCode' in error) {
-      throw error;
-    }
+    if (isHttpError(error)) throw error;
     logger.error('[AdminTwitchConfig] Failed to purge Twitch config cache', {
       action: 'purge_promoted_twitch_config',
       adminUserId: readAdminUserIdForLog(event),
@@ -96,6 +78,42 @@ async function purgeConfigCache(runtime: Record<string, unknown>, event: H3Event
       message: 'Twitch config saved but cache purge failed',
     });
   }
+}
+function readAnonKey(runtime: Record<string, unknown>): string {
+  return typeof runtime.supabaseAnonKey === 'string' ? runtime.supabaseAnonKey : '';
+}
+function readAuthHeader(event: H3Event): string {
+  const authHeader = getRequestHeader(event, 'authorization');
+  if (!authHeader) {
+    throw createError({ statusCode: 500, message: 'Cache purge config missing' });
+  }
+  return authHeader;
+}
+function isHttpError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'statusCode' in error;
+}
+async function invokeCachePurge(
+  supabaseUrl: string,
+  anonKey: string,
+  authHeader: string
+): Promise<void> {
+  const response = await fetch(`${supabaseUrl}${EDGE_FUNCTION_PATH}`, {
+    method: 'POST',
+    headers: {
+      Authorization: authHeader,
+      apikey: anonKey,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ purgeType: 'twitch-config' }),
+  });
+  if (response.ok) return;
+  throw await buildPurgeFailureError(response);
+}
+async function buildPurgeFailureError(response: Response): Promise<Error> {
+  const detail = await response.text().catch(() => '');
+  const suffix = detail ? `: ${detail}` : '';
+  const message = `Twitch config saved but cache purge failed (${response.status})${suffix}`;
+  return createError({ statusCode: 502, message });
 }
 async function updateConfig(
   supabaseUrl: string,

--- a/app/server/api/admin/twitch-config.post.ts
+++ b/app/server/api/admin/twitch-config.post.ts
@@ -1,8 +1,9 @@
-import { createError, defineEventHandler, readBody } from 'h3';
+import { createError, defineEventHandler, getRequestHeader, readBody } from 'h3';
 import { adminSupabaseFetch, getIsAdmin, normalizeSupabaseUrl } from '@/server/utils/adminSupabase';
 import { createLogger } from '@/server/utils/logger';
 import type { H3Event } from 'h3';
 const logger = createLogger('AdminTwitchConfig');
+const EDGE_FUNCTION_PATH = '/functions/v1/admin-cache-purge';
 const CHANNEL_REGEX = /^[a-z0-9_]{1,25}$/;
 const DISPLAY_NAME_MAX_LENGTH = 50;
 interface AdminTwitchConfigBody {
@@ -54,7 +55,47 @@ async function handleUpdate(event: H3Event): Promise<{ config: TwitchConfig; ver
     readAdminEmail(event),
     input
   );
+  await purgeConfigCache(runtime, event);
   return { config: saved.value, version: saved.version };
+}
+async function purgeConfigCache(runtime: Record<string, unknown>, event: H3Event): Promise<void> {
+  const supabaseUrl = readSupabaseUrl(runtime);
+  const anonKey = runtime.supabaseAnonKey;
+  const authHeader = getRequestHeader(event, 'authorization');
+  if (!supabaseUrl || !authHeader) {
+    throw createError({ statusCode: 500, message: 'Cache purge config missing' });
+  }
+  try {
+    const response = await fetch(`${supabaseUrl}${EDGE_FUNCTION_PATH}`, {
+      method: 'POST',
+      headers: {
+        Authorization: authHeader,
+        apikey: typeof anonKey === 'string' ? anonKey : '',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ purgeType: 'twitch-config' }),
+    });
+    if (!response.ok) {
+      const detail = await response.text().catch(() => '');
+      throw createError({
+        statusCode: 502,
+        message: `Twitch config saved but cache purge failed (${response.status})${detail ? `: ${detail}` : ''}`,
+      });
+    }
+  } catch (error) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
+    logger.error('[AdminTwitchConfig] Failed to purge Twitch config cache', {
+      action: 'purge_promoted_twitch_config',
+      adminUserId: readAdminUserIdForLog(event),
+      error,
+    });
+    throw createError({
+      statusCode: 502,
+      message: 'Twitch config saved but cache purge failed',
+    });
+  }
 }
 async function updateConfig(
   supabaseUrl: string,

--- a/app/server/api/admin/twitch-config.post.ts
+++ b/app/server/api/admin/twitch-config.post.ts
@@ -4,7 +4,7 @@ import { createLogger } from '@/server/utils/logger';
 import type { H3Event } from 'h3';
 const logger = createLogger('AdminTwitchConfig');
 const EDGE_FUNCTION_PATH = '/functions/v1/admin-cache-purge';
-const PURGE_TIMEOUT_MS = 10_000;
+const PURGE_TIMEOUT_MS = 25_000;
 const CHANNEL_REGEX = /^[a-z0-9_]{1,25}$/;
 const DISPLAY_NAME_MAX_LENGTH = 50;
 interface AdminTwitchConfigBody {

--- a/app/server/api/admin/twitch-config.post.ts
+++ b/app/server/api/admin/twitch-config.post.ts
@@ -4,6 +4,7 @@ import { createLogger } from '@/server/utils/logger';
 import type { H3Event } from 'h3';
 const logger = createLogger('AdminTwitchConfig');
 const EDGE_FUNCTION_PATH = '/functions/v1/admin-cache-purge';
+const PURGE_TIMEOUT_MS = 10_000;
 const CHANNEL_REGEX = /^[a-z0-9_]{1,25}$/;
 const DISPLAY_NAME_MAX_LENGTH = 50;
 interface AdminTwitchConfigBody {
@@ -62,7 +63,7 @@ async function purgeConfigCache(runtime: Record<string, unknown>, event: H3Event
   const supabaseUrl = readSupabaseUrl(runtime);
   const authHeader = readAuthHeader(event);
   if (!supabaseUrl) {
-    throw createError({ statusCode: 500, message: 'Cache purge config missing' });
+    throw createError({ statusCode: 502, message: 'Cache purge config missing' });
   }
   try {
     await invokeCachePurge(supabaseUrl, readAnonKey(runtime), authHeader);
@@ -85,7 +86,7 @@ function readAnonKey(runtime: Record<string, unknown>): string {
 function readAuthHeader(event: H3Event): string {
   const authHeader = getRequestHeader(event, 'authorization');
   if (!authHeader) {
-    throw createError({ statusCode: 500, message: 'Cache purge config missing' });
+    throw createError({ statusCode: 502, message: 'Cache purge config missing' });
   }
   return authHeader;
 }
@@ -97,17 +98,24 @@ async function invokeCachePurge(
   anonKey: string,
   authHeader: string
 ): Promise<void> {
-  const response = await fetch(`${supabaseUrl}${EDGE_FUNCTION_PATH}`, {
-    method: 'POST',
-    headers: {
-      Authorization: authHeader,
-      apikey: anonKey,
-      'Content-Type': 'application/json',
-    },
-    body: JSON.stringify({ purgeType: 'twitch-config' }),
-  });
-  if (response.ok) return;
-  throw await buildPurgeFailureError(response);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), PURGE_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${supabaseUrl}${EDGE_FUNCTION_PATH}`, {
+      method: 'POST',
+      headers: {
+        Authorization: authHeader,
+        apikey: anonKey,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ purgeType: 'twitch-config' }),
+      signal: controller.signal,
+    });
+    if (response.ok) return;
+    throw await buildPurgeFailureError(response);
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 async function buildPurgeFailureError(response: Response): Promise<Error> {
   const detail = await response.text().catch(() => '');

--- a/app/server/api/twitch/__tests__/config.test.ts
+++ b/app/server/api/twitch/__tests__/config.test.ts
@@ -74,8 +74,8 @@ describe('/api/twitch/config', () => {
     expect(setResponseHeadersMock).toHaveBeenCalledWith(
       {},
       {
-        'cache-control': 'public, max-age=300, s-maxage=3600',
-        'cloudflare-cdn-cache-control': 'public, max-age=3600',
+        'cache-control': 'public, max-age=300, s-maxage=2592000',
+        'cloudflare-cdn-cache-control': 'public, max-age=2592000',
         'cache-tag': 'promoted-twitch-config',
         vary: 'Origin',
       }

--- a/app/server/api/twitch/__tests__/config.test.ts
+++ b/app/server/api/twitch/__tests__/config.test.ts
@@ -30,7 +30,7 @@ const loadHandler = async () => {
   vi.resetModules();
   return (await import('@/server/api/twitch/config.get')).default as (
     event: unknown
-  ) => Promise<{ channel: string; displayName: string; enabled: boolean }>;
+  ) => Promise<{ channel: string; displayName: string; enabled: boolean; version: number }>;
 };
 describe('/api/twitch/config', () => {
   beforeEach(() => {
@@ -54,6 +54,7 @@ describe('/api/twitch/config', () => {
       channel: 'envstreamer',
       displayName: 'EnvStreamer',
       enabled: true,
+      version: 0,
     });
   });
   it('applies the database override and requires revalidation', async () => {
@@ -68,6 +69,7 @@ describe('/api/twitch/config', () => {
       channel: 'dbstreamer',
       displayName: 'DB Streamer',
       enabled: false,
+      version: 7,
     });
     expect(setResponseHeadersMock).toHaveBeenCalledWith(
       {},
@@ -95,17 +97,20 @@ describe('/api/twitch/config', () => {
       channel: 'envstreamer',
       displayName: 'EnvStreamer',
       enabled: true,
+      version: 2,
     });
   });
-  it('skips the database when Supabase config is missing', async () => {
+  it('does not cache the fallback when Supabase config is missing', async () => {
     runtimeConfig.supabaseUrl = '';
     const handler = await loadHandler();
     await expect(handler({})).resolves.toEqual({
       channel: 'envstreamer',
       displayName: 'EnvStreamer',
       enabled: true,
+      version: 0,
     });
     expect(adminSupabaseFetchMock).not.toHaveBeenCalled();
+    expect(setResponseHeadersMock).toHaveBeenCalledWith({}, { 'cache-control': 'no-store' });
   });
   it('falls back to env defaults when the database read fails', async () => {
     adminSupabaseFetchMock.mockRejectedValue(new Error('network down'));
@@ -114,6 +119,7 @@ describe('/api/twitch/config', () => {
       channel: 'envstreamer',
       displayName: 'EnvStreamer',
       enabled: true,
+      version: 0,
     });
     expect(setResponseHeadersMock).toHaveBeenCalledWith({}, { 'cache-control': 'no-store' });
   });
@@ -159,6 +165,7 @@ describe('/api/twitch/config', () => {
       channel: 'envstreamer',
       displayName: 'EnvStreamer',
       enabled: false,
+      version: 0,
     });
   });
   it('normalizes a Supabase URL that carries a query string', async () => {
@@ -181,8 +188,10 @@ describe('/api/twitch/config', () => {
         channel: 'envstreamer',
         displayName: 'EnvStreamer',
         enabled: true,
+        version: 0,
       });
       expect(adminSupabaseFetchMock).not.toHaveBeenCalled();
+      expect(setResponseHeadersMock).toHaveBeenCalledWith({}, { 'cache-control': 'no-store' });
     }
   );
 });

--- a/app/server/api/twitch/__tests__/config.test.ts
+++ b/app/server/api/twitch/__tests__/config.test.ts
@@ -115,6 +115,7 @@ describe('/api/twitch/config', () => {
       displayName: 'EnvStreamer',
       enabled: true,
     });
+    expect(setResponseHeadersMock).toHaveBeenCalledWith({}, { 'cache-control': 'no-store' });
   });
   it('reads the database on each handler execution (edge cache fills)', async () => {
     adminSupabaseFetchMock

--- a/app/server/api/twitch/__tests__/config.test.ts
+++ b/app/server/api/twitch/__tests__/config.test.ts
@@ -71,7 +71,12 @@ describe('/api/twitch/config', () => {
     });
     expect(setResponseHeadersMock).toHaveBeenCalledWith(
       {},
-      { 'cache-control': 'public, max-age=0, must-revalidate' }
+      {
+        'cache-control': 'public, max-age=300, s-maxage=31536000',
+        'cloudflare-cdn-cache-control': 'public, max-age=31536000',
+        'cache-tag': 'promoted-twitch-config',
+        vary: 'Origin',
+      }
     );
   });
   it('ignores malformed database override fields', async () => {
@@ -111,7 +116,7 @@ describe('/api/twitch/config', () => {
       enabled: true,
     });
   });
-  it('revalidates the database on every request so versions propagate across isolates', async () => {
+  it('reads the database on each handler execution (edge cache fills)', async () => {
     adminSupabaseFetchMock
       .mockResolvedValueOnce([
         {

--- a/app/server/api/twitch/__tests__/config.test.ts
+++ b/app/server/api/twitch/__tests__/config.test.ts
@@ -74,8 +74,8 @@ describe('/api/twitch/config', () => {
     expect(setResponseHeadersMock).toHaveBeenCalledWith(
       {},
       {
-        'cache-control': 'public, max-age=300, s-maxage=2592000',
-        'cloudflare-cdn-cache-control': 'public, max-age=2592000',
+        'cache-control': 'public, max-age=300, s-maxage=3600',
+        'cloudflare-cdn-cache-control': 'public, max-age=3600',
         'cache-tag': 'promoted-twitch-config',
         vary: 'Origin',
       }

--- a/app/server/api/twitch/__tests__/config.test.ts
+++ b/app/server/api/twitch/__tests__/config.test.ts
@@ -74,8 +74,8 @@ describe('/api/twitch/config', () => {
     expect(setResponseHeadersMock).toHaveBeenCalledWith(
       {},
       {
-        'cache-control': 'public, max-age=300, s-maxage=31536000',
-        'cloudflare-cdn-cache-control': 'public, max-age=31536000',
+        'cache-control': 'public, max-age=300, s-maxage=3600',
+        'cloudflare-cdn-cache-control': 'public, max-age=3600',
         'cache-tag': 'promoted-twitch-config',
         vary: 'Origin',
       }

--- a/app/server/api/twitch/__tests__/live.test.ts
+++ b/app/server/api/twitch/__tests__/live.test.ts
@@ -46,6 +46,13 @@ describe('/api/twitch/live', () => {
     const handler = await loadHandler();
     const result = await handler({});
     expect(result).toEqual({ isLive: true });
+    expect(setResponseHeadersMock).toHaveBeenCalledWith(
+      {},
+      {
+        'cache-control': 'public, max-age=30, s-maxage=60',
+        'cloudflare-cdn-cache-control': 'public, max-age=30',
+      }
+    );
     const [url, init] = fetchMock.mock.calls[0] ?? [];
     expect(url).toBe('https://gql.twitch.tv/gql');
     expect((init.headers as Record<string, string>)['Client-ID']).toBe('test-client-id');

--- a/app/server/api/twitch/config.get.ts
+++ b/app/server/api/twitch/config.get.ts
@@ -3,7 +3,13 @@ import { useRuntimeConfig } from '#imports';
 import { adminSupabaseFetch, normalizeSupabaseUrl } from '@/server/utils/adminSupabase';
 import { createLogger } from '@/server/utils/logger';
 const logger = createLogger('twitch-config');
-const REVALIDATE_HEADERS = { 'cache-control': 'public, max-age=0, must-revalidate' };
+const CACHE_TAG = 'promoted-twitch-config';
+const CACHE_HEADERS = {
+  'cache-control': 'public, max-age=300, s-maxage=31536000',
+  'cloudflare-cdn-cache-control': 'public, max-age=31536000',
+  'cache-tag': CACHE_TAG,
+  vary: 'Origin',
+};
 const SETTING_KEY = 'promoted_twitch';
 const DEFAULT_CHANNEL = 'honeyxxo';
 const CHANNEL_REGEX = /^[a-z0-9_]{1,25}$/;
@@ -91,6 +97,6 @@ export default defineEventHandler(async (event): Promise<TwitchConfig> => {
   const fallback = readFallback(runtime);
   const override = await readOverride(runtime);
   const config = resolveConfig(fallback, override.value);
-  setResponseHeaders(event, REVALIDATE_HEADERS);
+  setResponseHeaders(event, CACHE_HEADERS);
   return config;
 });

--- a/app/server/api/twitch/config.get.ts
+++ b/app/server/api/twitch/config.get.ts
@@ -5,8 +5,8 @@ import { createLogger } from '@/server/utils/logger';
 const logger = createLogger('twitch-config');
 const CACHE_TAG = 'promoted-twitch-config';
 const CACHE_HEADERS = {
-  'cache-control': 'public, max-age=300, s-maxage=31536000',
-  'cloudflare-cdn-cache-control': 'public, max-age=31536000',
+  'cache-control': 'public, max-age=300, s-maxage=3600',
+  'cloudflare-cdn-cache-control': 'public, max-age=3600',
   'cache-tag': CACHE_TAG,
   vary: 'Origin',
 };

--- a/app/server/api/twitch/config.get.ts
+++ b/app/server/api/twitch/config.get.ts
@@ -10,6 +10,7 @@ const CACHE_HEADERS = {
   'cache-tag': CACHE_TAG,
   vary: 'Origin',
 };
+const NO_STORE_HEADERS = { 'cache-control': 'no-store' };
 const SETTING_KEY = 'promoted_twitch';
 const DEFAULT_CHANNEL = 'honeyxxo';
 const CHANNEL_REGEX = /^[a-z0-9_]{1,25}$/;
@@ -29,6 +30,7 @@ interface SettingRow {
 }
 interface OverrideResult {
   value?: Record<string, unknown>;
+  failed?: boolean;
 }
 function normalizeChannel(value: unknown): string {
   if (typeof value !== 'string') return '';
@@ -85,7 +87,7 @@ async function fetchSetting(supabaseUrl: string, serviceKey: string): Promise<Ov
     return { value: rows?.[0]?.value };
   } catch (err) {
     logger.warn('Failed to read Twitch config override, falling back to env defaults', err);
-    return {};
+    return { failed: true };
   }
 }
 function readFallback(runtime: Record<string, unknown>): TwitchFallback {
@@ -97,6 +99,6 @@ export default defineEventHandler(async (event): Promise<TwitchConfig> => {
   const fallback = readFallback(runtime);
   const override = await readOverride(runtime);
   const config = resolveConfig(fallback, override.value);
-  setResponseHeaders(event, CACHE_HEADERS);
+  setResponseHeaders(event, override.failed ? NO_STORE_HEADERS : CACHE_HEADERS);
   return config;
 });

--- a/app/server/api/twitch/config.get.ts
+++ b/app/server/api/twitch/config.get.ts
@@ -4,9 +4,10 @@ import { adminSupabaseFetch, normalizeSupabaseUrl } from '@/server/utils/adminSu
 import { createLogger } from '@/server/utils/logger';
 const logger = createLogger('twitch-config');
 const CACHE_TAG = 'promoted-twitch-config';
+const EDGE_CACHE_TTL_SECONDS = 2_592_000;
 const CACHE_HEADERS = {
-  'cache-control': 'public, max-age=300, s-maxage=3600',
-  'cloudflare-cdn-cache-control': 'public, max-age=3600',
+  'cache-control': `public, max-age=300, s-maxage=${EDGE_CACHE_TTL_SECONDS}`,
+  'cloudflare-cdn-cache-control': `public, max-age=${EDGE_CACHE_TTL_SECONDS}`,
   'cache-tag': CACHE_TAG,
   vary: 'Origin',
 };

--- a/app/server/api/twitch/config.get.ts
+++ b/app/server/api/twitch/config.get.ts
@@ -19,6 +19,7 @@ interface TwitchConfig {
   channel: string;
   displayName: string;
   enabled: boolean;
+  version: number;
 }
 interface TwitchFallback {
   channel?: string;
@@ -27,9 +28,11 @@ interface TwitchFallback {
 }
 interface SettingRow {
   value?: Record<string, unknown>;
+  version?: number;
 }
 interface OverrideResult {
   value?: Record<string, unknown>;
+  version?: number;
   failed?: boolean;
 }
 function normalizeChannel(value: unknown): string {
@@ -50,9 +53,12 @@ function displayNameOr(value: unknown, fallback: string): string {
 function boolOr(value: unknown, fallback: boolean): boolean {
   return typeof value === 'boolean' ? value : fallback;
 }
-function resolveConfig(fallback: TwitchFallback, override?: Record<string, unknown>): TwitchConfig {
+function resolveConfig(
+  fallback: TwitchFallback,
+  override?: Record<string, unknown>
+): Omit<TwitchConfig, 'version'> {
   const channel = normalizeChannel(fallback.channel) || DEFAULT_CHANNEL;
-  const base: TwitchConfig = {
+  const base = {
     channel,
     displayName: displayNameOr(fallback.displayName, channel),
     enabled: boolOr(fallback.enabled, false),
@@ -74,7 +80,7 @@ function readServiceKey(runtime: Record<string, unknown>): string {
 async function readOverride(runtime: Record<string, unknown>): Promise<OverrideResult> {
   const supabaseUrl = readSupabaseUrl(runtime);
   const serviceKey = readServiceKey(runtime);
-  if (!supabaseUrl || !serviceKey) return {};
+  if (!supabaseUrl || !serviceKey) return { failed: true };
   return fetchSetting(supabaseUrl, serviceKey);
 }
 async function fetchSetting(supabaseUrl: string, serviceKey: string): Promise<OverrideResult> {
@@ -82,9 +88,9 @@ async function fetchSetting(supabaseUrl: string, serviceKey: string): Promise<Ov
     const rows = await adminSupabaseFetch<SettingRow[]>(
       supabaseUrl,
       serviceKey,
-      `/rest/v1/app_settings?select=value&key=eq.${SETTING_KEY}&limit=1`
+      `/rest/v1/app_settings?select=value,version&key=eq.${SETTING_KEY}&limit=1`
     );
-    return { value: rows?.[0]?.value };
+    return { value: rows?.[0]?.value, version: rows?.[0]?.version };
   } catch (err) {
     logger.warn('Failed to read Twitch config override, falling back to env defaults', err);
     return { failed: true };
@@ -100,5 +106,8 @@ export default defineEventHandler(async (event): Promise<TwitchConfig> => {
   const override = await readOverride(runtime);
   const config = resolveConfig(fallback, override.value);
   setResponseHeaders(event, override.failed ? NO_STORE_HEADERS : CACHE_HEADERS);
-  return config;
+  return {
+    ...config,
+    version: Number.isSafeInteger(override.version) ? (override.version as number) : 0,
+  };
 });

--- a/app/server/api/twitch/config.get.ts
+++ b/app/server/api/twitch/config.get.ts
@@ -4,7 +4,7 @@ import { adminSupabaseFetch, normalizeSupabaseUrl } from '@/server/utils/adminSu
 import { createLogger } from '@/server/utils/logger';
 const logger = createLogger('twitch-config');
 const CACHE_TAG = 'promoted-twitch-config';
-const EDGE_CACHE_TTL_SECONDS = 2_592_000;
+const EDGE_CACHE_TTL_SECONDS = 3_600;
 const CACHE_HEADERS = {
   'cache-control': `public, max-age=300, s-maxage=${EDGE_CACHE_TTL_SECONDS}`,
   'cloudflare-cdn-cache-control': `public, max-age=${EDGE_CACHE_TTL_SECONDS}`,

--- a/app/server/api/twitch/live.get.ts
+++ b/app/server/api/twitch/live.get.ts
@@ -5,7 +5,10 @@ import { TARKOVTRACKER_USER_AGENT } from '@/server/utils/userAgent';
 const logger = createLogger('twitch-live');
 const TWITCH_GQL_URL = 'https://gql.twitch.tv/gql';
 const CACHE_TTL_MS = 60_000;
-const LIVE_HEADERS = { 'cache-control': 'public, max-age=30, s-maxage=60' };
+const LIVE_HEADERS = {
+  'cache-control': 'public, max-age=30, s-maxage=60',
+  'cloudflare-cdn-cache-control': 'public, max-age=30',
+};
 let cachedResult: { channel: string; isLive: boolean; checkedAt: number } | null = null;
 export default defineEventHandler(async (event) => {
   const { twitchClientId } = useRuntimeConfig(event);

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -896,10 +896,11 @@ flowchart LR
 
 ### Flow
 
-1. `AdminTwitchConfigCard` loads the effective public configuration and obtains the current Supabase
-   access token before saving. After a successful save it also publishes the saved config to the
-   shared `usePromotedTwitch` client state, so the embed in the same tab adopts the change
-   immediately without waiting for a poll.
+1. `AdminTwitchConfigCard` loads the effective public configuration with browser caching disabled,
+   so a previously cached response cannot make a later save revert newer settings. It obtains the
+   current Supabase access token before saving. After a successful save it also publishes the saved
+   config to the shared `usePromotedTwitch` client state, so the embed in the same tab adopts the
+   change immediately without waiting for a poll.
 2. `POST /api/admin/twitch-config` requires authenticated admin membership and validates the Twitch
    channel, display name, and enabled flag. It calls `update_promoted_twitch_config`, which updates the
    `promoted_twitch` JSON value, advances its shared version, and writes the admin audit row in one

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -887,7 +887,7 @@ flowchart LR
     Write --> Audit[(admin_audit_log)]
     Write -->|purge tag after commit| Purge[Cloudflare Purge API<br/>promoted-twitch-config]
     Embed[PromotedTwitchEmbed] -->|once per mount + focus| Read[GET /api/twitch/config]
-    Read --> Edge[Edge cache, 1y TTL]
+    Read --> Edge[Edge cache, 1h TTL]
     Edge --> Settings
     Edge --> Fallback[Public runtime config fallback]
     Embed -->|every 60s while enabled| Live[GET /api/twitch/live]

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -915,11 +915,14 @@ flowchart LR
    missing table, missing row, malformed override, or unavailable database falls back safely instead
    of breaking the embed. The route reads the database only when the Pages Function executes — i.e.
    on cache fills. Its response carries `Cache-Tag: promoted-twitch-config` with a browser TTL of
-   five minutes (`max-age=300`) and a Cloudflare edge TTL of one year
-   (`s-maxage=31536000` / `cloudflare-cdn-cache-control: public, max-age=31536000`), so Cloudflare
-   serves cache hits without invoking the Function. When the database read fails, the fallback
+   five minutes (`max-age=300`) and a bounded Cloudflare edge TTL of one hour
+   (`s-maxage=3600` / `cloudflare-cdn-cache-control: public, max-age=3600`), so Cloudflare
+   serves cache hits without invoking the Function. The bounded TTL keeps a stale entry
+   self-healing: even if an in-flight cache fill stores a pre-purge response after the tag purge, or
+   a purge fails entirely, the stale value expires within an hour instead of pinning for a year. When
+   the database read fails, the fallback
    response is sent with `no-store` so a transient outage never pins the env-default fallback at the
-   edge for a year. Missing or invalid Supabase credentials are treated as the same uncacheable
+   edge. Missing or invalid Supabase credentials are treated as the same uncacheable
    failure. Successful responses include the settings version.
 5. `PromotedTwitchEmbed` fetches config once on mount and again on tab focus (an edge-cache hit),
    watches the shared client state for immediate propagation of admin saves in the same tab, and
@@ -965,9 +968,11 @@ flowchart LR
   promote a stream without a database override or admin write. The admin-managed override can change
   the effective channel, display name, and enabled state. A missing or malformed build-time flag
   resolves to disabled.
-- The config response must carry the `promoted-twitch-config` cache tag and long edge TTLs so
+- The config response must carry the `promoted-twitch-config` cache tag and a bounded edge TTL so
   Cloudflare serves cache hits without executing the Pages Function; the route and its database read
-  run only on cache fills. A failed database read must not be cached (`no-store`), so a transient
+  run only on cache fills. The bounded TTL bounds staleness: an in-flight fill that lands after a
+  purge, or a failed purge, recovers within the TTL instead of pinning a stale value indefinitely.
+  A failed database read must not be cached (`no-store`), so a transient
   outage cannot pin the env-default fallback at the edge.
 - The admin route must purge the `promoted-twitch-config` tag only after the database transaction
   commits. If invalidation fails, it must return the committed config with an explicit warning flag;

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -906,8 +906,9 @@ flowchart LR
    database transaction. A failure rolls back both writes.
 3. Only after the transaction commits does the route invoke the `admin-cache-purge` edge function
    with `purgeType: 'twitch-config'`, which calls the Cloudflare Purge API with the
-   `promoted-twitch-config` cache tag. A failed purge fails the save (`502`) so a broken
-   invalidation is never silent.
+   `promoted-twitch-config` cache tag. If the zone rejects tag purges, the edge function falls back
+   to purging the `/api/twitch/config` URL (apex and `www` variants). A failed purge fails the save
+   (`502`) so a broken invalidation is never silent.
 4. `GET /api/twitch/config` combines the build-time fallback with a validated database override. A
    missing table, missing row, malformed override, or unavailable database falls back safely instead
    of breaking the embed. The route reads the database only when the Pages Function executes — i.e.
@@ -937,7 +938,7 @@ flowchart LR
 - `app/composables/usePromotedTwitch.ts` — shared client config state for cross-component
   propagation.
 - `supabase/functions/admin-cache-purge/index.ts` — Cloudflare Purge API calls, including the
-  `twitch-config` tag purge.
+  `twitch-config` tag purge with a purge-by-URL fallback.
 - `supabase/migrations/20260814120000_add_app_settings.sql` — service-role-only settings table and
   transactional update/audit RPC.
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -885,9 +885,9 @@ flowchart LR
     Write --> Gate[Admin membership check]
     Gate --> Settings[(public.app_settings)]
     Write --> Audit[(admin_audit_log)]
-    Write -->|purge tag after commit| Purge[Cloudflare Purge API<br/>promoted-twitch-config]
+    Write -->|immediate + delayed purge| Purge[Cloudflare Purge API<br/>promoted-twitch-config]
     Embed[PromotedTwitchEmbed] -->|once per mount + focus| Read[GET /api/twitch/config]
-    Read --> Edge[Edge cache, 1h TTL]
+    Read --> Edge[Edge cache, 30d TTL]
     Edge --> Settings
     Edge --> Fallback[Public runtime config fallback]
     Embed -->|every 60s while enabled| Live[GET /api/twitch/live]
@@ -908,22 +908,25 @@ flowchart LR
 3. Only after the transaction commits does the route invoke the `admin-cache-purge` edge function
    with `purgeType: 'twitch-config'`, which calls the Cloudflare Purge API with the
    `promoted-twitch-config` cache tag. If the tag purge fails, the edge function falls back
-   to purging the `/api/twitch/config` URL (apex and `www` variants). If both purges fail, the route
-   returns the committed config with `cacheInvalidated: false`; the admin UI applies the saved value
-   locally and shows an explicit warning instead of encouraging a duplicate database write.
+   to purging the `/api/twitch/config` URL (apex and `www` variants). After a successful immediate
+   purge, `EdgeRuntime.waitUntil()` schedules the same purge six seconds later. That delay exceeds
+   the config route's five-second Supabase timeout, so a request that read the previous version before
+   the commit cannot refill the cache after both purges. If the immediate tag and URL purges both
+   fail, the route returns the committed config with `cacheInvalidated: false`; the admin UI applies
+   the saved value locally and shows an explicit warning instead of encouraging a duplicate database
+   write. A delayed purge failure is logged without changing the already returned save result.
 4. `GET /api/twitch/config` combines the build-time fallback with a validated database override. A
    missing table, missing row, malformed override, or unavailable database falls back safely instead
    of breaking the embed. The route reads the database only when the Pages Function executes — i.e.
    on cache fills. Its response carries `Cache-Tag: promoted-twitch-config` with a browser TTL of
-   five minutes (`max-age=300`) and a bounded Cloudflare edge TTL of one hour
-   (`s-maxage=3600` / `cloudflare-cdn-cache-control: public, max-age=3600`), so Cloudflare
-   serves cache hits without invoking the Function. The bounded TTL keeps a stale entry
-   self-healing: even if an in-flight cache fill stores a pre-purge response after the tag purge, or
-   a purge fails entirely, the stale value expires within an hour instead of pinning for a year. When
-   the database read fails, the fallback
-   response is sent with `no-store` so a transient outage never pins the env-default fallback at the
-   edge. Missing or invalid Supabase credentials are treated as the same uncacheable
-   failure. Successful responses include the settings version.
+   five minutes (`max-age=300`) and a bounded Cloudflare edge TTL of 30 days
+   (`s-maxage=2592000` / `cloudflare-cdn-cache-control: public, max-age=2592000`), so Cloudflare
+   serves cache hits without invoking the Function. The bounded TTL remains the final recovery path
+   if invalidation fails, while the delayed second purge prevents a successful invalidation from
+   being undone by an in-flight stale fill. When the database read fails, the fallback response is
+   sent with `no-store` so a transient outage never pins the env-default fallback at the edge.
+   Missing or invalid Supabase credentials are treated as the same uncacheable failure. Successful
+   responses include the settings version.
 5. `PromotedTwitchEmbed` fetches config once on mount and again on tab focus (an edge-cache hit),
    watches the shared client state for immediate propagation of admin saves in the same tab, and
    polls only `/api/twitch/live` every 60 seconds while `enabled === true`, pausing the timer while
@@ -948,7 +951,7 @@ flowchart LR
 - `app/composables/usePromotedTwitch.ts` — shared client config state for cross-component
   propagation.
 - `supabase/functions/admin-cache-purge/index.ts` — Cloudflare Purge API calls, including the
-  `twitch-config` tag purge with a purge-by-URL fallback.
+  immediate and delayed `twitch-config` tag purges with purge-by-URL fallbacks.
 - `supabase/migrations/20260814120000_add_app_settings.sql` — service-role-only settings table and
   transactional update/audit RPC.
 
@@ -970,13 +973,14 @@ flowchart LR
   resolves to disabled.
 - The config response must carry the `promoted-twitch-config` cache tag and a bounded edge TTL so
   Cloudflare serves cache hits without executing the Pages Function; the route and its database read
-  run only on cache fills. The bounded TTL bounds staleness: an in-flight fill that lands after a
-  purge, or a failed purge, recovers within the TTL instead of pinning a stale value indefinitely.
-  A failed database read must not be cached (`no-store`), so a transient
+  run only on cache fills. A failed database read must not be cached (`no-store`), so a transient
   outage cannot pin the env-default fallback at the edge.
 - The admin route must purge the `promoted-twitch-config` tag only after the database transaction
-  commits. If invalidation fails, it must return the committed config with an explicit warning flag;
-  the client must apply that config and visibly warn the admin without retrying the database write.
+  commits, then schedule a second purge after a delay longer than the config read timeout so an
+  in-flight stale fill cannot survive successful invalidation. If immediate invalidation fails, it
+  must return the committed config with an explicit warning flag; the client must apply that config
+  and visibly warn the admin without retrying the database write. The bounded TTL remains the final
+  recovery path when invalidation fails.
 - Mounted clients must never poll the config endpoint: they fetch it once per mount/focus and poll
   live status only while enabled, stopping while the tab is hidden. Older config versions and stale
   live-request generations must never overwrite the latest shared configuration or player state.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -907,8 +907,9 @@ flowchart LR
 3. Only after the transaction commits does the route invoke the `admin-cache-purge` edge function
    with `purgeType: 'twitch-config'`, which calls the Cloudflare Purge API with the
    `promoted-twitch-config` cache tag. If the tag purge fails, the edge function falls back
-   to purging the `/api/twitch/config` URL (apex and `www` variants). A failed purge fails the save
-   (`502`) so a broken invalidation is never silent.
+   to purging the `/api/twitch/config` URL (apex and `www` variants). If both purges fail, the route
+   returns the committed config with `cacheInvalidated: false`; the admin UI applies the saved value
+   locally and shows an explicit warning instead of encouraging a duplicate database write.
 4. `GET /api/twitch/config` combines the build-time fallback with a validated database override. A
    missing table, missing row, malformed override, or unavailable database falls back safely instead
    of breaking the embed. The route reads the database only when the Pages Function executes — i.e.
@@ -917,14 +918,17 @@ flowchart LR
    (`s-maxage=31536000` / `cloudflare-cdn-cache-control: public, max-age=31536000`), so Cloudflare
    serves cache hits without invoking the Function. When the database read fails, the fallback
    response is sent with `no-store` so a transient outage never pins the env-default fallback at the
-   edge for a year.
+   edge for a year. Missing or invalid Supabase credentials are treated as the same uncacheable
+   failure. Successful responses include the settings version.
 5. `PromotedTwitchEmbed` fetches config once on mount and again on tab focus (an edge-cache hit),
    watches the shared client state for immediate propagation of admin saves in the same tab, and
    polls only `/api/twitch/live` every 60 seconds while `enabled === true`, pausing the timer while
-   the tab is hidden. Live responses are edge-cached for 30 seconds, so the CDN absorbs the polling
-   traffic instead of the Function. Channel changes replace the player URL and clear a stored
-   dismissal, disabling hides an active player, and an unavailable config endpoint keeps the
-   build-time fallback working.
+   the tab is hidden. It ignores fetched configs older than the latest shared version, so a browser
+   cache hit or overlapping focus request cannot revert an admin save. Live responses are
+   edge-cached for 30 seconds, so the CDN absorbs the polling traffic instead of the Function.
+   Channel changes advance a request generation so stale live results cannot apply after a channel
+   cycles back. Channel changes replace the player URL and clear a stored dismissal, disabling hides
+   an active player, and an unavailable config endpoint keeps the build-time fallback working.
 
 ### Files
 
@@ -965,9 +969,11 @@ flowchart LR
   run only on cache fills. A failed database read must not be cached (`no-store`), so a transient
   outage cannot pin the env-default fallback at the edge.
 - The admin route must purge the `promoted-twitch-config` tag only after the database transaction
-  commits, and must fail the save if the purge fails.
+  commits. If invalidation fails, it must return the committed config with an explicit warning flag;
+  the client must apply that config and visibly warn the admin without retrying the database write.
 - Mounted clients must never poll the config endpoint: they fetch it once per mount/focus and poll
-  live status only while enabled, stopping while the tab is hidden.
+  live status only while enabled, stopping while the tab is hidden. Older config versions and stale
+  live-request generations must never overwrite the latest shared configuration or player state.
 
 ## 11. Boot-time asset-failure recovery
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -915,7 +915,9 @@ flowchart LR
    on cache fills. Its response carries `Cache-Tag: promoted-twitch-config` with a browser TTL of
    five minutes (`max-age=300`) and a Cloudflare edge TTL of one year
    (`s-maxage=31536000` / `cloudflare-cdn-cache-control: public, max-age=31536000`), so Cloudflare
-   serves cache hits without invoking the Function.
+   serves cache hits without invoking the Function. When the database read fails, the fallback
+   response is sent with `no-store` so a transient outage never pins the env-default fallback at the
+   edge for a year.
 5. `PromotedTwitchEmbed` fetches config once on mount and again on tab focus (an edge-cache hit),
    watches the shared client state for immediate propagation of admin saves in the same tab, and
    polls only `/api/twitch/live` every 60 seconds while `enabled === true`, pausing the timer while
@@ -960,7 +962,8 @@ flowchart LR
   resolves to disabled.
 - The config response must carry the `promoted-twitch-config` cache tag and long edge TTLs so
   Cloudflare serves cache hits without executing the Pages Function; the route and its database read
-  run only on cache fills.
+  run only on cache fills. A failed database read must not be cached (`no-store`), so a transient
+  outage cannot pin the env-default fallback at the edge.
 - The admin route must purge the `promoted-twitch-config` tag only after the database transaction
   commits, and must fail the save if the purge fails.
 - Mounted clients must never poll the config endpoint: they fetch it once per mount/focus and poll

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -914,7 +914,9 @@ flowchart LR
    the commit cannot refill the cache after both purges. If the immediate tag and URL purges both
    fail, the route returns the committed config with `cacheInvalidated: false`; the admin UI applies
    the saved value locally and shows an explicit warning instead of encouraging a duplicate database
-   write. A delayed purge failure is logged without changing the already returned save result.
+   write. The edge function records Twitch-only invalidations as `twitch_config_cache_purge`, not the
+   `cache_purge` action consumed by Tarkov game-data cache metadata. A delayed purge failure is logged
+   without changing the already returned save result.
 4. `GET /api/twitch/config` combines the build-time fallback with a validated database override. A
    missing table, missing row, malformed override, or unavailable database falls back safely instead
    of breaking the embed. The route reads the database only when the Pages Function executes — i.e.
@@ -984,8 +986,12 @@ flowchart LR
   recovery path when invalidation fails.
 - Mounted clients must refresh config every five minutes while visible and on mount/focus so remote
   enable, disable, and channel changes reach continuously open tabs. Config refreshes and live-status
-  polling stop while the tab is hidden. Older config versions and stale live-request generations must
-  never overwrite the latest shared configuration or player state.
+  checks stop while the tab is hidden, and pending lifecycle work must not start timers after unmount.
+  Older config versions and stale live-request generations must never overwrite the latest shared
+  configuration or player state.
+- Twitch-only invalidations must use the `twitch_config_cache_purge` audit action. The `cache_purge`
+  action is reserved for `all` and `tarkov-data` purges because `/api/tarkov/cache-meta` treats its
+  latest successful row as a signal to clear browser game-data caches.
 
 ## 11. Boot-time asset-failure recovery
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -874,7 +874,7 @@ flowchart LR
 **Summary.** The promoted Twitch embed uses build-time public runtime config as a safe fallback, but
 an administrator can change the active channel, display name, and enabled state without a frontend
 redeploy. The override is stored in a service-role-only settings table. The public config route is
-cached at the edge with a long TTL and explicitly invalidated after an admin update; live status is
+cached at the edge with a bounded TTL and explicitly invalidated after an admin update; live status is
 also edge-cached per TTL, so mounted clients do not invoke the Pages Function for every poll.
 
 ### Diagram
@@ -886,8 +886,8 @@ flowchart LR
     Gate --> Settings[(public.app_settings)]
     Write --> Audit[(admin_audit_log)]
     Write -->|immediate + delayed purge| Purge[Cloudflare Purge API<br/>promoted-twitch-config]
-    Embed[PromotedTwitchEmbed] -->|once per mount + focus| Read[GET /api/twitch/config]
-    Read --> Edge[Edge cache, 30d TTL]
+    Embed[PromotedTwitchEmbed] -->|mount, focus + every 5m| Read[GET /api/twitch/config]
+    Read --> Edge[Edge cache, 1h TTL]
     Edge --> Settings
     Edge --> Fallback[Public runtime config fallback]
     Embed -->|every 60s while enabled| Live[GET /api/twitch/live]
@@ -919,20 +919,21 @@ flowchart LR
    missing table, missing row, malformed override, or unavailable database falls back safely instead
    of breaking the embed. The route reads the database only when the Pages Function executes — i.e.
    on cache fills. Its response carries `Cache-Tag: promoted-twitch-config` with a browser TTL of
-   five minutes (`max-age=300`) and a bounded Cloudflare edge TTL of 30 days
-   (`s-maxage=2592000` / `cloudflare-cdn-cache-control: public, max-age=2592000`), so Cloudflare
-   serves cache hits without invoking the Function. The bounded TTL remains the final recovery path
+   five minutes (`max-age=300`) and a bounded Cloudflare edge TTL of one hour
+   (`s-maxage=3600` / `cloudflare-cdn-cache-control: public, max-age=3600`), so Cloudflare serves
+   cache hits without invoking the Function. The bounded TTL remains the final recovery path
    if invalidation fails, while the delayed second purge prevents a successful invalidation from
    being undone by an in-flight stale fill. When the database read fails, the fallback response is
    sent with `no-store` so a transient outage never pins the env-default fallback at the edge.
    Missing or invalid Supabase credentials are treated as the same uncacheable failure. Successful
    responses include the settings version.
-5. `PromotedTwitchEmbed` fetches config once on mount and again on tab focus (an edge-cache hit),
-   watches the shared client state for immediate propagation of admin saves in the same tab, and
-   polls only `/api/twitch/live` every 60 seconds while `enabled === true`, pausing the timer while
-   the tab is hidden. It ignores fetched configs older than the latest shared version, so a browser
-   cache hit or overlapping focus request cannot revert an admin save. Live responses are
-   edge-cached for 30 seconds, so the CDN absorbs the polling traffic instead of the Function.
+5. `PromotedTwitchEmbed` fetches config on mount, every five minutes while visible, and again on tab
+   focus. Browser and edge caching absorb those refreshes between fills. It watches the shared client
+   state for immediate propagation of admin saves in the same tab and polls `/api/twitch/live` every
+   60 seconds while `enabled === true`, pausing both timers while the tab is hidden. It ignores
+   fetched configs older than the latest shared version, so a browser cache hit or overlapping focus
+   request cannot revert an admin save. Live responses are edge-cached for 30 seconds, so the CDN
+   absorbs the polling traffic instead of the Function.
    Channel changes advance a request generation so stale live results cannot apply after a channel
    cycles back. Channel changes replace the player URL and clear a stored dismissal, disabling hides
    an active player, and an unavailable config endpoint keeps the build-time fallback working.
@@ -946,7 +947,7 @@ flowchart LR
 - `app/server/api/twitch/config.get.ts` — public fallback/override resolution and edge-cache
   headers.
 - `app/server/api/twitch/live.get.ts` — live-status check with short edge caching.
-- `app/components/PromotedTwitchEmbed.vue` — config-once fetch, live polling, and player state
+- `app/components/PromotedTwitchEmbed.vue` — bounded config refresh, live polling, and player state
   updates.
 - `app/composables/usePromotedTwitch.ts` — shared client config state for cross-component
   propagation.
@@ -981,9 +982,10 @@ flowchart LR
   must return the committed config with an explicit warning flag; the client must apply that config
   and visibly warn the admin without retrying the database write. The bounded TTL remains the final
   recovery path when invalidation fails.
-- Mounted clients must never poll the config endpoint: they fetch it once per mount/focus and poll
-  live status only while enabled, stopping while the tab is hidden. Older config versions and stale
-  live-request generations must never overwrite the latest shared configuration or player state.
+- Mounted clients must refresh config every five minutes while visible and on mount/focus so remote
+  enable, disable, and channel changes reach continuously open tabs. Config refreshes and live-status
+  polling stop while the tab is hidden. Older config versions and stale live-request generations must
+  never overwrite the latest shared configuration or player state.
 
 ## 11. Boot-time asset-failure recovery
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -906,7 +906,7 @@ flowchart LR
    database transaction. A failure rolls back both writes.
 3. Only after the transaction commits does the route invoke the `admin-cache-purge` edge function
    with `purgeType: 'twitch-config'`, which calls the Cloudflare Purge API with the
-   `promoted-twitch-config` cache tag. If the zone rejects tag purges, the edge function falls back
+   `promoted-twitch-config` cache tag. If the tag purge fails, the edge function falls back
    to purging the `/api/twitch/config` URL (apex and `www` variants). A failed purge fails the save
    (`502`) so a broken invalidation is never silent.
 4. `GET /api/twitch/config` combines the build-time fallback with a validated database override. A

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -873,8 +873,9 @@ flowchart LR
 
 **Summary.** The promoted Twitch embed uses build-time public runtime config as a safe fallback, but
 an administrator can change the active channel, display name, and enabled state without a frontend
-redeploy. The override is stored in a service-role-only settings table, resolved by a public Nitro
-route, and refreshed by mounted clients once per minute.
+redeploy. The override is stored in a service-role-only settings table. The public config route is
+cached at the edge with a long TTL and explicitly invalidated after an admin update; live status is
+also edge-cached per TTL, so mounted clients do not invoke the Pages Function for every poll.
 
 ### Diagram
 
@@ -884,36 +885,59 @@ flowchart LR
     Write --> Gate[Admin membership check]
     Gate --> Settings[(public.app_settings)]
     Write --> Audit[(admin_audit_log)]
-    Embed[PromotedTwitchEmbed] -->|every 60s| Read[GET /api/twitch/config]
-    Read --> Settings
-    Read --> Fallback[Public runtime config fallback]
-    Embed --> Live[GET /api/twitch/live]
+    Write -->|purge tag after commit| Purge[Cloudflare Purge API<br/>promoted-twitch-config]
+    Embed[PromotedTwitchEmbed] -->|once per mount + focus| Read[GET /api/twitch/config]
+    Read --> Edge[Edge cache, 1y TTL]
+    Edge --> Settings
+    Edge --> Fallback[Public runtime config fallback]
+    Embed -->|every 60s while enabled| Live[GET /api/twitch/live]
+    Live --> LiveEdge[Edge cache, 30s TTL]
 ```
 
 ### Flow
 
 1. `AdminTwitchConfigCard` loads the effective public configuration and obtains the current Supabase
-   access token before saving.
+   access token before saving. After a successful save it also publishes the saved config to the
+   shared `usePromotedTwitch` client state, so the embed in the same tab adopts the change
+   immediately without waiting for a poll.
 2. `POST /api/admin/twitch-config` requires authenticated admin membership and validates the Twitch
    channel, display name, and enabled flag. It calls `update_promoted_twitch_config`, which updates the
    `promoted_twitch` JSON value, advances its shared version, and writes the admin audit row in one
    database transaction. A failure rolls back both writes.
-3. `GET /api/twitch/config` combines the build-time fallback with a validated database override. A
+3. Only after the transaction commits does the route invoke the `admin-cache-purge` edge function
+   with `purgeType: 'twitch-config'`, which calls the Cloudflare Purge API with the
+   `promoted-twitch-config` cache tag. A failed purge fails the save (`502`) so a broken
+   invalidation is never silent.
+4. `GET /api/twitch/config` combines the build-time fallback with a validated database override. A
    missing table, missing row, malformed override, or unavailable database falls back safely instead
-   of breaking the embed. The route reads the database on every request and sends
-   `cache-control: public, max-age=0, must-revalidate`, so neither a Nitro isolate nor the edge can
-   serve an update without revalidating the database-backed value.
-4. `PromotedTwitchEmbed` refreshes the configuration before each live-status poll. Channel changes
-   replace the player URL and clear a stored dismissal, disabling hides an active player, and an
-   unavailable config endpoint keeps the build-time fallback working. Refreshes are single-flight, so
-   a slow request cannot be overtaken by the next 60-second tick.
+   of breaking the embed. The route reads the database only when the Pages Function executes — i.e.
+   on cache fills. Its response carries `Cache-Tag: promoted-twitch-config` with a browser TTL of
+   five minutes (`max-age=300`) and a Cloudflare edge TTL of one year
+   (`s-maxage=31536000` / `cloudflare-cdn-cache-control: public, max-age=31536000`), so Cloudflare
+   serves cache hits without invoking the Function.
+5. `PromotedTwitchEmbed` fetches config once on mount and again on tab focus (an edge-cache hit),
+   watches the shared client state for immediate propagation of admin saves in the same tab, and
+   polls only `/api/twitch/live` every 60 seconds while `enabled === true`, pausing the timer while
+   the tab is hidden. Live responses are edge-cached for 30 seconds, so the CDN absorbs the polling
+   traffic instead of the Function. Channel changes replace the player URL and clear a stored
+   dismissal, disabling hides an active player, and an unavailable config endpoint keeps the
+   build-time fallback working.
 
 ### Files
 
-- `app/features/admin/AdminTwitchConfigCard.vue` — admin form and authenticated save flow.
-- `app/server/api/admin/twitch-config.post.ts` — validation, admin authorization, upsert, and audit.
-- `app/server/api/twitch/config.get.ts` — public fallback/override resolution and revalidation.
-- `app/components/PromotedTwitchEmbed.vue` — minute polling and player state updates.
+- `app/features/admin/AdminTwitchConfigCard.vue` — admin form, authenticated save flow, and shared
+  state publish.
+- `app/server/api/admin/twitch-config.post.ts` — validation, admin authorization, upsert, audit, and
+  post-commit cache purge.
+- `app/server/api/twitch/config.get.ts` — public fallback/override resolution and edge-cache
+  headers.
+- `app/server/api/twitch/live.get.ts` — live-status check with short edge caching.
+- `app/components/PromotedTwitchEmbed.vue` — config-once fetch, live polling, and player state
+  updates.
+- `app/composables/usePromotedTwitch.ts` — shared client config state for cross-component
+  propagation.
+- `supabase/functions/admin-cache-purge/index.ts` — Cloudflare Purge API calls, including the
+  `twitch-config` tag purge.
 - `supabase/migrations/20260814120000_add_app_settings.sql` — service-role-only settings table and
   transactional update/audit RPC.
 
@@ -933,10 +957,13 @@ flowchart LR
   promote a stream without a database override or admin write. The admin-managed override can change
   the effective channel, display name, and enabled state. A missing or malformed build-time flag
   resolves to disabled.
-- Public responses must re-read the database-backed value instead of relying on module-local or
-  independently stale edge state.
-- Mounted clients re-read configuration on the same 60-second cadence as live status, so an admin
-  change takes effect without reload or redeploy within the next client poll after revalidation.
+- The config response must carry the `promoted-twitch-config` cache tag and long edge TTLs so
+  Cloudflare serves cache hits without executing the Pages Function; the route and its database read
+  run only on cache fills.
+- The admin route must purge the `promoted-twitch-config` tag only after the database transaction
+  commits, and must fail the save if the purge fails.
+- Mounted clients must never poll the config endpoint: they fetch it once per mount/focus and poll
+  live status only while enabled, stopping while the tab is hidden.
 
 ## 11. Boot-time asset-failure recovery
 

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -9,6 +9,7 @@ import {
 // Cloudflare API configuration
 const CLOUDFLARE_API_URL = 'https://api.cloudflare.com/client/v4';
 const EDGE_CACHE_PATH = '/__edge-cache/tarkov';
+const TWITCH_CONFIG_CACHE_TAG = 'promoted-twitch-config';
 const TARKOV_CACHE_KEYS = [
   { key: 'bootstrap', includesGameMode: false },
   { key: 'tasks-core', includesGameMode: true },
@@ -40,7 +41,7 @@ const TARKOV_LANGUAGES = [
 ];
 const TARKOV_GAME_MODES = ['regular', 'pve'];
 interface PurgeRequest {
-  purgeType: 'all' | 'tarkov-data';
+  purgeType: 'all' | 'tarkov-data' | 'twitch-config';
 }
 interface CloudflarePurgeResponse {
   success: boolean;
@@ -106,6 +107,68 @@ async function purgeAllCache(zoneId: string, apiToken: string): Promise<Cloudfla
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({ purge_everything: true }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+    if (!response.ok) {
+      const text = await response.text();
+      return {
+        success: false,
+        errors: [
+          { code: response.status, message: `Cloudflare API error (${response.status}): ${text}` },
+        ],
+        messages: [],
+      };
+    }
+    try {
+      return (await response.json()) as CloudflarePurgeResponse;
+    } catch (e) {
+      return {
+        success: false,
+        errors: [
+          {
+            code: 500,
+            message: `Invalid JSON response: ${e instanceof Error ? e.message : String(e)}`,
+          },
+        ],
+        messages: [],
+      };
+    }
+  } catch (err) {
+    const isTimeout = err instanceof DOMException && err.name === 'AbortError';
+    return {
+      success: false,
+      errors: [
+        {
+          code: isTimeout ? 408 : 500,
+          message: isTimeout
+            ? 'Request timed out after 8s'
+            : `Network error: ${err instanceof Error ? err.message : String(err)}`,
+        },
+      ],
+      messages: [],
+    };
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+/**
+ * Purge the promoted Twitch config cache entry by tag.
+ */
+async function purgeTwitchConfigCache(
+  zoneId: string,
+  apiToken: string
+): Promise<CloudflarePurgeResponse> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 8000);
+  try {
+    const response = await fetch(`${CLOUDFLARE_API_URL}/zones/${zoneId}/purge_cache`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${apiToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ tags: [TWITCH_CONFIG_CACHE_TAG] }),
       signal: controller.signal,
     });
     clearTimeout(timeoutId);
@@ -283,7 +346,7 @@ Deno.serve(async (req) => {
     }
     // Parse request body
     const rawBody = await req.text();
-    let body: Partial<PurgeRequest & { purge_type?: 'all' | 'tarkov-data' }>;
+    let body: Partial<PurgeRequest & { purge_type?: 'all' | 'tarkov-data' | 'twitch-config' }>;
     try {
       body = JSON.parse(rawBody) as Partial<PurgeRequest & { purge_type?: 'all' | 'tarkov-data' }>;
       // Support both camelCase (new) and snake_case (legacy) for backward compatibility
@@ -304,8 +367,12 @@ Deno.serve(async (req) => {
     }
     const purgeType = body.purgeType!;
     // Validate purge type
-    if (!['all', 'tarkov-data'].includes(purgeType)) {
-      return createErrorResponse("Invalid purgeType. Must be 'all' or 'tarkov-data'", 400, req);
+    if (!['all', 'tarkov-data', 'twitch-config'].includes(purgeType)) {
+      return createErrorResponse(
+        "Invalid purgeType. Must be 'all', 'tarkov-data', or 'twitch-config'",
+        400,
+        req
+      );
     }
     // Get Cloudflare credentials
     const zoneId = Deno.env.get('CLOUDFLARE_ZONE_ID');
@@ -314,27 +381,33 @@ Deno.serve(async (req) => {
       console.error('[admin-cache-purge] Missing Cloudflare credentials');
       return createErrorResponse('Cloudflare credentials not configured', 500, req);
     }
-    // Get base URL for cache key construction
+    // Get base URL for cache key construction (Tarkov data purges only)
     const baseUrl = Deno.env.get('APP_URL')?.trim();
-    if (!baseUrl) {
-      console.error('[admin-cache-purge] Missing APP_URL');
-      return createErrorResponse('Application URL not configured', 500, req);
-    }
-    try {
-      const protocol = new URL(baseUrl).protocol;
-      if (protocol !== 'http:' && protocol !== 'https:') {
-        throw new Error('Unsupported APP_URL protocol');
+    if (purgeType === 'tarkov-data') {
+      if (!baseUrl) {
+        console.error('[admin-cache-purge] Missing APP_URL');
+        return createErrorResponse('Application URL not configured', 500, req);
       }
-    } catch {
-      console.error('[admin-cache-purge] Invalid APP_URL');
-      return createErrorResponse('Application URL invalid', 500, req);
+      try {
+        const protocol = new URL(baseUrl).protocol;
+        if (protocol !== 'http:' && protocol !== 'https:') {
+          throw new Error('Unsupported APP_URL protocol');
+        }
+      } catch {
+        console.error('[admin-cache-purge] Invalid APP_URL');
+        return createErrorResponse('Application URL invalid', 500, req);
+      }
     }
     // Execute cache purge
     let purgeResult: CloudflarePurgeResponse;
     if (purgeType === 'all') {
       purgeResult = await purgeAllCache(zoneId, apiToken);
-    } else {
+    } else if (purgeType === 'twitch-config') {
+      purgeResult = await purgeTwitchConfigCache(zoneId, apiToken);
+    } else if (baseUrl) {
       purgeResult = await purgeTarkovDataCache(zoneId, apiToken, baseUrl);
+    } else {
+      return createErrorResponse('Application URL not configured', 500, req);
     }
     // Log the admin action
     await logAdminAction(
@@ -365,7 +438,9 @@ Deno.serve(async (req) => {
         message:
           purgeType === 'all'
             ? 'All cache purged successfully'
-            : 'Tarkov data cache purged successfully',
+            : purgeType === 'twitch-config'
+              ? 'Twitch config cache purged successfully'
+              : 'Tarkov data cache purged successfully',
         purgeType: purgeType,
         cloudflareResultId: purgeResult.result?.id,
         timestamp: new Date().toISOString(),

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -333,7 +333,6 @@ Deno.serve(async (req) => {
       console.error('[admin-cache-purge] Missing Cloudflare credentials');
       return createErrorResponse('Cloudflare credentials not configured', 500, req);
     }
-    // Get base URL for cache key construction (Tarkov data purges only)
     const baseUrl = Deno.env.get('APP_URL')?.trim() ?? '';
     if (purgeType === 'tarkov-data') {
       if (!baseUrl) {

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -10,6 +10,9 @@ import {
 const CLOUDFLARE_API_URL = 'https://api.cloudflare.com/client/v4';
 const EDGE_CACHE_PATH = '/__edge-cache/tarkov';
 const TWITCH_CONFIG_CACHE_TAG = 'promoted-twitch-config';
+const TWITCH_CONFIG_PATH = '/api/twitch/config';
+const PURGE_TIMEOUT_MS = 8000;
+const PURGE_CHUNK_SIZE = 30;
 const TARKOV_CACHE_KEYS = [
   { key: 'bootstrap', includesGameMode: false },
   { key: 'tasks-core', includesGameMode: true },
@@ -93,12 +96,42 @@ async function logAdminAction(
     console.error('[admin-cache-purge] Failed to log audit action:', error);
   }
 }
-/**
- * Purge entire Cloudflare cache for the zone
- */
-async function purgeAllCache(zoneId: string, apiToken: string): Promise<CloudflarePurgeResponse> {
+function errorResponse(code: number, message: string): CloudflarePurgeResponse {
+  return { success: false, errors: [{ code, message }], messages: [] };
+}
+function errorMessage(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+function isAbortError(err: unknown): boolean {
+  return err instanceof DOMException && err.name === 'AbortError';
+}
+function invalidJsonResponse(err: unknown): CloudflarePurgeResponse {
+  return errorResponse(500, `Invalid JSON response: ${errorMessage(err)}`);
+}
+function networkResponse(err: unknown): CloudflarePurgeResponse {
+  if (isAbortError(err)) {
+    return errorResponse(408, 'Request timed out after 8s');
+  }
+  return errorResponse(500, `Network error: ${errorMessage(err)}`);
+}
+async function parseResponse(response: Response): Promise<CloudflarePurgeResponse> {
+  if (!response.ok) {
+    const text = await response.text();
+    return errorResponse(response.status, `Cloudflare API error (${response.status}): ${text}`);
+  }
+  try {
+    return (await response.json()) as CloudflarePurgeResponse;
+  } catch (err) {
+    return invalidJsonResponse(err);
+  }
+}
+async function purgeCloudflareCache(
+  zoneId: string,
+  apiToken: string,
+  payload: Record<string, unknown>
+): Promise<CloudflarePurgeResponse> {
   const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 8000);
+  const timeoutId = setTimeout(() => controller.abort(), PURGE_TIMEOUT_MS);
   try {
     const response = await fetch(`${CLOUDFLARE_API_URL}/zones/${zoneId}/purge_cache`, {
       method: 'POST',
@@ -106,113 +139,117 @@ async function purgeAllCache(zoneId: string, apiToken: string): Promise<Cloudfla
         Authorization: `Bearer ${apiToken}`,
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ purge_everything: true }),
+      body: JSON.stringify(payload),
       signal: controller.signal,
     });
-    clearTimeout(timeoutId);
-    if (!response.ok) {
-      const text = await response.text();
-      return {
-        success: false,
-        errors: [
-          { code: response.status, message: `Cloudflare API error (${response.status}): ${text}` },
-        ],
-        messages: [],
-      };
-    }
-    try {
-      return (await response.json()) as CloudflarePurgeResponse;
-    } catch (e) {
-      return {
-        success: false,
-        errors: [
-          {
-            code: 500,
-            message: `Invalid JSON response: ${e instanceof Error ? e.message : String(e)}`,
-          },
-        ],
-        messages: [],
-      };
-    }
+    return await parseResponse(response);
   } catch (err) {
-    const isTimeout = err instanceof DOMException && err.name === 'AbortError';
-    return {
-      success: false,
-      errors: [
-        {
-          code: isTimeout ? 408 : 500,
-          message: isTimeout
-            ? 'Request timed out after 8s'
-            : `Network error: ${err instanceof Error ? err.message : String(err)}`,
-        },
-      ],
-      messages: [],
-    };
+    return networkResponse(err);
   } finally {
     clearTimeout(timeoutId);
   }
 }
 /**
- * Purge the promoted Twitch config cache entry by tag.
+ * Produce the origin variants (apex and www) for a given base URL so cache
+ * entries served on either hostname are both purged.
+ */
+function buildCacheOrigins(baseUrl: string): string[] {
+  const parsed = new URL(baseUrl);
+  const host = parsed.hostname;
+  const portSuffix = parsed.port ? `:${parsed.port}` : '';
+  const origins = [parsed.origin];
+  if (host.startsWith('www.')) {
+    origins.push(`${parsed.protocol}//${host.replace(/^www\./, '')}${portSuffix}`);
+  } else {
+    origins.push(`${parsed.protocol}//www.${host}${portSuffix}`);
+  }
+  return origins;
+}
+function chunkArray<T>(items: T[], size: number): T[][] {
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+function buildEntryUrls(
+  cacheBase: string,
+  entry: { key: string; includesGameMode: boolean }
+): string[] {
+  const urls: string[] = [];
+  for (const lang of TARKOV_LANGUAGES) {
+    if (entry.includesGameMode) {
+      for (const gameMode of TARKOV_GAME_MODES) {
+        urls.push(`${cacheBase}/${entry.key}-${lang}-${gameMode}`);
+      }
+    } else {
+      urls.push(`${cacheBase}/${entry.key}-${lang}`);
+    }
+  }
+  return urls;
+}
+function buildTarkovCacheUrls(baseUrl: string): string[] {
+  const urls: string[] = [];
+  for (const origin of buildCacheOrigins(baseUrl)) {
+    const cacheBase = `${origin}${EDGE_CACHE_PATH}`;
+    for (const entry of TARKOV_CACHE_KEYS) {
+      urls.push(...buildEntryUrls(cacheBase, entry));
+    }
+  }
+  return urls;
+}
+function buildTwitchConfigUrls(baseUrl: string): string[] {
+  return buildCacheOrigins(baseUrl).map((origin) => `${origin}${TWITCH_CONFIG_PATH}`);
+}
+function combinePurgeFailures(
+  first: CloudflarePurgeResponse,
+  second: CloudflarePurgeResponse
+): CloudflarePurgeResponse {
+  return { success: false, errors: [...first.errors, ...second.errors], messages: [] };
+}
+function purgeSuccessMessage(purgeType: PurgeRequest['purgeType']): string {
+  if (purgeType === 'all') return 'All cache purged successfully';
+  if (purgeType === 'twitch-config') return 'Twitch config cache purged successfully';
+  return 'Tarkov data cache purged successfully';
+}
+/**
+ * Purge entire Cloudflare cache for the zone
+ */
+function purgeAllCache(zoneId: string, apiToken: string): Promise<CloudflarePurgeResponse> {
+  return purgeCloudflareCache(zoneId, apiToken, { purge_everything: true });
+}
+/**
+ * Purge the promoted Twitch config cache entry by tag, falling back to a
+ * purge-by-URL when the zone rejects tag purges.
  */
 async function purgeTwitchConfigCache(
   zoneId: string,
-  apiToken: string
+  apiToken: string,
+  baseUrl: string
 ): Promise<CloudflarePurgeResponse> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), 8000);
-  try {
-    const response = await fetch(`${CLOUDFLARE_API_URL}/zones/${zoneId}/purge_cache`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${apiToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ tags: [TWITCH_CONFIG_CACHE_TAG] }),
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-    if (!response.ok) {
-      const text = await response.text();
-      return {
-        success: false,
-        errors: [
-          { code: response.status, message: `Cloudflare API error (${response.status}): ${text}` },
-        ],
-        messages: [],
-      };
-    }
-    try {
-      return (await response.json()) as CloudflarePurgeResponse;
-    } catch (e) {
-      return {
-        success: false,
-        errors: [
-          {
-            code: 500,
-            message: `Invalid JSON response: ${e instanceof Error ? e.message : String(e)}`,
-          },
-        ],
-        messages: [],
-      };
-    }
-  } catch (err) {
-    const isTimeout = err instanceof DOMException && err.name === 'AbortError';
-    return {
-      success: false,
-      errors: [
-        {
-          code: isTimeout ? 408 : 500,
-          message: isTimeout
-            ? 'Request timed out after 8s'
-            : `Network error: ${err instanceof Error ? err.message : String(err)}`,
-        },
-      ],
-      messages: [],
-    };
-  } finally {
-    clearTimeout(timeoutId);
+  const tagPurge = await purgeCloudflareCache(zoneId, apiToken, {
+    tags: [TWITCH_CONFIG_CACHE_TAG],
+  });
+  if (tagPurge.success) return tagPurge;
+  const urlPurge = await purgeCloudflareCache(zoneId, apiToken, {
+    files: buildTwitchConfigUrls(baseUrl),
+  });
+  if (urlPurge.success) return urlPurge;
+  return combinePurgeFailures(tagPurge, urlPurge);
+}
+function markPurgeFailure(
+  aggregate: CloudflarePurgeResponse,
+  result: CloudflarePurgeResponse
+): void {
+  if (!result.success) {
+    aggregate.success = false;
+    aggregate.errors.push(...(result.errors ?? []));
   }
+  aggregate.messages.push(...(result.messages ?? []));
+}
+function collectPurgeIds(ids: string[], result: CloudflarePurgeResponse): void {
+  const id = result.result?.id;
+  if (id) ids.push(id);
 }
 /**
  * Purge specific Tarkov data cache URLs
@@ -222,108 +259,20 @@ async function purgeTarkovDataCache(
   apiToken: string,
   baseUrl: string
 ): Promise<CloudflarePurgeResponse> {
-  const parsed = new URL(baseUrl);
-  const origins = new Set<string>();
-  origins.add(parsed.origin);
-  const host = parsed.hostname;
-  const portSuffix = parsed.port ? `:${parsed.port}` : '';
-  if (host.startsWith('www.')) {
-    origins.add(`${parsed.protocol}//${host.replace(/^www\./, '')}${portSuffix}`);
-  } else {
-    origins.add(`${parsed.protocol}//www.${host}${portSuffix}`);
-  }
-  const baseUrls = Array.from(origins);
-  const urlsToPurge: string[] = [];
-  for (const base of baseUrls) {
-    const cacheBase = `${base}${EDGE_CACHE_PATH}`;
-    for (const entry of TARKOV_CACHE_KEYS) {
-      for (const lang of TARKOV_LANGUAGES) {
-        if (entry.includesGameMode) {
-          for (const gameMode of TARKOV_GAME_MODES) {
-            urlsToPurge.push(`${cacheBase}/${entry.key}-${lang}-${gameMode}`);
-          }
-        } else {
-          urlsToPurge.push(`${cacheBase}/${entry.key}-${lang}`);
-        }
-      }
-    }
-  }
-  // Cloudflare limits files to 30 per call
-  const CHUNK_SIZE = 30;
-  const chunks: string[][] = [];
-  for (let i = 0; i < urlsToPurge.length; i += CHUNK_SIZE) {
-    chunks.push(urlsToPurge.slice(i, i + CHUNK_SIZE));
-  }
-  const aggregatedResult: CloudflarePurgeResponse = {
+  const aggregate: CloudflarePurgeResponse = {
     success: true,
     errors: [],
     messages: [],
     result: { id: '' },
   };
   const resultIds: string[] = [];
-  // Execute purge for each chunk
-  for (const chunk of chunks) {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 8000);
-    try {
-      const response = await fetch(`${CLOUDFLARE_API_URL}/zones/${zoneId}/purge_cache`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${apiToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ files: chunk }),
-        signal: controller.signal,
-      });
-      if (!response.ok) {
-        const text = await response.text();
-        aggregatedResult.success = false;
-        aggregatedResult.errors.push({
-          code: response.status,
-          message: `Cloudflare API error (${response.status} ${response.statusText}): ${text}`,
-        });
-        continue;
-      }
-      let data: CloudflarePurgeResponse;
-      try {
-        data = (await response.json()) as CloudflarePurgeResponse;
-      } catch (e) {
-        aggregatedResult.success = false;
-        aggregatedResult.errors.push({
-          code: 500,
-          message: `Invalid JSON response: ${e instanceof Error ? e.message : String(e)}`,
-        });
-        continue;
-      }
-      if (!data.success) {
-        aggregatedResult.success = false;
-        if (data.errors) {
-          aggregatedResult.errors.push(...data.errors);
-        }
-      }
-      if (data.messages) {
-        aggregatedResult.messages.push(...data.messages);
-      }
-      if (data.result?.id) {
-        resultIds.push(data.result.id);
-      }
-    } catch (err) {
-      const isTimeout = err instanceof DOMException && err.name === 'AbortError';
-      console.error('[admin-cache-purge] Error purging chunk:', err);
-      aggregatedResult.success = false;
-      aggregatedResult.errors.push({
-        code: isTimeout ? 408 : 500,
-        message: isTimeout
-          ? 'Request timed out after 8s'
-          : `Network error: ${err instanceof Error ? err.message : String(err)}`,
-      });
-    } finally {
-      clearTimeout(timeoutId);
-    }
+  for (const chunk of chunkArray(buildTarkovCacheUrls(baseUrl), PURGE_CHUNK_SIZE)) {
+    const result = await purgeCloudflareCache(zoneId, apiToken, { files: chunk });
+    markPurgeFailure(aggregate, result);
+    collectPurgeIds(resultIds, result);
   }
-  // Combine IDs from all successful chunks
-  aggregatedResult.result = { id: resultIds.join(',') };
-  return aggregatedResult;
+  aggregate.result = { id: resultIds.join(',') };
+  return aggregate;
 }
 Deno.serve(async (req) => {
   // Handle CORS preflight
@@ -348,7 +297,9 @@ Deno.serve(async (req) => {
     const rawBody = await req.text();
     let body: Partial<PurgeRequest & { purge_type?: 'all' | 'tarkov-data' | 'twitch-config' }>;
     try {
-      body = JSON.parse(rawBody) as Partial<PurgeRequest & { purge_type?: 'all' | 'tarkov-data' }>;
+      body = JSON.parse(rawBody) as Partial<
+        PurgeRequest & { purge_type?: 'all' | 'tarkov-data' | 'twitch-config' }
+      >;
       // Support both camelCase (new) and snake_case (legacy) for backward compatibility
       if (!body.purgeType && !body.purge_type) {
         body.purgeType = 'tarkov-data';
@@ -381,15 +332,16 @@ Deno.serve(async (req) => {
       console.error('[admin-cache-purge] Missing Cloudflare credentials');
       return createErrorResponse('Cloudflare credentials not configured', 500, req);
     }
-    // Get base URL for cache key construction (Tarkov data purges only)
-    const baseUrl = Deno.env.get('APP_URL')?.trim();
-    if (purgeType === 'tarkov-data') {
-      if (!baseUrl) {
+    // Get base URL for cache key construction (non-"all" purges only)
+    const rawBaseUrl = Deno.env.get('APP_URL')?.trim();
+    let baseUrl = '';
+    if (purgeType !== 'all') {
+      if (!rawBaseUrl) {
         console.error('[admin-cache-purge] Missing APP_URL');
         return createErrorResponse('Application URL not configured', 500, req);
       }
       try {
-        const protocol = new URL(baseUrl).protocol;
+        const protocol = new URL(rawBaseUrl).protocol;
         if (protocol !== 'http:' && protocol !== 'https:') {
           throw new Error('Unsupported APP_URL protocol');
         }
@@ -397,17 +349,16 @@ Deno.serve(async (req) => {
         console.error('[admin-cache-purge] Invalid APP_URL');
         return createErrorResponse('Application URL invalid', 500, req);
       }
+      baseUrl = rawBaseUrl;
     }
     // Execute cache purge
     let purgeResult: CloudflarePurgeResponse;
     if (purgeType === 'all') {
       purgeResult = await purgeAllCache(zoneId, apiToken);
     } else if (purgeType === 'twitch-config') {
-      purgeResult = await purgeTwitchConfigCache(zoneId, apiToken);
-    } else if (baseUrl) {
-      purgeResult = await purgeTarkovDataCache(zoneId, apiToken, baseUrl);
+      purgeResult = await purgeTwitchConfigCache(zoneId, apiToken, baseUrl);
     } else {
-      return createErrorResponse('Application URL not configured', 500, req);
+      purgeResult = await purgeTarkovDataCache(zoneId, apiToken, baseUrl);
     }
     // Log the admin action
     await logAdminAction(
@@ -435,12 +386,7 @@ Deno.serve(async (req) => {
     return createSuccessResponse(
       {
         success: true,
-        message:
-          purgeType === 'all'
-            ? 'All cache purged successfully'
-            : purgeType === 'twitch-config'
-              ? 'Twitch config cache purged successfully'
-              : 'Tarkov data cache purged successfully',
+        message: purgeSuccessMessage(purgeType),
         purgeType: purgeType,
         cloudflareResultId: purgeResult.result?.id,
         timestamp: new Date().toISOString(),

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -45,6 +45,11 @@ const TARKOV_LANGUAGES = [
 ];
 const TARKOV_GAME_MODES = ['regular', 'pve'];
 type PurgeType = 'all' | 'tarkov-data' | 'twitch-config';
+const PURGE_AUDIT_ACTION: Record<PurgeType, string> = {
+  all: 'cache_purge',
+  'tarkov-data': 'cache_purge',
+  'twitch-config': 'twitch_config_cache_purge',
+};
 interface PurgeRequest {
   purgeType: PurgeType;
 }
@@ -403,7 +408,7 @@ Deno.serve(async (req) => {
     await logAdminAction(
       supabase,
       user.id,
-      'cache_purge',
+      PURGE_AUDIT_ACTION[purgeType],
       {
         purgeType: purgeType,
         success: purgeResult.success,

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -43,8 +43,9 @@ const TARKOV_LANGUAGES = [
   'zh',
 ];
 const TARKOV_GAME_MODES = ['regular', 'pve'];
+type PurgeType = 'all' | 'tarkov-data' | 'twitch-config';
 interface PurgeRequest {
-  purgeType: 'all' | 'tarkov-data' | 'twitch-config';
+  purgeType: PurgeType;
 }
 interface CloudflarePurgeResponse {
   success: boolean;
@@ -212,7 +213,7 @@ function combinePurgeFailures(
     messages: [],
   };
 }
-function purgeSuccessMessage(purgeType: PurgeRequest['purgeType']): string {
+function purgeSuccessMessage(purgeType: PurgeType): string {
   if (purgeType === 'all') return 'All cache purged successfully';
   if (purgeType === 'twitch-config') return 'Twitch config cache purged successfully';
   return 'Tarkov data cache purged successfully';
@@ -296,11 +297,9 @@ Deno.serve(async (req) => {
     }
     // Parse request body
     const rawBody = await req.text();
-    let body: Partial<PurgeRequest & { purge_type?: 'all' | 'tarkov-data' | 'twitch-config' }>;
+    let body: Partial<PurgeRequest & { purge_type?: PurgeType }>;
     try {
-      body = JSON.parse(rawBody) as Partial<
-        PurgeRequest & { purge_type?: 'all' | 'tarkov-data' | 'twitch-config' }
-      >;
+      body = JSON.parse(rawBody) as Partial<PurgeRequest & { purge_type?: PurgeType }>;
       // Support both camelCase (new) and snake_case (legacy) for backward compatibility
       if (!body.purgeType && !body.purge_type) {
         body.purgeType = 'tarkov-data';

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -149,10 +149,6 @@ async function purgeCloudflareCache(
     clearTimeout(timeoutId);
   }
 }
-/**
- * Produce the origin variants (apex and www) for a given base URL so cache
- * entries served on either hostname are both purged.
- */
 function buildCacheOrigins(baseUrl: string): string[] {
   const parsed = new URL(baseUrl);
   const host = parsed.hostname;
@@ -218,10 +214,6 @@ function purgeSuccessMessage(purgeType: PurgeRequest['purgeType']): string {
 function purgeAllCache(zoneId: string, apiToken: string): Promise<CloudflarePurgeResponse> {
   return purgeCloudflareCache(zoneId, apiToken, { purge_everything: true });
 }
-/**
- * Purge the promoted Twitch config cache entry by tag, falling back to a
- * purge-by-URL when the zone rejects tag purges.
- */
 async function purgeTwitchConfigCache(
   zoneId: string,
   apiToken: string,

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -56,7 +56,7 @@ interface CloudflarePurgeResponse {
 }
 interface EdgeRuntimeGlobal {
   EdgeRuntime?: {
-    waitUntil<T>(promise: Promise<T>): Promise<T>;
+    waitUntil<T>(promise: Promise<T>): void;
   };
 }
 type SupabaseClient = AuthSuccess['supabase'];
@@ -254,10 +254,11 @@ function scheduleBackgroundTask(task: () => Promise<unknown>): void {
     console.error('[admin-cache-purge] EdgeRuntime unavailable; delayed purge not scheduled');
     return;
   }
+  const backgroundTask = task().catch((error) => {
+    console.error('[admin-cache-purge] Delayed purge task rejected:', error);
+  });
   try {
-    void EdgeRuntime.waitUntil(task()).catch((error) => {
-      console.error('[admin-cache-purge] Delayed purge task rejected:', error);
-    });
+    EdgeRuntime.waitUntil(backgroundTask);
   } catch (error) {
     console.error('[admin-cache-purge] Failed to schedule delayed purge:', error);
   }

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -195,13 +195,22 @@ function buildTarkovCacheUrls(baseUrl: string): string[] {
   return urls;
 }
 function buildTwitchConfigUrls(baseUrl: string): string[] {
-  return buildCacheOrigins(baseUrl).map((origin) => `${origin}${TWITCH_CONFIG_PATH}`);
+  if (!baseUrl) return [];
+  try {
+    return buildCacheOrigins(baseUrl).map((origin) => `${origin}${TWITCH_CONFIG_PATH}`);
+  } catch {
+    return [];
+  }
 }
 function combinePurgeFailures(
   first: CloudflarePurgeResponse,
   second: CloudflarePurgeResponse
 ): CloudflarePurgeResponse {
-  return { success: false, errors: [...first.errors, ...second.errors], messages: [] };
+  return {
+    success: false,
+    errors: [...(first.errors ?? []), ...(second.errors ?? [])],
+    messages: [],
+  };
 }
 function purgeSuccessMessage(purgeType: PurgeRequest['purgeType']): string {
   if (purgeType === 'all') return 'All cache purged successfully';
@@ -223,9 +232,9 @@ async function purgeTwitchConfigCache(
     tags: [TWITCH_CONFIG_CACHE_TAG],
   });
   if (tagPurge.success) return tagPurge;
-  const urlPurge = await purgeCloudflareCache(zoneId, apiToken, {
-    files: buildTwitchConfigUrls(baseUrl),
-  });
+  const urls = buildTwitchConfigUrls(baseUrl);
+  if (urls.length === 0) return tagPurge;
+  const urlPurge = await purgeCloudflareCache(zoneId, apiToken, { files: urls });
   if (urlPurge.success) return urlPurge;
   return combinePurgeFailures(tagPurge, urlPurge);
 }
@@ -324,16 +333,15 @@ Deno.serve(async (req) => {
       console.error('[admin-cache-purge] Missing Cloudflare credentials');
       return createErrorResponse('Cloudflare credentials not configured', 500, req);
     }
-    // Get base URL for cache key construction (non-"all" purges only)
-    const rawBaseUrl = Deno.env.get('APP_URL')?.trim();
-    let baseUrl = '';
-    if (purgeType !== 'all') {
-      if (!rawBaseUrl) {
+    // Get base URL for cache key construction (Tarkov data purges only)
+    const baseUrl = Deno.env.get('APP_URL')?.trim() ?? '';
+    if (purgeType === 'tarkov-data') {
+      if (!baseUrl) {
         console.error('[admin-cache-purge] Missing APP_URL');
         return createErrorResponse('Application URL not configured', 500, req);
       }
       try {
-        const protocol = new URL(rawBaseUrl).protocol;
+        const protocol = new URL(baseUrl).protocol;
         if (protocol !== 'http:' && protocol !== 'https:') {
           throw new Error('Unsupported APP_URL protocol');
         }
@@ -341,7 +349,6 @@ Deno.serve(async (req) => {
         console.error('[admin-cache-purge] Invalid APP_URL');
         return createErrorResponse('Application URL invalid', 500, req);
       }
-      baseUrl = rawBaseUrl;
     }
     // Execute cache purge
     let purgeResult: CloudflarePurgeResponse;

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -11,6 +11,7 @@ const CLOUDFLARE_API_URL = 'https://api.cloudflare.com/client/v4';
 const EDGE_CACHE_PATH = '/__edge-cache/tarkov';
 const TWITCH_CONFIG_CACHE_TAG = 'promoted-twitch-config';
 const TWITCH_CONFIG_PATH = '/api/twitch/config';
+const TWITCH_CONFIG_REPURGE_DELAY_MS = 6000;
 const PURGE_TIMEOUT_MS = 8000;
 const PURGE_CHUNK_SIZE = 30;
 const TARKOV_CACHE_KEYS = [
@@ -52,6 +53,11 @@ interface CloudflarePurgeResponse {
   errors: Array<{ code: number; message: string }>;
   messages: string[];
   result?: { id: string } | null;
+}
+interface EdgeRuntimeGlobal {
+  EdgeRuntime?: {
+    waitUntil<T>(promise: Promise<T>): Promise<T>;
+  };
 }
 type SupabaseClient = AuthSuccess['supabase'];
 /**
@@ -239,6 +245,36 @@ async function purgeTwitchConfigCache(
   if (urlPurge.success) return urlPurge;
   return combinePurgeFailures(tagPurge, urlPurge);
 }
+function wait(milliseconds: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+function scheduleBackgroundTask(task: () => Promise<unknown>): void {
+  const { EdgeRuntime } = globalThis as unknown as EdgeRuntimeGlobal;
+  if (!EdgeRuntime) {
+    console.error('[admin-cache-purge] EdgeRuntime unavailable; delayed purge not scheduled');
+    return;
+  }
+  try {
+    void EdgeRuntime.waitUntil(task());
+  } catch (error) {
+    console.error('[admin-cache-purge] Failed to schedule delayed purge:', error);
+  }
+}
+async function repurgeTwitchConfigCache(
+  zoneId: string,
+  apiToken: string,
+  baseUrl: string
+): Promise<void> {
+  try {
+    await wait(TWITCH_CONFIG_REPURGE_DELAY_MS);
+    const result = await purgeTwitchConfigCache(zoneId, apiToken, baseUrl);
+    if (!result.success) {
+      console.error('[admin-cache-purge] Delayed Twitch config purge failed:', result.errors);
+    }
+  } catch (error) {
+    console.error('[admin-cache-purge] Delayed Twitch config purge failed:', error);
+  }
+}
 function markPurgeFailure(
   aggregate: CloudflarePurgeResponse,
   result: CloudflarePurgeResponse
@@ -356,6 +392,9 @@ Deno.serve(async (req) => {
       purgeResult = await purgeTwitchConfigCache(zoneId, apiToken, baseUrl);
     } else {
       purgeResult = await purgeTarkovDataCache(zoneId, apiToken, baseUrl);
+    }
+    if (purgeType === 'twitch-config' && purgeResult.success) {
+      scheduleBackgroundTask(() => repurgeTwitchConfigCache(zoneId, apiToken, baseUrl));
     }
     // Log the admin action
     await logAdminAction(

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -255,7 +255,9 @@ function scheduleBackgroundTask(task: () => Promise<unknown>): void {
     return;
   }
   try {
-    void EdgeRuntime.waitUntil(task());
+    void EdgeRuntime.waitUntil(task()).catch((error) => {
+      console.error('[admin-cache-purge] Delayed purge task rejected:', error);
+    });
   } catch (error) {
     console.error('[admin-cache-purge] Failed to schedule delayed purge:', error);
   }


### PR DESCRIPTION
## Summary

Replaces the promoted-Twitch "database revalidation + minute polling" contract with a cache-and-invalidate contract to stop ~634k dynamic Pages Function requests/day (config 465k, live 168k on Aug 15).

**Root cause:** both `/api/twitch/config` (`max-age=0, must-revalidate`) and `/api/twitch/live` (`s-maxage=60`) reported `cf-cache-status: DYNAMIC` in production — `Cache-Control` alone did not edge-cache Pages Function responses on this zone. The only working pattern is `Cloudflare-CDN-Cache-Control` (already used by `/api/tarkov/cache-meta`).

## Changes

- **`/api/twitch/config`** — now sends `Cache-Control: public, max-age=300, s-maxage=3600`, `Cloudflare-CDN-Cache-Control: public, max-age=3600`, `Cache-Tag: promoted-twitch-config`. Cloudflare serves cache hits without invoking the Function; the Supabase read runs only on cache fills.
- **`/api/twitch/live`** — adds `Cloudflare-CDN-Cache-Control: public, max-age=30` so the CDN absorbs per-client polling; keeps the module-level Twitch-GQL backstop.
- **Admin update purge** — `POST /api/admin/twitch-config` invokes the existing `admin-cache-purge` edge function (new `twitch-config` type) with the admin's Bearer token **after** the DB transaction commits, purging the `promoted-twitch-config` tag via the Cloudflare Purge API. A successful immediate purge schedules the same purge six seconds later with `EdgeRuntime.waitUntil()` so a stale in-flight cache fill cannot survive both passes. Twitch-only purges use a dedicated audit action so game-data clients do not treat them as Tarkov-data invalidations. Immediate purge failure is returned with the committed config as an explicit warning. No new env vars/secrets are needed — credentials stay in the Edge Function.
- **`PromotedTwitchEmbed.vue`** — fetches config on mount, tab focus, and every five minutes while visible (browser/edge-cache hits between fills); polls `/api/twitch/live` every 60s while enabled; timers and immediate checks stop when the tab is hidden or the component unmounts; watches new shared `usePromotedTwitch` state so an admin save in the same tab applies immediately.
- **`AdminTwitchConfigCard.vue`** — publishes saved config to the shared state.
- **`docs/SYSTEMS.md`** — §10 rewritten: cache-and-invalidate invariants replace revalidation/minute-polling invariants.

## Validation

- Full suite: 255 files / 2461 tests pass; typecheck, ESLint, Fallow, blank-lines, OpenAPI validation, i18n check, and Deno check + lint all clean.

## Post-deploy verification

1. `curl -sI https://tarkovtracker.org/api/twitch/config` twice → second `cf-cache-status: HIT`, `DYNAMIC` gone.
2. Admin save → next config request re-fills (`MISS`), confirming the tag purge.
3. Cloudflare Analytics: Twitch pair should drop from ~634k dynamic requests/day to a handful of cache fills.

## Notes

- Browser TTL of 5 min (`max-age=300`) means propagation to already-open tabs is ≤5 min (admin's own tab is immediate via shared state); the purge keeps the CDN correct immediately.
- The edge TTL is one hour, bounding recovery if both invalidation passes fail while still reducing function invocations to cache fills. `Cache-Tag` purges are available on all plans since April 2025; if the zone rejects tag purges, both the immediate and delayed passes fall back to purge-by-URL.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Promoted Twitch settings update immediately after saving.
  - Channel changes trigger a fresh live-status check and clear previous dismissals.
  - Polling runs only while enabled and the page is visible.
  - Restoring page visibility refreshes settings and live status.
  - Visitors are informed that changes may take up to five minutes to appear.

- **Bug Fixes**
  - Prevented duplicate or stale live-status updates.
  - Improved player and polling cleanup.
  - Saves now warn when cache refresh is delayed.

- **Performance**
  - Added caching for configuration and live-status responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR moves promoted Twitch configuration to an edge-cache-and-invalidate model and hardens client reconciliation around admin saves and asynchronous live checks.
- Adds tagged Cloudflare caching and immediate plus delayed cache invalidation.
- Returns committed configuration when invalidation fails and publishes it into shared client state.
- Uses versioned configuration and generation-scoped live requests to prevent stale responses from overwriting current state.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/components/PromotedTwitchEmbed.vue | Adds version-aware shared configuration, visibility-scoped polling, and generation-keyed live requests that resolve the previously reported channel race. |
| app/server/api/admin/twitch-config.post.ts | Performs cache invalidation after persistence and preserves the committed response when invalidation fails. |
| app/features/admin/AdminTwitchConfigCard.vue | Applies committed configuration to local and shared state before reporting purge warnings. |
| app/server/api/twitch/config.get.ts | Adds browser and Cloudflare cache policy, cache tagging, and versioned configuration responses. |
| supabase/functions/admin-cache-purge/index.ts | Adds tagged Twitch-config purging, URL fallback, delayed repurge, and distinct audit classification. |
| docs/SYSTEMS.md | Updates the promoted Twitch system specification for the cache-and-invalidate contract. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant A as Admin UI
  participant N as Admin API
  participant D as Supabase DB
  participant P as Cache Purge Function
  participant C as Cloudflare Cache
  participant E as Twitch Embed
  A->>N: Save config with Bearer token
  N->>D: Commit config and audit update
  D-->>N: Config plus version
  N->>P: Purge promoted-twitch-config
  P->>C: Immediate tag purge
  P-->>N: Purge result
  N-->>A: Committed config plus cacheInvalidated
  A->>E: Publish versioned shared config
  P->>C: Delayed second purge
  E->>C: Periodic config refresh
  C-->>E: Cached config
```
</details>

<sub>Reviews (14): Last reviewed commit: ["fix(admin): close Twitch lifecycle races"](https://github.com/tarkovtracker-org/tarkovtracker/commit/128e13ab3646dde555128f972556bddb8b1a761d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53671644)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://github.com/tarkovtracker-org/tarkovtracker/blob/main/AGENTS.md))
- Knowledge Base — [Promoted Twitch Configuration](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/promoted-twitch-config.md)
- Knowledge Base — [Supabase Edge Functions: shared helpers and account/discord/admin utilities](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/supabase-edge-functions.md)
</details>

<!-- /greptile_comment -->