### PR TITLE
fix(hideout): handle EFT 1.1 currency requirements

### DIFF
--- a/app/composables/__tests__/useGraphBuilder.test.ts
+++ b/app/composables/__tests__/useGraphBuilder.test.ts
@@ -3,7 +3,7 @@ import { useGraphBuilder } from '@/composables/useGraphBuilder';
 import type { HideoutStation, Task } from '@/types/tarkov';
 describe('useGraphBuilder hideout requirements', () => {
   it.each(['5449016a4bdc2d6f028b456f', '5696686a4bdc2da3298b456a', '569668774bdc2da2298b4568'])(
-    'excludes currency item %s from needed inventory items',
+    'preserves currency item %s in hideout requirement metadata',
     (itemId) => {
       const stations: HideoutStation[] = [
         {
@@ -31,7 +31,13 @@ describe('useGraphBuilder hideout requirements', () => {
         },
       ];
       const { processHideoutData } = useGraphBuilder();
-      expect(processHideoutData(stations).neededItemHideoutModules).toEqual([]);
+      expect(processHideoutData(stations).neededItemHideoutModules).toMatchObject([
+        {
+          id: `currency-${itemId}`,
+          item: { id: itemId, name: 'Currency' },
+          count: 25000,
+        },
+      ]);
     }
   );
 });

--- a/app/composables/__tests__/useGraphBuilder.test.ts
+++ b/app/composables/__tests__/useGraphBuilder.test.ts
@@ -1,6 +1,40 @@
 import { describe, expect, it } from 'vitest';
 import { useGraphBuilder } from '@/composables/useGraphBuilder';
-import type { Task } from '@/types/tarkov';
+import type { HideoutStation, Task } from '@/types/tarkov';
+describe('useGraphBuilder hideout requirements', () => {
+  it.each(['5449016a4bdc2d6f028b456f', '5696686a4bdc2da3298b456a', '569668774bdc2da2298b4568'])(
+    'excludes currency item %s from needed inventory items',
+    (itemId) => {
+      const stations: HideoutStation[] = [
+        {
+          id: 'station-1',
+          name: 'Heating',
+          levels: [
+            {
+              id: 'station-1-level-1',
+              level: 1,
+              constructionTime: 0,
+              itemRequirements: [
+                {
+                  id: `currency-${itemId}`,
+                  item: { id: itemId, name: 'Currency' },
+                  count: 25000,
+                  quantity: 25000,
+                },
+              ],
+              stationLevelRequirements: [],
+              skillRequirements: [],
+              traderRequirements: [],
+              crafts: [],
+            },
+          ],
+        },
+      ];
+      const { processHideoutData } = useGraphBuilder();
+      expect(processHideoutData(stations).neededItemHideoutModules).toEqual([]);
+    }
+  );
+});
 describe('useGraphBuilder alternatives', () => {
   it('does not create alternatives from failed-only requirements', () => {
     const prerequisite: Task = {

--- a/app/composables/__tests__/useNeededItems.test.ts
+++ b/app/composables/__tests__/useNeededItems.test.ts
@@ -278,6 +278,20 @@ describe('useNeededItems', () => {
       const { neededItems } = await setup();
       expect(neededItems.allItems.value.length).toBe(6);
     });
+    it('excludes currency requirements from needed inventory items', async () => {
+      const currency = createItem('5449016a4bdc2d6f028b456f', 'Roubles');
+      const currencyRequirement = createHideoutModule(
+        'currency-roubles',
+        'station-1',
+        1,
+        currency,
+        400000
+      );
+      const { neededItems } = await setup({
+        metadataStore: { neededItemHideoutModules: [currencyRequirement] },
+      });
+      expect(neededItems.allItems.value).not.toContainEqual(currencyRequirement);
+    });
     it('preserves separate progress keys for objectives that need the same item', async () => {
       const sharedMod = createItem('560d657b4bdc2da74d8b4572', 'Shared weapon mod');
       const firstObjectiveId = '676529af9c90953d090882ea';

--- a/app/composables/useGraphBuilder.ts
+++ b/app/composables/useGraphBuilder.ts
@@ -1,3 +1,4 @@
+import { isCurrencyItemId } from '@/utils/constants';
 import {
   createGraph,
   type TaskGraph,
@@ -308,7 +309,7 @@ export function useGraphBuilder() {
     const neededItems: NeededItemHideoutModule[] = [];
     modules.forEach((module) => {
       module.itemRequirements?.forEach((req) => {
-        if (req?.item?.id) {
+        if (req?.item?.id && !isCurrencyItemId(req.item.id)) {
           // Parse FIR status from attributes field
           let foundInRaid = false;
           if (req.attributes && Array.isArray(req.attributes)) {

--- a/app/composables/useGraphBuilder.ts
+++ b/app/composables/useGraphBuilder.ts
@@ -1,4 +1,3 @@
-import { isCurrencyItemId } from '@/utils/constants';
 import {
   createGraph,
   type TaskGraph,
@@ -309,7 +308,7 @@ export function useGraphBuilder() {
     const neededItems: NeededItemHideoutModule[] = [];
     modules.forEach((module) => {
       module.itemRequirements?.forEach((req) => {
-        if (req?.item?.id && !isCurrencyItemId(req.item.id)) {
+        if (req?.item?.id) {
           // Parse FIR status from attributes field
           let foundInRaid = false;
           if (req.attributes && Array.isArray(req.attributes)) {

--- a/app/composables/useNeededItems.ts
+++ b/app/composables/useNeededItems.ts
@@ -8,6 +8,7 @@ import { useMetadataStore } from '@/stores/useMetadata';
 import { usePreferencesStore } from '@/stores/usePreferences';
 import { useProgressStore } from '@/stores/useProgress';
 import { useTarkovStore } from '@/stores/useTarkov';
+import { isCurrencyItemId } from '@/utils/constants';
 import { fuzzyMatch } from '@/utils/fuzzySearch';
 import { logger } from '@/utils/logger';
 import { perfNow, roundPerfMs } from '@/utils/perf';
@@ -26,6 +27,10 @@ import type {
 const DEFAULT_FULL_LOAD_TIMEOUT_MS = 5000;
 const DEFAULT_FULL_LOAD_MIN_TIME_MS = 16;
 const DEFAULT_FULL_LOAD_DELAY_MS = 1500;
+const isTrackableHideoutRequirement = (need: NeededItemHideoutModule): boolean => {
+  const itemId = getNeededItemId(need);
+  return !itemId || !isCurrencyItemId(itemId);
+};
 type FullItemsLoadOptions = {
   priority?: 'normal' | 'high';
   timeout?: number;
@@ -95,7 +100,9 @@ export function useNeededItems(options: UseNeededItemsOptions = {}): UseNeededIt
     logger.info(`[NeededItemsPerf] ${event}`, payload);
   };
   const neededItemTaskObjectives = computed(() => metadataStore.neededItemTaskObjectives);
-  const neededItemHideoutModules = computed(() => metadataStore.neededItemHideoutModules);
+  const neededItemHideoutModules = computed(() =>
+    metadataStore.neededItemHideoutModules.filter(isTrackableHideoutRequirement)
+  );
   const itemsFullLoaded = computed(() => metadataStore.itemsFullLoaded);
   const items = computed(() => metadataStore.items);
   const viewMode = computed({

--- a/app/features/hideout/HideoutRequirement.vue
+++ b/app/features/hideout/HideoutRequirement.vue
@@ -201,9 +201,7 @@
     isCurrency.value ? formattedCurrency.value : props.requirement.item.name
   );
   const itemLabelClass = computed(() =>
-    isCurrency.value
-      ? 'text-[9px] whitespace-nowrap sm:text-[10px]'
-      : 'line-clamp-2 text-[11px] sm:text-xs'
+    isCurrency.value ? 'break-all text-[9px] sm:text-[10px]' : 'line-clamp-2 text-[11px] sm:text-xs'
   );
   // Context menu
   const contextMenu = ref<InstanceType<typeof ContextMenuType>>();

--- a/app/features/hideout/HideoutRequirement.vue
+++ b/app/features/hideout/HideoutRequirement.vue
@@ -12,18 +12,13 @@
   >
     <!-- Item Image -->
     <div class="relative mb-1.5 h-14 w-14 shrink-0 sm:mb-2 sm:h-16 sm:w-16">
-      <div
-        v-if="isCurrency"
-        class="border-surface-700 bg-surface-900/80 text-primary-300 flex h-full w-full items-center justify-center rounded border text-2xl font-bold sm:text-3xl"
-      >
-        {{ currencySymbol }}
-      </div>
       <GameItem
-        v-else
         :item-id="requirement.item.id"
         :item-name="requirement.item.name"
         :dev-link="requirement.item.link"
         :wiki-link="requirement.item.wikiLink"
+        :icon-link="requirement.item.iconLink"
+        :image512px-link="requirement.item.image512pxLink"
         size="small"
         :show-actions="false"
         simple-mode
@@ -184,6 +179,8 @@
         name?: string;
         link?: string | null;
         wikiLink?: string | null;
+        iconLink?: string;
+        image512pxLink?: string;
       };
       count: number;
       attributes?: Array<{

--- a/app/features/hideout/HideoutRequirement.vue
+++ b/app/features/hideout/HideoutRequirement.vue
@@ -12,7 +12,14 @@
   >
     <!-- Item Image -->
     <div class="relative mb-1.5 h-14 w-14 shrink-0 sm:mb-2 sm:h-16 sm:w-16">
+      <div
+        v-if="isCurrency"
+        class="border-surface-700 bg-surface-900/80 text-primary-300 flex h-full w-full items-center justify-center rounded border text-2xl font-bold sm:text-3xl"
+      >
+        {{ currencySymbol }}
+      </div>
       <GameItem
+        v-else
         :item-id="requirement.item.id"
         :item-name="requirement.item.name"
         :dev-link="requirement.item.link"
@@ -29,14 +36,17 @@
         <UIcon name="i-mdi-check-circle" class="text-success-300 h-6 w-6 sm:h-8 sm:w-8" />
       </div>
       <!-- FiR Badge -->
-      <AppTooltip v-if="isFoundInRaid" :text="$t('common.found_in_raid_required')">
+      <AppTooltip v-if="!isCurrency && isFoundInRaid" :text="$t('common.found_in_raid_required')">
         <UIcon
           name="i-mdi-checkbox-marked-circle-outline"
           class="text-warning-400 absolute -top-1 -right-1 h-3 w-3"
         />
       </AppTooltip>
       <!-- Count Badge for multi-count items -->
-      <div v-if="requiredCount > 1" class="absolute right-0 -bottom-1 left-0 flex justify-center">
+      <div
+        v-if="!isCurrency && requiredCount > 1"
+        class="absolute right-0 -bottom-1 left-0 flex justify-center"
+      >
         <div
           class="border-surface-700 bg-surface-900/90 rounded border px-1 py-0.5 text-[9px] font-bold sm:px-1.5 sm:text-[10px]"
           :class="isComplete ? 'text-success-400' : 'text-surface-300'"
@@ -47,9 +57,14 @@
     </div>
     <!-- Item Name -->
     <div
-      class="text-surface-200 line-clamp-2 w-full text-center text-[11px] leading-tight font-medium sm:text-xs"
+      class="text-surface-200 w-full text-center leading-tight font-medium"
+      :class="
+        isCurrency
+          ? 'text-[9px] whitespace-nowrap sm:text-[10px]'
+          : 'line-clamp-2 text-[11px] sm:text-xs'
+      "
     >
-      {{ requirement.item.name }}
+      {{ isCurrency ? formattedCurrency : requirement.item.name }}
     </div>
   </div>
   <!-- Context Menu for Manual Count Adjustment -->
@@ -80,8 +95,8 @@
           close();
         "
       />
-      <div v-if="requiredCount > 1" class="border-surface-700 my-1 border-t" />
-      <template v-if="requiredCount > 1">
+      <div v-if="!isCurrency && requiredCount > 1" class="border-surface-700 my-1 border-t" />
+      <template v-if="!isCurrency && requiredCount > 1">
         <div class="space-y-2 px-3 py-2">
           <div class="text-surface-400 text-xs">
             {{ $t('page.hideout.stationcard.requirement.set_custom_amount') }}
@@ -155,6 +170,7 @@
   import GameItem from '@/components/ui/GameItem.vue';
   import { useWikiLink } from '@/composables/useWikiLink';
   import { useTarkovStore } from '@/stores/useTarkov';
+  import { getCurrencySymbol } from '@/utils/constants';
   import { useLocaleNumberFormatter } from '@/utils/formatters';
   import { openExternalUrl } from '@/utils/redirect';
   import type ContextMenuType from '@/components/ui/ContextMenu.vue';
@@ -185,6 +201,11 @@
   const formatNumber = useLocaleNumberFormatter();
   const requirementId = computed(() => props.requirement.id);
   const requiredCount = computed(() => props.requirement.count);
+  const currencySymbol = computed(() => getCurrencySymbol(props.requirement.item.id) ?? '');
+  const isCurrency = computed(() => currencySymbol.value !== '');
+  const formattedCurrency = computed(
+    () => `${currencySymbol.value}${formatNumber(requiredCount.value)}`
+  );
   // Context menu
   const contextMenu = ref<InstanceType<typeof ContextMenuType>>();
   const pendingContextEvent = ref<MouseEvent | null>(null);

--- a/app/features/hideout/HideoutRequirement.vue
+++ b/app/features/hideout/HideoutRequirement.vue
@@ -31,17 +31,14 @@
         <UIcon name="i-mdi-check-circle" class="text-success-300 h-6 w-6 sm:h-8 sm:w-8" />
       </div>
       <!-- FiR Badge -->
-      <AppTooltip v-if="!isCurrency && isFoundInRaid" :text="$t('common.found_in_raid_required')">
+      <AppTooltip v-if="showFoundInRaidBadge" :text="$t('common.found_in_raid_required')">
         <UIcon
           name="i-mdi-checkbox-marked-circle-outline"
           class="text-warning-400 absolute -top-1 -right-1 h-3 w-3"
         />
       </AppTooltip>
       <!-- Count Badge for multi-count items -->
-      <div
-        v-if="!isCurrency && requiredCount > 1"
-        class="absolute right-0 -bottom-1 left-0 flex justify-center"
-      >
+      <div v-if="showPartialCount" class="absolute right-0 -bottom-1 left-0 flex justify-center">
         <div
           class="border-surface-700 bg-surface-900/90 rounded border px-1 py-0.5 text-[9px] font-bold sm:px-1.5 sm:text-[10px]"
           :class="isComplete ? 'text-success-400' : 'text-surface-300'"
@@ -53,13 +50,9 @@
     <!-- Item Name -->
     <div
       class="text-surface-200 w-full text-center leading-tight font-medium"
-      :class="
-        isCurrency
-          ? 'text-[9px] whitespace-nowrap sm:text-[10px]'
-          : 'line-clamp-2 text-[11px] sm:text-xs'
-      "
+      :class="itemLabelClass"
     >
-      {{ isCurrency ? formattedCurrency : requirement.item.name }}
+      {{ itemLabel }}
     </div>
   </div>
   <!-- Context Menu for Manual Count Adjustment -->
@@ -90,8 +83,8 @@
           close();
         "
       />
-      <div v-if="!isCurrency && requiredCount > 1" class="border-surface-700 my-1 border-t" />
-      <template v-if="!isCurrency && requiredCount > 1">
+      <div v-if="showPartialCount" class="border-surface-700 my-1 border-t" />
+      <template v-if="showPartialCount">
         <div class="space-y-2 px-3 py-2">
           <div class="text-surface-400 text-xs">
             {{ $t('page.hideout.stationcard.requirement.set_custom_amount') }}
@@ -200,8 +193,17 @@
   const requiredCount = computed(() => props.requirement.count);
   const currencySymbol = computed(() => getCurrencySymbol(props.requirement.item.id) ?? '');
   const isCurrency = computed(() => currencySymbol.value !== '');
+  const showPartialCount = computed(() => !isCurrency.value && requiredCount.value > 1);
   const formattedCurrency = computed(
     () => `${currencySymbol.value}${formatNumber(requiredCount.value)}`
+  );
+  const itemLabel = computed(() =>
+    isCurrency.value ? formattedCurrency.value : props.requirement.item.name
+  );
+  const itemLabelClass = computed(() =>
+    isCurrency.value
+      ? 'text-[9px] whitespace-nowrap sm:text-[10px]'
+      : 'line-clamp-2 text-[11px] sm:text-xs'
   );
   // Context menu
   const contextMenu = ref<InstanceType<typeof ContextMenuType>>();
@@ -214,6 +216,7 @@
     );
     return firAttribute?.value === 'true';
   });
+  const showFoundInRaidBadge = computed(() => !isCurrency.value && isFoundInRaid.value);
   // Get current count from store (synced with needed items page)
   const currentCount = computed(() => {
     const storeCount = tarkovStore.getHideoutPartCount(requirementId.value);

--- a/app/features/hideout/__tests__/HideoutRequirement.test.ts
+++ b/app/features/hideout/__tests__/HideoutRequirement.test.ts
@@ -16,7 +16,7 @@ vi.mock('@/stores/useTarkov', () => ({
   }),
 }));
 vi.mock('@/utils/formatters', () => ({
-  useLocaleNumberFormatter: () => (value: number) => String(value),
+  useLocaleNumberFormatter: () => (value: number) => value.toLocaleString('en-US'),
 }));
 describe('HideoutRequirement', () => {
   const defaultProps = {
@@ -35,11 +35,18 @@ describe('HideoutRequirement', () => {
   };
   const defaultStubs = {
     AppTooltip: true,
-    ContextMenu: true,
+    ContextMenu: {
+      template: '<div><slot :close="close" /></div>',
+      methods: { close: vi.fn(), open: vi.fn() },
+    },
     ContextMenuItem: true,
     GameItem: true,
     UButton: true,
     UIcon: true,
+  };
+  const globalOptions = {
+    mocks: { $t: (key: string) => key },
+    stubs: defaultStubs,
   };
   beforeEach(() => {
     vi.clearAllMocks();
@@ -49,7 +56,7 @@ describe('HideoutRequirement', () => {
   it('marks requirement complete when clicked while incomplete', async () => {
     const wrapper = mount(HideoutRequirement, {
       props: defaultProps,
-      global: { stubs: defaultStubs },
+      global: globalOptions,
     });
     await wrapper.find('.group').trigger('click');
     expect(setHideoutPartCountMock).toHaveBeenCalledWith('req-1', 3);
@@ -60,16 +67,53 @@ describe('HideoutRequirement', () => {
     isComplete = true;
     const wrapper = mount(HideoutRequirement, {
       props: defaultProps,
-      global: { stubs: defaultStubs },
+      global: globalOptions,
     });
     await wrapper.find('.group').trigger('click');
     expect(setHideoutPartCountMock).toHaveBeenCalledWith('req-1', 0);
     expect(setHideoutPartUncompleteMock).toHaveBeenCalledWith('req-1');
   });
+  it.each([
+    ['5449016a4bdc2d6f028b456f', 'Roubles', 400000, '₽400,000'],
+    ['5696686a4bdc2da3298b456a', 'Dollars', 25000, '$25,000'],
+    ['569668774bdc2da2298b4568', 'Euros', 200000, '€200,000'],
+  ])('renders %s as a formatted money requirement', (itemId, name, count, expected) => {
+    const wrapper = mount(HideoutRequirement, {
+      props: {
+        ...defaultProps,
+        requirement: {
+          count,
+          id: `currency-${itemId}`,
+          item: { id: itemId, name },
+        },
+      },
+      global: globalOptions,
+    });
+    expect(wrapper.text()).toContain(expected);
+    expect(wrapper.findComponent({ name: 'GameItem' }).exists()).toBe(false);
+    expect(wrapper.find('input[type="number"]').exists()).toBe(false);
+  });
+  it('keeps currency requirements manually completable without partial counters', async () => {
+    const wrapper = mount(HideoutRequirement, {
+      props: {
+        ...defaultProps,
+        requirement: {
+          count: 400000,
+          id: 'roubles-requirement',
+          item: { id: '5449016a4bdc2d6f028b456f', name: 'Roubles' },
+        },
+      },
+      global: globalOptions,
+    });
+    expect(wrapper.text()).not.toContain('0/400,000');
+    await wrapper.find('.group').trigger('click');
+    expect(setHideoutPartCountMock).toHaveBeenCalledWith('roubles-requirement', 400000);
+    expect(setHideoutPartCompleteMock).toHaveBeenCalledWith('roubles-requirement');
+  });
   it('suppresses native context menu on right-click', async () => {
     const wrapper = mount(HideoutRequirement, {
       props: defaultProps,
-      global: { stubs: defaultStubs },
+      global: globalOptions,
     });
     const element = wrapper.find('.group');
     const event = new MouseEvent('contextmenu', {

--- a/app/features/hideout/__tests__/HideoutRequirement.test.ts
+++ b/app/features/hideout/__tests__/HideoutRequirement.test.ts
@@ -40,7 +40,11 @@ describe('HideoutRequirement', () => {
       methods: { close: vi.fn(), open: vi.fn() },
     },
     ContextMenuItem: true,
-    GameItem: true,
+    GameItem: {
+      name: 'GameItem',
+      props: ['iconLink', 'image512pxLink', 'itemId'],
+      template: '<div />',
+    },
     UButton: true,
     UIcon: true,
   };
@@ -90,8 +94,31 @@ describe('HideoutRequirement', () => {
       global: globalOptions,
     });
     expect(wrapper.text()).toContain(expected);
-    expect(wrapper.findComponent({ name: 'GameItem' }).exists()).toBe(false);
+    const gameItem = wrapper.findComponent({ name: 'GameItem' });
+    expect(gameItem.exists()).toBe(true);
+    expect(gameItem.props('itemId')).toBe(itemId);
     expect(wrapper.find('input[type="number"]').exists()).toBe(false);
+  });
+  it('passes currency image metadata to the in-game item display', () => {
+    const wrapper = mount(HideoutRequirement, {
+      props: {
+        ...defaultProps,
+        requirement: {
+          count: 400000,
+          id: 'roubles-image-requirement',
+          item: {
+            id: '5449016a4bdc2d6f028b456f',
+            iconLink: 'https://assets.tarkov.dev/roubles-icon.webp',
+            image512pxLink: 'https://assets.tarkov.dev/roubles-512.webp',
+            name: 'Roubles',
+          },
+        },
+      },
+      global: globalOptions,
+    });
+    const gameItem = wrapper.findComponent({ name: 'GameItem' });
+    expect(gameItem.props('iconLink')).toBe('https://assets.tarkov.dev/roubles-icon.webp');
+    expect(gameItem.props('image512pxLink')).toBe('https://assets.tarkov.dev/roubles-512.webp');
   });
   it('keeps currency requirements manually completable without partial counters', async () => {
     const wrapper = mount(HideoutRequirement, {

--- a/app/features/hideout/__tests__/HideoutRequirement.test.ts
+++ b/app/features/hideout/__tests__/HideoutRequirement.test.ts
@@ -99,6 +99,23 @@ describe('HideoutRequirement', () => {
     expect(gameItem.props('itemId')).toBe(itemId);
     expect(wrapper.find('input[type="number"]').exists()).toBe(false);
   });
+  it('allows long currency amounts to wrap inside the requirement card', () => {
+    const wrapper = mount(HideoutRequirement, {
+      props: {
+        ...defaultProps,
+        requirement: {
+          count: 10000000,
+          id: 'large-roubles-requirement',
+          item: { id: '5449016a4bdc2d6f028b456f', name: 'Roubles' },
+        },
+      },
+      global: globalOptions,
+    });
+    const label = wrapper.find('.text-surface-200.w-full');
+    expect(label.text()).toBe('₽10,000,000');
+    expect(label.classes()).toContain('break-all');
+    expect(label.classes()).not.toContain('whitespace-nowrap');
+  });
   it('passes currency image metadata to the in-game item display', () => {
     const wrapper = mount(HideoutRequirement, {
       props: {

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -123,6 +123,16 @@ export const CURRENCY_ITEM_IDS = [
   '5449016a4bdc2d6f028b456f', // Roubles (RUB)
   '569668774bdc2da2298b4568', // Euros (EUR)
 ] as const;
+export type CurrencyItemId = (typeof CURRENCY_ITEM_IDS)[number];
+export const CURRENCY_SYMBOLS = {
+  '5449016a4bdc2d6f028b456f': '₽',
+  '5696686a4bdc2da3298b456a': '$',
+  '569668774bdc2da2298b4568': '€',
+} as const satisfies Record<CurrencyItemId, string>;
+export const isCurrencyItemId = (itemId: string): itemId is CurrencyItemId =>
+  CURRENCY_ITEM_IDS.includes(itemId as CurrencyItemId);
+export const getCurrencySymbol = (itemId: string): string | null =>
+  isCurrencyItemId(itemId) ? CURRENCY_SYMBOLS[itemId] : null;
 // API Language Configuration
 export const API_SUPPORTED_LANGUAGES = [
   'cs', // Czech


### PR DESCRIPTION
## Summary

- render EFT 1.1 hideout money requirements as localized RUB, USD, and EUR amounts
- keep money requirements manually completable without item-style partial counters
- exclude currencies from derived Needed Items inventory requirements
- cover all three supported currency item IDs with component and graph-builder tests

## Why

EFT 1.1 added money costs to many hideout upgrades. The upstream payload represents those costs as item requirements, so TarkovTracker previously treated amounts such as 400,000 roubles like ordinary inventory item counts.

## Validation

- `pnpm run typecheck`
- `pnpm run lint`
- `pnpm run test` — 260 files, 2522 tests passed
- `pnpm run i18n:check` — passed with existing non-fatal Crowdin drift warnings
- `pnpm run validate:openapi`
- browser validation on `/hideout` confirmed formatted money cards and no partial count badges
- browser validation on `/needed-items` confirmed currency requirements are absent

## Production readiness

- no data model or persisted progress shape changes
- no database, API, environment, or dependency changes
- existing manual completion semantics are preserved
- rollback is a normal Cloudflare Pages deployment rollback

## Review note

The local Cubic review integration could not run because its subscription is expired. A direct diff review and the repository's full production-readiness validation commands were completed instead.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hideout currency requirements now display currency symbols, images, and formatted values for roubles, dollars, and euros.
  * Currency requirements can be completed manually without partial-count or Found-in-Raid controls.

* **Bug Fixes**
  * Currency requirements are no longer incorrectly included in needed inventory item tracking.
  * Improved consistency for hideout requirement display and interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR recognizes the three supported EFT currencies in hideout requirements while preserving their metadata for progression history.
- Formats hideout currency costs with localized numbers and currency symbols.
- Keeps currency requirements manually completable without item-style partial counters or Found-in-Raid badges.
- Excludes currency costs from Needed Items without removing metadata used by progression labels.
- Adds focused component and graph-builder coverage for RUB, USD, and EUR.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/composables/useNeededItems.ts | Filters currencies only from the Needed Items view, leaving shared hideout metadata intact. |
| app/features/hideout/HideoutRequirement.vue | Recognizes currency requirements and renders formatted monetary amounts while retaining binary completion behavior. |
| app/utils/constants.ts | Centralizes supported currency IDs, symbols, and currency-identification helpers. |
| app/composables/__tests__/useGraphBuilder.test.ts | Verifies all supported currencies remain available in hideout requirement metadata. |
| app/composables/__tests__/useNeededItems.test.ts | Verifies currency requirements are excluded from derived inventory needs. |
| app/features/hideout/__tests__/HideoutRequirement.test.ts | Covers formatting, images, wrapping, and manual completion for currency requirements. |

</details>

<sub>Reviews (4): Last reviewed commit: ["fix(hideout): wrap large currency amount..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/9b7841b9c96f86ac8ab6d8a7c7a4ae54b09c03ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55008103)</sub>

<!-- /greptile_comment -->