### PR TITLE
fix(i18n): add missing danger_zone confirm_instruction key

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -2140,6 +2140,7 @@
       "xp_progress_value": "{percent}% toward the next level"
     },
     "danger_zone": {
+      "confirm_instruction": "Type {word} to confirm resetting all data:",
       "confirm_word": "DELETE"
     },
     "log_import": {


### PR DESCRIPTION
## Summary
Fixes #768

The "Reset All Data" confirmation dialog in `ResetProgressSection.vue` references `settings.danger_zone.confirm_instruction` via `<i18n-t>`, but the key was never added to `app/locales/en.json`. Unlike `$t()`, `<i18n-t>` has no inline fallback argument, so users saw the raw keypath rendered instead of the instruction text.

Added the missing EN source key, mirroring the existing prestige pattern (`settings.prestige.confirm_instruction`: "Type {word} to confirm prestige:"). Crowdin will propagate translations to non-English locales on next sync; they fall back to English at runtime in the meantime.

## Changes
- `app/locales/en.json`: add `settings.danger_zone.confirm_instruction` = "Type {word} to confirm resetting all data:"

## Validation
- `pnpm run i18n:check` — exit 0 (no snake_case violations; only pre-existing informational drift)
- `pnpm exec vitest run app/features/settings/__tests__/ResetProgressSection.test.ts` — 6/6 passed

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds the missing English translation used by the reset-all-data confirmation dialog.
- Defines `settings.danger_zone.confirm_instruction` with the expected `{word}` placeholder.
- Restores readable fallback text instead of exposing the raw translation key.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable defects identified.

The added key matches the component’s keypath and named interpolation slot, follows the repository’s English-only localization workflow, and remains available to other locales through the configured English fallback.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/locales/en.json | Adds the missing reset confirmation instruction under the correct namespace with interpolation matching its existing consumer. |

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(i18n): add missing danger\_zone confi..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/9a52d9411bcd3efb79b32f0671d570c2c0f2d9e2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56639711)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an English confirmation prompt for resetting all data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->