### PR TITLE
fix(api): require HTTPS for overlay data

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,12 @@ Naming:
   stale overlay immediately while one Cloudflare-lifetime refresh runs in the background; failed
   deferred refreshes back off for one minute. Other overlay-enabled Tarkov-data routes cache their
   final corrected payload. Preserve this ordering so no cache layer pins stale hideout corrections.
+- Overlay data must be fetched over HTTPS on every server path. `OVERLAY_URL` must be HTTPS
+  (anything else falls back to the trusted `raw.githubusercontent.com` default), and no redirect may
+  downgrade to plaintext: `app/server/utils/overlay.ts` follows redirects manually with a per-hop
+  HTTPS check and a 3-hop cap, and the streamer Kappa editions fetch passes `redirect: 'error'`. New
+  server-side overlay consumers must do one or the other. See the Overlay corrections section of
+  `docs/SYSTEMS.md`.
 - Task adaptation and overlay patches carry trader requirements in the raw upstream shape (one
   `traderRequirements` list discriminated by `requirementType`). The adapter and `applyOverlay`
   split them into `traderLevelRequirements` (level gates) and reputation-only `traderRequirements`;

--- a/app/server/api/streamer/[userId]/[mode]/kappa.get.ts
+++ b/app/server/api/streamer/[userId]/[mode]/kappa.get.ts
@@ -201,7 +201,9 @@ const getEditions = async (): Promise<GameEdition[]> => {
   }
   editionsFetchPromise = (async () => {
     try {
-      const overlay = await $fetch<{ editions?: Record<string, GameEdition> }>(OVERLAY_URL);
+      const overlay = await $fetch<{ editions?: Record<string, GameEdition> }>(OVERLAY_URL, {
+        redirect: 'error',
+      });
       const editions = overlay?.editions ? Object.values(overlay.editions) : [];
       if (editions.length > 0) {
         const entry: EditionsCachePayload = {

--- a/app/server/api/streamer/__tests__/kappa.test.ts
+++ b/app/server/api/streamer/__tests__/kappa.test.ts
@@ -154,6 +154,10 @@ describe('Streamer Kappa API', () => {
       'no-store, max-age=0'
     );
     expect(mockComputeStreamerKappaMetrics).toHaveBeenCalled();
+    expect(mockDollarFetch).toHaveBeenCalledWith(
+      expect.stringContaining('tarkov-data-overlay/main/dist/overlay.json'),
+      { redirect: 'error' }
+    );
     expect(result).toMatchObject({
       displayName: 'PublicPlayer',
       items: { collected: 10, percentage: 50, remaining: 10, total: 20 },

--- a/app/server/utils/__tests__/overlay.integration.test.ts
+++ b/app/server/utils/__tests__/overlay.integration.test.ts
@@ -42,6 +42,61 @@ describe('overlay URL validation', () => {
     );
   });
 });
+describe('overlay redirect handling', () => {
+  const redirectTo = (location: string) =>
+    new Response(null, { status: 302, headers: { location } });
+  it('rejects a redirect to a non-HTTPS overlay target', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectTo('http://overlay.example.com/overlay.json'));
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({ data: { tasks: [] } });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ redirect: 'manual' })
+    );
+    expect(result.dataOverlay).toMatchObject({ status: 'missing' });
+  });
+  it('rejects a redirect that omits a location header', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce(new Response(null, { status: 302 }));
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({ data: { tasks: [] } });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(result.dataOverlay).toMatchObject({ status: 'missing' });
+  });
+  it('follows an HTTPS redirect and applies the overlay', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectTo('https://overlay.example.com/redirected.json'))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ $meta: { version: 'redirect-v1' } }), { status: 200 })
+      );
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({ data: { tasks: [] } });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenLastCalledWith(
+      'https://overlay.example.com/redirected.json',
+      expect.any(Object)
+    );
+    expect(result.dataOverlay).toMatchObject({ status: 'fresh', version: 'redirect-v1' });
+  });
+  it('stops following once the redirect limit is exceeded', async () => {
+    let hop = 0;
+    const fetchMock = vi.fn(async () => {
+      hop += 1;
+      return redirectTo(`https://overlay.example.com/hop-${hop}.json`);
+    });
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({ data: { tasks: [] } });
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(result.dataOverlay).toMatchObject({ status: 'missing' });
+  });
+});
 describe('applyOverlay locale integration', () => {
   it('applies the selected locale after global and mode corrections', async () => {
     const fetchMock = stubOverlayFetch({

--- a/app/server/utils/__tests__/overlay.integration.test.ts
+++ b/app/server/utils/__tests__/overlay.integration.test.ts
@@ -11,8 +11,36 @@ const stubOverlayFetch = (overlay: unknown) => {
 };
 afterEach(() => {
   vi.resetModules();
+  vi.unstubAllEnvs();
   vi.unstubAllGlobals();
   vi.useRealTimers();
+});
+describe('overlay URL validation', () => {
+  it.each([
+    'http://overlay.example.com/overlay.json',
+    'ftp://overlay.example.com/overlay.json',
+    'file:///tmp/overlay.json',
+    'not-a-url',
+  ])('falls back to the trusted HTTPS overlay for %s', async (overlayUrl) => {
+    vi.stubEnv('OVERLAY_URL', overlayUrl);
+    const fetchMock = stubOverlayFetch({ $meta: { version: 'url-test-v1' } });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    await applyOverlay({ data: { tasks: [] } });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://raw.githubusercontent.com/tarkovtracker-org/tarkov-data-overlay/main/dist/overlay.json',
+      expect.any(Object)
+    );
+  });
+  it('uses a configured HTTPS overlay URL', async () => {
+    vi.stubEnv('OVERLAY_URL', 'https://overlay.example.com/custom.json');
+    const fetchMock = stubOverlayFetch({ $meta: { version: 'url-test-v1' } });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    await applyOverlay({ data: { tasks: [] } });
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://overlay.example.com/custom.json',
+      expect.any(Object)
+    );
+  });
 });
 describe('applyOverlay locale integration', () => {
   it('applies the selected locale after global and mode corrections', async () => {

--- a/app/server/utils/__tests__/overlay.integration.test.ts
+++ b/app/server/utils/__tests__/overlay.integration.test.ts
@@ -45,6 +45,12 @@ describe('overlay URL validation', () => {
 describe('overlay redirect handling', () => {
   const redirectTo = (location: string) =>
     new Response(null, { status: 302, headers: { location } });
+  const redirectWithBody = (location: string, cancel: () => Promise<undefined>) =>
+    ({
+      status: 302,
+      headers: new Headers({ location }),
+      body: { cancel },
+    }) as unknown as Response;
   it('rejects a redirect to a non-HTTPS overlay target', async () => {
     const fetchMock = vi
       .fn()
@@ -95,6 +101,22 @@ describe('overlay redirect handling', () => {
     const result = await applyOverlay({ data: { tasks: [] } });
     expect(fetchMock).toHaveBeenCalledTimes(4);
     expect(result.dataOverlay).toMatchObject({ status: 'missing' });
+  });
+  it.each([
+    ['follows', 'https://overlay.example.com/redirected.json'],
+    ['rejects', 'http://overlay.example.com/overlay.json'],
+  ])('releases the redirect body when it %s the next target', async (_outcome, location) => {
+    const cancel = vi.fn(async () => undefined);
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(redirectWithBody(location, cancel))
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ $meta: { version: 'redirect-v2' } }), { status: 200 })
+      );
+    vi.stubGlobal('fetch', fetchMock as typeof fetch);
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    await applyOverlay({ data: { tasks: [] } });
+    expect(cancel).toHaveBeenCalledTimes(1);
   });
 });
 describe('applyOverlay locale integration', () => {

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -179,6 +179,7 @@ async function fetchOverlayOverHttps(signal: AbortSignal): Promise<Response> {
       headers: { Accept: 'application/json', 'User-Agent': TARKOVTRACKER_USER_AGENT },
     });
     if (!OVERLAY_REDIRECT_STATUSES.has(response.status)) return response;
+    await response.body?.cancel();
     currentUrl = resolveOverlayRedirect(response, currentUrl);
   }
   throw new Error(`overlay_redirect_limit_exceeded (${MAX_OVERLAY_REDIRECTS})`);

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -67,7 +67,7 @@ const FETCH_TIMEOUT_MS = 5000; // 5 seconds
 // Note: Using raw.githubusercontent.com directly until jsDelivr cache propagates
 const DEFAULT_OVERLAY_URL =
   'https://raw.githubusercontent.com/tarkovtracker-org/tarkov-data-overlay/main/dist/overlay.json';
-const ALLOWED_OVERLAY_PROTOCOLS = ['https:', 'http:'];
+const OVERLAY_PROTOCOL = 'https:';
 function resolveOverlayUrl(value: string | undefined): string {
   const candidate = value ? value.trim() : DEFAULT_OVERLAY_URL;
   let url: URL;
@@ -76,7 +76,7 @@ function resolveOverlayUrl(value: string | undefined): string {
   } catch {
     return DEFAULT_OVERLAY_URL;
   }
-  if (!ALLOWED_OVERLAY_PROTOCOLS.includes(url.protocol)) return DEFAULT_OVERLAY_URL;
+  if (url.protocol !== OVERLAY_PROTOCOL) return DEFAULT_OVERLAY_URL;
   return url.toString();
 }
 const OVERLAY_URL = resolveOverlayUrl(process.env.OVERLAY_URL);

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -68,6 +68,8 @@ const FETCH_TIMEOUT_MS = 5000; // 5 seconds
 const DEFAULT_OVERLAY_URL =
   'https://raw.githubusercontent.com/tarkovtracker-org/tarkov-data-overlay/main/dist/overlay.json';
 const OVERLAY_PROTOCOL = 'https:';
+const MAX_OVERLAY_REDIRECTS = 3;
+const OVERLAY_REDIRECT_STATUSES = new Set([301, 302, 303, 307, 308]);
 function resolveOverlayUrl(value: string | undefined): string {
   const candidate = value ? value.trim() : DEFAULT_OVERLAY_URL;
   let url: URL;
@@ -154,6 +156,33 @@ function buildOverlayFailure(error: string): OverlayFetchResult {
   lastOverlayMeta = buildOverlayMeta(cachedOverlay, cachedOverlay ? 'stale' : 'missing', { error });
   return { overlay: cachedOverlay, meta: lastOverlayMeta };
 }
+function resolveOverlayRedirect(response: Response, currentUrl: string): string {
+  const location = response.headers.get('location');
+  if (!location) throw new Error(`overlay_redirect_without_location (${response.status})`);
+  let target: URL;
+  try {
+    target = new URL(location, currentUrl);
+  } catch {
+    throw new Error('overlay_redirect_malformed_location');
+  }
+  if (target.protocol !== OVERLAY_PROTOCOL) {
+    throw new Error(`overlay_redirect_insecure_scheme (${target.protocol})`);
+  }
+  return target.toString();
+}
+async function fetchOverlayOverHttps(signal: AbortSignal): Promise<Response> {
+  let currentUrl = OVERLAY_URL_WITH_BUSTER;
+  for (let hop = 0; hop <= MAX_OVERLAY_REDIRECTS; hop += 1) {
+    const response = await fetch(currentUrl, {
+      signal,
+      redirect: 'manual',
+      headers: { Accept: 'application/json', 'User-Agent': TARKOVTRACKER_USER_AGENT },
+    });
+    if (!OVERLAY_REDIRECT_STATUSES.has(response.status)) return response;
+    currentUrl = resolveOverlayRedirect(response, currentUrl);
+  }
+  throw new Error(`overlay_redirect_limit_exceeded (${MAX_OVERLAY_REDIRECTS})`);
+}
 function createOverlayRequest(): {
   clearTimeout: () => void;
   response: Promise<Response>;
@@ -162,12 +191,7 @@ function createOverlayRequest(): {
   const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
   return {
     clearTimeout: () => clearTimeout(timeoutId),
-    response: Promise.resolve().then(() =>
-      fetch(OVERLAY_URL_WITH_BUSTER, {
-        signal: controller.signal,
-        headers: { Accept: 'application/json', 'User-Agent': TARKOVTRACKER_USER_AGENT },
-      })
-    ),
+    response: Promise.resolve().then(() => fetchOverlayOverHttps(controller.signal)),
   };
 }
 async function processOverlayResponse(

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -393,9 +393,13 @@ sequenceDiagram
   `FETCH_TIMEOUT_MS = 5000`. On timeout, fall back to the cached overlay.
 - A missing or malformed overlay must never cause a 5xx; the base payload is returned with
   `X-Overlay-Status: missing`.
-- Overlay data must only be fetched over HTTPS. A non-HTTPS `OVERLAY_URL` must resolve to the
-  trusted default, and no redirect hop may downgrade the transport — the fetch must fail rather than
-  read a payload served over plaintext.
+- Overlay data must only be fetched over HTTPS on every server path. A non-HTTPS `OVERLAY_URL` must
+  resolve to the trusted default, and no redirect hop may downgrade the transport — the fetch must
+  fail rather than read a payload served over plaintext. `applyOverlay` follows HTTPS redirects
+  manually; the streamer Kappa editions fetch in
+  `app/server/api/streamer/[userId]/[mode]/kappa.get.ts` uses `redirect: 'error'` because its URL is
+  a hardcoded constant that never redirects. Any new server-side overlay consumer must do one or the
+  other.
 - Overlay metadata (`status`, `version`, `generated`, `sha256`) must be propagated to response
   headers so we can debug which correction was applied. Routes that apply an overlay after
   `edgeCache()` must call `setOverlayResponseHeaders()` before returning.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -342,6 +342,8 @@ sequenceDiagram
 
 - Module-level cache (`cachedOverlay`, `cacheTimestamp`) with a 1-hour TTL
   (`OVERLAY_CACHE_TTL = 3600000`).
+- The configured overlay URL must use HTTPS. Invalid URLs and non-HTTPS schemes fall back to the
+  trusted `raw.githubusercontent.com` source so corrections cannot be modified in transit.
 - Overlay task patches carry trader requirements in the raw upstream shape: one
   `traderRequirements` list discriminated by `requirementType` (`level` gates
   trader loyalty level, `reputation` gates standing). `applyOverlay` re-splits
@@ -387,6 +389,8 @@ sequenceDiagram
   `FETCH_TIMEOUT_MS = 5000`. On timeout, fall back to the cached overlay.
 - A missing or malformed overlay must never cause a 5xx; the base payload is returned with
   `X-Overlay-Status: missing`.
+- Overlay data must only be fetched over HTTPS; a non-HTTPS `OVERLAY_URL` must resolve to the
+  trusted default instead.
 - Overlay metadata (`status`, `version`, `generated`, `sha256`) must be propagated to response
   headers so we can debug which correction was applied. Routes that apply an overlay after
   `edgeCache()` must call `setOverlayResponseHeaders()` before returning.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -344,6 +344,10 @@ sequenceDiagram
   (`OVERLAY_CACHE_TTL = 3600000`).
 - The configured overlay URL must use HTTPS. Invalid URLs and non-HTTPS schemes fall back to the
   trusted `raw.githubusercontent.com` source so corrections cannot be modified in transit.
+- Redirects are followed manually (`redirect: 'manual'`) for at most `MAX_OVERLAY_REDIRECTS = 3`
+  hops, and every hop must also be HTTPS. A redirect to a non-HTTPS target, a redirect without a
+  `location` header, or exceeding the hop limit aborts the fetch and leaves the previous overlay in
+  place.
 - Overlay task patches carry trader requirements in the raw upstream shape: one
   `traderRequirements` list discriminated by `requirementType` (`level` gates
   trader loyalty level, `reputation` gates standing). `applyOverlay` re-splits
@@ -389,8 +393,9 @@ sequenceDiagram
   `FETCH_TIMEOUT_MS = 5000`. On timeout, fall back to the cached overlay.
 - A missing or malformed overlay must never cause a 5xx; the base payload is returned with
   `X-Overlay-Status: missing`.
-- Overlay data must only be fetched over HTTPS; a non-HTTPS `OVERLAY_URL` must resolve to the
-  trusted default instead.
+- Overlay data must only be fetched over HTTPS. A non-HTTPS `OVERLAY_URL` must resolve to the
+  trusted default, and no redirect hop may downgrade the transport — the fetch must fail rather than
+  read a payload served over plaintext.
 - Overlay metadata (`status`, `version`, `generated`, `sha256`) must be propagated to response
   headers so we can debug which correction was applied. Routes that apply an overlay after
   `edgeCache()` must call `setOverlayResponseHeaders()` before returning.


### PR DESCRIPTION
## Summary

- require configured overlay sources to use HTTPS
- fall back to the trusted GitHub overlay when `OVERLAY_URL` is invalid or uses HTTP or another unsupported scheme
- add regression coverage for rejected schemes and valid HTTPS overrides
- document the transport-integrity invariant in `docs/SYSTEMS.md`

## Why

Overlay corrections are merged into public task, item, trader, and hideout responses. Allowing a plain HTTP source permits those corrections to be modified in transit.

This deliberately does not retain a localhost HTTP exception. The overlay is production data that influences public API responses, and an explicit HTTPS-only invariant is simpler to audit and prevents an environment configuration from silently weakening transport integrity.

## Validation

- `pnpm exec vitest run app/server/utils/__tests__/overlay.integration.test.ts app/server/utils/__tests__/overlay.test.ts`
- `pnpm exec eslint app/server/utils/overlay.ts app/server/utils/__tests__/overlay.integration.test.ts --max-warnings=0`
- `pnpm run typecheck`
- `pnpm run lint:blank-lines -- app/server/utils/overlay.ts app/server/utils/__tests__/overlay.integration.test.ts`
- `pnpm run lint:fallow`
- `pnpm exec prettier --check docs/SYSTEMS.md app/server/utils/overlay.ts app/server/utils/__tests__/overlay.integration.test.ts`
- `git diff --check`

Closes #746

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Overlay fetching now follows HTTPS redirects, up to three hops.
  * Redirects with missing locations, insecure URLs, malformed targets, or excessive hops are rejected.
  * Invalid or non-secure overlay URLs preserve the previously active overlay.
  * Redirect responses are properly stopped when fetching cannot continue.

* **Documentation**
  * Updated configuration guidance to describe HTTPS-only redirect handling, redirect limits, and fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR enforces HTTPS transport for overlay data and preserves existing cached-data fallbacks.
- Rejects invalid or non-HTTPS configured overlay URLs in favor of the trusted GitHub source.
- Manually follows up to three HTTPS redirects while rejecting insecure, malformed, or excessive redirect chains.
- Disables redirect following for the streamer Kappa editions fetch.
- Adds regression coverage and synchronizes the system documentation and repository guidance.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/server/utils/overlay.ts | Enforces HTTPS configuration and per-hop redirect validation while retaining stale-overlay fallback behavior. |
| app/server/utils/__tests__/overlay.integration.test.ts | Adds coverage for URL validation, secure redirects, redirect limits, and redirect-body cleanup. |
| app/server/api/streamer/[userId]/[mode]/kappa.get.ts | Prevents the hardcoded editions overlay request from automatically following redirects. |
| app/server/api/streamer/__tests__/kappa.test.ts | Verifies that the editions request uses the redirect-error policy. |
| docs/SYSTEMS.md | Documents the HTTPS-only overlay invariant, redirect policy, and fallback behavior. |
| AGENTS.md | Records the overlay transport-integrity requirement for future server-side consumers. |

</details>

<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant API as API handler
  participant Overlay as Overlay utility
  participant Source as HTTPS overlay source
  API->>Overlay: Request overlay data
  Overlay->>Overlay: Validate configured URL scheme
  alt Invalid or non-HTTPS URL
    Overlay->>Overlay: Select trusted GitHub URL
  end
  Overlay->>Source: Fetch with redirect: manual
  alt HTTPS redirect within three-hop limit
    Source-->>Overlay: 3xx with Location
    Overlay->>Overlay: Validate next URL as HTTPS
    Overlay->>Source: Fetch next hop
  else Invalid redirect or fetch failure
    Overlay-->>API: Stale cached or missing overlay
  else Valid overlay response
    Source-->>Overlay: Overlay JSON
    Overlay-->>API: Fresh overlay
  end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(api): reject redirects on the stream..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/8b6c05e5351c0947e5c4d94466b26e25b13b91eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55020533)</sub>

**Context used:**

- Knowledge Base — [Frontend App (Nuxt)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/frontend-app.md)

<!-- /greptile_comment -->