### PR TITLE
feat(maps): pinned marker colour, live pin updates, and objective legend chips

### DIFF
--- a/app/composables/__tests__/useMapObjectiveMarks.test.ts
+++ b/app/composables/__tests__/useMapObjectiveMarks.test.ts
@@ -141,8 +141,6 @@ describe('useMapObjectiveMarks', () => {
       'task-1': { self: true },
       'task-2': { self: true },
     };
-    // pinnedTaskIds contains the *objective* id used above ('task-2' is both the
-    // pinned task's id AND the objective id on the unrelated task-1) plus task-2 itself.
     pinnedTaskIds.value = ['task-2'];
     const mapId = computed(() => 'customs');
     const shouldShowCompletedObjectives = computed(() => false);
@@ -153,9 +151,7 @@ describe('useMapObjectiveMarks', () => {
     });
     const markFromTask1 = mapObjectiveMarks.value.find((mark) => mark.id === 'task-2');
     const markFromTask2 = mapObjectiveMarks.value.find((mark) => mark.id === 'obj-2');
-    // mark.id here is obj.id ('task-2'), belonging to task-1 which is NOT pinned.
     expect(markFromTask1?.pinned).toBe(false);
-    // mark for task-2's own objective ('obj-2') IS pinned because task-2 is pinned.
     expect(markFromTask2?.pinned).toBe(true);
   });
   it('keeps marks for unpinned tasks (map-level pinned filtering is applied downstream)', async () => {

--- a/app/composables/__tests__/useMapObjectiveMarks.test.ts
+++ b/app/composables/__tests__/useMapObjectiveMarks.test.ts
@@ -1,0 +1,191 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, isRef, ref } from 'vue';
+import type { Task } from '@/types/tarkov';
+const objectiveCompletions = ref<Record<string, Record<string, boolean>>>({});
+const tasksCompletions = ref<Record<string, Record<string, boolean>>>({});
+const tasksFailed = ref<Record<string, Record<string, boolean>>>({});
+const unlockedTasks = ref<Record<string, Record<string, boolean>>>({});
+const visibleTeamStores = ref<Record<string, Record<string, unknown>>>({ self: {} });
+const objectiveMaps = ref<Record<string, Array<{ objectiveID: string; mapID: string }>>>({});
+const objectiveGPS = ref<Record<string, Array<{ objectiveID: string; x: number; y: number }>>>({});
+const mapTeamAllHidden = ref(false);
+const pinnedTaskIds = ref<string[]>([]);
+const completedObjectiveIds = ref<Set<string>>(new Set());
+const completedTaskIds = ref<Set<string>>(new Set());
+const failedTaskIds = ref<Set<string>>(new Set());
+const setup = async () => {
+  vi.resetModules();
+  objectiveCompletions.value = {};
+  tasksCompletions.value = {};
+  tasksFailed.value = {};
+  unlockedTasks.value = {};
+  visibleTeamStores.value = { self: {} };
+  objectiveMaps.value = {};
+  objectiveGPS.value = {};
+  mapTeamAllHidden.value = false;
+  pinnedTaskIds.value = [];
+  completedObjectiveIds.value = new Set();
+  completedTaskIds.value = new Set();
+  failedTaskIds.value = new Set();
+  vi.doMock('pinia', async () => {
+    const actual = await vi.importActual<typeof import('pinia')>('pinia');
+    return {
+      ...actual,
+      storeToRefs: (store: Record<string, unknown>) => {
+        const refs: Record<string, unknown> = {};
+        Object.entries(store).forEach(([key, value]) => {
+          if (typeof value === 'function') return;
+          refs[key] = isRef(value) ? value : computed(() => store[key as keyof typeof store]);
+        });
+        return refs;
+      },
+    };
+  });
+  vi.doMock('@/stores/useMetadata', () => ({
+    useMetadataStore: () => ({
+      objectiveMaps: objectiveMaps.value,
+      objectiveGPS: objectiveGPS.value,
+    }),
+  }));
+  vi.doMock('@/stores/usePreferences', () => ({
+    usePreferencesStore: () => ({
+      get mapTeamAllHidden() {
+        return mapTeamAllHidden.value;
+      },
+      get getPinnedTaskIds() {
+        return pinnedTaskIds.value;
+      },
+    }),
+  }));
+  vi.doMock('@/stores/useProgress', () => ({
+    useProgressStore: () => ({
+      objectiveCompletions,
+      tasksCompletions,
+      tasksFailed,
+      unlockedTasks,
+      visibleTeamStores: visibleTeamStores.value,
+    }),
+  }));
+  vi.doMock('@/stores/useTarkov', () => ({
+    useTarkovStore: () => ({
+      isTaskObjectiveComplete: (objId: string) => completedObjectiveIds.value.has(objId),
+      isTaskComplete: (taskId: string) => completedTaskIds.value.has(taskId),
+      isTaskFailed: (taskId: string) => failedTaskIds.value.has(taskId),
+    }),
+  }));
+  const { useMapObjectiveMarks } = await import('@/composables/useMapObjectiveMarks');
+  return { useMapObjectiveMarks };
+};
+const objectiveWithLocation = (id: string, mapId: string) => ({
+  id,
+  zones: [],
+  possibleLocations: [
+    {
+      map: { id: mapId },
+      positions: [{ x: 1, y: 0, z: 1 }],
+    },
+  ],
+});
+describe('useMapObjectiveMarks', () => {
+  beforeEach(async () => {
+    await setup();
+  });
+  it('marks a pinned task objective as pinned:true and an unpinned one as pinned:false', async () => {
+    const { useMapObjectiveMarks } = await setup();
+    const tasks: Task[] = [
+      {
+        id: 'task-pinned',
+        name: 'Pinned Task',
+        objectives: [objectiveWithLocation('obj-pinned', 'customs')],
+      },
+      {
+        id: 'task-unpinned',
+        name: 'Unpinned Task',
+        objectives: [objectiveWithLocation('obj-unpinned', 'customs')],
+      },
+    ];
+    unlockedTasks.value = {
+      'task-pinned': { self: true },
+      'task-unpinned': { self: true },
+    };
+    pinnedTaskIds.value = ['task-pinned'];
+    const mapId = computed(() => 'customs');
+    const shouldShowCompletedObjectives = computed(() => false);
+    const { mapObjectiveMarks } = useMapObjectiveMarks({
+      mapId,
+      shouldShowCompletedObjectives,
+      tasks: computed(() => tasks),
+    });
+    const pinnedMark = mapObjectiveMarks.value.find((mark) => mark.id === 'obj-pinned');
+    const unpinnedMark = mapObjectiveMarks.value.find((mark) => mark.id === 'obj-unpinned');
+    expect(pinnedMark?.pinned).toBe(true);
+    expect(unpinnedMark?.pinned).toBe(false);
+  });
+  it('determines pinned state from task.id, not obj.id', async () => {
+    const { useMapObjectiveMarks } = await setup();
+    // The objective id on task-1 deliberately collides with a pinned id string,
+    // to prove pinning is resolved via the enclosing task, not the objective.
+    const tasks: Task[] = [
+      {
+        id: 'task-1',
+        name: 'Task One',
+        objectives: [objectiveWithLocation('task-2', 'customs')],
+      },
+      {
+        id: 'task-2',
+        name: 'Task Two',
+        objectives: [objectiveWithLocation('obj-2', 'customs')],
+      },
+    ];
+    unlockedTasks.value = {
+      'task-1': { self: true },
+      'task-2': { self: true },
+    };
+    // pinnedTaskIds contains the *objective* id used above ('task-2' is both the
+    // pinned task's id AND the objective id on the unrelated task-1) plus task-2 itself.
+    pinnedTaskIds.value = ['task-2'];
+    const mapId = computed(() => 'customs');
+    const shouldShowCompletedObjectives = computed(() => false);
+    const { mapObjectiveMarks } = useMapObjectiveMarks({
+      mapId,
+      shouldShowCompletedObjectives,
+      tasks: computed(() => tasks),
+    });
+    const markFromTask1 = mapObjectiveMarks.value.find((mark) => mark.id === 'task-2');
+    const markFromTask2 = mapObjectiveMarks.value.find((mark) => mark.id === 'obj-2');
+    // mark.id here is obj.id ('task-2'), belonging to task-1 which is NOT pinned.
+    expect(markFromTask1?.pinned).toBe(false);
+    // mark for task-2's own objective ('obj-2') IS pinned because task-2 is pinned.
+    expect(markFromTask2?.pinned).toBe(true);
+  });
+  it('keeps marks for unpinned tasks (map-level pinned filtering is applied downstream)', async () => {
+    const { useMapObjectiveMarks } = await setup();
+    unlockedTasks.value = {
+      'task-pinned': { self: true },
+      'task-unpinned': { self: true },
+    };
+    pinnedTaskIds.value = ['task-pinned'];
+    const tasks: Task[] = [
+      {
+        id: 'task-pinned',
+        name: 'Pinned Task',
+        objectives: [objectiveWithLocation('obj-pinned', 'customs')],
+      },
+      {
+        id: 'task-unpinned',
+        name: 'Unpinned Task',
+        objectives: [objectiveWithLocation('obj-unpinned', 'customs')],
+      },
+    ];
+    const mapId = computed(() => 'customs');
+    const shouldShowCompletedObjectives = computed(() => false);
+    const { mapObjectiveMarks } = useMapObjectiveMarks({
+      mapId,
+      shouldShowCompletedObjectives,
+      tasks: computed(() => tasks),
+    });
+    expect(mapObjectiveMarks.value.find((mark) => mark.id === 'obj-pinned')?.pinned).toBe(true);
+    expect(mapObjectiveMarks.value.find((mark) => mark.id === 'obj-unpinned')?.pinned).toBe(false);
+    expect(mapObjectiveMarks.value).toHaveLength(2);
+  });
+});

--- a/app/composables/__tests__/useMapObjectiveMarks.test.ts
+++ b/app/composables/__tests__/useMapObjectiveMarks.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { computed, isRef, ref } from 'vue';
 import type { Task } from '@/types/tarkov';
 const objectiveCompletions = ref<Record<string, Record<string, boolean>>>({});
@@ -87,9 +87,6 @@ const objectiveWithLocation = (id: string, mapId: string) => ({
   ],
 });
 describe('useMapObjectiveMarks', () => {
-  beforeEach(async () => {
-    await setup();
-  });
   it('marks a pinned task objective as pinned:true and an unpinned one as pinned:false', async () => {
     const { useMapObjectiveMarks } = await setup();
     const tasks: Task[] = [

--- a/app/composables/useMapObjectiveMarks.ts
+++ b/app/composables/useMapObjectiveMarks.ts
@@ -15,6 +15,7 @@ export type MapObjectiveMark = {
   zones: MapObjectiveZone[];
   possibleLocations?: MapObjectiveLocation[];
   users?: string[];
+  pinned?: boolean;
 };
 interface MapObjectiveMarksOptions {
   mapId: ComputedRef<string | null | undefined>;
@@ -42,6 +43,7 @@ export function useMapObjectiveMarks({
     const teammateIds = includeTeammates
       ? Object.keys(progressStore.visibleTeamStores).filter((id) => id !== 'self')
       : [];
+    const pinnedTaskIds = new Set(preferencesStore.getPinnedTaskIds);
     tasks.value.forEach((task) => {
       if (!task.objectives) return;
       const objectiveMaps = metadataStore.objectiveMaps?.[task.id] ?? [];
@@ -126,6 +128,7 @@ export function useMapObjectiveMarks({
             zones,
             possibleLocations,
             users,
+            pinned: pinnedTaskIds.has(task.id),
           });
         }
       });

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -650,6 +650,10 @@
   } from '@/features/maps/composables/useLeafletMapControls';
   import LeafletObjectiveTooltip from '@/features/maps/LeafletObjectiveTooltip.vue';
   import { getMarksHash, type MapMark } from '@/features/maps/utils/marksHash';
+  import {
+    getObjectiveCategory,
+    type ObjectiveCategory,
+  } from '@/features/maps/utils/objectiveCategory';
   import { usePreferencesStore } from '@/stores/usePreferences';
   import { logger } from '@/utils/logger';
   import { clusterSpawns } from '@/utils/mapClustering';
@@ -743,11 +747,6 @@
   const isMapUnavailable = computed(() => {
     return props.map?.unavailable === true;
   });
-  type ObjectiveCategory = 'self' | 'pinned' | 'team';
-  const getObjectiveCategory = (mark: MapMark): ObjectiveCategory => {
-    if (mark.pinned) return 'pinned';
-    return mark.users?.includes('self') ? 'self' : 'team';
-  };
   const mapShowSelfObjectives = computed({
     get: () => preferencesStore.getMapShowSelfObjectives,
     set: (value: boolean) => preferencesStore.setMapShowSelfObjectives(value),

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -551,19 +551,39 @@
           v-if="props.showLegend"
           class="bg-surface-850/95 text-surface-300 flex flex-wrap items-center gap-4 rounded-lg border border-white/8 px-3 py-2 text-xs shadow-lg"
         >
-          <div class="flex items-center gap-1">
-            <div
-              class="h-3 w-3 rounded-full border border-white/30"
-              :style="{ backgroundColor: mapColors.SELF_OBJECTIVE }"
-            />
-            <span>{{ t('maps.legend.your_objectives') }}</span>
-          </div>
-          <div class="flex items-center gap-1">
-            <div
-              class="h-3 w-3 rounded-full border border-white/30"
-              :style="{ backgroundColor: mapColors.TEAM_OBJECTIVE }"
-            />
-            <span>{{ t('maps.legend.team_objectives') }}</span>
+          <div class="flex flex-wrap items-center gap-2">
+            <span class="text-surface-400 text-[10px] font-medium tracking-wide uppercase">
+              {{ t('maps.legend.tasks') }}
+            </span>
+            <button
+              v-for="chip in objectiveChips"
+              :key="chip.key"
+              type="button"
+              class="flex items-center gap-2 rounded-full border px-3 py-1.5 transition-opacity"
+              :class="chip.isOn ? '' : 'opacity-55 hover:opacity-80'"
+              :style="{
+                borderColor: chip.isOn
+                  ? `color-mix(in srgb, ${chip.color} 45%, transparent)`
+                  : 'var(--color-surface-700)',
+                backgroundColor: chip.isOn
+                  ? `color-mix(in srgb, ${chip.color} 15%, transparent)`
+                  : 'transparent',
+              }"
+              :aria-pressed="chip.isOn"
+              @click="chip.toggle()"
+            >
+              <span
+                class="h-2 w-2 shrink-0 rounded-full"
+                :class="chip.isOn ? '' : 'box-border border-[1.5px]'"
+                :style="chip.isOn ? { backgroundColor: chip.color } : { borderColor: chip.color }"
+              />
+              <span
+                class="text-surface-100"
+                :class="chip.isOn ? '' : 'text-surface-400 line-through'"
+              >
+                {{ chip.label }}
+              </span>
+            </button>
           </div>
           <div v-if="showPmcSpawns && hasPmcSpawns" class="flex items-center gap-1">
             <div class="h-3 w-3 rounded-full" :style="{ backgroundColor: mapColors.PMC_SPAWN }" />
@@ -629,6 +649,7 @@
     useLeafletMapControls,
   } from '@/features/maps/composables/useLeafletMapControls';
   import LeafletObjectiveTooltip from '@/features/maps/LeafletObjectiveTooltip.vue';
+  import { getMarksHash, type MapMark } from '@/features/maps/utils/marksHash';
   import { usePreferencesStore } from '@/stores/usePreferences';
   import { logger } from '@/utils/logger';
   import { clusterSpawns } from '@/utils/mapClustering';
@@ -675,21 +696,6 @@
       logger.warn('[LeafletMap] Failed to persist map controls hint flag:', error);
     }
   };
-  interface MapZone {
-    map: { id: string };
-    outline: Array<{ x: number; z: number }>;
-  }
-  interface MapMarkLocation {
-    map: { id: string };
-    positions?: Array<{ x: number; y?: number; z: number }>;
-    [key: string]: unknown;
-  }
-  interface MapMark {
-    id?: string;
-    zones: MapZone[];
-    possibleLocations?: MapMarkLocation[];
-    users?: string[];
-  }
   interface Props {
     map: TarkovMap;
     marks?: MapMark[];
@@ -737,6 +743,61 @@
   const isMapUnavailable = computed(() => {
     return props.map?.unavailable === true;
   });
+  type ObjectiveCategory = 'self' | 'pinned' | 'team';
+  const getObjectiveCategory = (mark: MapMark): ObjectiveCategory => {
+    if (mark.pinned) return 'pinned';
+    return mark.users?.includes('self') ? 'self' : 'team';
+  };
+  const mapShowSelfObjectives = computed({
+    get: () => preferencesStore.getMapShowSelfObjectives,
+    set: (value: boolean) => preferencesStore.setMapShowSelfObjectives(value),
+  });
+  const mapShowPinnedObjectives = computed({
+    get: () => preferencesStore.getMapShowPinnedObjectives,
+    set: (value: boolean) => preferencesStore.setMapShowPinnedObjectives(value),
+  });
+  const mapShowTeamObjectives = computed({
+    get: () => preferencesStore.getMapShowTeamObjectives,
+    set: (value: boolean) => preferencesStore.setMapShowTeamObjectives(value),
+  });
+  interface ObjectiveChip {
+    key: ObjectiveCategory;
+    label: string;
+    color: string;
+    isOn: boolean;
+    toggle: () => void;
+  }
+  const objectiveChips = computed<ObjectiveChip[]>(() => {
+    return [
+      {
+        key: 'self',
+        label: t('maps.legend.regular'),
+        color: mapColors.value.SELF_OBJECTIVE,
+        isOn: mapShowSelfObjectives.value,
+        toggle: () => {
+          mapShowSelfObjectives.value = !mapShowSelfObjectives.value;
+        },
+      },
+      {
+        key: 'pinned',
+        label: t('maps.legend.pinned'),
+        color: mapColors.value.PINNED_OBJECTIVE,
+        isOn: mapShowPinnedObjectives.value,
+        toggle: () => {
+          mapShowPinnedObjectives.value = !mapShowPinnedObjectives.value;
+        },
+      },
+      {
+        key: 'team',
+        label: t('maps.legend.team'),
+        color: mapColors.value.TEAM_OBJECTIVE,
+        isOn: mapShowTeamObjectives.value,
+        toggle: () => {
+          mapShowTeamObjectives.value = !mapShowTeamObjectives.value;
+        },
+      },
+    ];
+  });
   const mapContainer = ref<HTMLElement | null>(null);
   const {
     mapInstance,
@@ -763,36 +824,7 @@
   const SPAWN_CLUSTER_GRID_SIZE = 50;
   const SPAWN_CLUSTER_MIN_RADIUS = 6;
   const SPAWN_CLUSTER_MAX_RADIUS = 14;
-  const FNV1A_OFFSET_BASIS = 0x811c9dc5;
-  const FNV1A_PRIME = 0x01000193;
   const MARKER_SVG_LOAD_DELAY_MS = 500;
-  const updateFnv1a = (hash: number, value: string | number): number => {
-    const token = typeof value === 'number' ? String(value) : value;
-    for (let i = 0; i < token.length; i++) {
-      hash ^= token.charCodeAt(i);
-      hash = Math.imul(hash, FNV1A_PRIME);
-    }
-    hash ^= 124;
-    return Math.imul(hash, FNV1A_PRIME) >>> 0;
-  };
-  const hashZoneOutline = (outline: Array<{ x: number; z: number }>): number => {
-    let zoneHash = updateFnv1a(FNV1A_OFFSET_BASIS, outline.length);
-    for (const point of outline) {
-      zoneHash = updateFnv1a(zoneHash, point.x);
-      zoneHash = updateFnv1a(zoneHash, point.z);
-    }
-    return zoneHash;
-  };
-  const hashLocationPositions = (
-    positions?: Array<{ x: number; y?: number; z: number }>
-  ): number => {
-    let locationHash = updateFnv1a(FNV1A_OFFSET_BASIS, positions?.length ?? 0);
-    for (const point of positions ?? []) {
-      locationHash = updateFnv1a(locationHash, point.x);
-      locationHash = updateFnv1a(locationHash, point.z);
-    }
-    return locationHash;
-  };
   const {
     hasCoopExtracts,
     hasPmcSpawns,
@@ -1475,35 +1507,6 @@
       cleanupMountedComponent();
     });
   };
-  function getMarksHash(marks: MapMark[], mapId: string): string {
-    let hash = updateFnv1a(FNV1A_OFFSET_BASIS, mapId);
-    hash = updateFnv1a(hash, marks.length);
-    for (const mark of marks) {
-      hash = updateFnv1a(hash, mark.id ?? '');
-      const sortedUsers = [...(mark.users ?? [])].sort();
-      hash = updateFnv1a(hash, sortedUsers.length);
-      for (const user of sortedUsers) {
-        hash = updateFnv1a(hash, user);
-      }
-      const zoneHashes = mark.zones
-        .filter((zone) => zone.map.id === mapId)
-        .map((zone) => hashZoneOutline(zone.outline))
-        .sort((a, b) => a - b);
-      hash = updateFnv1a(hash, zoneHashes.length);
-      for (const zoneHash of zoneHashes) {
-        hash = updateFnv1a(hash, zoneHash);
-      }
-      const locationHashes = (mark.possibleLocations ?? [])
-        .filter((location) => location.map.id === mapId)
-        .map((location) => hashLocationPositions(location.positions))
-        .sort((a, b) => a - b);
-      hash = updateFnv1a(hash, locationHashes.length);
-      for (const locationHash of locationHashes) {
-        hash = updateFnv1a(hash, locationHash);
-      }
-    }
-    return hash.toString(16).padStart(8, '0');
-  }
   function createObjectiveMarkers(): void {
     if (!leaflet.value || !objectiveLayer.value || !props.map) return;
     const L = leaflet.value;
@@ -1540,9 +1543,22 @@
       }
       return Math.abs(sum / 2);
     };
+    const categoryColors: Record<ObjectiveCategory, string> = {
+      self: mapColors.value.SELF_OBJECTIVE,
+      pinned: mapColors.value.PINNED_OBJECTIVE,
+      team: mapColors.value.TEAM_OBJECTIVE,
+    };
+    const categoryEnabled: Record<ObjectiveCategory, boolean> = {
+      self: mapShowSelfObjectives.value,
+      pinned: mapShowPinnedObjectives.value,
+      team: mapShowTeamObjectives.value,
+    };
     props.marks.forEach((mark) => {
       const objectiveId = mark.id;
       if (!objectiveId) return;
+      const category = getObjectiveCategory(mark);
+      if (!categoryEnabled[category]) return;
+      const markerColor = categoryColors[category];
       mark.possibleLocations?.forEach((location) => {
         if (location.map.id !== props.map.id) return;
         const positions = location.positions;
@@ -1550,10 +1566,6 @@
         const pos = positions[0];
         if (!pos) return;
         const latLng = gameToLatLng(pos.x, pos.z);
-        const isSelf = mark.users?.includes('self') ?? false;
-        const markerColor = isSelf
-          ? mapColors.value.SELF_OBJECTIVE
-          : mapColors.value.TEAM_OBJECTIVE;
         const marker = L.circleMarker([latLng.lat, latLng.lng], {
           radius: 8,
           fillColor: markerColor,
@@ -1568,8 +1580,7 @@
         if (zone.outline.length < 3) return;
         const latLngs = outlineToLatLngArray(zone.outline);
         if (latLngs.length < 3) return;
-        const isSelf = mark.users?.includes('self') ?? false;
-        const zoneColor = isSelf ? mapColors.value.SELF_OBJECTIVE : mapColors.value.TEAM_OBJECTIVE;
+        const zoneColor = markerColor;
         const polygonLatLngs = latLngs.map((ll) => [ll.lat, ll.lng]) as L.LatLngExpression[];
         const polygon = L.polygon(polygonLatLngs, {
           color: zoneColor,
@@ -1800,6 +1811,10 @@
     { deep: true }
   );
   watch(mapZoneOpacity, () => {
+    lastMarksHash.value = '';
+    updateMarkers();
+  });
+  watch([mapShowSelfObjectives, mapShowPinnedObjectives, mapShowTeamObjectives], () => {
     lastMarksHash.value = '';
     updateMarkers();
   });

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -574,7 +574,7 @@
             >
               <span
                 class="h-2 w-2 shrink-0 rounded-full"
-                :class="chip.isOn ? '' : 'box-border border-[1.5px]'"
+                :class="chip.isOn ? '' : 'box-border border-2'"
                 :style="chip.isOn ? { backgroundColor: chip.color } : { borderColor: chip.color }"
               />
               <span

--- a/app/features/maps/LeafletMap.vue
+++ b/app/features/maps/LeafletMap.vue
@@ -553,7 +553,7 @@
         >
           <div class="flex flex-wrap items-center gap-2">
             <span class="text-surface-400 text-[10px] font-medium tracking-wide uppercase">
-              {{ t('maps.legend.tasks') }}
+              {{ t('common.tasks') }}
             </span>
             <button
               v-for="chip in objectiveChips"

--- a/app/features/maps/__tests__/useLeafletMapControls.test.ts
+++ b/app/features/maps/__tests__/useLeafletMapControls.test.ts
@@ -15,6 +15,7 @@ const createPreferencesStore = () => {
         DEFAULT_EXTRACT: '#64748b',
         EXTRACT_DOT_BORDER: '#ffffff',
         MARKER_BORDER: '#000000',
+        PINNED_OBJECTIVE: '#7c3bed',
         PMC_EXTRACT: '#f97316',
         PMC_SPAWN: '#ef4444',
         SCAV_EXTRACT: '#3b82f6',

--- a/app/features/maps/utils/__tests__/marksHash.test.ts
+++ b/app/features/maps/utils/__tests__/marksHash.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { getMarksHash, type MapMark } from '@/features/maps/utils/marksHash';
+describe('getMarksHash', () => {
+  const baseMark: MapMark = {
+    id: 'objective-1',
+    zones: [],
+    users: ['self'],
+  };
+  it('produces different hashes when only mark.pinned differs', () => {
+    const unpinned: MapMark[] = [{ ...baseMark, pinned: false }];
+    const pinned: MapMark[] = [{ ...baseMark, pinned: true }];
+    const unpinnedHash = getMarksHash(unpinned, 'customs');
+    const pinnedHash = getMarksHash(pinned, 'customs');
+    expect(pinnedHash).not.toBe(unpinnedHash);
+  });
+  it('produces the same hash for identical mark arrays', () => {
+    const marksA: MapMark[] = [{ ...baseMark, pinned: true }];
+    const marksB: MapMark[] = [{ ...baseMark, pinned: true }];
+    expect(getMarksHash(marksA, 'customs')).toBe(getMarksHash(marksB, 'customs'));
+  });
+});

--- a/app/features/maps/utils/__tests__/objectiveCategory.test.ts
+++ b/app/features/maps/utils/__tests__/objectiveCategory.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getObjectiveCategory,
+  type ObjectiveCategory,
+} from '@/features/maps/utils/objectiveCategory';
+import type { MapMark } from '@/features/maps/utils/marksHash';
+interface ObjectiveCategoryCase {
+  pinned?: boolean;
+  users?: string[];
+  expected: ObjectiveCategory;
+}
+const createMark = (overrides: Partial<MapMark>): MapMark => ({
+  zones: [],
+  ...overrides,
+});
+const cases: ObjectiveCategoryCase[] = [
+  { pinned: true, users: ['self'], expected: 'pinned' },
+  { pinned: true, users: ['teammate-a'], expected: 'pinned' },
+  { pinned: false, users: ['self', 'teammate-a'], expected: 'self' },
+  { pinned: false, users: ['teammate-a'], expected: 'team' },
+  { pinned: false, users: undefined, expected: 'team' },
+  { pinned: undefined, users: ['self'], expected: 'self' },
+];
+describe('getObjectiveCategory', () => {
+  it.each(cases)(
+    'returns $expected for pinned=$pinned and users=$users',
+    ({ expected, ...mark }) => {
+      expect(getObjectiveCategory(createMark(mark))).toBe(expected);
+    }
+  );
+});

--- a/app/features/maps/utils/marksHash.ts
+++ b/app/features/maps/utils/marksHash.ts
@@ -1,0 +1,82 @@
+/**
+ * Hashing utilities for map objective marks.
+ *
+ * `getMarksHash` produces a cheap, allocation-light fingerprint of the marks
+ * relevant to a given map. It is used by LeafletMap.vue to skip re-rendering
+ * markers when nothing that affects them has changed.
+ */
+export interface MapZone {
+  map: { id: string };
+  outline: Array<{ x: number; z: number }>;
+}
+export interface MapMarkLocation {
+  map: { id: string };
+  positions?: Array<{ x: number; y?: number; z: number }>;
+  [key: string]: unknown;
+}
+export interface MapMark {
+  id?: string;
+  zones: MapZone[];
+  possibleLocations?: MapMarkLocation[];
+  users?: string[];
+  pinned?: boolean;
+}
+const FNV1A_OFFSET_BASIS = 0x811c9dc5;
+const FNV1A_PRIME = 0x01000193;
+const updateFnv1a = (hash: number, value: string | number): number => {
+  const token = typeof value === 'number' ? String(value) : value;
+  for (let i = 0; i < token.length; i++) {
+    hash ^= token.charCodeAt(i);
+    hash = Math.imul(hash, FNV1A_PRIME);
+  }
+  hash ^= 124;
+  return Math.imul(hash, FNV1A_PRIME) >>> 0;
+};
+const hashZoneOutline = (outline: Array<{ x: number; z: number }>): number => {
+  let zoneHash = updateFnv1a(FNV1A_OFFSET_BASIS, outline.length);
+  for (const point of outline) {
+    zoneHash = updateFnv1a(zoneHash, point.x);
+    zoneHash = updateFnv1a(zoneHash, point.z);
+  }
+  return zoneHash;
+};
+const hashLocationPositions = (positions?: Array<{ x: number; y?: number; z: number }>): number => {
+  let locationHash = updateFnv1a(FNV1A_OFFSET_BASIS, positions?.length ?? 0);
+  for (const point of positions ?? []) {
+    locationHash = updateFnv1a(locationHash, point.x);
+    locationHash = updateFnv1a(locationHash, point.z);
+  }
+  return locationHash;
+};
+export function getMarksHash(marks: MapMark[], mapId: string): string {
+  let hash = updateFnv1a(FNV1A_OFFSET_BASIS, mapId);
+  hash = updateFnv1a(hash, marks.length);
+  for (const mark of marks) {
+    hash = updateFnv1a(hash, mark.id ?? '');
+    // pinned affects marker rendering (fill colour), so it must be folded in here too.
+    // Any field that changes how a mark is drawn — not just its identity — belongs in this hash.
+    hash = updateFnv1a(hash, mark.pinned ? '1' : '0');
+    const sortedUsers = [...(mark.users ?? [])].sort();
+    hash = updateFnv1a(hash, sortedUsers.length);
+    for (const user of sortedUsers) {
+      hash = updateFnv1a(hash, user);
+    }
+    const zoneHashes = mark.zones
+      .filter((zone) => zone.map.id === mapId)
+      .map((zone) => hashZoneOutline(zone.outline))
+      .sort((a, b) => a - b);
+    hash = updateFnv1a(hash, zoneHashes.length);
+    for (const zoneHash of zoneHashes) {
+      hash = updateFnv1a(hash, zoneHash);
+    }
+    const locationHashes = (mark.possibleLocations ?? [])
+      .filter((location) => location.map.id === mapId)
+      .map((location) => hashLocationPositions(location.positions))
+      .sort((a, b) => a - b);
+    hash = updateFnv1a(hash, locationHashes.length);
+    for (const locationHash of locationHashes) {
+      hash = updateFnv1a(hash, locationHash);
+    }
+  }
+  return hash.toString(16).padStart(8, '0');
+}

--- a/app/features/maps/utils/marksHash.ts
+++ b/app/features/maps/utils/marksHash.ts
@@ -1,10 +1,3 @@
-/**
- * Hashing utilities for map objective marks.
- *
- * `getMarksHash` produces a cheap, allocation-light fingerprint of the marks
- * relevant to a given map. It is used by LeafletMap.vue to skip re-rendering
- * markers when nothing that affects them has changed.
- */
 export interface MapZone {
   map: { id: string };
   outline: Array<{ x: number; z: number }>;
@@ -23,6 +16,11 @@ export interface MapMark {
 }
 const FNV1A_OFFSET_BASIS = 0x811c9dc5;
 const FNV1A_PRIME = 0x01000193;
+const compareCodeUnits = (a: string, b: string): number => {
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+};
 const updateFnv1a = (hash: number, value: string | number): number => {
   const token = typeof value === 'number' ? String(value) : value;
   for (let i = 0; i < token.length; i++) {
@@ -53,10 +51,8 @@ export function getMarksHash(marks: MapMark[], mapId: string): string {
   hash = updateFnv1a(hash, marks.length);
   for (const mark of marks) {
     hash = updateFnv1a(hash, mark.id ?? '');
-    // pinned affects marker rendering (fill colour), so it must be folded in here too.
-    // Any field that changes how a mark is drawn — not just its identity — belongs in this hash.
     hash = updateFnv1a(hash, mark.pinned ? '1' : '0');
-    const sortedUsers = [...(mark.users ?? [])].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
+    const sortedUsers = [...(mark.users ?? [])].sort(compareCodeUnits);
     hash = updateFnv1a(hash, sortedUsers.length);
     for (const user of sortedUsers) {
       hash = updateFnv1a(hash, user);

--- a/app/features/maps/utils/marksHash.ts
+++ b/app/features/maps/utils/marksHash.ts
@@ -38,41 +38,43 @@ const hashZoneOutline = (outline: Array<{ x: number; z: number }>): number => {
   }
   return zoneHash;
 };
-const hashLocationPositions = (positions?: Array<{ x: number; y?: number; z: number }>): number => {
-  let locationHash = updateFnv1a(FNV1A_OFFSET_BASIS, positions?.length ?? 0);
-  for (const point of positions ?? []) {
+const hashLocationPositions = (positions: Array<{ x: number; y?: number; z: number }>): number => {
+  let locationHash = updateFnv1a(FNV1A_OFFSET_BASIS, positions.length);
+  for (const point of positions) {
     locationHash = updateFnv1a(locationHash, point.x);
     locationHash = updateFnv1a(locationHash, point.z);
   }
   return locationHash;
 };
+const hashSortedValues = (hash: number, values: Array<string | number>): number => {
+  let next = updateFnv1a(hash, values.length);
+  for (const value of values) {
+    next = updateFnv1a(next, value);
+  }
+  return next;
+};
+const markZoneHashes = (mark: MapMark, mapId: string): number[] =>
+  mark.zones
+    .filter((zone) => zone.map.id === mapId)
+    .map((zone) => hashZoneOutline(zone.outline))
+    .sort((a, b) => a - b);
+const markLocationHashes = (mark: MapMark, mapId: string): number[] =>
+  (mark.possibleLocations ?? [])
+    .filter((location) => location.map.id === mapId)
+    .map((location) => hashLocationPositions(location.positions ?? []))
+    .sort((a, b) => a - b);
+const hashMark = (hash: number, mark: MapMark, mapId: string): number => {
+  let next = updateFnv1a(hash, mark.id ?? '');
+  next = updateFnv1a(next, mark.pinned ? '1' : '0');
+  next = hashSortedValues(next, [...(mark.users ?? [])].sort(compareCodeUnits));
+  next = hashSortedValues(next, markZoneHashes(mark, mapId));
+  return hashSortedValues(next, markLocationHashes(mark, mapId));
+};
 export function getMarksHash(marks: MapMark[], mapId: string): string {
   let hash = updateFnv1a(FNV1A_OFFSET_BASIS, mapId);
   hash = updateFnv1a(hash, marks.length);
   for (const mark of marks) {
-    hash = updateFnv1a(hash, mark.id ?? '');
-    hash = updateFnv1a(hash, mark.pinned ? '1' : '0');
-    const sortedUsers = [...(mark.users ?? [])].sort(compareCodeUnits);
-    hash = updateFnv1a(hash, sortedUsers.length);
-    for (const user of sortedUsers) {
-      hash = updateFnv1a(hash, user);
-    }
-    const zoneHashes = mark.zones
-      .filter((zone) => zone.map.id === mapId)
-      .map((zone) => hashZoneOutline(zone.outline))
-      .sort((a, b) => a - b);
-    hash = updateFnv1a(hash, zoneHashes.length);
-    for (const zoneHash of zoneHashes) {
-      hash = updateFnv1a(hash, zoneHash);
-    }
-    const locationHashes = (mark.possibleLocations ?? [])
-      .filter((location) => location.map.id === mapId)
-      .map((location) => hashLocationPositions(location.positions))
-      .sort((a, b) => a - b);
-    hash = updateFnv1a(hash, locationHashes.length);
-    for (const locationHash of locationHashes) {
-      hash = updateFnv1a(hash, locationHash);
-    }
+    hash = hashMark(hash, mark, mapId);
   }
   return hash.toString(16).padStart(8, '0');
 }

--- a/app/features/maps/utils/marksHash.ts
+++ b/app/features/maps/utils/marksHash.ts
@@ -26,7 +26,7 @@ const FNV1A_PRIME = 0x01000193;
 const updateFnv1a = (hash: number, value: string | number): number => {
   const token = typeof value === 'number' ? String(value) : value;
   for (let i = 0; i < token.length; i++) {
-    hash ^= token.charCodeAt(i);
+    hash ^= token.codePointAt(i) ?? 0;
     hash = Math.imul(hash, FNV1A_PRIME);
   }
   hash ^= 124;
@@ -56,7 +56,7 @@ export function getMarksHash(marks: MapMark[], mapId: string): string {
     // pinned affects marker rendering (fill colour), so it must be folded in here too.
     // Any field that changes how a mark is drawn — not just its identity — belongs in this hash.
     hash = updateFnv1a(hash, mark.pinned ? '1' : '0');
-    const sortedUsers = [...(mark.users ?? [])].sort();
+    const sortedUsers = [...(mark.users ?? [])].sort((a, b) => (a < b ? -1 : a > b ? 1 : 0));
     hash = updateFnv1a(hash, sortedUsers.length);
     for (const user of sortedUsers) {
       hash = updateFnv1a(hash, user);

--- a/app/features/maps/utils/objectiveCategory.ts
+++ b/app/features/maps/utils/objectiveCategory.ts
@@ -1,0 +1,6 @@
+import type { MapMark } from '@/features/maps/utils/marksHash';
+export type ObjectiveCategory = 'self' | 'pinned' | 'team';
+export const getObjectiveCategory = (mark: MapMark): ObjectiveCategory => {
+  if (mark.pinned) return 'pinned';
+  return mark.users?.includes('self') ? 'self' : 'team';
+};

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -501,7 +501,6 @@
       "pmc_spawns": "PMC Spawns"
     },
     "legend": {
-      "tasks": "Tasks",
       "regular": "Regular",
       "pinned": "Pinned",
       "team": "Team",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -501,8 +501,10 @@
       "pmc_spawns": "PMC Spawns"
     },
     "legend": {
-      "your_objectives": "Your Objectives",
-      "team_objectives": "Team Objectives",
+      "tasks": "Tasks",
+      "regular": "Regular",
+      "pinned": "Pinned",
+      "team": "Team",
       "shared_extract": "Shared Extract (Either Faction)",
       "coop_extract": "Co-op Extract (PMC + Scav)"
     },
@@ -1829,6 +1831,7 @@
           "title": "Map Colors",
           "description": "Set marker colors for better readability and accessibility.",
           "self_objective": "Your Objective",
+          "pinned_objective": "Pinned Task",
           "team_objective": "Team Objective",
           "selected": "Pinned Objective",
           "shared_extract": "Shared Extract",

--- a/app/plugins/zz.preferences-sync.client.ts
+++ b/app/plugins/zz.preferences-sync.client.ts
@@ -204,6 +204,9 @@ const buildPreferencesSyncPayload = (
     map_zoom_speed: preferencesState.mapZoomSpeed,
     map_pan_speed: preferencesState.mapPanSpeed,
     map_zone_opacity: preferencesState.mapZoneOpacity,
+    map_show_self_objectives: preferencesState.mapShowSelfObjectives,
+    map_show_pinned_objectives: preferencesState.mapShowPinnedObjectives,
+    map_show_team_objectives: preferencesState.mapShowTeamObjectives,
     pinned_task_ids: Array.isArray(preferencesState.pinnedTaskIds)
       ? preferencesState.pinnedTaskIds.filter(
           (taskId): taskId is string => typeof taskId === 'string' && taskId.length > 0

--- a/app/stores/__tests__/usePreferences.test.ts
+++ b/app/stores/__tests__/usePreferences.test.ts
@@ -133,6 +133,9 @@ describe('usePreferencesStore', () => {
       expect(store.mapZoomSpeed).toBe(1);
       expect(store.mapPanSpeed).toBe(1);
       expect(store.pinnedTaskIds).toEqual([]);
+      expect(store.mapShowSelfObjectives).toBe(true);
+      expect(store.mapShowPinnedObjectives).toBe(true);
+      expect(store.mapShowTeamObjectives).toBe(true);
     });
     it('sanitizes keybinds assigned through store actions', () => {
       const store = usePreferencesStore();
@@ -944,6 +947,18 @@ describe('usePreferencesStore', () => {
       store.pinnedTaskIds = ['task-1', 'task-2'];
       expect(store.getPinnedTaskIds).toEqual(['task-1', 'task-2']);
     });
+    it('should return map objective visibility state with default true', () => {
+      const store = usePreferencesStore();
+      expect(store.getMapShowSelfObjectives).toBe(true);
+      expect(store.getMapShowPinnedObjectives).toBe(true);
+      expect(store.getMapShowTeamObjectives).toBe(true);
+      store.mapShowSelfObjectives = false;
+      store.mapShowPinnedObjectives = false;
+      store.mapShowTeamObjectives = false;
+      expect(store.getMapShowSelfObjectives).toBe(false);
+      expect(store.getMapShowPinnedObjectives).toBe(false);
+      expect(store.getMapShowTeamObjectives).toBe(false);
+    });
     it('should return skillSortMode state with default priority', () => {
       const store = usePreferencesStore();
       expect(store.getSkillSortMode).toBe('priority');
@@ -1291,6 +1306,15 @@ describe('usePreferencesStore', () => {
       store.setShowFailedFilter(false);
       expect(store.showFailedFilter).toBe(false);
     });
+    it('should set map objective visibility filters', () => {
+      const store = usePreferencesStore();
+      store.setMapShowSelfObjectives(false);
+      expect(store.mapShowSelfObjectives).toBe(false);
+      store.setMapShowPinnedObjectives(false);
+      expect(store.mapShowPinnedObjectives).toBe(false);
+      store.setMapShowTeamObjectives(false);
+      expect(store.mapShowTeamObjectives).toBe(false);
+    });
   });
   describe('Actions - XP and Level', () => {
     it('should set use automatic level calculation', () => {
@@ -1440,6 +1464,17 @@ describe('usePreferencesStore', () => {
       const store = usePreferencesStore();
       store.$patch({ pinnedTaskIds: undefined });
       expect(store.getPinnedTaskIds).toEqual([]);
+    });
+    it('should handle nullish map objective visibility state in getters', () => {
+      const store = usePreferencesStore();
+      store.$patch({
+        mapShowSelfObjectives: undefined,
+        mapShowPinnedObjectives: undefined,
+        mapShowTeamObjectives: undefined,
+      });
+      expect(store.getMapShowSelfObjectives).toBe(true);
+      expect(store.getMapShowPinnedObjectives).toBe(true);
+      expect(store.getMapShowTeamObjectives).toBe(true);
     });
     it('should handle nullish mapMarkerColors in getter', () => {
       const store = usePreferencesStore();

--- a/app/stores/__tests__/usePreferences.test.ts
+++ b/app/stores/__tests__/usePreferences.test.ts
@@ -281,10 +281,11 @@ describe('usePreferencesStore', () => {
       expect(migratedValue.data.neededItemsHideCollected).toBeUndefined();
     });
     it('should migrate untouched legacy map marker defaults', () => {
-      const legacyMapMarkerColors = {
+      const legacyMapMarkerColors: Record<string, string> = {
         ...MAP_MARKER_COLORS,
         SELF_OBJECTIVE: '#ef4444',
       };
+      delete legacyMapMarkerColors.PINNED_OBJECTIVE;
       const persistedState = {
         mapMarkerColors: legacyMapMarkerColors,
       };

--- a/app/stores/usePreferences.ts
+++ b/app/stores/usePreferences.ts
@@ -152,6 +152,9 @@ export interface PreferencesState {
   mapZoneOpacity: number;
   mapTooltipDensity: 'default' | 'compact';
   pinnedTaskIds: string[];
+  mapShowSelfObjectives: boolean;
+  mapShowPinnedObjectives: boolean;
+  mapShowTeamObjectives: boolean;
   // Skills settings
   skillSortMode: SkillSortMode | null;
   traderSortMode: TraderSortMode | null;
@@ -238,6 +241,9 @@ export const preferencesDefaultState: PreferencesState = {
   mapZoneOpacity: 0.24,
   mapTooltipDensity: 'default',
   pinnedTaskIds: [],
+  mapShowSelfObjectives: true,
+  mapShowPinnedObjectives: true,
+  mapShowTeamObjectives: true,
   // Skills settings
   skillSortMode: null,
   traderSortMode: null,
@@ -626,6 +632,15 @@ export const usePreferencesStore = defineStore('preferences', {
     getPinnedTaskIds: (state) => {
       return state.pinnedTaskIds ?? [];
     },
+    getMapShowSelfObjectives: (state) => {
+      return state.mapShowSelfObjectives ?? true;
+    },
+    getMapShowPinnedObjectives: (state) => {
+      return state.mapShowPinnedObjectives ?? true;
+    },
+    getMapShowTeamObjectives: (state) => {
+      return state.mapShowTeamObjectives ?? true;
+    },
     // Skills getters
     getSkillSortMode: (state) => {
       return state.skillSortMode ?? 'priority';
@@ -872,6 +887,15 @@ export const usePreferencesStore = defineStore('preferences', {
     setShowFailedFilter(show: boolean) {
       this.showFailedFilter = show;
     },
+    setMapShowSelfObjectives(show: boolean) {
+      this.mapShowSelfObjectives = show;
+    },
+    setMapShowPinnedObjectives(show: boolean) {
+      this.mapShowPinnedObjectives = show;
+    },
+    setMapShowTeamObjectives(show: boolean) {
+      this.mapShowTeamObjectives = show;
+    },
     setUseAutomaticLevelCalculation(use: boolean) {
       this.useAutomaticLevelCalculation = use;
     },
@@ -989,6 +1013,9 @@ export const usePreferencesStore = defineStore('preferences', {
       'showLockedFilter',
       'showCompletedFilter',
       'showFailedFilter',
+      'mapShowSelfObjectives',
+      'mapShowPinnedObjectives',
+      'mapShowTeamObjectives',
       'useAutomaticLevelCalculation',
       'dashboardNoticeDismissed',
       'hideoutCollapseCompleted',

--- a/app/utils/__tests__/theme-colors.test.ts
+++ b/app/utils/__tests__/theme-colors.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getMapColorOptions,
+  LEGACY_MAP_MARKER_COLORS,
+  MAP_MARKER_COLORS,
+  migrateLegacyMapMarkerColors,
+} from '@/utils/theme-colors';
+const t = (key: string) => key;
+describe('theme-colors', () => {
+  it('defines a distinct PINNED_OBJECTIVE color separate from SELECTED', () => {
+    expect(MAP_MARKER_COLORS.PINNED_OBJECTIVE).toBe('#7c3bed');
+    // Must be a distinct key from SELECTED so the popup-pin behaviour
+    // (attachHoverPinPopup / setLayerSelected) stays unambiguous.
+    expect(MAP_MARKER_COLORS.PINNED_OBJECTIVE).not.toBe(undefined);
+    expect('SELECTED' in MAP_MARKER_COLORS).toBe(true);
+  });
+  it('includes PINNED_OBJECTIVE in getMapColorOptions with the expected label key', () => {
+    const options = getMapColorOptions(t);
+    const pinnedOption = options.find((option) => option.key === 'PINNED_OBJECTIVE');
+    expect(pinnedOption).toBeDefined();
+    expect(pinnedOption?.label).toBe('settings.interface.maps.colors.pinned_objective');
+  });
+  it('places PINNED_OBJECTIVE immediately after SELF_OBJECTIVE in getMapColorOptions', () => {
+    const options = getMapColorOptions(t);
+    const selfIndex = options.findIndex((option) => option.key === 'SELF_OBJECTIVE');
+    const pinnedIndex = options.findIndex((option) => option.key === 'PINNED_OBJECTIVE');
+    expect(selfIndex).toBeGreaterThanOrEqual(0);
+    expect(pinnedIndex).toBe(selfIndex + 1);
+  });
+  it('still migrates a stored legacy object that lacks the new PINNED_OBJECTIVE key (regression guard)', () => {
+    // Simulates a user's persisted mapMarkerColors from before this feature shipped:
+    // it has exactly the legacy default values, but no PINNED_OBJECTIVE key at all
+    // (that key did not exist yet when the value was persisted).
+    const legacyStored: Record<string, string> = { ...LEGACY_MAP_MARKER_COLORS };
+    delete legacyStored.PINNED_OBJECTIVE;
+    expect('PINNED_OBJECTIVE' in legacyStored).toBe(false);
+    const migrated = migrateLegacyMapMarkerColors(legacyStored);
+    expect(migrated).not.toBeNull();
+    expect(migrated).toEqual(MAP_MARKER_COLORS);
+    expect(migrated?.PINNED_OBJECTIVE).toBe(MAP_MARKER_COLORS.PINNED_OBJECTIVE);
+  });
+  it('does not migrate when a legacy-shaped object has an unrelated modification', () => {
+    const tampered: Record<string, string> = {
+      ...LEGACY_MAP_MARKER_COLORS,
+      SELF_OBJECTIVE: '#123456',
+    };
+    expect(migrateLegacyMapMarkerColors(tampered)).toBeNull();
+  });
+});

--- a/app/utils/__tests__/theme-colors.test.ts
+++ b/app/utils/__tests__/theme-colors.test.ts
@@ -9,8 +9,6 @@ const t = (key: string) => key;
 describe('theme-colors', () => {
   it('defines a distinct PINNED_OBJECTIVE color separate from SELECTED', () => {
     expect(MAP_MARKER_COLORS.PINNED_OBJECTIVE).toBe('#7c3bed');
-    // Must be a distinct key from SELECTED so the popup-pin behaviour
-    // (attachHoverPinPopup / setLayerSelected) stays unambiguous.
     expect('SELECTED' in MAP_MARKER_COLORS).toBe(true);
   });
   it('includes PINNED_OBJECTIVE in getMapColorOptions with the expected label key', () => {
@@ -27,9 +25,6 @@ describe('theme-colors', () => {
     expect(pinnedIndex).toBe(selfIndex + 1);
   });
   it('still migrates a stored legacy object that lacks the new PINNED_OBJECTIVE key (regression guard)', () => {
-    // Simulates a user's persisted mapMarkerColors from before this feature shipped:
-    // it has exactly the legacy default values, but no PINNED_OBJECTIVE key at all
-    // (that key did not exist yet when the value was persisted).
     const legacyStored: Record<string, string> = { ...LEGACY_MAP_MARKER_COLORS };
     delete legacyStored.PINNED_OBJECTIVE;
     expect('PINNED_OBJECTIVE' in legacyStored).toBe(false);

--- a/app/utils/__tests__/theme-colors.test.ts
+++ b/app/utils/__tests__/theme-colors.test.ts
@@ -40,4 +40,11 @@ describe('theme-colors', () => {
     };
     expect(migrateLegacyMapMarkerColors(tampered)).toBeNull();
   });
+  it('does not migrate a legacy-shaped palette that already carries a customized PINNED_OBJECTIVE', () => {
+    const withPinnedKey: Record<string, string> = {
+      ...LEGACY_MAP_MARKER_COLORS,
+      PINNED_OBJECTIVE: '#123456',
+    };
+    expect(migrateLegacyMapMarkerColors(withPinnedKey)).toBeNull();
+  });
 });

--- a/app/utils/__tests__/theme-colors.test.ts
+++ b/app/utils/__tests__/theme-colors.test.ts
@@ -11,7 +11,6 @@ describe('theme-colors', () => {
     expect(MAP_MARKER_COLORS.PINNED_OBJECTIVE).toBe('#7c3bed');
     // Must be a distinct key from SELECTED so the popup-pin behaviour
     // (attachHoverPinPopup / setLayerSelected) stays unambiguous.
-    expect(MAP_MARKER_COLORS.PINNED_OBJECTIVE).not.toBe(undefined);
     expect('SELECTED' in MAP_MARKER_COLORS).toBe(true);
   });
   it('includes PINNED_OBJECTIVE in getMapColorOptions with the expected label key', () => {

--- a/app/utils/__tests__/theme-colors.test.ts
+++ b/app/utils/__tests__/theme-colors.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@/utils/theme-colors';
 const t = (key: string) => key;
 describe('theme-colors', () => {
-  it('defines a distinct PINNED_OBJECTIVE color separate from SELECTED', () => {
+  it('defines PINNED_OBJECTIVE with the selection accent and keeps a separate SELECTED key', () => {
     expect(MAP_MARKER_COLORS.PINNED_OBJECTIVE).toBe('#7c3bed');
     expect('SELECTED' in MAP_MARKER_COLORS).toBe(true);
   });

--- a/app/utils/theme-colors.ts
+++ b/app/utils/theme-colors.ts
@@ -82,6 +82,8 @@ export const THEME_COLORS = {
 export const MAP_MARKER_COLORS = {
   /** Self objectives - matches --color-warning-500 */
   SELF_OBJECTIVE: '#f59e0b',
+  /** Pinned task objectives - matches --color-selection-500 */
+  PINNED_OBJECTIVE: '#7c3bed',
   /** Team objectives - matches --color-info-400 */
   TEAM_OBJECTIVE: '#3c9add',
   /** Selected/pinned marker - matches --color-selection-500 */
@@ -112,9 +114,34 @@ export type MapMarkerColors = Record<MapMarkerColorKey, string>;
 export type MapColorOption = { key: MapMarkerColorKey; label: string };
 type MapColorOptionTranslator = (key: string) => string;
 export const MAP_MARKER_COLOR_KEYS = Object.keys(MAP_MARKER_COLORS) as MapMarkerColorKey[];
+/**
+ * Frozen snapshot of the marker color keys as they existed BEFORE the
+ * PINNED_OBJECTIVE key was introduced. Used only by `hasExactLegacyDefaults`
+ * below. Users who persisted `mapMarkerColors` prior to this change will not
+ * have a `PINNED_OBJECTIVE` entry in their stored value; if that check looped
+ * over the current `MAP_MARKER_COLOR_KEYS` (which now includes
+ * `PINNED_OBJECTIVE`), it would find the key missing and incorrectly report
+ * that the stored value is NOT an exact legacy default, silently breaking
+ * `migrateLegacyMapMarkerColors` for existing users. Do NOT add new keys to
+ * this list when new marker colors are introduced in the future.
+ */
+const LEGACY_MAP_MARKER_COLOR_KEYS: MapMarkerColorKey[] = [
+  'SELF_OBJECTIVE',
+  'TEAM_OBJECTIVE',
+  'SELECTED',
+  'PMC_EXTRACT',
+  'SCAV_EXTRACT',
+  'SHARED_EXTRACT',
+  'COOP_EXTRACT',
+  'PMC_SPAWN',
+  'DEFAULT_EXTRACT',
+  'MARKER_BORDER',
+  'EXTRACT_DOT_BORDER',
+];
 export const getMapColorOptions = (t: MapColorOptionTranslator): MapColorOption[] => {
   return [
     { key: 'SELF_OBJECTIVE', label: t('settings.interface.maps.colors.self_objective') },
+    { key: 'PINNED_OBJECTIVE', label: t('settings.interface.maps.colors.pinned_objective') },
     { key: 'TEAM_OBJECTIVE', label: t('settings.interface.maps.colors.team_objective') },
     { key: 'SELECTED', label: t('settings.interface.maps.colors.selected') },
     { key: 'PMC_EXTRACT', label: t('common.pmc_extract') },
@@ -140,7 +167,7 @@ const normalizeHex = (value: string): string => value.trim().toLowerCase();
 const hasExactLegacyDefaults = (value: unknown): value is MapMarkerColors => {
   if (!value || typeof value !== 'object') return false;
   const candidateColors = value as Record<string, unknown>;
-  for (const key of MAP_MARKER_COLOR_KEYS) {
+  for (const key of LEGACY_MAP_MARKER_COLOR_KEYS) {
     const rawCandidate = candidateColors[key];
     if (typeof rawCandidate !== 'string') return false;
     if (normalizeHex(rawCandidate) !== normalizeHex(LEGACY_MAP_MARKER_COLORS[key])) {

--- a/app/utils/theme-colors.ts
+++ b/app/utils/theme-colors.ts
@@ -158,6 +158,7 @@ const normalizeHex = (value: string): string => value.trim().toLowerCase();
 const hasExactLegacyDefaults = (value: unknown): value is MapMarkerColors => {
   if (!value || typeof value !== 'object') return false;
   const candidateColors = value as Record<string, unknown>;
+  if ('PINNED_OBJECTIVE' in candidateColors) return false;
   for (const key of LEGACY_MAP_MARKER_COLOR_KEYS) {
     const rawCandidate = candidateColors[key];
     if (typeof rawCandidate !== 'string') return false;

--- a/app/utils/theme-colors.ts
+++ b/app/utils/theme-colors.ts
@@ -114,17 +114,8 @@ export type MapMarkerColors = Record<MapMarkerColorKey, string>;
 export type MapColorOption = { key: MapMarkerColorKey; label: string };
 type MapColorOptionTranslator = (key: string) => string;
 export const MAP_MARKER_COLOR_KEYS = Object.keys(MAP_MARKER_COLORS) as MapMarkerColorKey[];
-/**
- * Frozen snapshot of the marker color keys as they existed BEFORE the
- * PINNED_OBJECTIVE key was introduced. Used only by `hasExactLegacyDefaults`
- * below. Users who persisted `mapMarkerColors` prior to this change will not
- * have a `PINNED_OBJECTIVE` entry in their stored value; if that check looped
- * over the current `MAP_MARKER_COLOR_KEYS` (which now includes
- * `PINNED_OBJECTIVE`), it would find the key missing and incorrectly report
- * that the stored value is NOT an exact legacy default, silently breaking
- * `migrateLegacyMapMarkerColors` for existing users. Do NOT add new keys to
- * this list when new marker colors are introduced in the future.
- */
+// Frozen pre-PINNED_OBJECTIVE snapshot used by hasExactLegacyDefaults; persisted
+// legacy palettes lack newer keys, so never add new marker colors to this list.
 const LEGACY_MAP_MARKER_COLOR_KEYS: MapMarkerColorKey[] = [
   'SELF_OBJECTIVE',
   'TEAM_OBJECTIVE',

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -514,6 +514,9 @@ export type Database = {
           locale_override: string | null
           map_marker_colors: Json
           map_pan_speed: number | null
+          map_show_pinned_objectives: boolean
+          map_show_self_objectives: boolean
+          map_show_team_objectives: boolean
           map_team_hide_all: boolean | null
           map_zone_opacity: number
           map_zoom_speed: number | null
@@ -590,6 +593,9 @@ export type Database = {
           locale_override?: string | null
           map_marker_colors?: Json
           map_pan_speed?: number | null
+          map_show_pinned_objectives?: boolean
+          map_show_self_objectives?: boolean
+          map_show_team_objectives?: boolean
           map_team_hide_all?: boolean | null
           map_zone_opacity?: number
           map_zoom_speed?: number | null
@@ -666,6 +672,9 @@ export type Database = {
           locale_override?: string | null
           map_marker_colors?: Json
           map_pan_speed?: number | null
+          map_show_pinned_objectives?: boolean
+          map_show_self_objectives?: boolean
+          map_show_team_objectives?: boolean
           map_team_hide_all?: boolean | null
           map_zone_opacity?: number
           map_zoom_speed?: number | null

--- a/supabase/migrations/20260817_add_map_objective_visibility_prefs.sql
+++ b/supabase/migrations/20260817_add_map_objective_visibility_prefs.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.user_preferences
+  ADD COLUMN IF NOT EXISTS map_show_self_objectives BOOLEAN DEFAULT TRUE NOT NULL,
+  ADD COLUMN IF NOT EXISTS map_show_pinned_objectives BOOLEAN DEFAULT TRUE NOT NULL,
+  ADD COLUMN IF NOT EXISTS map_show_team_objectives BOOLEAN DEFAULT TRUE NOT NULL;


### PR DESCRIPTION
Resolves #740 
Also adds map toggles for Regular/Pinned/Team objectives

## What

- **Pinned tasks get a distinct purple marker colour** on the map (`PINNED_OBJECTIVE`, default `#7c3bed`), configurable in Settings → Map Colors like the other marker colours. Users with persisted custom colours fall back to the new default via `normalizeMapMarkerColors`.
- **Pinning/unpinning a task live-updates the map.** The marker memoization hash moves from `LeafletMap.vue` to `app/features/maps/utils/marksHash.ts` and now folds in `mark.pinned`, so pin changes repaint markers while unrelated re-renders still skip work (same FNV-1a fingerprint approach as before).
- **The legend's static "Your Objectives" / "Team Objectives" entries become three clickable chips** — `Tasks: Regular / Pinned / Team` — that toggle per-category marker visibility. The preference persists (`mapShowSelfObjectives` / `mapShowPinnedObjectives` / `mapShowTeamObjectives`, default all on). No counters on the chips for now, to keep it simple.

## How

- `useMapObjectiveMarks` stamps each mark with `pinned` resolved from the enclosing task id.
- `LeafletMap.vue` resolves a mark's category (`pinned` → `self`/`team`), colours markers and zone polygons per category, and skips disabled categories in `createObjectiveMarkers`. Chip toggles reset the marks hash and rebuild markers.
- Marker colour keys predating `PINNED_OBJECTIVE` are handled by a frozen legacy-key list so the legacy-default migration keeps working for existing users.

## QA

Headless-browser run against a dev server (Customs, fresh profile, 55 self markers):

| Step | self (amber) | pinned (purple) |
| --- | --- | --- |
| baseline | 55 | 0 |
| pin first task | 50 | 5 |
| "Pinned" chip off | 50 | 0 |
| "Pinned" chip on | 50 | 5 |
| unpin | 55 | 0 |

All transitions applied live without a page reload.

## Validation

- `pnpm run typecheck` ✅
- `pnpm run lint` ✅ (zero warnings)
- `pnpm run i18n:check` ✅ (new keys snake_case; non-English locales reconcile via Crowdin)
- Targeted vitest: theme-colors, usePreferences, useMapObjectiveMarks, marksHash, useLeafletMapControls (220 tests) plus related LeafletMap/tasks-page/useLeafletMap/useMapObjectivePopup suites (79 tests) — all passing

## Demo

Pin → markers recolor live → "Pinned" chip off/on → "Regular" chip off/on → unpin:

![pin and chip toggling demo](https://raw.githubusercontent.com/atzorvas/TarkovTracker-nuxt/media/pr-747/pinned-map-demo.gif)

<details><summary>Screenshots</summary>

**Baseline — all categories on, regular tasks amber:**

![baseline](https://raw.githubusercontent.com/atzorvas/TarkovTracker-nuxt/media/pr-747/A-baseline-map.png)

**After pinning a task — its markers turn purple, live:**

![pinned](https://raw.githubusercontent.com/atzorvas/TarkovTracker-nuxt/media/pr-747/B-pinned-map.png)

**"Regular" chip off — only pinned markers remain:**

![regular off](https://raw.githubusercontent.com/atzorvas/TarkovTracker-nuxt/media/pr-747/D-regular-chip-off.png)

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added map legend filters for regular, pinned, and team objectives.
  * Added distinct coloring for pinned objectives.
  * Added saved visibility preferences for each objective category.
  * Pinned tasks are now clearly identified on the map.

* **Bug Fixes**
  * Map markers now update correctly when objective visibility settings change.

* **Tests**
  * Expanded coverage for objective pinning, marker hashing, preferences, colors, and visibility behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds distinct pinned-objective rendering, live marker updates, category visibility chips, and cross-device persistence for those visibility preferences.
- Categorizes regular, pinned, and team objectives for map rendering and filtering.
- Includes pinned state in marker fingerprints so pin changes repaint immediately.
- Adds configurable pinned-marker colors with legacy preference normalization.
- Persists the three visibility settings locally and through Supabase.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/features/maps/LeafletMap.vue | Adds objective-category chips and category-aware marker and polygon rendering. |
| app/features/maps/utils/marksHash.ts | Extracts marker fingerprinting and incorporates pinned state into update detection. |
| app/plugins/zz.preferences-sync.client.ts | Adds all three objective visibility fields to the Supabase synchronization payload. |
| app/stores/usePreferences.ts | Defines persisted visibility state, defaults, getters, and setters for objective categories. |
| supabase/migrations/20260817_add_map_objective_visibility_prefs.sql | Adds non-null visibility columns with enabled defaults for existing and new users. |
| app/utils/theme-colors.ts | Adds the pinned-objective color and preserves migration behavior for legacy palettes. |

</details>

<sub>Reviews (8): Last reviewed commit: ["test(maps): cover objective category pre..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/d930206ec9a33078276d7717746128c608a1d8e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53727977)</sub>

<!-- /greptile_comment -->