### PR TITLE
fix(api): validate teamId as a UUID before the membership query

### DIFF
--- a/app/server/api/team/__tests__/members.test.ts
+++ b/app/server/api/team/__tests__/members.test.ts
@@ -11,6 +11,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { H3Event, H3EventContext } from 'h3';
 type SiteConfigStackEntry = Record<string, unknown>;
+const VALID_TEAM_ID = '33333333-3333-4333-8333-333333333333';
 const { mockGetQuery, mockGetRequestHeader, mockFetch } = vi.hoisted(() => ({
   mockGetQuery: vi.fn(),
   mockGetRequestHeader: vi.fn(),
@@ -79,7 +80,7 @@ describe('Team Members API', () => {
       const originalNodeEnv = process.env.NODE_ENV;
       process.env.NODE_ENV = 'production';
       vi.resetModules();
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       try {
         mockFetch
           .mockResolvedValueOnce({
@@ -132,13 +133,13 @@ describe('Team Members API', () => {
     });
     it('should throw error when supabaseUrl is missing', async () => {
       runtimeConfig.supabaseUrl = '';
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       const { default: handler } = await import('@/server/api/team/members');
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Service configuration error');
     });
     it('should allow missing supabaseServiceKey when auth header exists', async () => {
       runtimeConfig.supabaseServiceKey = '';
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockGetRequestHeader.mockImplementation((_, header: string) => {
         if (header === 'authorization') return 'Bearer valid-token';
         return undefined;
@@ -166,14 +167,14 @@ describe('Team Members API', () => {
     });
     it('should require auth token when supabaseServiceKey is missing', async () => {
       runtimeConfig.supabaseServiceKey = '';
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockGetRequestHeader.mockReturnValue(undefined);
       const { default: handler } = await import('@/server/api/team/members');
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Missing auth token');
     });
     it('should throw error when supabaseAnonKey is missing', async () => {
       runtimeConfig.supabaseAnonKey = '';
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       const { default: handler } = await import('@/server/api/team/members');
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Service configuration error');
     });
@@ -184,13 +185,42 @@ describe('Team Members API', () => {
       const { default: handler } = await import('@/server/api/team/members');
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('teamId is required');
     });
-    it('should reject invalid teamId format', async () => {
-      mockGetQuery.mockReturnValue({ teamId: 'team-1&select=*' });
+    it.each([
+      ['a query-injection payload', 'team-1&select=*'],
+      ['a non-UUID alphanumeric id', 'abc'],
+      ['a placeholder non-UUID string', 'not-a-uuid'],
+      ['a UUID missing a segment', '33333333-3333-4333-8333'],
+      ['a UUID with invalid characters', '33333333-3333-4333-8333-33333333333g'],
+      ['an oversized string', 'a'.repeat(200)],
+    ])('should reject %s as teamId', async (_description, teamId) => {
+      mockGetQuery.mockReturnValue({ teamId });
       const { default: handler } = await import('@/server/api/team/members');
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Invalid teamId');
     });
+    it('should reject a whitespace-only teamId as missing', async () => {
+      mockGetQuery.mockReturnValue({ teamId: '   ' });
+      const { default: handler } = await import('@/server/api/team/members');
+      await expect(handler(mockEvent as H3Event)).rejects.toThrow('teamId is required');
+    });
+    it('should accept a valid UUID teamId regardless of case', async () => {
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID.toUpperCase() });
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ game_mode: 'pvp', user_id: '11111111-1111-4111-8111-111111111111' }],
+        })
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ user_id: '11111111-1111-4111-8111-111111111111' }],
+        })
+        .mockResolvedValueOnce({ ok: true, json: async () => [] })
+        .mockResolvedValueOnce({ ok: true, json: async () => [] });
+      const { default: handler } = await import('@/server/api/team/members');
+      const result = await handler(mockEvent as H3Event);
+      expect(result.members).toEqual(['11111111-1111-4111-8111-111111111111']);
+    });
     it('should require user to be team member', async () => {
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       // Mock empty membership check
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -200,7 +230,7 @@ describe('Team Members API', () => {
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Not a team member');
     });
     it('should handle failed membership check', async () => {
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       // Mock failed membership check
       mockFetch.mockResolvedValueOnce({
         ok: false,
@@ -210,7 +240,7 @@ describe('Team Members API', () => {
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Failed membership check');
     });
     it('should handle failed members fetch', async () => {
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockFetch
         // Mock successful membership check
         .mockResolvedValueOnce({
@@ -226,7 +256,7 @@ describe('Team Members API', () => {
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Failed to load members');
     });
     it('should return members when user is valid team member', async () => {
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       // Mock successful membership check
       mockFetch
         .mockResolvedValueOnce({
@@ -297,7 +327,7 @@ describe('Team Members API', () => {
   });
   describe('Profile fallback handling', () => {
     it('returns a partial team response when the legacy fallback fetch throws', async () => {
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
@@ -319,7 +349,7 @@ describe('Team Members API', () => {
       expect(result.profiles).toEqual({});
     });
     it('falls back to legacy progress when the summary row has no level', async () => {
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
@@ -368,7 +398,7 @@ describe('Team Members API', () => {
       });
     });
     it('summarizes legacy persistent progress when normalized team rows are missing', async () => {
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
@@ -411,7 +441,7 @@ describe('Team Members API', () => {
       });
     });
     it('reads the season-aware summary view instead of progress blobs', async () => {
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockFetch
         .mockResolvedValueOnce({
           ok: true,
@@ -451,7 +481,7 @@ describe('Team Members API', () => {
     it('keeps profiles available when optional edition metadata fails', async () => {
       const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       try {
-        mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+        mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
         mockFetch
           .mockResolvedValueOnce({
             ok: true,
@@ -487,7 +517,7 @@ describe('Team Members API', () => {
         expect(warnSpy).toHaveBeenCalledWith(
           '[TeamMembers]',
           'Team edition metadata fetch failed',
-          { status: 503, teamId: 'team-456' }
+          { status: 503, teamId: VALID_TEAM_ID }
         );
       } finally {
         warnSpy.mockRestore();
@@ -496,7 +526,7 @@ describe('Team Members API', () => {
     it('should fall back to individual fetches if bulk fetch fails', async () => {
       const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
       try {
-        mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+        mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
         mockFetch
           // Mock successful membership check
           .mockResolvedValueOnce({
@@ -566,13 +596,13 @@ describe('Team Members API', () => {
         },
         ...BASE_SITE_CONTEXT,
       };
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       const { default: handler } = await import('@/server/api/team/members');
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Invalid token');
     });
     it('should validate auth token when context.auth is missing', async () => {
       mockEvent.context = { ...BASE_SITE_CONTEXT };
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockGetRequestHeader.mockImplementation((_, header: string) => {
         if (header === 'authorization') return 'Bearer valid-token';
         return undefined;
@@ -612,14 +642,14 @@ describe('Team Members API', () => {
     });
     it('should reject requests without auth token or context', async () => {
       mockEvent.context = { ...BASE_SITE_CONTEXT };
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockGetRequestHeader.mockReturnValue(undefined); // No auth header
       const { default: handler } = await import('@/server/api/team/members');
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Missing auth token');
     });
     it('should reject requests with invalid auth token format', async () => {
       mockEvent.context = { ...BASE_SITE_CONTEXT };
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockGetRequestHeader.mockImplementation((_, header: string) => {
         if (header === 'authorization') return 'InvalidFormat token123';
         return undefined;
@@ -629,7 +659,7 @@ describe('Team Members API', () => {
     });
     it('should reject requests when token validation fails', async () => {
       mockEvent.context = { ...BASE_SITE_CONTEXT };
-      mockGetQuery.mockReturnValue({ teamId: 'team-456' });
+      mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockGetRequestHeader.mockImplementation((_, header: string) => {
         if (header === 'authorization') return 'Bearer invalid-token';
         return undefined;

--- a/app/server/api/team/__tests__/members.test.ts
+++ b/app/server/api/team/__tests__/members.test.ts
@@ -11,7 +11,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { H3Event, H3EventContext } from 'h3';
 type SiteConfigStackEntry = Record<string, unknown>;
-const VALID_TEAM_ID = '33333333-3333-4333-8333-333333333333';
+const VALID_TEAM_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5';
 const { mockGetQuery, mockGetRequestHeader, mockFetch } = vi.hoisted(() => ({
   mockGetQuery: vi.fn(),
   mockGetRequestHeader: vi.fn(),
@@ -196,6 +196,7 @@ describe('Team Members API', () => {
       mockGetQuery.mockReturnValue({ teamId });
       const { default: handler } = await import('@/server/api/team/members');
       await expect(handler(mockEvent as H3Event)).rejects.toThrow('Invalid teamId');
+      expect(mockFetch).not.toHaveBeenCalled();
     });
     it('should reject a whitespace-only teamId as missing', async () => {
       mockGetQuery.mockReturnValue({ teamId: '   ' });

--- a/app/server/api/team/members.ts
+++ b/app/server/api/team/members.ts
@@ -21,7 +21,6 @@ import {
 import type { ApiProtectionConfig } from '@/server/middleware/api-protection';
 const logger = createLogger('TeamMembers');
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-const TEAM_ID_REGEX = /^[a-zA-Z0-9-]{1,64}$/;
 const REST_FETCH_TIMEOUT_MS = 8000;
 const RATE_LIMIT_WINDOW_MS = 60000;
 const DEFAULT_TEAM_MEMBERS_RATE_LIMIT_PER_MINUTE = 120;
@@ -30,7 +29,6 @@ const TEAM_MEMBERS_CACHE_PREFIX = 'team-members';
 const TEAM_MEMBERS_RATE_LIMIT_PREFIX = 'team-members-rate';
 const isTestEnvironment = process.env.NODE_ENV === 'test';
 const isValidUuid = (value: string): boolean => UUID_REGEX.test(value);
-const isValidTeamId = (value: string): boolean => TEAM_ID_REGEX.test(value);
 const buildRestPath = (resource: string, params: Record<string, string | number>): string => {
   const searchParams = new URLSearchParams();
   for (const [key, value] of Object.entries(params)) {
@@ -231,7 +229,7 @@ export default defineEventHandler(async (event) => {
   if (!teamId) {
     throw createError({ statusCode: 400, statusMessage: 'teamId is required' });
   }
-  if (!isValidTeamId(teamId)) {
+  if (!isValidUuid(teamId)) {
     throw createError({ statusCode: 400, statusMessage: 'Invalid teamId' });
   }
   const teamMembersRateLimitPerMinute = toPositiveInteger(


### PR DESCRIPTION
## Problem

`/api/team/members` validates `teamId` with `TEAM_ID_REGEX = /^[a-zA-Z0-9-]{1,64}$/`, but `team_memberships.team_id` is a `UUID` column.

A non-UUID teamId such as `abc` passes that check and is interpolated into the PostgREST filter `team_id=eq.abc`. PostgREST rejects it with 400 (invalid input syntax for type uuid), and the generic non-ok handling turns that into:

```
500 Failed membership check
```

So client-supplied garbage surfaces as a server error and pollutes the error logs, where it can mask real outages.

Reproduced against a self-hosted stack: `GET /api/team/members?teamId=abc` with a valid session returns 500.

## Fix

Reuse the `UUID_REGEX`/`isValidUuid` helper that already exists in the same file (it validates the authenticated user id) for `teamId` as well, so malformed input is rejected with the existing `400 Invalid teamId` response before any request reaches Supabase. The now-unused `TEAM_ID_REGEX`/`isValidTeamId` are removed.

## Tests

Extended `app/server/api/team/__tests__/members.test.ts`:

- non-UUID alphanumeric, placeholder string, truncated UUID, UUID with invalid characters, query-injection payload, oversized string → 400 `Invalid teamId`
- whitespace-only → 400 `teamId is required` (`.trim()` empties it before the format check)
- uppercase UUID → happy path preserved (UUIDs are case-insensitive; matches the existing `i`-flag convention used for user ids)

Existing happy-path fixtures used the placeholder `'team-456'`, which is not a valid UUID, so they were updated to a real UUID constant.

Verified red-before-green: with the fix reverted, the new cases fail with the old symptom (unhandled downstream errors from the malformed PostgREST call rather than a clean 400).

`pnpm run typecheck`, `pnpm run lint` (zero warnings) and `pnpm exec vitest run` on the file (29/29) all pass.

## Note on a sibling, deliberately not touched

`app/composables/api/useEdgeFunctions.ts` carries its own `TEAM_ID_REGEX`/`assertValidTeamId` with the same loose pattern, used as a client-side pre-check before the team edge functions. Different call path (no direct PostgREST query is built there), so it is left out to keep this PR to one topic. Happy to follow up separately if you want it aligned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for team identifiers by requiring properly formatted UUIDs.
  * Invalid, malformed, oversized, and whitespace-only team IDs are now rejected consistently.
  * Valid UUIDs are accepted regardless of letter casing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR validates `/api/team/members` team identifiers as UUIDs before querying Supabase and expands coverage for malformed and uppercase identifiers.
- Replaces the permissive team-ID validation with the existing UUID validator.
- Updates fixtures to use a valid UUID and verifies malformed inputs do not reach Supabase.
</details>

<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The implementation appears safe to merge.

No blocking failure remains.
</details>

<details open><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| app/server/api/team/members.ts | Reuses strict UUID validation for `teamId`, preventing malformed identifiers from reaching the membership query. |
| app/server/api/team/__tests__/members.test.ts | Updates team fixtures to UUIDs and adds deterministic coverage for malformed, whitespace-only, oversized, and uppercase identifiers. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test(api): strengthen teamId validation ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/aeb3b0f965bfbd41a3862bfb331e83f5e92861fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55042014)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Context used - AGENTS.md ([source](https://github.com/tarkovtracker-org/tarkovtracker/blob/main/AGENTS.md))
- Knowledge Base — [Frontend App (Nuxt)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/frontend-app.md)
- Knowledge Base — [Team Functions (Create, Join, Kick, Leave, Members)](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/team-functions.md)
</details>

<!-- /greptile_comment -->