### PR TITLE
fix(api): harden account deletion concurrency

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -15,7 +15,7 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 - `Type Check` — `vue-tsc` / Nuxt type checking
 - `Test (shard 1/4)` … `Test (shard 4/4)` — Vitest with coverage, sharded across 4 parallel jobs. The `github-actions` reporter annotates failed tests directly on the PR diff so the failing test name and assertion are visible without digging into logs. Per-shard coverage is merged by Codecov.
 - `Validate` — Production Nuxt build + artifact upload (main branch only)
-- `Supabase DB` — Reset + lint local migrations
+- `Supabase DB` — Reset + pgTAP regressions + lint local migrations
 - `Systems drift check` — verifies `docs/SYSTEMS.md` invariants against the codebase
 - `Workers` — Validate api-gateway (typecheck, OpenAPI, tests)
 
@@ -107,7 +107,7 @@ normal code PRs. Socket PR alerts are limited to dependency manifest changes by 
 gh run list              # List recent runs
 gh run view <run-id>     # View run details
 gh run watch             # Watch running workflow
-pnpm run supabase:check   # Validate local Supabase migration reset + lint
+pnpm run supabase:check   # Reset, run pgTAP regressions, and lint Supabase migrations
 ```
 
 ## Local Testing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
           deno-version: v2.9.4
       - name: Run Deno tests
         if: matrix.shard == 1
-        run: deno test supabase/functions/_shared/team-mode.deno.test.ts
+        run: deno test supabase/functions/_shared/*.deno.test.ts
       - name: Run shard ${{ matrix.shard }}/${{ matrix.total }}
         run: pnpm exec vitest run --coverage --shard=${{ matrix.shard }}/${{ matrix.total }}
       - name: Upload coverage to Codecov

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,7 +238,9 @@ Naming:
 - Account deletion requests consume their three-per-minute limit and record the allowed attempt in
   one `consume_account_deletion_attempt` transaction. Both the initiating function and reconciler
   must atomically claim work through `claim_account_deletion_job`; a fresh `in_progress` claim has a
-  15-minute lease before reconciliation can recover it. Both RPCs remain service-role-only.
+  15-minute lease before reconciliation can recover it. Completion and failure writes must match
+  the current claim's fencing token. Only a new user request can revive a dead-lettered job. Both
+  RPCs remain service-role-only.
 - The promoted Twitch stream supports a build-time fallback and an admin-managed override.
   `NUXT_PUBLIC_PROMOTED_TWITCH_ENABLED=true` directly enables the build-time fallback without an
   admin write. `public.app_settings` is service-role-only; `/api/twitch/config` resolves the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ can read it and an agent can verify any claim against the code. Each system sect
 
 Install: `pnpm install` | Worktree bootstrap: `bash scripts/setup-worktree.sh` | Dev: `pnpm run dev` (localhost:3000) | Build: `pnpm run build` | Preview: `pnpm run preview` | Static: `pnpm run generate`
 
-Test: `pnpm run test` | Watch: `pnpm run test:watch` | Coverage: `pnpm run test:coverage` | API gateway: `pnpm run test:api-gateway` | Production observer: `pnpm run prod-db:test` | Single file: `pnpm exec vitest run path/to/file.test.ts` | By name: `pnpm exec vitest run -t "pattern"`
+Test: `pnpm run test` | Watch: `pnpm run test:watch` | Coverage: `pnpm run test:coverage` | API gateway: `pnpm run test:api-gateway` | Supabase DB: `pnpm run supabase:check` (reset + pgTAP + lint) | Production observer: `pnpm run prod-db:test` | Single file: `pnpm exec vitest run path/to/file.test.ts` | By name: `pnpm exec vitest run -t "pattern"`
 
 API gateway bindings: `pnpm --filter api-gateway run types` regenerates the checked-in
 `workers/api-gateway/worker-configuration.d.ts`; `pnpm --filter api-gateway run types:check` detects
@@ -235,6 +235,10 @@ Naming:
 - API token renames update only `api_tokens.note` through authenticated owner-scoped RLS. They
   must never rotate or replace the token or change its ID, value or hash, permissions, game mode,
   or usage data.
+- Account deletion requests consume their three-per-minute limit and record the allowed attempt in
+  one `consume_account_deletion_attempt` transaction. Both the initiating function and reconciler
+  must atomically claim work through `claim_account_deletion_job`; a fresh `in_progress` claim has a
+  15-minute lease before reconciliation can recover it. Both RPCs remain service-role-only.
 - The promoted Twitch stream supports a build-time fallback and an admin-managed override.
   `NUXT_PUBLIC_PROMOTED_TWITCH_ENABLED=true` directly enables the build-time fallback without an
   admin write. `public.app_settings` is service-role-only; `/api/twitch/config` resolves the

--- a/deno.lock
+++ b/deno.lock
@@ -2,17 +2,28 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@*": "1.0.19",
-    "jsr:@std/internal@^1.0.12": "1.0.14"
+    "jsr:@std/assert@1.0.19": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
+    "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/testing@1.0.19": "1.0.19"
   },
   "jsr": {
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/internal@1.0.14": {
       "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/testing@1.0.19": {
+      "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/internal@^1.0.14"
+      ]
     }
   },
   "workspace": {

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -279,12 +279,14 @@ Important:
 
 `account-delete` currently uses a **dedicated** path:
 
-1. Query recent rows in `account_deletion_attempts` for the user
-2. Allow max **3 attempts / 60s**
-3. Insert an attempt row, then enqueue deletion work
+1. Call `consume_account_deletion_attempt` to serialize each user's requests in Postgres
+2. Allow and record max **3 attempts / 60s** in the same transaction
+3. Atomically claim the deletion job through `claim_account_deletion_job`
 
-This is **not** wired through `consume_mutation_rate_limit` today. Functionally fine, but it is a
-second pattern for “sensitive mutation limiting.”
+This is **not** wired through `consume_mutation_rate_limit` today. It remains a second pattern for
+“sensitive mutation limiting” because the dedicated table also retains the deletion audit history.
+Both RPCs are service-role-only. A job claim holds a 15-minute lease; the reconciler can recover a
+stale `in_progress` job after that lease, but parallel workers cannot process a fresh claim.
 
 Preferred future shape: add an `account-delete` scope to the shared mutation limiter and keep
 `account_deletion_attempts` only if audit history is still needed.

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -286,7 +286,8 @@ Important:
 This is **not** wired through `consume_mutation_rate_limit` today. It remains a second pattern for
 “sensitive mutation limiting” because the dedicated table also retains the deletion audit history.
 Both RPCs are service-role-only. A job claim holds a 15-minute lease; the reconciler can recover a
-stale `in_progress` job after that lease, but parallel workers cannot process a fresh claim.
+stale `in_progress` job after that lease, but a fencing token prevents the stale worker from
+overwriting its replacement. Only an explicit user request can reset and revive dead-lettered work.
 
 Preferred future shape: add an `account-delete` scope to the shared mutation limiter and keep
 `account_deletion_attempts` only if audit history is still needed.

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -46,7 +46,8 @@ Semantic versioning with automated releases:
 **Jobs:**
 
 - Runs tests and build
-- Validates local Supabase migrations with `pnpm run supabase:check`
+- Resets and lints local Supabase migrations and runs pgTAP database regressions with
+  `pnpm run supabase:check`
 - Generates changelog from conventional commits
 - Creates GitHub releases
 - Updates version in package.json

--- a/scripts/check-supabase-db.sh
+++ b/scripts/check-supabase-db.sh
@@ -12,4 +12,5 @@ if ! pnpm exec supabase status >/dev/null 2>&1; then
   started_local_stack=true
 fi
 pnpm exec supabase db reset --no-seed
+pnpm exec supabase test db supabase/tests/database
 pnpm exec supabase db lint --schema public --fail-on error

--- a/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
@@ -7,6 +7,7 @@ import {
   deleteUserWithRetry,
   getErrorMessage,
   isNotFoundError,
+  markDeletionCompleted,
   type AccountDeletionClient,
 } from './account-deletion-lifecycle.ts';
 const asClient = (value: unknown) => value as AccountDeletionClient;
@@ -112,5 +113,20 @@ describe('account deletion lifecycle', () => {
         },
       },
     ]);
+  });
+  it('reports a lost lease when a fenced completion updates no rows', async () => {
+    const filter = {
+      limit: () => Promise.resolve({ data: [], error: null }),
+    };
+    const update: Record<string, unknown> = {};
+    update.eq = () => update;
+    update.select = () => filter;
+    const client = asClient({
+      from: () => ({ update: () => update }),
+    });
+    assertEquals(
+      await markDeletionCompleted(client, 'user-id', 'stale-token', '[account-delete-test]'),
+      false
+    );
   });
 });

--- a/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertMatch } from 'jsr:@std/assert@1.0.19';
+import { describe, it } from 'jsr:@std/testing@1.0.19/bdd';
 import {
   claimDeletionJob,
   computeBackoffMs,
@@ -9,105 +10,107 @@ import {
   type AccountDeletionClient,
 } from './account-deletion-lifecycle.ts';
 const asClient = (value: unknown) => value as AccountDeletionClient;
-Deno.test('normalizes deletion errors and recognizes supported not-found shapes', () => {
-  assertEquals(getErrorMessage(new Error('failure')), 'failure');
-  assertEquals(isNotFoundError({ status: 404 }), true);
-  assertEquals(isNotFoundError({ code: 'user_not_found' }), true);
-  assertEquals(isNotFoundError({ message: 'User with id abc not found' }), true);
-  assertEquals(isNotFoundError({ message: 'No user exists for this identifier' }), true);
-  assertEquals(isNotFoundError({ message: 'permission denied' }), false);
-});
-Deno.test('computes bounded exponential backoff with injectable jitter', () => {
-  assertEquals(
-    computeBackoffMs(1, 300, 5000, () => 0),
-    300
-  );
-  assertEquals(
-    computeBackoffMs(3, 300, 5000, () => 0.5),
-    1325
-  );
-  assertEquals(
-    computeBackoffMs(8, 300, 5000, () => 0.99),
-    5000
-  );
-});
-Deno.test('retries auth deletion without sleeping after the final failure', async () => {
-  let attempts = 0;
-  const waits: number[] = [];
-  const client = asClient({
-    auth: {
-      admin: {
-        deleteUser: () => {
-          attempts += 1;
-          return Promise.resolve({ error: new Error(`failure ${attempts}`) });
+describe('account deletion lifecycle', () => {
+  it('normalizes deletion errors and recognizes supported not-found shapes', () => {
+    assertEquals(getErrorMessage(new Error('failure')), 'failure');
+    assertEquals(isNotFoundError({ status: 404 }), true);
+    assertEquals(isNotFoundError({ code: 'user_not_found' }), true);
+    assertEquals(isNotFoundError({ message: 'User with id abc not found' }), true);
+    assertEquals(isNotFoundError({ message: 'No user exists for this identifier' }), true);
+    assertEquals(isNotFoundError({ message: 'permission denied' }), false);
+  });
+  it('computes bounded exponential backoff with injectable jitter', () => {
+    assertEquals(
+      computeBackoffMs(1, 300, 5000, () => 0),
+      300
+    );
+    assertEquals(
+      computeBackoffMs(3, 300, 5000, () => 0.5),
+      1325
+    );
+    assertEquals(
+      computeBackoffMs(8, 300, 5000, () => 0.99),
+      5000
+    );
+  });
+  it('retries auth deletion without sleeping after the final failure', async () => {
+    let attempts = 0;
+    const waits: number[] = [];
+    const client = asClient({
+      auth: {
+        admin: {
+          deleteUser: () => {
+            attempts += 1;
+            return Promise.resolve({ error: new Error(`failure ${attempts}`) });
+          },
         },
       },
-    },
+    });
+    const result = await deleteUserWithRetry(client, 'user-id', (ms) => {
+      waits.push(ms);
+      return Promise.resolve();
+    });
+    assertEquals(result.ok, false);
+    assertEquals(result.attempts, 4);
+    assertEquals(attempts, 4);
+    assertEquals(waits.length, 3);
+    assertMatch(getErrorMessage(result.lastError), /failure 4/);
   });
-  const result = await deleteUserWithRetry(client, 'user-id', (ms) => {
-    waits.push(ms);
-    return Promise.resolve();
-  });
-  assertEquals(result.ok, false);
-  assertEquals(result.attempts, 4);
-  assertEquals(attempts, 4);
-  assertEquals(waits.length, 3);
-  assertMatch(getErrorMessage(result.lastError), /failure 4/);
-});
-Deno.test('treats a missing auth user as a completed deletion', async () => {
-  const client = asClient({
-    auth: {
-      admin: {
-        deleteUser: () => Promise.resolve({ error: { code: 'user_not_found' } }),
+  it('treats a missing auth user as a completed deletion', async () => {
+    const client = asClient({
+      auth: {
+        admin: {
+          deleteUser: () => Promise.resolve({ error: { code: 'user_not_found' } }),
+        },
       },
-    },
+    });
+    assertEquals(await deleteUserWithRetry(client, 'user-id'), {
+      ok: true,
+      attempts: 1,
+      lastError: null,
+    });
   });
-  assertEquals(await deleteUserWithRetry(client, 'user-id'), {
-    ok: true,
-    attempts: 1,
-    lastError: null,
-  });
-});
-Deno.test('maps atomic claim and rate-limit RPC results', async () => {
-  const calls: Array<{ fn: string; args?: Record<string, unknown> }> = [];
-  const client = asClient({
-    rpc: (fn: string, args?: Record<string, unknown>) => {
-      calls.push({ fn, args });
-      if (fn === 'claim_account_deletion_job') {
+  it('maps atomic claim and rate-limit RPC results', async () => {
+    const calls: Array<{ fn: string; args?: Record<string, unknown> }> = [];
+    const client = asClient({
+      rpc: (fn: string, args?: Record<string, unknown>) => {
+        calls.push({ fn, args });
+        if (fn === 'claim_account_deletion_job') {
+          return Promise.resolve({
+            data: [{ claimed: false, status: 'in_progress', claim_token: 'claim-token' }],
+            error: null,
+          });
+        }
         return Promise.resolve({
-          data: [{ claimed: false, status: 'in_progress', claim_token: 'claim-token' }],
+          data: [{ allowed: false, retry_after_seconds: 42 }],
           error: null,
         });
-      }
-      return Promise.resolve({
-        data: [{ allowed: false, retry_after_seconds: 42 }],
-        error: null,
-      });
-    },
-  });
-  assertEquals(await claimDeletionJob(client, 'user-id', true), {
-    claimed: false,
-    status: 'in_progress',
-    claimToken: 'claim-token',
-    error: null,
-  });
-  assertEquals(await consumeDeletionAttempt(client, 'user-id', '127.0.0.1', 'agent'), {
-    allowed: false,
-    retryAfterSeconds: 42,
-    error: null,
-  });
-  assertEquals(calls, [
-    {
-      fn: 'claim_account_deletion_job',
-      args: { p_user_id: 'user-id', p_create_if_missing: true },
-    },
-    {
-      fn: 'consume_account_deletion_attempt',
-      args: {
-        p_user_id: 'user-id',
-        p_ip_address: '127.0.0.1',
-        p_user_agent: 'agent',
       },
-    },
-  ]);
+    });
+    assertEquals(await claimDeletionJob(client, 'user-id', true), {
+      claimed: false,
+      status: 'in_progress',
+      claimToken: 'claim-token',
+      error: null,
+    });
+    assertEquals(await consumeDeletionAttempt(client, 'user-id', '127.0.0.1', 'agent'), {
+      allowed: false,
+      retryAfterSeconds: 42,
+      error: null,
+    });
+    assertEquals(calls, [
+      {
+        fn: 'claim_account_deletion_job',
+        args: { p_user_id: 'user-id', p_create_if_missing: true },
+      },
+      {
+        fn: 'consume_account_deletion_attempt',
+        args: {
+          p_user_id: 'user-id',
+          p_ip_address: '127.0.0.1',
+          p_user_agent: 'agent',
+        },
+      },
+    ]);
+  });
 });

--- a/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
@@ -114,7 +114,7 @@ describe('account deletion lifecycle', () => {
       },
     ]);
   });
-  it('reports a lost lease when a fenced completion updates no rows', async () => {
+  it('distinguishes a lost lease from a fenced transition error', async () => {
     const filter = {
       limit: () => Promise.resolve({ data: [], error: null }),
     };
@@ -126,7 +126,20 @@ describe('account deletion lifecycle', () => {
     });
     assertEquals(
       await markDeletionCompleted(client, 'user-id', 'stale-token', '[account-delete-test]'),
-      false
+      'lease_lost'
+    );
+    const errorFilter = {
+      limit: () => Promise.resolve({ data: null, error: new Error('database unavailable') }),
+    };
+    const errorUpdate: Record<string, unknown> = {};
+    errorUpdate.eq = () => errorUpdate;
+    errorUpdate.select = () => errorFilter;
+    const errorClient = asClient({
+      from: () => ({ update: () => errorUpdate }),
+    });
+    assertEquals(
+      await markDeletionCompleted(errorClient, 'user-id', 'claim-token', '[account-delete-test]'),
+      'error'
     );
   });
 });

--- a/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
@@ -1,0 +1,109 @@
+import { assertEquals, assertMatch } from 'jsr:@std/assert@1.0.19';
+import {
+  claimDeletionJob,
+  computeBackoffMs,
+  consumeDeletionAttempt,
+  deleteUserWithRetry,
+  getErrorMessage,
+  isNotFoundError,
+  type AccountDeletionClient,
+} from './account-deletion-lifecycle.ts';
+const asClient = (value: unknown) => value as AccountDeletionClient;
+Deno.test('normalizes deletion errors and recognizes supported not-found shapes', () => {
+  assertEquals(getErrorMessage(new Error('failure')), 'failure');
+  assertEquals(isNotFoundError({ status: 404 }), true);
+  assertEquals(isNotFoundError({ code: 'user_not_found' }), true);
+  assertEquals(isNotFoundError({ message: 'User with id abc not found' }), true);
+  assertEquals(isNotFoundError({ message: 'No user exists for this identifier' }), true);
+  assertEquals(isNotFoundError({ message: 'permission denied' }), false);
+});
+Deno.test('computes bounded exponential backoff with injectable jitter', () => {
+  assertEquals(
+    computeBackoffMs(1, 300, 5000, () => 0),
+    300
+  );
+  assertEquals(
+    computeBackoffMs(3, 300, 5000, () => 0.5),
+    1325
+  );
+  assertEquals(
+    computeBackoffMs(8, 300, 5000, () => 0.99),
+    5000
+  );
+});
+Deno.test('retries auth deletion without sleeping after the final failure', async () => {
+  let attempts = 0;
+  const waits: number[] = [];
+  const client = asClient({
+    auth: {
+      admin: {
+        deleteUser: () => {
+          attempts += 1;
+          return Promise.resolve({ error: new Error(`failure ${attempts}`) });
+        },
+      },
+    },
+  });
+  const result = await deleteUserWithRetry(client, 'user-id', (ms) => {
+    waits.push(ms);
+    return Promise.resolve();
+  });
+  assertEquals(result.ok, false);
+  assertEquals(result.attempts, 4);
+  assertEquals(attempts, 4);
+  assertEquals(waits.length, 3);
+  assertMatch(getErrorMessage(result.lastError), /failure 4/);
+});
+Deno.test('treats a missing auth user as a completed deletion', async () => {
+  const client = asClient({
+    auth: {
+      admin: {
+        deleteUser: () => Promise.resolve({ error: { code: 'user_not_found' } }),
+      },
+    },
+  });
+  assertEquals(await deleteUserWithRetry(client, 'user-id'), {
+    ok: true,
+    attempts: 1,
+    lastError: null,
+  });
+});
+Deno.test('maps atomic claim and rate-limit RPC results', async () => {
+  const calls: Array<{ fn: string; args?: Record<string, unknown> }> = [];
+  const client = asClient({
+    rpc: (fn: string, args?: Record<string, unknown>) => {
+      calls.push({ fn, args });
+      if (fn === 'claim_account_deletion_job') {
+        return Promise.resolve({ data: [{ claimed: false, status: 'in_progress' }], error: null });
+      }
+      return Promise.resolve({
+        data: [{ allowed: false, retry_after_seconds: 42 }],
+        error: null,
+      });
+    },
+  });
+  assertEquals(await claimDeletionJob(client, 'user-id', true), {
+    claimed: false,
+    status: 'in_progress',
+    error: null,
+  });
+  assertEquals(await consumeDeletionAttempt(client, 'user-id', '127.0.0.1', 'agent'), {
+    allowed: false,
+    retryAfterSeconds: 42,
+    error: null,
+  });
+  assertEquals(calls, [
+    {
+      fn: 'claim_account_deletion_job',
+      args: { p_user_id: 'user-id', p_create_if_missing: true },
+    },
+    {
+      fn: 'consume_account_deletion_attempt',
+      args: {
+        p_user_id: 'user-id',
+        p_ip_address: '127.0.0.1',
+        p_user_agent: 'agent',
+      },
+    },
+  ]);
+});

--- a/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts
@@ -74,7 +74,10 @@ Deno.test('maps atomic claim and rate-limit RPC results', async () => {
     rpc: (fn: string, args?: Record<string, unknown>) => {
       calls.push({ fn, args });
       if (fn === 'claim_account_deletion_job') {
-        return Promise.resolve({ data: [{ claimed: false, status: 'in_progress' }], error: null });
+        return Promise.resolve({
+          data: [{ claimed: false, status: 'in_progress', claim_token: 'claim-token' }],
+          error: null,
+        });
       }
       return Promise.resolve({
         data: [{ allowed: false, retry_after_seconds: 42 }],
@@ -85,6 +88,7 @@ Deno.test('maps atomic claim and rate-limit RPC results', async () => {
   assertEquals(await claimDeletionJob(client, 'user-id', true), {
     claimed: false,
     status: 'in_progress',
+    claimToken: 'claim-token',
     error: null,
   });
   assertEquals(await consumeDeletionAttempt(client, 'user-id', '127.0.0.1', 'agent'), {

--- a/supabase/functions/_shared/account-deletion-lifecycle.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.ts
@@ -17,9 +17,9 @@ export interface AccountDeletionFilterBuilder<T> {
       ((value: { data: T[] | null; error: unknown }) => TResult1 | PromiseLike<TResult1>) | null
   ): PromiseLike<TResult1>;
 }
-interface AccountDeletionTransformBuilder {
-  eq(column: string, value: unknown): Promise<{ error: unknown }>;
-  or(filter: string): Promise<{ error: unknown }>;
+interface AccountDeletionTransformBuilder extends PromiseLike<{ error: unknown }> {
+  eq(column: string, value: unknown): AccountDeletionTransformBuilder;
+  or(filter: string): AccountDeletionTransformBuilder;
 }
 export interface AccountDeletionClient {
   from<T extends keyof Database['public']['Tables']>(
@@ -50,6 +50,13 @@ const getRpcResult = (data: unknown) => {
   if (!Array.isArray(data)) return null;
   const result: unknown = data[0];
   return result && typeof result === 'object' ? (result as Record<string, unknown>) : null;
+};
+const getRpcBoolean = (result: Record<string, unknown> | null, field: string) =>
+  Boolean(result && result[field] === true);
+const getRpcString = (result: Record<string, unknown> | null, field: string) => {
+  if (!result) return null;
+  const value = result[field];
+  return typeof value === 'string' ? value : null;
 };
 const sleep = (ms: number) =>
   new Promise<void>((resolve) => {
@@ -179,6 +186,7 @@ const getFailureTransition = (attempt: number, deadLetter: boolean, now: string)
 export const recordDeletionFailure = async (
   supabase: AccountDeletionClient,
   userId: string,
+  claimToken: string,
   reason: string,
   details: Record<string, unknown>,
   logPrefix: string
@@ -200,8 +208,10 @@ export const recordDeletionFailure = async (
       updated_at: now,
       completed_at: null,
       dead_lettered_at: transition.deadLetteredAt,
+      claim_token: null,
     })
-    .eq('user_id', userId);
+    .eq('user_id', userId)
+    .eq('claim_token', claimToken);
   if (error) console.error(`${logPrefix} Failed to update deletion job:`, error);
   if (deadLetter) {
     console.error(`${logPrefix} Deletion job dead-lettered:`, { userId, reason, details });
@@ -210,6 +220,7 @@ export const recordDeletionFailure = async (
 export const markDeletionCompleted = async (
   supabase: AccountDeletionClient,
   userId: string,
+  claimToken: string,
   logPrefix: string
 ) => {
   const now = new Date().toISOString();
@@ -224,8 +235,10 @@ export const markDeletionCompleted = async (
       last_error_at: null,
       next_run_at: null,
       dead_lettered_at: null,
+      claim_token: null,
     })
-    .eq('user_id', userId);
+    .eq('user_id', userId)
+    .eq('claim_token', claimToken);
   if (error) console.error(`${logPrefix} Failed to mark deletion job completed:`, error);
 };
 export const claimDeletionJob = async (
@@ -239,8 +252,9 @@ export const claimDeletionJob = async (
   });
   const result = getRpcResult(data);
   return {
-    claimed: result?.claimed === true,
-    status: typeof result?.status === 'string' ? result.status : null,
+    claimed: getRpcBoolean(result, 'claimed'),
+    status: getRpcString(result, 'status'),
+    claimToken: getRpcString(result, 'claim_token'),
     error,
   };
 };

--- a/supabase/functions/_shared/account-deletion-lifecycle.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.ts
@@ -1,0 +1,247 @@
+import type { Database } from './database.types.ts';
+const AUTH_DELETE_MAX_ATTEMPTS = 4;
+const AUTH_DELETE_BASE_DELAY_MS = 300;
+const AUTH_DELETE_MAX_DELAY_MS = 5000;
+const CLEANUP_MAX_ATTEMPTS = 5;
+const CLEANUP_BASE_DELAY_MS = 5 * 60 * 1000;
+const CLEANUP_MAX_DELAY_MS = 60 * 60 * 1000;
+interface FilterBuilder<T> {
+  eq(column: string, value: unknown): FilterBuilder<T>;
+  or(filter: string): Promise<{ error: unknown }>;
+  limit(count: number): FilterBuilder<T>;
+  then<TResult1 = { data: T[] | null; error: unknown }>(
+    onfulfilled?:
+      ((value: { data: T[] | null; error: unknown }) => TResult1 | PromiseLike<TResult1>) | null
+  ): PromiseLike<TResult1>;
+}
+interface TransformBuilder {
+  eq(column: string, value: unknown): Promise<{ error: unknown }>;
+  or(filter: string): Promise<{ error: unknown }>;
+}
+export interface AccountDeletionClient {
+  from<T extends keyof Database['public']['Tables']>(
+    table: T
+  ): {
+    select(columns?: string): FilterBuilder<Database['public']['Tables'][T]['Row']>;
+    update(values: unknown): TransformBuilder;
+    delete(): TransformBuilder;
+  };
+  auth: {
+    admin: {
+      deleteUser(id: string): Promise<{ error: unknown }>;
+    };
+  };
+  rpc(fn: string, args?: Record<string, unknown>): Promise<{ data: unknown; error: unknown }>;
+}
+export interface DeletionJobState {
+  attempts: number;
+  maxAttempts: number;
+  status: string | null;
+}
+const getRpcResult = (data: unknown) => {
+  if (!Array.isArray(data)) return null;
+  const result: unknown = data[0];
+  return result && typeof result === 'object' ? (result as Record<string, unknown>) : null;
+};
+export const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });
+export const getErrorMessage = (error: unknown) => {
+  if (typeof error === 'string') return error;
+  if (error instanceof Error) return error.message;
+  if (error && typeof error === 'object' && 'message' in error) {
+    return String((error as { message?: unknown }).message);
+  }
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return String(error);
+  }
+};
+export const serializeError = (error: unknown) => {
+  if (error instanceof Error) {
+    return { name: error.name, message: error.message, stack: error.stack };
+  }
+  if (error && typeof error === 'object') return error;
+  return { message: String(error) };
+};
+export const isNotFoundError = (error: unknown) => {
+  if (error && typeof error === 'object') {
+    if ('status' in error && (error as { status?: number }).status === 404) return true;
+    if ('code' in error) {
+      const code = (error as { code?: string }).code;
+      if (code === 'user_not_found' || code === '404') return true;
+    }
+  }
+  const message = getErrorMessage(error).toLowerCase();
+  return (
+    message === 'user not found' ||
+    message.includes('no user') ||
+    (message.includes('user') && message.includes('not found'))
+  );
+};
+export const computeBackoffMs = (
+  attempt: number,
+  baseMs: number,
+  maxMs: number,
+  random = Math.random
+) => {
+  const jitter = Math.floor(random() * 250);
+  const delay = baseMs * Math.pow(2, Math.max(0, attempt - 1)) + jitter;
+  return Math.min(delay, maxMs);
+};
+export const deleteUserWithRetry = async (
+  supabase: AccountDeletionClient,
+  userId: string,
+  wait = sleep
+): Promise<{ ok: boolean; attempts: number; lastError: unknown | null }> => {
+  let lastError: unknown | null = null;
+  for (let attempt = 1; attempt <= AUTH_DELETE_MAX_ATTEMPTS; attempt += 1) {
+    const { error } = await supabase.auth.admin.deleteUser(userId);
+    if (!error || isNotFoundError(error)) {
+      return { ok: true, attempts: attempt, lastError: null };
+    }
+    lastError = error;
+    if (attempt < AUTH_DELETE_MAX_ATTEMPTS) {
+      await wait(computeBackoffMs(attempt, AUTH_DELETE_BASE_DELAY_MS, AUTH_DELETE_MAX_DELAY_MS));
+    }
+  }
+  return { ok: false, attempts: AUTH_DELETE_MAX_ATTEMPTS, lastError };
+};
+export const cleanupUserData = async (supabase: AccountDeletionClient, userId: string) => {
+  const deletions = [
+    ['team_memberships', supabase.from('team_memberships').delete().eq('user_id', userId)],
+    ['api_tokens', supabase.from('api_tokens').delete().eq('user_id', userId)],
+    ['user_progress', supabase.from('user_progress').delete().eq('user_id', userId)],
+    ['user_preferences', supabase.from('user_preferences').delete().eq('user_id', userId)],
+    ['user_system', supabase.from('user_system').delete().eq('user_id', userId)],
+    [
+      'team_events',
+      supabase
+        .from('team_events')
+        .delete()
+        .or(`initiated_by.eq.${userId},target_user.eq.${userId}`),
+    ],
+  ] as const;
+  const cleanupErrors: Record<string, string> = {};
+  const results = await Promise.allSettled(deletions.map(([, deletion]) => deletion));
+  results.forEach((result, index) => {
+    const table = deletions[index][0];
+    if (result.status === 'rejected') {
+      cleanupErrors[table] = getErrorMessage(result.reason);
+    } else if (result.value.error) {
+      cleanupErrors[table] = getErrorMessage(result.value.error);
+    }
+  });
+  return cleanupErrors;
+};
+export const getDeletionJobState = async (
+  supabase: AccountDeletionClient,
+  userId: string,
+  logPrefix: string
+): Promise<DeletionJobState> => {
+  const { data, error } = await supabase
+    .from('account_deletion_jobs')
+    .select('attempts,max_attempts,status')
+    .eq('user_id', userId)
+    .limit(1);
+  if (error) console.error(`${logPrefix} Failed to fetch deletion job state:`, error);
+  const job = data?.[0];
+  return {
+    attempts: job?.attempts ?? 0,
+    maxAttempts: job?.max_attempts ?? CLEANUP_MAX_ATTEMPTS,
+    status: job?.status ?? null,
+  };
+};
+export const recordDeletionFailure = async (
+  supabase: AccountDeletionClient,
+  userId: string,
+  reason: string,
+  details: Record<string, unknown>,
+  logPrefix: string
+) => {
+  const now = new Date().toISOString();
+  const { attempts, maxAttempts } = await getDeletionJobState(supabase, userId, logPrefix);
+  const nextAttempts = attempts + 1;
+  const deadLetter = nextAttempts >= maxAttempts;
+  const nextRunAt = deadLetter
+    ? null
+    : new Date(
+        Date.now() + computeBackoffMs(nextAttempts, CLEANUP_BASE_DELAY_MS, CLEANUP_MAX_DELAY_MS)
+      ).toISOString();
+  const { error } = await supabase
+    .from('account_deletion_jobs')
+    .update({
+      status: deadLetter ? 'dead_lettered' : 'failed',
+      attempts: nextAttempts,
+      last_error: reason,
+      last_error_details: details,
+      last_error_at: now,
+      next_run_at: nextRunAt,
+      updated_at: now,
+      completed_at: null,
+      dead_lettered_at: deadLetter ? now : null,
+    })
+    .eq('user_id', userId);
+  if (error) console.error(`${logPrefix} Failed to update deletion job:`, error);
+  if (deadLetter) {
+    console.error(`${logPrefix} Deletion job dead-lettered:`, { userId, reason, details });
+  }
+};
+export const markDeletionCompleted = async (
+  supabase: AccountDeletionClient,
+  userId: string,
+  logPrefix: string
+) => {
+  const now = new Date().toISOString();
+  const { error } = await supabase
+    .from('account_deletion_jobs')
+    .update({
+      status: 'completed',
+      updated_at: now,
+      completed_at: now,
+      last_error: null,
+      last_error_details: null,
+      last_error_at: null,
+      next_run_at: null,
+      dead_lettered_at: null,
+    })
+    .eq('user_id', userId);
+  if (error) console.error(`${logPrefix} Failed to mark deletion job completed:`, error);
+};
+export const claimDeletionJob = async (
+  supabase: AccountDeletionClient,
+  userId: string,
+  createIfMissing: boolean
+) => {
+  const { data, error } = await supabase.rpc('claim_account_deletion_job', {
+    p_user_id: userId,
+    p_create_if_missing: createIfMissing,
+  });
+  const result = getRpcResult(data);
+  return {
+    claimed: result?.claimed === true,
+    status: typeof result?.status === 'string' ? result.status : null,
+    error,
+  };
+};
+export const consumeDeletionAttempt = async (
+  supabase: AccountDeletionClient,
+  userId: string,
+  ipAddress: string | null,
+  userAgent: string | null
+) => {
+  const { data, error } = await supabase.rpc('consume_account_deletion_attempt', {
+    p_user_id: userId,
+    p_ip_address: ipAddress,
+    p_user_agent: userAgent,
+  });
+  const result = getRpcResult(data);
+  return {
+    allowed: result?.allowed === true,
+    retryAfterSeconds:
+      typeof result?.retry_after_seconds === 'number' ? result.retry_after_seconds : 60,
+    error,
+  };
+};

--- a/supabase/functions/_shared/account-deletion-lifecycle.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.ts
@@ -52,7 +52,7 @@ const getRpcResult = (data: unknown) => {
   return result && typeof result === 'object' ? (result as Record<string, unknown>) : null;
 };
 const getRpcBoolean = (result: Record<string, unknown> | null, field: string) =>
-  Boolean(result && result[field] === true);
+  result?.[field] === true;
 const getRpcString = (result: Record<string, unknown> | null, field: string) => {
   if (!result) return null;
   const value = result[field];
@@ -116,8 +116,8 @@ export const deleteUserWithRetry = async (
   supabase: AccountDeletionClient,
   userId: string,
   wait = sleep
-): Promise<{ ok: boolean; attempts: number; lastError: unknown | null }> => {
-  let lastError: unknown | null = null;
+): Promise<{ ok: boolean; attempts: number; lastError: unknown }> => {
+  let lastError: unknown;
   for (let attempt = 1; attempt <= AUTH_DELETE_MAX_ATTEMPTS; attempt += 1) {
     const { error } = await supabase.auth.admin.deleteUser(userId);
     if (isDeletionComplete(error)) {

--- a/supabase/functions/_shared/account-deletion-lifecycle.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.ts
@@ -184,8 +184,11 @@ const getFailureTransition = (attempt: number, deadLetter: boolean, now: string)
     deadLetteredAt: null,
   } as const;
 };
-const hasPersistedTransition = (data: unknown, error: unknown) =>
-  !error && Array.isArray(data) && data.length === 1;
+export type DeletionTransitionResult = 'persisted' | 'lease_lost' | 'error';
+const getDeletionTransitionResult = (data: unknown, error: unknown): DeletionTransitionResult => {
+  if (error) return 'error';
+  return Array.isArray(data) && data.length === 1 ? 'persisted' : 'lease_lost';
+};
 export const recordDeletionFailure = async (
   supabase: AccountDeletionClient,
   userId: string,
@@ -218,11 +221,11 @@ export const recordDeletionFailure = async (
     .select('user_id')
     .limit(1);
   if (error) console.error(`${logPrefix} Failed to update deletion job:`, error);
-  const persisted = hasPersistedTransition(data, error);
-  if (deadLetter && persisted) {
+  const result = getDeletionTransitionResult(data, error);
+  if (deadLetter && result === 'persisted') {
     console.error(`${logPrefix} Deletion job dead-lettered:`, { userId, reason, details });
   }
-  return persisted;
+  return result;
 };
 export const markDeletionCompleted = async (
   supabase: AccountDeletionClient,
@@ -249,7 +252,7 @@ export const markDeletionCompleted = async (
     .select('user_id')
     .limit(1);
   if (error) console.error(`${logPrefix} Failed to mark deletion job completed:`, error);
-  return hasPersistedTransition(data, error);
+  return getDeletionTransitionResult(data, error);
 };
 export const claimDeletionJob = async (
   supabase: AccountDeletionClient,

--- a/supabase/functions/_shared/account-deletion-lifecycle.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.ts
@@ -20,6 +20,7 @@ export interface AccountDeletionFilterBuilder<T> {
 interface AccountDeletionTransformBuilder extends PromiseLike<{ error: unknown }> {
   eq(column: string, value: unknown): AccountDeletionTransformBuilder;
   or(filter: string): AccountDeletionTransformBuilder;
+  select(columns?: string): AccountDeletionFilterBuilder<Record<string, unknown>>;
 }
 export interface AccountDeletionClient {
   from<T extends keyof Database['public']['Tables']>(
@@ -183,6 +184,8 @@ const getFailureTransition = (attempt: number, deadLetter: boolean, now: string)
     deadLetteredAt: null,
   } as const;
 };
+const hasPersistedTransition = (data: unknown, error: unknown) =>
+  !error && Array.isArray(data) && data.length === 1;
 export const recordDeletionFailure = async (
   supabase: AccountDeletionClient,
   userId: string,
@@ -196,7 +199,7 @@ export const recordDeletionFailure = async (
   const nextAttempts = attempts + 1;
   const deadLetter = nextAttempts >= maxAttempts;
   const transition = getFailureTransition(nextAttempts, deadLetter, now);
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('account_deletion_jobs')
     .update({
       status: transition.status,
@@ -211,11 +214,15 @@ export const recordDeletionFailure = async (
       claim_token: null,
     })
     .eq('user_id', userId)
-    .eq('claim_token', claimToken);
+    .eq('claim_token', claimToken)
+    .select('user_id')
+    .limit(1);
   if (error) console.error(`${logPrefix} Failed to update deletion job:`, error);
-  if (deadLetter) {
+  const persisted = hasPersistedTransition(data, error);
+  if (deadLetter && persisted) {
     console.error(`${logPrefix} Deletion job dead-lettered:`, { userId, reason, details });
   }
+  return persisted;
 };
 export const markDeletionCompleted = async (
   supabase: AccountDeletionClient,
@@ -224,7 +231,7 @@ export const markDeletionCompleted = async (
   logPrefix: string
 ) => {
   const now = new Date().toISOString();
-  const { error } = await supabase
+  const { data, error } = await supabase
     .from('account_deletion_jobs')
     .update({
       status: 'completed',
@@ -238,8 +245,11 @@ export const markDeletionCompleted = async (
       claim_token: null,
     })
     .eq('user_id', userId)
-    .eq('claim_token', claimToken);
+    .eq('claim_token', claimToken)
+    .select('user_id')
+    .limit(1);
   if (error) console.error(`${logPrefix} Failed to mark deletion job completed:`, error);
+  return hasPersistedTransition(data, error);
 };
 export const claimDeletionJob = async (
   supabase: AccountDeletionClient,

--- a/supabase/functions/_shared/account-deletion-lifecycle.ts
+++ b/supabase/functions/_shared/account-deletion-lifecycle.ts
@@ -5,16 +5,19 @@ const AUTH_DELETE_MAX_DELAY_MS = 5000;
 const CLEANUP_MAX_ATTEMPTS = 5;
 const CLEANUP_BASE_DELAY_MS = 5 * 60 * 1000;
 const CLEANUP_MAX_DELAY_MS = 60 * 60 * 1000;
-interface FilterBuilder<T> {
-  eq(column: string, value: unknown): FilterBuilder<T>;
-  or(filter: string): Promise<{ error: unknown }>;
-  limit(count: number): FilterBuilder<T>;
+export interface AccountDeletionFilterBuilder<T> {
+  eq(column: string, value: unknown): AccountDeletionFilterBuilder<T>;
+  neq(column: string, value: unknown): AccountDeletionFilterBuilder<T>;
+  gte(column: string, value: unknown): AccountDeletionFilterBuilder<T>;
+  order(column: string, options?: unknown): AccountDeletionFilterBuilder<T>;
+  or(filter: string): AccountDeletionFilterBuilder<T>;
+  limit(count: number): AccountDeletionFilterBuilder<T>;
   then<TResult1 = { data: T[] | null; error: unknown }>(
     onfulfilled?:
       ((value: { data: T[] | null; error: unknown }) => TResult1 | PromiseLike<TResult1>) | null
   ): PromiseLike<TResult1>;
 }
-interface TransformBuilder {
+interface AccountDeletionTransformBuilder {
   eq(column: string, value: unknown): Promise<{ error: unknown }>;
   or(filter: string): Promise<{ error: unknown }>;
 }
@@ -22,9 +25,9 @@ export interface AccountDeletionClient {
   from<T extends keyof Database['public']['Tables']>(
     table: T
   ): {
-    select(columns?: string): FilterBuilder<Database['public']['Tables'][T]['Row']>;
-    update(values: unknown): TransformBuilder;
-    delete(): TransformBuilder;
+    select(columns?: string): AccountDeletionFilterBuilder<Database['public']['Tables'][T]['Row']>;
+    update(values: unknown): AccountDeletionTransformBuilder;
+    delete(): AccountDeletionTransformBuilder;
   };
   auth: {
     admin: {
@@ -38,26 +41,36 @@ export interface DeletionJobState {
   maxAttempts: number;
   status: string | null;
 }
+const DEFAULT_DELETION_JOB_STATE: DeletionJobState = {
+  attempts: 0,
+  maxAttempts: CLEANUP_MAX_ATTEMPTS,
+  status: null,
+};
 const getRpcResult = (data: unknown) => {
   if (!Array.isArray(data)) return null;
   const result: unknown = data[0];
   return result && typeof result === 'object' ? (result as Record<string, unknown>) : null;
 };
-export const sleep = (ms: number) =>
+const sleep = (ms: number) =>
   new Promise<void>((resolve) => {
     setTimeout(resolve, ms);
   });
-export const getErrorMessage = (error: unknown) => {
-  if (typeof error === 'string') return error;
-  if (error instanceof Error) return error.message;
-  if (error && typeof error === 'object' && 'message' in error) {
-    return String((error as { message?: unknown }).message);
-  }
+const getObjectErrorMessage = (error: object) => {
+  if (!('message' in error)) return null;
+  return String((error as { message?: unknown }).message);
+};
+const stringifyUnknown = (error: unknown) => {
   try {
     return JSON.stringify(error);
   } catch {
     return String(error);
   }
+};
+const isObject = (value: unknown): value is object => typeof value === 'object' && value !== null;
+export const getErrorMessage = (error: unknown) => {
+  if (typeof error === 'string') return error;
+  if (isObject(error)) return getObjectErrorMessage(error) ?? stringifyUnknown(error);
+  return stringifyUnknown(error);
 };
 export const serializeError = (error: unknown) => {
   if (error instanceof Error) {
@@ -66,21 +79,21 @@ export const serializeError = (error: unknown) => {
   if (error && typeof error === 'object') return error;
   return { message: String(error) };
 };
-export const isNotFoundError = (error: unknown) => {
-  if (error && typeof error === 'object') {
-    if ('status' in error && (error as { status?: number }).status === 404) return true;
-    if ('code' in error) {
-      const code = (error as { code?: string }).code;
-      if (code === 'user_not_found' || code === '404') return true;
-    }
-  }
+const hasNotFoundStatus = (error: unknown) =>
+  Boolean(error && typeof error === 'object' && 'status' in error && error.status === 404);
+const hasNotFoundCode = (error: unknown) => {
+  if (!error || typeof error !== 'object' || !('code' in error)) return false;
+  return ['user_not_found', '404'].includes(String(error.code));
+};
+const hasNotFoundMessage = (error: unknown) => {
   const message = getErrorMessage(error).toLowerCase();
   return (
-    message === 'user not found' ||
-    message.includes('no user') ||
-    (message.includes('user') && message.includes('not found'))
+    ['user not found', 'no user'].some((pattern) => message.includes(pattern)) ||
+    /user.*not found|not found.*user/.test(message)
   );
 };
+export const isNotFoundError = (error: unknown) =>
+  [hasNotFoundStatus(error), hasNotFoundCode(error), hasNotFoundMessage(error)].some(Boolean);
 export const computeBackoffMs = (
   attempt: number,
   baseMs: number,
@@ -91,6 +104,7 @@ export const computeBackoffMs = (
   const delay = baseMs * Math.pow(2, Math.max(0, attempt - 1)) + jitter;
   return Math.min(delay, maxMs);
 };
+const isDeletionComplete = (error: unknown) => !error || isNotFoundError(error);
 export const deleteUserWithRetry = async (
   supabase: AccountDeletionClient,
   userId: string,
@@ -99,7 +113,7 @@ export const deleteUserWithRetry = async (
   let lastError: unknown | null = null;
   for (let attempt = 1; attempt <= AUTH_DELETE_MAX_ATTEMPTS; attempt += 1) {
     const { error } = await supabase.auth.admin.deleteUser(userId);
-    if (!error || isNotFoundError(error)) {
+    if (isDeletionComplete(error)) {
       return { ok: true, attempts: attempt, lastError: null };
     }
     lastError = error;
@@ -147,12 +161,20 @@ export const getDeletionJobState = async (
     .eq('user_id', userId)
     .limit(1);
   if (error) console.error(`${logPrefix} Failed to fetch deletion job state:`, error);
-  const job = data?.[0];
+  const job = Array.isArray(data) ? data[0] : undefined;
+  if (!job) return DEFAULT_DELETION_JOB_STATE;
+  return { attempts: job.attempts, maxAttempts: job.max_attempts, status: job.status };
+};
+const getFailureTransition = (attempt: number, deadLetter: boolean, now: string) => {
+  if (deadLetter) {
+    return { status: 'dead_lettered', nextRunAt: null, deadLetteredAt: now } as const;
+  }
+  const delay = computeBackoffMs(attempt, CLEANUP_BASE_DELAY_MS, CLEANUP_MAX_DELAY_MS);
   return {
-    attempts: job?.attempts ?? 0,
-    maxAttempts: job?.max_attempts ?? CLEANUP_MAX_ATTEMPTS,
-    status: job?.status ?? null,
-  };
+    status: 'failed',
+    nextRunAt: new Date(Date.now() + delay).toISOString(),
+    deadLetteredAt: null,
+  } as const;
 };
 export const recordDeletionFailure = async (
   supabase: AccountDeletionClient,
@@ -165,23 +187,19 @@ export const recordDeletionFailure = async (
   const { attempts, maxAttempts } = await getDeletionJobState(supabase, userId, logPrefix);
   const nextAttempts = attempts + 1;
   const deadLetter = nextAttempts >= maxAttempts;
-  const nextRunAt = deadLetter
-    ? null
-    : new Date(
-        Date.now() + computeBackoffMs(nextAttempts, CLEANUP_BASE_DELAY_MS, CLEANUP_MAX_DELAY_MS)
-      ).toISOString();
+  const transition = getFailureTransition(nextAttempts, deadLetter, now);
   const { error } = await supabase
     .from('account_deletion_jobs')
     .update({
-      status: deadLetter ? 'dead_lettered' : 'failed',
+      status: transition.status,
       attempts: nextAttempts,
       last_error: reason,
       last_error_details: details,
       last_error_at: now,
-      next_run_at: nextRunAt,
+      next_run_at: transition.nextRunAt,
       updated_at: now,
       completed_at: null,
-      dead_lettered_at: deadLetter ? now : null,
+      dead_lettered_at: transition.deadLetteredAt,
     })
     .eq('user_id', userId);
   if (error) console.error(`${logPrefix} Failed to update deletion job:`, error);

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -938,7 +938,7 @@ export type Database = {
       claim_account_deletion_job: {
         Args: { p_create_if_missing?: boolean; p_user_id: string }
         Returns: {
-          claim_token: string
+          claim_token: string | null
           claimed: boolean
           status: string
         }[]

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -61,6 +61,7 @@ export type Database = {
       account_deletion_jobs: {
         Row: {
           attempts: number
+          claim_token: string | null
           completed_at: string | null
           created_at: string | null
           dead_lettered_at: string | null
@@ -75,6 +76,7 @@ export type Database = {
         }
         Insert: {
           attempts?: number
+          claim_token?: string | null
           completed_at?: string | null
           created_at?: string | null
           dead_lettered_at?: string | null
@@ -89,6 +91,7 @@ export type Database = {
         }
         Update: {
           attempts?: number
+          claim_token?: string | null
           completed_at?: string | null
           created_at?: string | null
           dead_lettered_at?: string | null
@@ -942,6 +945,7 @@ export type Database = {
       claim_account_deletion_job: {
         Args: { p_create_if_missing?: boolean; p_user_id: string }
         Returns: {
+          claim_token: string
           claimed: boolean
           status: string
         }[]

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -935,19 +935,19 @@ export type Database = {
         }
         Returns: undefined
       }
-      cleanup_old_deletion_attempts: {
-        Args: { retention_days?: number }
-        Returns: {
-          deleted_count: number
-          oldest_remaining: string
-        }[]
-      }
       claim_account_deletion_job: {
         Args: { p_create_if_missing?: boolean; p_user_id: string }
         Returns: {
           claim_token: string
           claimed: boolean
           status: string
+        }[]
+      }
+      cleanup_old_deletion_attempts: {
+        Args: { retention_days?: number }
+        Returns: {
+          deleted_count: number
+          oldest_remaining: string
         }[]
       }
       consume_account_deletion_attempt: {

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -939,6 +939,24 @@ export type Database = {
           oldest_remaining: string
         }[]
       }
+      claim_account_deletion_job: {
+        Args: { p_create_if_missing?: boolean; p_user_id: string }
+        Returns: {
+          claimed: boolean
+          status: string
+        }[]
+      }
+      consume_account_deletion_attempt: {
+        Args: {
+          p_ip_address: string
+          p_user_agent: string
+          p_user_id: string
+        }
+        Returns: {
+          allowed: boolean
+          retry_after_seconds: number
+        }[]
+      }
       consume_mutation_rate_limit: {
         Args: {
           p_limit: number

--- a/supabase/functions/account-delete-reconcile/index.ts
+++ b/supabase/functions/account-delete-reconcile/index.ts
@@ -15,6 +15,7 @@ import {
   recordDeletionFailure,
   serializeError,
   type AccountDeletionClient,
+  type DeletionTransitionResult,
 } from '../_shared/account-deletion-lifecycle.ts';
 const DEFAULT_BATCH_LIMIT = 20;
 const MAX_BATCH_LIMIT = 100;
@@ -70,8 +71,18 @@ const listJobs = async (
   }
   return { data: data ?? [], error: null } as const;
 };
-const getTransitionResult = async <T>(transition: Promise<boolean>, result: T, userId: string) =>
-  (await transition) ? result : { userId, status: 'lease_lost', skipped: true };
+const getTransitionResult = async <T>(
+  transition: Promise<DeletionTransitionResult>,
+  result: T,
+  userId: string
+) => {
+  const transitionResult = await transition;
+  if (transitionResult === 'persisted') return result;
+  if (transitionResult === 'lease_lost') {
+    return { userId, status: 'lease_lost', skipped: true };
+  }
+  return { userId, status: 'transition_failed' };
+};
 const TERMINAL_DELETION_STATUSES = new Set(['completed', 'dead_lettered']);
 const getSkippedJobResult = (status: string | null, userId: string, dryRun: boolean) => {
   const normalizedStatus = status ?? 'pending';

--- a/supabase/functions/account-delete-reconcile/index.ts
+++ b/supabase/functions/account-delete-reconcile/index.ts
@@ -70,21 +70,25 @@ const listJobs = async (
   }
   return { data: data ?? [], error: null } as const;
 };
+const getTransitionResult = async <T>(transition: Promise<boolean>, result: T, userId: string) =>
+  (await transition) ? result : { userId, status: 'lease_lost', skipped: true };
+const TERMINAL_DELETION_STATUSES = new Set(['completed', 'dead_lettered']);
+const getSkippedJobResult = (status: string | null, userId: string, dryRun: boolean) => {
+  const normalizedStatus = status ?? 'pending';
+  if (TERMINAL_DELETION_STATUSES.has(normalizedStatus)) {
+    return { userId, status: normalizedStatus, skipped: true };
+  }
+  if (!dryRun) return null;
+  return { userId, status: normalizedStatus, dryRun: true };
+};
 const processDeletionJob = async (
   supabase: AccountDeletionClient,
   userId: string,
   dryRun: boolean
 ) => {
   const { status } = await getDeletionJobState(supabase, userId, '[account-delete-reconcile]');
-  if (status === 'completed') {
-    return { userId, status: 'completed', skipped: true };
-  }
-  if (status === 'dead_lettered') {
-    return { userId, status: 'dead_lettered', skipped: true };
-  }
-  if (dryRun) {
-    return { userId, status: status ?? 'pending', dryRun: true };
-  }
+  const skippedResult = getSkippedJobResult(status, userId, dryRun);
+  if (skippedResult) return skippedResult;
   const claim = await claimDeletionJob(supabase, userId, false);
   if (claim.error) {
     console.error('[account-delete-reconcile] Failed to claim deletion job:', claim.error);
@@ -95,34 +99,43 @@ const processDeletionJob = async (
   }
   const authDeleteResult = await deleteUserWithRetry(supabase, userId);
   if (!authDeleteResult.ok) {
-    await recordDeletionFailure(
-      supabase,
-      userId,
-      claim.claimToken,
-      'auth_delete_failed',
-      {
-        stage: 'auth_delete',
-        attempts: authDeleteResult.attempts,
-        error: serializeError(authDeleteResult.lastError),
-      },
-      '[account-delete-reconcile]'
+    return getTransitionResult(
+      recordDeletionFailure(
+        supabase,
+        userId,
+        claim.claimToken,
+        'auth_delete_failed',
+        {
+          stage: 'auth_delete',
+          attempts: authDeleteResult.attempts,
+          error: serializeError(authDeleteResult.lastError),
+        },
+        '[account-delete-reconcile]'
+      ),
+      { userId, status: 'failed', stage: 'auth_delete' },
+      userId
     );
-    return { userId, status: 'failed', stage: 'auth_delete' };
   }
   const cleanupErrors = await cleanupUserData(supabase, userId);
   if (Object.keys(cleanupErrors).length > 0) {
-    await recordDeletionFailure(
-      supabase,
-      userId,
-      claim.claimToken,
-      'cleanup_failed',
-      { stage: 'cleanup', errors: cleanupErrors },
-      '[account-delete-reconcile]'
+    return getTransitionResult(
+      recordDeletionFailure(
+        supabase,
+        userId,
+        claim.claimToken,
+        'cleanup_failed',
+        { stage: 'cleanup', errors: cleanupErrors },
+        '[account-delete-reconcile]'
+      ),
+      { userId, status: 'failed', stage: 'cleanup', errors: cleanupErrors },
+      userId
     );
-    return { userId, status: 'failed', stage: 'cleanup', errors: cleanupErrors };
   }
-  await markDeletionCompleted(supabase, userId, claim.claimToken, '[account-delete-reconcile]');
-  return { userId, status: 'completed' };
+  return getTransitionResult(
+    markDeletionCompleted(supabase, userId, claim.claimToken, '[account-delete-reconcile]'),
+    { userId, status: 'completed' },
+    userId
+  );
 };
 Deno.serve(async (req) => {
   const corsResponse = handleCorsPreflight(req);

--- a/supabase/functions/account-delete-reconcile/index.ts
+++ b/supabase/functions/account-delete-reconcile/index.ts
@@ -90,7 +90,7 @@ const processDeletionJob = async (
     console.error('[account-delete-reconcile] Failed to claim deletion job:', claim.error);
     return { userId, status: 'claim_failed' };
   }
-  if (!claim.claimed) {
+  if (!claim.claimed || !claim.claimToken) {
     return { userId, status: claim.status ?? 'missing', skipped: true };
   }
   const authDeleteResult = await deleteUserWithRetry(supabase, userId);
@@ -98,6 +98,7 @@ const processDeletionJob = async (
     await recordDeletionFailure(
       supabase,
       userId,
+      claim.claimToken,
       'auth_delete_failed',
       {
         stage: 'auth_delete',
@@ -113,13 +114,14 @@ const processDeletionJob = async (
     await recordDeletionFailure(
       supabase,
       userId,
+      claim.claimToken,
       'cleanup_failed',
       { stage: 'cleanup', errors: cleanupErrors },
       '[account-delete-reconcile]'
     );
     return { userId, status: 'failed', stage: 'cleanup', errors: cleanupErrors };
   }
-  await markDeletionCompleted(supabase, userId, '[account-delete-reconcile]');
+  await markDeletionCompleted(supabase, userId, claim.claimToken, '[account-delete-reconcile]');
   return { userId, status: 'completed' };
 };
 Deno.serve(async (req) => {

--- a/supabase/functions/account-delete-reconcile/index.ts
+++ b/supabase/functions/account-delete-reconcile/index.ts
@@ -16,37 +16,8 @@ import {
   serializeError,
   type AccountDeletionClient,
 } from '../_shared/account-deletion-lifecycle.ts';
-import type { Database } from '../_shared/database.types.ts';
 const DEFAULT_BATCH_LIMIT = 20;
 const MAX_BATCH_LIMIT = 100;
-interface PostgrestFilterBuilder<T> {
-  eq(column: string, value: unknown): PostgrestFilterBuilder<T>;
-  order(column: string, options?: unknown): PostgrestFilterBuilder<T>;
-  or(filter: string): PostgrestFilterBuilder<T>;
-  limit(count: number): PostgrestFilterBuilder<T>;
-  then<TResult1 = { data: T[] | null; error: unknown }>(
-    onfulfilled?:
-      ((value: { data: T[] | null; error: unknown }) => TResult1 | PromiseLike<TResult1>) | null
-  ): PromiseLike<TResult1>;
-}
-interface PostgrestTransformBuilder {
-  eq(column: string, value: unknown): Promise<{ error: unknown }>;
-  or(filter: string): Promise<{ error: unknown }>;
-}
-interface TypedSupabaseClient {
-  from<T extends keyof Database['public']['Tables']>(
-    table: T
-  ): {
-    select(columns?: string): PostgrestFilterBuilder<Database['public']['Tables'][T]['Row']>;
-    update(values: unknown): PostgrestTransformBuilder;
-    delete(): PostgrestTransformBuilder;
-  };
-  auth: {
-    admin: {
-      deleteUser(id: string): Promise<{ error: unknown }>;
-    };
-  };
-}
 interface ReconcileRequest {
   action?: 'list' | 'process';
   userId?: string;
@@ -54,7 +25,10 @@ interface ReconcileRequest {
   includeDeadLettered?: boolean;
   dryRun?: boolean;
 }
-async function verifyAdminStatus(supabase: TypedSupabaseClient, userId: string): Promise<boolean> {
+async function verifyAdminStatus(
+  supabase: AccountDeletionClient,
+  userId: string
+): Promise<boolean> {
   const { data, error } = await supabase
     .from('user_system')
     .select('is_admin')
@@ -67,7 +41,7 @@ async function verifyAdminStatus(supabase: TypedSupabaseClient, userId: string):
   return data[0]?.is_admin === true;
 }
 const listJobs = async (
-  supabase: TypedSupabaseClient,
+  supabase: AccountDeletionClient,
   limit: number,
   includeDeadLettered: boolean
 ) => {
@@ -97,16 +71,11 @@ const listJobs = async (
   return { data: data ?? [], error: null } as const;
 };
 const processDeletionJob = async (
-  supabase: TypedSupabaseClient,
+  supabase: AccountDeletionClient,
   userId: string,
   dryRun: boolean
 ) => {
-  const lifecycleClient = supabase as unknown as AccountDeletionClient;
-  const { status } = await getDeletionJobState(
-    lifecycleClient,
-    userId,
-    '[account-delete-reconcile]'
-  );
+  const { status } = await getDeletionJobState(supabase, userId, '[account-delete-reconcile]');
   if (status === 'completed') {
     return { userId, status: 'completed', skipped: true };
   }
@@ -116,7 +85,7 @@ const processDeletionJob = async (
   if (dryRun) {
     return { userId, status: status ?? 'pending', dryRun: true };
   }
-  const claim = await claimDeletionJob(lifecycleClient, userId, false);
+  const claim = await claimDeletionJob(supabase, userId, false);
   if (claim.error) {
     console.error('[account-delete-reconcile] Failed to claim deletion job:', claim.error);
     return { userId, status: 'claim_failed' };
@@ -124,10 +93,10 @@ const processDeletionJob = async (
   if (!claim.claimed) {
     return { userId, status: claim.status ?? 'missing', skipped: true };
   }
-  const authDeleteResult = await deleteUserWithRetry(lifecycleClient, userId);
+  const authDeleteResult = await deleteUserWithRetry(supabase, userId);
   if (!authDeleteResult.ok) {
     await recordDeletionFailure(
-      lifecycleClient,
+      supabase,
       userId,
       'auth_delete_failed',
       {
@@ -139,10 +108,10 @@ const processDeletionJob = async (
     );
     return { userId, status: 'failed', stage: 'auth_delete' };
   }
-  const cleanupErrors = await cleanupUserData(lifecycleClient, userId);
+  const cleanupErrors = await cleanupUserData(supabase, userId);
   if (Object.keys(cleanupErrors).length > 0) {
     await recordDeletionFailure(
-      lifecycleClient,
+      supabase,
       userId,
       'cleanup_failed',
       { stage: 'cleanup', errors: cleanupErrors },
@@ -150,7 +119,7 @@ const processDeletionJob = async (
     );
     return { userId, status: 'failed', stage: 'cleanup', errors: cleanupErrors };
   }
-  await markDeletionCompleted(lifecycleClient, userId, '[account-delete-reconcile]');
+  await markDeletionCompleted(supabase, userId, '[account-delete-reconcile]');
   return { userId, status: 'completed' };
 };
 Deno.serve(async (req) => {
@@ -164,7 +133,7 @@ Deno.serve(async (req) => {
       return createErrorResponse(authResult.error, authResult.status, req);
     }
     const { user, supabase: sbClient } = authResult as AuthSuccess;
-    const supabase = sbClient as unknown as TypedSupabaseClient;
+    const supabase = sbClient as unknown as AccountDeletionClient;
     const isAdmin = await verifyAdminStatus(supabase, user.id);
     if (!isAdmin) {
       return createErrorResponse('Forbidden', 403, req);

--- a/supabase/functions/account-delete-reconcile/index.ts
+++ b/supabase/functions/account-delete-reconcile/index.ts
@@ -6,12 +6,17 @@ import {
   createSuccessResponse,
   type AuthSuccess,
 } from 'shared/auth';
+import {
+  claimDeletionJob,
+  cleanupUserData,
+  deleteUserWithRetry,
+  getDeletionJobState,
+  markDeletionCompleted,
+  recordDeletionFailure,
+  serializeError,
+  type AccountDeletionClient,
+} from '../_shared/account-deletion-lifecycle.ts';
 import type { Database } from '../_shared/database.types.ts';
-const AUTH_DELETE_MAX_ATTEMPTS = 4;
-const AUTH_DELETE_BASE_DELAY_MS = 300;
-const AUTH_DELETE_MAX_DELAY_MS = 5000;
-const CLEANUP_BASE_DELAY_MS = 5 * 60 * 1000;
-const CLEANUP_MAX_DELAY_MS = 60 * 60 * 1000;
 const DEFAULT_BATCH_LIMIT = 20;
 const MAX_BATCH_LIMIT = 100;
 interface PostgrestFilterBuilder<T> {
@@ -21,8 +26,7 @@ interface PostgrestFilterBuilder<T> {
   limit(count: number): PostgrestFilterBuilder<T>;
   then<TResult1 = { data: T[] | null; error: unknown }>(
     onfulfilled?:
-      | ((value: { data: T[] | null; error: unknown }) => TResult1 | PromiseLike<TResult1>)
-      | null
+      ((value: { data: T[] | null; error: unknown }) => TResult1 | PromiseLike<TResult1>) | null
   ): PromiseLike<TResult1>;
 }
 interface PostgrestTransformBuilder {
@@ -36,10 +40,6 @@ interface TypedSupabaseClient {
     select(columns?: string): PostgrestFilterBuilder<Database['public']['Tables'][T]['Row']>;
     update(values: unknown): PostgrestTransformBuilder;
     delete(): PostgrestTransformBuilder;
-    upsert(
-      values: Database['public']['Tables'][T]['Insert'],
-      options?: { onConflict?: string }
-    ): Promise<{ error: unknown }>;
   };
   auth: {
     admin: {
@@ -54,202 +54,7 @@ interface ReconcileRequest {
   includeDeadLettered?: boolean;
   dryRun?: boolean;
 }
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
-const getErrorMessage = (error: unknown) => {
-  if (typeof error === 'string') return error;
-  if (error instanceof Error) return error.message;
-  if (error && typeof error === 'object' && 'message' in error) {
-    return String((error as { message?: unknown }).message);
-  }
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
-};
-const serializeError = (error: unknown) => {
-  if (error instanceof Error) {
-    return { name: error.name, message: error.message, stack: error.stack };
-  }
-  if (error && typeof error === 'object') return error;
-  return { message: String(error) };
-};
-const isNotFoundError = (error: unknown) => {
-  if (error && typeof error === 'object' && 'status' in error) {
-    const status = (error as { status?: number }).status;
-    if (status === 404) return true;
-  }
-  const message = getErrorMessage(error).toLowerCase();
-  return (
-    message.includes('user not found') ||
-    message.includes('no user') ||
-    (message.includes('not found') && message.includes('user'))
-  );
-};
-const computeBackoffMs = (attempt: number, baseMs: number, maxMs: number) => {
-  const jitter = Math.floor(Math.random() * 250);
-  const delay = baseMs * Math.pow(2, Math.max(0, attempt - 1)) + jitter;
-  return Math.min(delay, maxMs);
-};
-const deleteUserWithRetry = async (
-  supabase: TypedSupabaseClient,
-  userId: string
-): Promise<{ ok: boolean; attempts: number; lastError: unknown | null }> => {
-  let lastError: unknown | null = null;
-  for (let attempt = 1; attempt <= AUTH_DELETE_MAX_ATTEMPTS; attempt += 1) {
-    const { error } = await supabase.auth.admin.deleteUser(userId);
-    if (!error || isNotFoundError(error)) {
-      return { ok: true, attempts: attempt, lastError: null };
-    }
-    lastError = error;
-    if (attempt < AUTH_DELETE_MAX_ATTEMPTS) {
-      const delay = computeBackoffMs(
-        attempt,
-        AUTH_DELETE_BASE_DELAY_MS,
-        AUTH_DELETE_MAX_DELAY_MS
-      );
-      await sleep(delay);
-    }
-  }
-  return { ok: false, attempts: AUTH_DELETE_MAX_ATTEMPTS, lastError };
-};
-const cleanupUserData = async (supabase: TypedSupabaseClient, userId: string) => {
-  const cleanupErrors: Record<string, string> = {};
-  const deletionPromises = [
-    {
-      tableKey: 'team_memberships',
-      promise: supabase.from('team_memberships').delete().eq('user_id', userId),
-    },
-    {
-      tableKey: 'api_tokens',
-      promise: supabase.from('api_tokens').delete().eq('user_id', userId),
-    },
-    {
-      tableKey: 'user_progress',
-      promise: supabase.from('user_progress').delete().eq('user_id', userId),
-    },
-    {
-      tableKey: 'user_preferences',
-      promise: supabase.from('user_preferences').delete().eq('user_id', userId),
-    },
-    {
-      tableKey: 'user_system',
-      promise: supabase.from('user_system').delete().eq('user_id', userId),
-    },
-    {
-      tableKey: 'team_events',
-      promise: supabase
-        .from('team_events')
-        .delete()
-        .or(`initiated_by.eq.${userId},target_user.eq.${userId}`),
-    },
-  ].map(({ tableKey, promise }) =>
-    promise
-      .then(({ error }) => ({ tableKey, error }))
-      .catch((error) => {
-        const tableError = new Error(`Failed to delete ${tableKey} rows`);
-        Object.assign(tableError, { cause: error, tableKey });
-        throw tableError;
-      })
-  );
-  const results = await Promise.allSettled(deletionPromises);
-  for (const result of results) {
-    if (result.status === 'fulfilled') {
-      if (result.value.error) {
-        cleanupErrors[result.value.tableKey] = getErrorMessage(result.value.error);
-      }
-      continue;
-    }
-    const reason = result.reason as { cause?: unknown; tableKey?: string };
-    const tableKey = typeof reason?.tableKey === 'string' ? reason.tableKey : 'unknown';
-    const error =
-      reason && typeof reason === 'object' && 'cause' in reason ? reason.cause : reason;
-    cleanupErrors[tableKey] = getErrorMessage(error);
-  }
-  return cleanupErrors;
-};
-const getDeletionJobState = async (supabase: TypedSupabaseClient, userId: string) => {
-  const { data, error } = await supabase
-    .from('account_deletion_jobs')
-    .select('attempts,max_attempts,status')
-    .eq('user_id', userId)
-    .limit(1);
-  if (error) {
-    console.error('[account-delete-reconcile] Failed to fetch deletion job state:', error);
-  }
-  const job = data?.[0];
-  return {
-    attempts: job?.attempts ?? 0,
-    maxAttempts: job?.max_attempts ?? 5,
-    status: job?.status ?? null,
-  };
-};
-const recordDeletionFailure = async (
-  supabase: TypedSupabaseClient,
-  userId: string,
-  reason: string,
-  details: Record<string, unknown>
-) => {
-  const now = new Date().toISOString();
-  const { attempts, maxAttempts } = await getDeletionJobState(supabase, userId);
-  const nextAttempts = attempts + 1;
-  const deadLetter = nextAttempts >= maxAttempts;
-  const nextRunAt = deadLetter
-    ? null
-    : new Date(
-        Date.now() + computeBackoffMs(nextAttempts, CLEANUP_BASE_DELAY_MS, CLEANUP_MAX_DELAY_MS)
-      ).toISOString();
-  const { error } = await supabase
-    .from('account_deletion_jobs')
-    .update({
-      status: deadLetter ? 'dead_lettered' : 'failed',
-      attempts: nextAttempts,
-      last_error: reason,
-      last_error_details: details,
-      last_error_at: now,
-      next_run_at: nextRunAt,
-      updated_at: now,
-      completed_at: null,
-      dead_lettered_at: deadLetter ? now : null,
-    })
-    .eq('user_id', userId);
-  if (error) {
-    console.error('[account-delete-reconcile] Failed to update deletion job:', error);
-  }
-  if (deadLetter) {
-    console.error('[account-delete-reconcile] Deletion job dead-lettered:', {
-      userId,
-      reason,
-      details,
-    });
-  }
-};
-const markDeletionCompleted = async (supabase: TypedSupabaseClient, userId: string) => {
-  const now = new Date().toISOString();
-  const { error } = await supabase
-    .from('account_deletion_jobs')
-    .update({
-      status: 'completed',
-      updated_at: now,
-      completed_at: now,
-      last_error: null,
-      last_error_details: null,
-      last_error_at: null,
-      next_run_at: null,
-      dead_lettered_at: null,
-    })
-    .eq('user_id', userId);
-  if (error) {
-    console.error('[account-delete-reconcile] Failed to mark deletion job completed:', error);
-  }
-};
-async function verifyAdminStatus(
-  supabase: TypedSupabaseClient,
-  userId: string
-): Promise<boolean> {
+async function verifyAdminStatus(supabase: TypedSupabaseClient, userId: string): Promise<boolean> {
   const { data, error } = await supabase
     .from('user_system')
     .select('is_admin')
@@ -296,8 +101,12 @@ const processDeletionJob = async (
   userId: string,
   dryRun: boolean
 ) => {
-  const now = new Date().toISOString();
-  const { status } = await getDeletionJobState(supabase, userId);
+  const lifecycleClient = supabase as unknown as AccountDeletionClient;
+  const { status } = await getDeletionJobState(
+    lifecycleClient,
+    userId,
+    '[account-delete-reconcile]'
+  );
   if (status === 'completed') {
     return { userId, status: 'completed', skipped: true };
   }
@@ -307,41 +116,41 @@ const processDeletionJob = async (
   if (dryRun) {
     return { userId, status: status ?? 'pending', dryRun: true };
   }
-  const { error: jobUpsertError } = await supabase
-    .from('account_deletion_jobs')
-    .upsert(
-      {
-        user_id: userId,
-        status: 'in_progress',
-        updated_at: now,
-        next_run_at: null,
-        last_error: null,
-        last_error_details: null,
-        last_error_at: null,
-      },
-      { onConflict: 'user_id' }
-    );
-  if (jobUpsertError) {
-    console.error('[account-delete-reconcile] Failed to upsert deletion job:', jobUpsertError);
+  const claim = await claimDeletionJob(lifecycleClient, userId, false);
+  if (claim.error) {
+    console.error('[account-delete-reconcile] Failed to claim deletion job:', claim.error);
+    return { userId, status: 'claim_failed' };
   }
-  const authDeleteResult = await deleteUserWithRetry(supabase, userId);
+  if (!claim.claimed) {
+    return { userId, status: claim.status ?? 'missing', skipped: true };
+  }
+  const authDeleteResult = await deleteUserWithRetry(lifecycleClient, userId);
   if (!authDeleteResult.ok) {
-    await recordDeletionFailure(supabase, userId, 'auth_delete_failed', {
-      stage: 'auth_delete',
-      attempts: authDeleteResult.attempts,
-      error: serializeError(authDeleteResult.lastError),
-    });
+    await recordDeletionFailure(
+      lifecycleClient,
+      userId,
+      'auth_delete_failed',
+      {
+        stage: 'auth_delete',
+        attempts: authDeleteResult.attempts,
+        error: serializeError(authDeleteResult.lastError),
+      },
+      '[account-delete-reconcile]'
+    );
     return { userId, status: 'failed', stage: 'auth_delete' };
   }
-  const cleanupErrors = await cleanupUserData(supabase, userId);
+  const cleanupErrors = await cleanupUserData(lifecycleClient, userId);
   if (Object.keys(cleanupErrors).length > 0) {
-    await recordDeletionFailure(supabase, userId, 'cleanup_failed', {
-      stage: 'cleanup',
-      errors: cleanupErrors,
-    });
+    await recordDeletionFailure(
+      lifecycleClient,
+      userId,
+      'cleanup_failed',
+      { stage: 'cleanup', errors: cleanupErrors },
+      '[account-delete-reconcile]'
+    );
     return { userId, status: 'failed', stage: 'cleanup', errors: cleanupErrors };
   }
-  await markDeletionCompleted(supabase, userId);
+  await markDeletionCompleted(lifecycleClient, userId, '[account-delete-reconcile]');
   return { userId, status: 'completed' };
 };
 Deno.serve(async (req) => {
@@ -367,10 +176,7 @@ Deno.serve(async (req) => {
       body = {};
     }
     const action = body.action ?? (body.userId ? 'process' : 'list');
-    const limit = Math.min(
-      Math.max(body.limit ?? DEFAULT_BATCH_LIMIT, 1),
-      MAX_BATCH_LIMIT
-    );
+    const limit = Math.min(Math.max(body.limit ?? DEFAULT_BATCH_LIMIT, 1), MAX_BATCH_LIMIT);
     if (action === 'list') {
       const { data, error } = await listJobs(supabase, limit, Boolean(body.includeDeadLettered));
       if (error) {

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -5,14 +5,18 @@ import {
   createErrorResponse,
   createSuccessResponse,
 } from 'shared/auth';
+import {
+  claimDeletionJob,
+  cleanupUserData,
+  consumeDeletionAttempt,
+  deleteUserWithRetry,
+  getErrorMessage,
+  markDeletionCompleted,
+  recordDeletionFailure,
+  serializeError,
+  type AccountDeletionClient,
+} from '../_shared/account-deletion-lifecycle.ts';
 import type { Database } from '../_shared/database.types.ts';
-const AUTH_DELETE_MAX_ATTEMPTS = 4;
-const AUTH_DELETE_BASE_DELAY_MS = 300;
-const CLEANUP_MAX_ATTEMPTS = 5;
-const CLEANUP_BASE_DELAY_MS = 5 * 60 * 1000;
-const CLEANUP_MAX_DELAY_MS = 60 * 60 * 1000;
-const RATE_LIMIT_WINDOW_MS = 60 * 1000; // 1 minute
-const RATE_LIMIT_MAX_ATTEMPTS = 3; // Max 3 deletion requests per minute
 // Interfaces to mock Supabase client typing locally
 interface PostgrestFilterBuilder<T> {
   eq(column: string, value: unknown): PostgrestFilterBuilder<T>;
@@ -21,15 +25,12 @@ interface PostgrestFilterBuilder<T> {
   order(column: string, options?: unknown): PostgrestFilterBuilder<T>;
   then<TResult1 = { data: T[] | null; error: unknown }>(
     onfulfilled?:
-      | ((value: { data: T[] | null; error: unknown }) => TResult1 | PromiseLike<TResult1>)
-      | null
+      ((value: { data: T[] | null; error: unknown }) => TResult1 | PromiseLike<TResult1>) | null
   ): PromiseLike<TResult1>;
 }
 interface PostgrestTransformBuilder {
   eq(column: string, value: unknown): Promise<{ error: unknown }>;
   or(filter: string): Promise<{ error: unknown }>;
-  gte(column: string, value: unknown): this;
-  order(column: string, options?: { ascending?: boolean }): this;
 }
 interface TypedSupabaseClient {
   from<T extends keyof Database['public']['Tables']>(
@@ -38,11 +39,6 @@ interface TypedSupabaseClient {
     select(columns?: string): PostgrestFilterBuilder<Database['public']['Tables'][T]['Row']>;
     update(values: unknown): PostgrestTransformBuilder;
     delete(): PostgrestTransformBuilder;
-    insert(values: Database['public']['Tables'][T]['Insert']): Promise<{ error: unknown }>;
-    upsert(
-      values: Database['public']['Tables'][T]['Insert'],
-      options?: { onConflict?: string }
-    ): Promise<{ error: unknown }>;
   };
   auth: {
     admin: {
@@ -51,177 +47,6 @@ interface TypedSupabaseClient {
   };
   rpc(fn: string, args?: Record<string, unknown>): Promise<{ data: unknown; error: unknown }>;
 }
-const sleep = (ms: number) =>
-  new Promise<void>((resolve) => {
-    setTimeout(resolve, ms);
-  });
-const getErrorMessage = (error: unknown) => {
-  if (typeof error === 'string') return error;
-  if (error instanceof Error) return error.message;
-  if (error && typeof error === 'object' && 'message' in error) {
-    return String((error as { message?: unknown }).message);
-  }
-  try {
-    return JSON.stringify(error);
-  } catch {
-    return String(error);
-  }
-};
-const serializeError = (error: unknown) => {
-  if (error instanceof Error) {
-    return { name: error.name, message: error.message, stack: error.stack };
-  }
-  if (error && typeof error === 'object') return error;
-  return { message: String(error) };
-};
-const isNotFoundError = (error: unknown) => {
-  // Check for HTTP 404 status
-  if (error && typeof error === 'object') {
-    if ('status' in error) {
-      const status = (error as { status?: number }).status;
-      if (status === 404) return true;
-    }
-    // Check for specific error codes from Supabase Auth
-    if ('code' in error) {
-      const code = (error as { code?: string }).code;
-      if (code === 'user_not_found' || code === '404') return true;
-    }
-  }
-  // Fallback to message matching with specific patterns
-  const message = getErrorMessage(error).toLowerCase();
-  return (
-    (message === 'user not found') ||
-    (message.includes('user with id') && message.includes('not found')) ||
-    (message.startsWith('no user found'))
-  );
-};
-const computeBackoffMs = (attempt: number, baseMs: number, maxMs: number) => {
-  const jitter = Math.floor(Math.random() * 250);
-  const delay = baseMs * Math.pow(2, Math.max(0, attempt - 1)) + jitter;
-  return Math.min(delay, maxMs);
-};
-const deleteUserWithRetry = async (
-  supabase: TypedSupabaseClient,
-  userId: string
-): Promise<{ ok: boolean; attempts: number; lastError: unknown | null }> => {
-  let lastError: unknown | null = null;
-  for (let attempt = 1; attempt <= AUTH_DELETE_MAX_ATTEMPTS; attempt += 1) {
-    const { error } = await supabase.auth.admin.deleteUser(userId);
-    if (!error || isNotFoundError(error)) {
-      return { ok: true, attempts: attempt, lastError: null };
-    }
-    lastError = error;
-    const delay = computeBackoffMs(attempt, AUTH_DELETE_BASE_DELAY_MS, 5000);
-    await sleep(delay);
-  }
-  return { ok: false, attempts: AUTH_DELETE_MAX_ATTEMPTS, lastError };
-};
-const cleanupUserData = async (supabase: TypedSupabaseClient, userId: string) => {
-  const cleanupErrors: Record<string, string> = {};
-  const { error: membershipDeleteError } = await supabase
-    .from('team_memberships')
-    .delete()
-    .eq('user_id', userId);
-  if (membershipDeleteError) {
-    cleanupErrors.team_memberships = getErrorMessage(membershipDeleteError);
-  }
-  const { error: apiTokensError } = await supabase
-    .from('api_tokens')
-    .delete()
-    .eq('user_id', userId);
-  if (apiTokensError) cleanupErrors.api_tokens = getErrorMessage(apiTokensError);
-  const { error: progressError } = await supabase
-    .from('user_progress')
-    .delete()
-    .eq('user_id', userId);
-  if (progressError) cleanupErrors.user_progress = getErrorMessage(progressError);
-  const { error: preferencesError } = await supabase
-    .from('user_preferences')
-    .delete()
-    .eq('user_id', userId);
-  if (preferencesError) cleanupErrors.user_preferences = getErrorMessage(preferencesError);
-  const { error: userSystemError } = await supabase
-    .from('user_system')
-    .delete()
-    .eq('user_id', userId);
-  if (userSystemError) cleanupErrors.user_system = getErrorMessage(userSystemError);
-  const { error: teamEventsError } = await supabase
-    .from('team_events')
-    .delete()
-    .or(`initiated_by.eq.${userId},target_user.eq.${userId}`);
-  if (teamEventsError) cleanupErrors.team_events = getErrorMessage(teamEventsError);
-  return cleanupErrors;
-};
-const getDeletionJobState = async (supabase: TypedSupabaseClient, userId: string) => {
-  const { data, error } = await supabase
-    .from('account_deletion_jobs')
-    .select('attempts,max_attempts,status')
-    .eq('user_id', userId);
-  if (error) {
-    console.error('[account-delete] Failed to fetch deletion job state:', error);
-  }
-  const job = data?.[0];
-  return {
-    attempts: job?.attempts ?? 0,
-    maxAttempts: job?.max_attempts ?? CLEANUP_MAX_ATTEMPTS,
-    status: job?.status ?? null,
-  };
-};
-const recordDeletionFailure = async (
-  supabase: TypedSupabaseClient,
-  userId: string,
-  reason: string,
-  details: Record<string, unknown>
-) => {
-  const now = new Date().toISOString();
-  const { attempts, maxAttempts } = await getDeletionJobState(supabase, userId);
-  const nextAttempts = attempts + 1;
-  const deadLetter = nextAttempts >= maxAttempts;
-  const nextRunAt = deadLetter
-    ? null
-    : new Date(
-        Date.now() + computeBackoffMs(nextAttempts, CLEANUP_BASE_DELAY_MS, CLEANUP_MAX_DELAY_MS)
-      ).toISOString();
-  const { error } = await supabase
-    .from('account_deletion_jobs')
-    .update({
-      status: deadLetter ? 'dead_lettered' : 'failed',
-      attempts: nextAttempts,
-      last_error: reason,
-      last_error_details: details,
-      last_error_at: now,
-      next_run_at: nextRunAt,
-      updated_at: now,
-      completed_at: null,
-      dead_lettered_at: deadLetter ? now : null,
-    })
-    .eq('user_id', userId);
-  if (error) {
-    console.error('[account-delete] Failed to update deletion job:', error);
-  }
-  if (deadLetter) {
-    console.error('[account-delete] Deletion job dead-lettered:', { userId, reason, details });
-  }
-};
-const markDeletionCompleted = async (supabase: TypedSupabaseClient, userId: string) => {
-  const now = new Date().toISOString();
-  const { error } = await supabase
-    .from('account_deletion_jobs')
-    .update({
-      status: 'completed',
-      updated_at: now,
-      completed_at: now,
-      last_error: null,
-      last_error_details: null,
-      last_error_at: null,
-      next_run_at: null,
-      dead_lettered_at: null,
-    })
-    .eq('user_id', userId);
-  if (error) {
-    console.error('[account-delete] Failed to mark deletion job completed:', error);
-  }
-};
 Deno.serve(async (req) => {
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;
@@ -234,66 +59,49 @@ Deno.serve(async (req) => {
     }
     const { user, supabase: sbClient } = authResult;
     const supabase = sbClient as unknown as TypedSupabaseClient;
-    const now = new Date().toISOString();
-    // Rate limiting: Check for recent deletion attempts
-    const rateLimitTimestamp = new Date(Date.now() - RATE_LIMIT_WINDOW_MS).toISOString();
-    const { data: recentAttempts, error: rateLimitError } = await supabase
-      .from('account_deletion_attempts')
-      .select('attempted_at')
-      .eq('user_id', user.id)
-      .gte('attempted_at', rateLimitTimestamp)
-      .order('attempted_at', { ascending: false });
-    if (!rateLimitError && recentAttempts && recentAttempts.length >= RATE_LIMIT_MAX_ATTEMPTS) {
-      const oldestAttempt = recentAttempts[recentAttempts.length - 1];
-      const attemptedAt = oldestAttempt.attempted_at;
-      const timeRemaining = attemptedAt
-        ? Math.ceil((new Date(attemptedAt).getTime() + RATE_LIMIT_WINDOW_MS - Date.now()) / 1000)
-        : 60;
+    const lifecycleClient = supabase as unknown as AccountDeletionClient;
+    const ipAddress = req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || null;
+    const userAgent = req.headers.get('user-agent') || null;
+    const attempt = await consumeDeletionAttempt(lifecycleClient, user.id, ipAddress, userAgent);
+    if (attempt.error) {
+      console.error('[account-delete] Failed to enforce deletion rate limit:', attempt.error);
+      return createErrorResponse(
+        'Failed to initialize account deletion. Please try again.',
+        500,
+        req
+      );
+    }
+    if (!attempt.allowed) {
       console.warn('[account-delete] Rate limit exceeded for user:', user.id);
       return createErrorResponse(
-        `Too many deletion requests. Please wait ${timeRemaining} seconds before trying again.`,
+        `Too many deletion requests. Please wait ${attempt.retryAfterSeconds} seconds before trying again.`,
         429,
         req
       );
     }
-    // Record this deletion attempt for rate limiting
-    const ipAddress = req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || null;
-    const userAgent = req.headers.get('user-agent') || null;
-    const { error: attemptInsertError } = await supabase
-      .from('account_deletion_attempts')
-      .insert({
-        user_id: user.id,
-        attempted_at: now,
-        ip_address: ipAddress,
-        user_agent: userAgent,
-      });
-    if (attemptInsertError) {
-      console.error('[account-delete] Failed to record deletion attempt:', attemptInsertError);
-      // Continue anyway - rate limiting failure shouldn't block deletion
-    }
-    // Initialize job tracking - this MUST succeed before proceeding
-    const { error: jobUpsertError } = await supabase.from('account_deletion_jobs').upsert(
-      {
-        user_id: user.id,
-        status: 'in_progress',
-        last_error: null,
-        last_error_details: null,
-        last_error_at: null,
-        next_run_at: null,
-        updated_at: now,
-        completed_at: null,
-        dead_lettered_at: null,
-      },
-      { onConflict: 'user_id' }
-    );
-    if (jobUpsertError) {
+    const claim = await claimDeletionJob(lifecycleClient, user.id, true);
+    if (claim.error) {
       console.error('[account-delete] FATAL: Failed to initialize deletion job tracking:', {
-        error: serializeError(jobUpsertError),
+        error: serializeError(claim.error),
         userId: user.id,
       });
       return createErrorResponse(
         'Failed to initialize account deletion. Please try again later.',
         500,
+        req
+      );
+    }
+    if (!claim.claimed) {
+      return createSuccessResponse(
+        {
+          success: claim.status === 'completed',
+          cleanupScheduled: claim.status !== 'completed',
+          message:
+            claim.status === 'completed'
+              ? 'Account deletion is already complete.'
+              : 'Account deletion is already in progress.',
+        },
+        202,
         req
       );
     }
@@ -303,10 +111,13 @@ Deno.serve(async (req) => {
       .eq('owner_id', user.id);
     if (teamQueryError) {
       console.error('[account-delete] Failed to fetch owned teams:', teamQueryError);
-      await recordDeletionFailure(supabase, user.id, 'team_query_failed', {
-        stage: 'team_transfer',
-        error: serializeError(teamQueryError),
-      });
+      await recordDeletionFailure(
+        lifecycleClient,
+        user.id,
+        'team_query_failed',
+        { stage: 'team_transfer', error: serializeError(teamQueryError) },
+        '[account-delete]'
+      );
       return createErrorResponse('Failed to fetch owned teams', 500, req);
     }
     // Process all owned teams and collect errors before proceeding
@@ -359,27 +170,36 @@ Deno.serve(async (req) => {
       }
     }
     if (teamErrors.length > 0) {
-      await recordDeletionFailure(supabase, user.id, 'team_transfer_failed', {
-        stage: 'team_transfer',
-        errors: teamErrors,
-      });
+      await recordDeletionFailure(
+        lifecycleClient,
+        user.id,
+        'team_transfer_failed',
+        { stage: 'team_transfer', errors: teamErrors },
+        '[account-delete]'
+      );
       return createErrorResponse(
         'Failed to process team ownership transfers. Please try again.',
         500,
         req
       );
     }
-    const authDeleteResult = await deleteUserWithRetry(supabase, user.id);
+    const authDeleteResult = await deleteUserWithRetry(lifecycleClient, user.id);
     if (!authDeleteResult.ok) {
       console.error('[account-delete] Failed to delete auth user:', authDeleteResult.lastError);
-      await recordDeletionFailure(supabase, user.id, 'auth_delete_failed', {
-        stage: 'auth_delete',
-        attempts: authDeleteResult.attempts,
-        error: serializeError(authDeleteResult.lastError),
-      });
+      await recordDeletionFailure(
+        lifecycleClient,
+        user.id,
+        'auth_delete_failed',
+        {
+          stage: 'auth_delete',
+          attempts: authDeleteResult.attempts,
+          error: serializeError(authDeleteResult.lastError),
+        },
+        '[account-delete]'
+      );
       return createErrorResponse('Failed to delete account', 500, req);
     }
-    const cleanupErrors = await cleanupUserData(supabase, user.id);
+    const cleanupErrors = await cleanupUserData(lifecycleClient, user.id);
     if (Object.keys(cleanupErrors).length > 0) {
       // Sanitize errors - log table names but not error details from sensitive tables
       const SENSITIVE_TABLES = ['api_tokens'];
@@ -390,10 +210,13 @@ Deno.serve(async (req) => {
         ])
       );
       console.error('[account-delete] Cleanup errors after auth delete:', sanitizedErrors);
-      await recordDeletionFailure(supabase, user.id, 'cleanup_failed', {
-        stage: 'cleanup',
-        errors: cleanupErrors,
-      });
+      await recordDeletionFailure(
+        lifecycleClient,
+        user.id,
+        'cleanup_failed',
+        { stage: 'cleanup', errors: cleanupErrors },
+        '[account-delete]'
+      );
       // Return 202 Accepted to indicate auth deletion succeeded but cleanup is async
       return createSuccessResponse(
         {
@@ -405,7 +228,7 @@ Deno.serve(async (req) => {
         req
       );
     }
-    await markDeletionCompleted(supabase, user.id);
+    await markDeletionCompleted(lifecycleClient, user.id, '[account-delete]');
     return createSuccessResponse({ success: true }, 200, req);
   } catch (error) {
     console.error('[account-delete] Unexpected error:', error);

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -16,37 +16,6 @@ import {
   serializeError,
   type AccountDeletionClient,
 } from '../_shared/account-deletion-lifecycle.ts';
-import type { Database } from '../_shared/database.types.ts';
-// Interfaces to mock Supabase client typing locally
-interface PostgrestFilterBuilder<T> {
-  eq(column: string, value: unknown): PostgrestFilterBuilder<T>;
-  neq(column: string, value: unknown): PostgrestFilterBuilder<T>;
-  gte(column: string, value: unknown): PostgrestFilterBuilder<T>;
-  order(column: string, options?: unknown): PostgrestFilterBuilder<T>;
-  then<TResult1 = { data: T[] | null; error: unknown }>(
-    onfulfilled?:
-      ((value: { data: T[] | null; error: unknown }) => TResult1 | PromiseLike<TResult1>) | null
-  ): PromiseLike<TResult1>;
-}
-interface PostgrestTransformBuilder {
-  eq(column: string, value: unknown): Promise<{ error: unknown }>;
-  or(filter: string): Promise<{ error: unknown }>;
-}
-interface TypedSupabaseClient {
-  from<T extends keyof Database['public']['Tables']>(
-    table: T
-  ): {
-    select(columns?: string): PostgrestFilterBuilder<Database['public']['Tables'][T]['Row']>;
-    update(values: unknown): PostgrestTransformBuilder;
-    delete(): PostgrestTransformBuilder;
-  };
-  auth: {
-    admin: {
-      deleteUser(id: string): Promise<{ error: unknown }>;
-    };
-  };
-  rpc(fn: string, args?: Record<string, unknown>): Promise<{ data: unknown; error: unknown }>;
-}
 Deno.serve(async (req) => {
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;
@@ -58,11 +27,10 @@ Deno.serve(async (req) => {
       return createErrorResponse(authResult.error, authResult.status, req);
     }
     const { user, supabase: sbClient } = authResult;
-    const supabase = sbClient as unknown as TypedSupabaseClient;
-    const lifecycleClient = supabase as unknown as AccountDeletionClient;
+    const supabase = sbClient as unknown as AccountDeletionClient;
     const ipAddress = req.headers.get('x-forwarded-for') || req.headers.get('x-real-ip') || null;
     const userAgent = req.headers.get('user-agent') || null;
-    const attempt = await consumeDeletionAttempt(lifecycleClient, user.id, ipAddress, userAgent);
+    const attempt = await consumeDeletionAttempt(supabase, user.id, ipAddress, userAgent);
     if (attempt.error) {
       console.error('[account-delete] Failed to enforce deletion rate limit:', attempt.error);
       return createErrorResponse(
@@ -79,7 +47,7 @@ Deno.serve(async (req) => {
         req
       );
     }
-    const claim = await claimDeletionJob(lifecycleClient, user.id, true);
+    const claim = await claimDeletionJob(supabase, user.id, true);
     if (claim.error) {
       console.error('[account-delete] FATAL: Failed to initialize deletion job tracking:', {
         error: serializeError(claim.error),
@@ -112,7 +80,7 @@ Deno.serve(async (req) => {
     if (teamQueryError) {
       console.error('[account-delete] Failed to fetch owned teams:', teamQueryError);
       await recordDeletionFailure(
-        lifecycleClient,
+        supabase,
         user.id,
         'team_query_failed',
         { stage: 'team_transfer', error: serializeError(teamQueryError) },
@@ -171,7 +139,7 @@ Deno.serve(async (req) => {
     }
     if (teamErrors.length > 0) {
       await recordDeletionFailure(
-        lifecycleClient,
+        supabase,
         user.id,
         'team_transfer_failed',
         { stage: 'team_transfer', errors: teamErrors },
@@ -183,11 +151,11 @@ Deno.serve(async (req) => {
         req
       );
     }
-    const authDeleteResult = await deleteUserWithRetry(lifecycleClient, user.id);
+    const authDeleteResult = await deleteUserWithRetry(supabase, user.id);
     if (!authDeleteResult.ok) {
       console.error('[account-delete] Failed to delete auth user:', authDeleteResult.lastError);
       await recordDeletionFailure(
-        lifecycleClient,
+        supabase,
         user.id,
         'auth_delete_failed',
         {
@@ -199,7 +167,7 @@ Deno.serve(async (req) => {
       );
       return createErrorResponse('Failed to delete account', 500, req);
     }
-    const cleanupErrors = await cleanupUserData(lifecycleClient, user.id);
+    const cleanupErrors = await cleanupUserData(supabase, user.id);
     if (Object.keys(cleanupErrors).length > 0) {
       // Sanitize errors - log table names but not error details from sensitive tables
       const SENSITIVE_TABLES = ['api_tokens'];
@@ -211,7 +179,7 @@ Deno.serve(async (req) => {
       );
       console.error('[account-delete] Cleanup errors after auth delete:', sanitizedErrors);
       await recordDeletionFailure(
-        lifecycleClient,
+        supabase,
         user.id,
         'cleanup_failed',
         { stage: 'cleanup', errors: cleanupErrors },
@@ -228,7 +196,7 @@ Deno.serve(async (req) => {
         req
       );
     }
-    await markDeletionCompleted(lifecycleClient, user.id, '[account-delete]');
+    await markDeletionCompleted(supabase, user.id, '[account-delete]');
     return createSuccessResponse({ success: true }, 200, req);
   } catch (error) {
     console.error('[account-delete] Unexpected error:', error);

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -15,6 +15,7 @@ import {
   recordDeletionFailure,
   serializeError,
   type AccountDeletionClient,
+  type DeletionTransitionResult,
 } from '../_shared/account-deletion-lifecycle.ts';
 const createLeaseLostResponse = (req: Request) =>
   createSuccessResponse(
@@ -27,10 +28,15 @@ const createLeaseLostResponse = (req: Request) =>
     req
   );
 const createTransitionResponse = async (
-  transition: Promise<boolean>,
+  transition: Promise<DeletionTransitionResult>,
   response: Response,
   req: Request
-) => ((await transition) ? response : createLeaseLostResponse(req));
+) => {
+  const result = await transition;
+  if (result === 'persisted') return response;
+  if (result === 'lease_lost') return createLeaseLostResponse(req);
+  return createErrorResponse('Failed to update account deletion status.', 500, req);
+};
 Deno.serve(async (req) => {
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -59,7 +59,7 @@ Deno.serve(async (req) => {
         req
       );
     }
-    if (!claim.claimed) {
+    if (!claim.claimed || !claim.claimToken) {
       return createSuccessResponse(
         {
           success: claim.status === 'completed',
@@ -82,6 +82,7 @@ Deno.serve(async (req) => {
       await recordDeletionFailure(
         supabase,
         user.id,
+        claim.claimToken,
         'team_query_failed',
         { stage: 'team_transfer', error: serializeError(teamQueryError) },
         '[account-delete]'
@@ -141,6 +142,7 @@ Deno.serve(async (req) => {
       await recordDeletionFailure(
         supabase,
         user.id,
+        claim.claimToken,
         'team_transfer_failed',
         { stage: 'team_transfer', errors: teamErrors },
         '[account-delete]'
@@ -157,6 +159,7 @@ Deno.serve(async (req) => {
       await recordDeletionFailure(
         supabase,
         user.id,
+        claim.claimToken,
         'auth_delete_failed',
         {
           stage: 'auth_delete',
@@ -181,6 +184,7 @@ Deno.serve(async (req) => {
       await recordDeletionFailure(
         supabase,
         user.id,
+        claim.claimToken,
         'cleanup_failed',
         { stage: 'cleanup', errors: cleanupErrors },
         '[account-delete]'
@@ -196,7 +200,7 @@ Deno.serve(async (req) => {
         req
       );
     }
-    await markDeletionCompleted(supabase, user.id, '[account-delete]');
+    await markDeletionCompleted(supabase, user.id, claim.claimToken, '[account-delete]');
     return createSuccessResponse({ success: true }, 200, req);
   } catch (error) {
     console.error('[account-delete] Unexpected error:', error);

--- a/supabase/functions/account-delete/index.ts
+++ b/supabase/functions/account-delete/index.ts
@@ -16,6 +16,21 @@ import {
   serializeError,
   type AccountDeletionClient,
 } from '../_shared/account-deletion-lifecycle.ts';
+const createLeaseLostResponse = (req: Request) =>
+  createSuccessResponse(
+    {
+      success: false,
+      cleanupScheduled: true,
+      message: 'Account deletion is already in progress.',
+    },
+    202,
+    req
+  );
+const createTransitionResponse = async (
+  transition: Promise<boolean>,
+  response: Response,
+  req: Request
+) => ((await transition) ? response : createLeaseLostResponse(req));
 Deno.serve(async (req) => {
   const corsResponse = handleCorsPreflight(req);
   if (corsResponse) return corsResponse;
@@ -79,7 +94,7 @@ Deno.serve(async (req) => {
       .eq('owner_id', user.id);
     if (teamQueryError) {
       console.error('[account-delete] Failed to fetch owned teams:', teamQueryError);
-      await recordDeletionFailure(
+      const transition = recordDeletionFailure(
         supabase,
         user.id,
         claim.claimToken,
@@ -87,7 +102,11 @@ Deno.serve(async (req) => {
         { stage: 'team_transfer', error: serializeError(teamQueryError) },
         '[account-delete]'
       );
-      return createErrorResponse('Failed to fetch owned teams', 500, req);
+      return createTransitionResponse(
+        transition,
+        createErrorResponse('Failed to fetch owned teams', 500, req),
+        req
+      );
     }
     // Process all owned teams and collect errors before proceeding
     const teamErrors: Array<{ teamId: string; error: string }> = [];
@@ -139,7 +158,7 @@ Deno.serve(async (req) => {
       }
     }
     if (teamErrors.length > 0) {
-      await recordDeletionFailure(
+      const transition = recordDeletionFailure(
         supabase,
         user.id,
         claim.claimToken,
@@ -147,16 +166,20 @@ Deno.serve(async (req) => {
         { stage: 'team_transfer', errors: teamErrors },
         '[account-delete]'
       );
-      return createErrorResponse(
-        'Failed to process team ownership transfers. Please try again.',
-        500,
+      return createTransitionResponse(
+        transition,
+        createErrorResponse(
+          'Failed to process team ownership transfers. Please try again.',
+          500,
+          req
+        ),
         req
       );
     }
     const authDeleteResult = await deleteUserWithRetry(supabase, user.id);
     if (!authDeleteResult.ok) {
       console.error('[account-delete] Failed to delete auth user:', authDeleteResult.lastError);
-      await recordDeletionFailure(
+      const transition = recordDeletionFailure(
         supabase,
         user.id,
         claim.claimToken,
@@ -168,7 +191,11 @@ Deno.serve(async (req) => {
         },
         '[account-delete]'
       );
-      return createErrorResponse('Failed to delete account', 500, req);
+      return createTransitionResponse(
+        transition,
+        createErrorResponse('Failed to delete account', 500, req),
+        req
+      );
     }
     const cleanupErrors = await cleanupUserData(supabase, user.id);
     if (Object.keys(cleanupErrors).length > 0) {
@@ -181,7 +208,7 @@ Deno.serve(async (req) => {
         ])
       );
       console.error('[account-delete] Cleanup errors after auth delete:', sanitizedErrors);
-      await recordDeletionFailure(
+      const transition = recordDeletionFailure(
         supabase,
         user.id,
         claim.claimToken,
@@ -190,18 +217,25 @@ Deno.serve(async (req) => {
         '[account-delete]'
       );
       // Return 202 Accepted to indicate auth deletion succeeded but cleanup is async
-      return createSuccessResponse(
-        {
-          success: true,
-          cleanupScheduled: true,
-          message: 'Account deleted. Data cleanup will complete shortly.',
-        },
-        202,
+      return createTransitionResponse(
+        transition,
+        createSuccessResponse(
+          {
+            success: true,
+            cleanupScheduled: true,
+            message: 'Account deleted. Data cleanup will complete shortly.',
+          },
+          202,
+          req
+        ),
         req
       );
     }
-    await markDeletionCompleted(supabase, user.id, claim.claimToken, '[account-delete]');
-    return createSuccessResponse({ success: true }, 200, req);
+    return createTransitionResponse(
+      markDeletionCompleted(supabase, user.id, claim.claimToken, '[account-delete]'),
+      createSuccessResponse({ success: true }, 200, req),
+      req
+    );
   } catch (error) {
     console.error('[account-delete] Unexpected error:', error);
     return createErrorResponse('Internal server error', 500, req);

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -3,18 +3,28 @@
   "specifiers": {
     "jsr:@std/assert@*": "1.0.19",
     "jsr:@std/assert@1.0.19": "1.0.19",
+    "jsr:@std/assert@^1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.14",
+    "jsr:@std/internal@^1.0.14": "1.0.14",
+    "jsr:@std/testing@1.0.19": "1.0.19",
     "npm:@supabase/supabase-js@2": "2.110.2"
   },
   "jsr": {
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
       "dependencies": [
-        "jsr:@std/internal"
+        "jsr:@std/internal@^1.0.12"
       ]
     },
     "@std/internal@1.0.14": {
       "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    },
+    "@std/testing@1.0.19": {
+      "integrity": "f4236172365b216728dc3cc8b5e80a9f4c33083d1e4ede7613d5b25b4014898e",
+      "dependencies": [
+        "jsr:@std/assert@^1.0.19",
+        "jsr:@std/internal@^1.0.14"
+      ]
     }
   },
   "npm": {

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -2,6 +2,7 @@
   "version": "5",
   "specifiers": {
     "jsr:@std/assert@*": "1.0.19",
+    "jsr:@std/assert@1.0.19": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.14",
     "npm:@supabase/supabase-js@2": "2.110.2"
   },

--- a/supabase/migrations/20260825131739_harden_account_deletion_concurrency.sql
+++ b/supabase/migrations/20260825131739_harden_account_deletion_concurrency.sql
@@ -62,13 +62,17 @@ GRANT EXECUTE ON FUNCTION public.consume_account_deletion_attempt(UUID, TEXT, TE
 COMMENT ON FUNCTION public.consume_account_deletion_attempt(UUID, TEXT, TEXT) IS
   'Atomically enforces and records the three-per-minute account deletion attempt limit.';
 
+ALTER TABLE public.account_deletion_jobs
+  ADD COLUMN claim_token UUID;
+
 CREATE OR REPLACE FUNCTION public.claim_account_deletion_job(
   p_user_id UUID,
   p_create_if_missing BOOLEAN DEFAULT FALSE
 )
 RETURNS TABLE (
   claimed BOOLEAN,
-  status TEXT
+  status TEXT,
+  claim_token UUID
 )
 LANGUAGE plpgsql
 SECURITY DEFINER
@@ -92,11 +96,15 @@ BEGIN
 
   UPDATE public.account_deletion_jobs AS adj
   SET status = 'in_progress',
+      attempts = CASE WHEN adj.status = 'dead_lettered' THEN 0 ELSE adj.attempts END,
       updated_at = v_now,
       next_run_at = NULL,
       last_error = NULL,
       last_error_details = NULL,
-      last_error_at = NULL
+      last_error_at = NULL,
+      completed_at = NULL,
+      dead_lettered_at = NULL,
+      claim_token = gen_random_uuid()
   WHERE adj.user_id = p_user_id
     AND (
       (
@@ -107,17 +115,18 @@ BEGIN
         adj.status = 'in_progress'
         AND adj.updated_at <= v_now - INTERVAL '15 minutes'
       )
+      OR (p_create_if_missing AND adj.status = 'dead_lettered')
     )
-  RETURNING TRUE, adj.status
-  INTO claimed, status;
+  RETURNING TRUE, adj.status, adj.claim_token
+  INTO claimed, status, claim_token;
 
   IF FOUND THEN
     RETURN NEXT;
     RETURN;
   END IF;
 
-  SELECT FALSE, adj.status
-  INTO claimed, status
+  SELECT FALSE, adj.status, adj.claim_token
+  INTO claimed, status, claim_token
   FROM public.account_deletion_jobs AS adj
   WHERE adj.user_id = p_user_id;
 
@@ -133,4 +142,4 @@ GRANT EXECUTE ON FUNCTION public.claim_account_deletion_job(UUID, BOOLEAN)
   TO service_role;
 
 COMMENT ON FUNCTION public.claim_account_deletion_job(UUID, BOOLEAN) IS
-  'Atomically claims a due account deletion job and recovers in-progress jobs after a 15-minute lease.';
+  'Atomically claims deletion work with a fencing token and recovers jobs after a 15-minute lease.';

--- a/supabase/migrations/20260825131739_harden_account_deletion_concurrency.sql
+++ b/supabase/migrations/20260825131739_harden_account_deletion_concurrency.sql
@@ -1,0 +1,136 @@
+CREATE OR REPLACE FUNCTION public.consume_account_deletion_attempt(
+  p_user_id UUID,
+  p_ip_address TEXT,
+  p_user_agent TEXT
+)
+RETURNS TABLE (
+  allowed BOOLEAN,
+  retry_after_seconds INTEGER
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_now TIMESTAMPTZ;
+  v_oldest_attempt TIMESTAMPTZ;
+  v_attempt_count INTEGER;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('account-deletion-attempt'), hashtext(p_user_id::TEXT));
+  v_now := clock_timestamp();
+
+  SELECT COUNT(*), MIN(ada.attempted_at)
+  INTO v_attempt_count, v_oldest_attempt
+  FROM public.account_deletion_attempts AS ada
+  WHERE ada.user_id = p_user_id
+    AND ada.attempted_at >= v_now - INTERVAL '1 minute';
+
+  IF v_attempt_count >= 3 THEN
+    RETURN QUERY
+    SELECT
+      FALSE,
+      GREATEST(CEIL(EXTRACT(EPOCH FROM (v_oldest_attempt + INTERVAL '1 minute' - v_now)))::INTEGER, 1);
+    RETURN;
+  END IF;
+
+  INSERT INTO public.account_deletion_attempts (
+    user_id,
+    attempted_at,
+    ip_address,
+    user_agent
+  )
+  VALUES (
+    p_user_id,
+    v_now,
+    p_ip_address,
+    p_user_agent
+  );
+
+  RETURN QUERY SELECT TRUE, 0;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.consume_account_deletion_attempt(UUID, TEXT, TEXT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.consume_account_deletion_attempt(UUID, TEXT, TEXT)
+  TO service_role;
+
+COMMENT ON FUNCTION public.consume_account_deletion_attempt(UUID, TEXT, TEXT) IS
+  'Atomically enforces and records the three-per-minute account deletion attempt limit.';
+
+CREATE OR REPLACE FUNCTION public.claim_account_deletion_job(
+  p_user_id UUID,
+  p_create_if_missing BOOLEAN DEFAULT FALSE
+)
+RETURNS TABLE (
+  claimed BOOLEAN,
+  status TEXT
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_now TIMESTAMPTZ;
+BEGIN
+  IF p_user_id IS NULL THEN
+    RAISE EXCEPTION 'p_user_id is required';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(hashtext('account-deletion-job'), hashtext(p_user_id::TEXT));
+  v_now := clock_timestamp();
+
+  IF p_create_if_missing THEN
+    INSERT INTO public.account_deletion_jobs (user_id, status, next_run_at, updated_at)
+    VALUES (p_user_id, 'pending', v_now, v_now)
+    ON CONFLICT (user_id) DO NOTHING;
+  END IF;
+
+  UPDATE public.account_deletion_jobs AS adj
+  SET status = 'in_progress',
+      updated_at = v_now,
+      next_run_at = NULL,
+      last_error = NULL,
+      last_error_details = NULL,
+      last_error_at = NULL
+  WHERE adj.user_id = p_user_id
+    AND (
+      (
+        adj.status IN ('pending', 'failed')
+        AND (adj.next_run_at IS NULL OR adj.next_run_at <= v_now)
+      )
+      OR (
+        adj.status = 'in_progress'
+        AND adj.updated_at <= v_now - INTERVAL '15 minutes'
+      )
+    )
+  RETURNING TRUE, adj.status
+  INTO claimed, status;
+
+  IF FOUND THEN
+    RETURN NEXT;
+    RETURN;
+  END IF;
+
+  SELECT FALSE, adj.status
+  INTO claimed, status
+  FROM public.account_deletion_jobs AS adj
+  WHERE adj.user_id = p_user_id;
+
+  IF FOUND THEN
+    RETURN NEXT;
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.claim_account_deletion_job(UUID, BOOLEAN)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.claim_account_deletion_job(UUID, BOOLEAN)
+  TO service_role;
+
+COMMENT ON FUNCTION public.claim_account_deletion_job(UUID, BOOLEAN) IS
+  'Atomically claims a due account deletion job and recovers in-progress jobs after a 15-minute lease.';

--- a/supabase/tests/database/account_deletion_concurrency.test.sql
+++ b/supabase/tests/database/account_deletion_concurrency.test.sql
@@ -17,39 +17,35 @@ VALUES
   ((SELECT job_user FROM deletion_test_fixture), 'account-delete-719@example.invalid'),
   ((SELECT fence_user FROM deletion_test_fixture), 'account-delete-720@example.invalid');
 
-SELECT is(
-  (SELECT allowed FROM public.consume_account_deletion_attempt(
+CREATE FUNCTION pg_temp.consume_test_attempt()
+RETURNS BOOLEAN
+LANGUAGE SQL
+AS $$
+  SELECT allowed
+  FROM public.consume_account_deletion_attempt(
     (SELECT rate_user FROM deletion_test_fixture),
     (SELECT request_ip FROM deletion_test_fixture),
     (SELECT test_agent FROM deletion_test_fixture)
-  )),
+  );
+$$;
+
+SELECT is(
+  pg_temp.consume_test_attempt(),
   TRUE,
   'allows the first deletion attempt'
 );
 SELECT is(
-  (SELECT allowed FROM public.consume_account_deletion_attempt(
-    (SELECT rate_user FROM deletion_test_fixture),
-    (SELECT request_ip FROM deletion_test_fixture),
-    (SELECT test_agent FROM deletion_test_fixture)
-  )),
+  pg_temp.consume_test_attempt(),
   TRUE,
   'allows the second deletion attempt'
 );
 SELECT is(
-  (SELECT allowed FROM public.consume_account_deletion_attempt(
-    (SELECT rate_user FROM deletion_test_fixture),
-    (SELECT request_ip FROM deletion_test_fixture),
-    (SELECT test_agent FROM deletion_test_fixture)
-  )),
+  pg_temp.consume_test_attempt(),
   TRUE,
   'allows the third deletion attempt'
 );
 SELECT is(
-  (SELECT allowed FROM public.consume_account_deletion_attempt(
-    (SELECT rate_user FROM deletion_test_fixture),
-    (SELECT request_ip FROM deletion_test_fixture),
-    (SELECT test_agent FROM deletion_test_fixture)
-  )),
+  pg_temp.consume_test_attempt(),
   FALSE,
   'rejects a fourth deletion attempt in the same minute'
 );

--- a/supabase/tests/database/account_deletion_concurrency.test.sql
+++ b/supabase/tests/database/account_deletion_concurrency.test.sql
@@ -2,37 +2,48 @@ BEGIN;
 
 SELECT plan(18);
 
+\set rate_user '00000000-0000-0000-0000-000000000718'
+\set job_user '00000000-0000-0000-0000-000000000719'
+\set fence_user '00000000-0000-0000-0000-000000000720'
+\set request_ip '127.0.0.1'
+\set test_agent 'pgTAP'
+\set execute_privilege 'EXECUTE'
+
 INSERT INTO auth.users (id, email)
 VALUES
-  ('00000000-0000-0000-0000-000000000718', 'account-delete-718@example.invalid'),
-  ('00000000-0000-0000-0000-000000000719', 'account-delete-719@example.invalid'),
-  ('00000000-0000-0000-0000-000000000720', 'account-delete-720@example.invalid');
+  (:'rate_user', 'account-delete-718@example.invalid'),
+  (:'job_user', 'account-delete-719@example.invalid'),
+  (:'fence_user', 'account-delete-720@example.invalid');
 
 SELECT results_eq(
-  $$ SELECT allowed FROM public.consume_account_deletion_attempt(
-    '00000000-0000-0000-0000-000000000718', '127.0.0.1', 'pgTAP'
-  ) $$,
+  FORMAT(
+    'SELECT allowed FROM public.consume_account_deletion_attempt(%L, %L, %L)',
+    :'rate_user', :'request_ip', :'test_agent'
+  ),
   $$ VALUES (TRUE) $$,
   'allows the first deletion attempt'
 );
 SELECT results_eq(
-  $$ SELECT allowed FROM public.consume_account_deletion_attempt(
-    '00000000-0000-0000-0000-000000000718', '127.0.0.1', 'pgTAP'
-  ) $$,
+  FORMAT(
+    'SELECT allowed FROM public.consume_account_deletion_attempt(%L, %L, %L)',
+    :'rate_user', :'request_ip', :'test_agent'
+  ),
   $$ VALUES (TRUE) $$,
   'allows the second deletion attempt'
 );
 SELECT results_eq(
-  $$ SELECT allowed FROM public.consume_account_deletion_attempt(
-    '00000000-0000-0000-0000-000000000718', '127.0.0.1', 'pgTAP'
-  ) $$,
+  FORMAT(
+    'SELECT allowed FROM public.consume_account_deletion_attempt(%L, %L, %L)',
+    :'rate_user', :'request_ip', :'test_agent'
+  ),
   $$ VALUES (TRUE) $$,
   'allows the third deletion attempt'
 );
 SELECT results_eq(
-  $$ SELECT allowed FROM public.consume_account_deletion_attempt(
-    '00000000-0000-0000-0000-000000000718', '127.0.0.1', 'pgTAP'
-  ) $$,
+  FORMAT(
+    'SELECT allowed FROM public.consume_account_deletion_attempt(%L, %L, %L)',
+    :'rate_user', :'request_ip', :'test_agent'
+  ),
   $$ VALUES (FALSE) $$,
   'rejects a fourth deletion attempt in the same minute'
 );
@@ -40,74 +51,60 @@ SELECT is(
   (
     SELECT COUNT(*)::INTEGER
     FROM public.account_deletion_attempts
-    WHERE user_id = '00000000-0000-0000-0000-000000000718'
+    WHERE user_id = :'rate_user'
   ),
   3,
   'records only allowed deletion attempts'
 );
 
 SELECT results_eq(
-  $$ SELECT claimed FROM public.claim_account_deletion_job(
-    '00000000-0000-0000-0000-000000000719', TRUE
-  ) $$,
+  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, TRUE)', :'job_user'),
   $$ VALUES (TRUE) $$,
   'creates and claims a missing deletion job'
 );
 SELECT results_eq(
-  $$ SELECT claimed FROM public.claim_account_deletion_job(
-    '00000000-0000-0000-0000-000000000719', TRUE
-  ) $$,
+  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, TRUE)', :'job_user'),
   $$ VALUES (FALSE) $$,
   'does not claim a job with an active lease twice'
 );
 
 UPDATE public.account_deletion_jobs
 SET status = 'failed', next_run_at = NOW() + INTERVAL '1 minute'
-WHERE user_id = '00000000-0000-0000-0000-000000000719';
+WHERE user_id = :'job_user';
 SELECT results_eq(
-  $$ SELECT claimed FROM public.claim_account_deletion_job(
-    '00000000-0000-0000-0000-000000000719', FALSE
-  ) $$,
+  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, FALSE)', :'job_user'),
   $$ VALUES (FALSE) $$,
   'does not claim a failed job before its retry time'
 );
 
 UPDATE public.account_deletion_jobs
 SET next_run_at = NOW() - INTERVAL '1 second'
-WHERE user_id = '00000000-0000-0000-0000-000000000719';
+WHERE user_id = :'job_user';
 SELECT results_eq(
-  $$ SELECT claimed FROM public.claim_account_deletion_job(
-    '00000000-0000-0000-0000-000000000719', FALSE
-  ) $$,
+  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, FALSE)', :'job_user'),
   $$ VALUES (TRUE) $$,
   'claims a failed job after its retry time'
 );
 
 UPDATE public.account_deletion_jobs
 SET status = 'in_progress', updated_at = NOW() - INTERVAL '16 minutes'
-WHERE user_id = '00000000-0000-0000-0000-000000000719';
+WHERE user_id = :'job_user';
 SELECT results_eq(
-  $$ SELECT claimed FROM public.claim_account_deletion_job(
-    '00000000-0000-0000-0000-000000000719', FALSE
-  ) $$,
+  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, FALSE)', :'job_user'),
   $$ VALUES (TRUE) $$,
   'recovers a deletion job after its lease expires'
 );
 
 UPDATE public.account_deletion_jobs
 SET status = 'dead_lettered', attempts = 5, dead_lettered_at = NOW()
-WHERE user_id = '00000000-0000-0000-0000-000000000719';
+WHERE user_id = :'job_user';
 SELECT results_eq(
-  $$ SELECT claimed FROM public.claim_account_deletion_job(
-    '00000000-0000-0000-0000-000000000719', FALSE
-  ) $$,
+  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, FALSE)', :'job_user'),
   $$ VALUES (FALSE) $$,
   'the reconciler cannot revive a dead-lettered job'
 );
 SELECT results_eq(
-  $$ SELECT claimed FROM public.claim_account_deletion_job(
-    '00000000-0000-0000-0000-000000000719', TRUE
-  ) $$,
+  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, TRUE)', :'job_user'),
   $$ VALUES (TRUE) $$,
   'an explicit user request revives a dead-lettered job'
 );
@@ -115,7 +112,7 @@ SELECT is(
   (
     SELECT attempts
     FROM public.account_deletion_jobs
-    WHERE user_id = '00000000-0000-0000-0000-000000000719'
+    WHERE user_id = :'job_user'
   ),
   0,
   'reviving a dead-lettered job resets its attempt budget'
@@ -124,16 +121,16 @@ SELECT is(
 CREATE TEMP TABLE first_claim AS
 SELECT claim_token
 FROM public.claim_account_deletion_job(
-  '00000000-0000-0000-0000-000000000720',
+  :'fence_user',
   TRUE
 );
 UPDATE public.account_deletion_jobs
 SET updated_at = NOW() - INTERVAL '16 minutes'
-WHERE user_id = '00000000-0000-0000-0000-000000000720';
+WHERE user_id = :'fence_user';
 CREATE TEMP TABLE second_claim AS
 SELECT claim_token
 FROM public.claim_account_deletion_job(
-  '00000000-0000-0000-0000-000000000720',
+  :'fence_user',
   FALSE
 );
 SELECT isnt(
@@ -145,7 +142,7 @@ CREATE TEMP TABLE stale_update_result AS
 WITH stale_update AS (
   UPDATE public.account_deletion_jobs
   SET status = 'completed'
-  WHERE user_id = '00000000-0000-0000-0000-000000000720'
+  WHERE user_id = :'fence_user'
     AND claim_token = (SELECT claim_token FROM first_claim)
   RETURNING 1
 )
@@ -160,7 +157,7 @@ SELECT ok(
   NOT has_function_privilege(
     'anon',
     'public.consume_account_deletion_attempt(uuid,text,text)',
-    'EXECUTE'
+    :'execute_privilege'
   ),
   'anonymous callers cannot consume deletion attempts'
 );
@@ -168,7 +165,7 @@ SELECT ok(
   NOT has_function_privilege(
     'authenticated',
     'public.claim_account_deletion_job(uuid,boolean)',
-    'EXECUTE'
+    :'execute_privilege'
   ),
   'authenticated callers cannot claim deletion jobs'
 );
@@ -176,7 +173,7 @@ SELECT ok(
   has_function_privilege(
     'service_role',
     'public.claim_account_deletion_job(uuid,boolean)',
-    'EXECUTE'
+    :'execute_privilege'
   ),
   'the service role can claim deletion jobs'
 );

--- a/supabase/tests/database/account_deletion_concurrency.test.sql
+++ b/supabase/tests/database/account_deletion_concurrency.test.sql
@@ -1,0 +1,123 @@
+BEGIN;
+
+SELECT plan(13);
+
+INSERT INTO auth.users (id, email)
+VALUES
+  ('00000000-0000-0000-0000-000000000718', 'account-delete-718@example.invalid'),
+  ('00000000-0000-0000-0000-000000000719', 'account-delete-719@example.invalid');
+
+SELECT results_eq(
+  $$ SELECT allowed FROM public.consume_account_deletion_attempt(
+    '00000000-0000-0000-0000-000000000718', '127.0.0.1', 'pgTAP'
+  ) $$,
+  $$ VALUES (TRUE) $$,
+  'allows the first deletion attempt'
+);
+SELECT results_eq(
+  $$ SELECT allowed FROM public.consume_account_deletion_attempt(
+    '00000000-0000-0000-0000-000000000718', '127.0.0.1', 'pgTAP'
+  ) $$,
+  $$ VALUES (TRUE) $$,
+  'allows the second deletion attempt'
+);
+SELECT results_eq(
+  $$ SELECT allowed FROM public.consume_account_deletion_attempt(
+    '00000000-0000-0000-0000-000000000718', '127.0.0.1', 'pgTAP'
+  ) $$,
+  $$ VALUES (TRUE) $$,
+  'allows the third deletion attempt'
+);
+SELECT results_eq(
+  $$ SELECT allowed FROM public.consume_account_deletion_attempt(
+    '00000000-0000-0000-0000-000000000718', '127.0.0.1', 'pgTAP'
+  ) $$,
+  $$ VALUES (FALSE) $$,
+  'rejects a fourth deletion attempt in the same minute'
+);
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.account_deletion_attempts
+    WHERE user_id = '00000000-0000-0000-0000-000000000718'
+  ),
+  3,
+  'records only allowed deletion attempts'
+);
+
+SELECT results_eq(
+  $$ SELECT claimed FROM public.claim_account_deletion_job(
+    '00000000-0000-0000-0000-000000000719', TRUE
+  ) $$,
+  $$ VALUES (TRUE) $$,
+  'creates and claims a missing deletion job'
+);
+SELECT results_eq(
+  $$ SELECT claimed FROM public.claim_account_deletion_job(
+    '00000000-0000-0000-0000-000000000719', TRUE
+  ) $$,
+  $$ VALUES (FALSE) $$,
+  'does not claim a job with an active lease twice'
+);
+
+UPDATE public.account_deletion_jobs
+SET status = 'failed', next_run_at = NOW() + INTERVAL '1 minute'
+WHERE user_id = '00000000-0000-0000-0000-000000000719';
+SELECT results_eq(
+  $$ SELECT claimed FROM public.claim_account_deletion_job(
+    '00000000-0000-0000-0000-000000000719', FALSE
+  ) $$,
+  $$ VALUES (FALSE) $$,
+  'does not claim a failed job before its retry time'
+);
+
+UPDATE public.account_deletion_jobs
+SET next_run_at = NOW() - INTERVAL '1 second'
+WHERE user_id = '00000000-0000-0000-0000-000000000719';
+SELECT results_eq(
+  $$ SELECT claimed FROM public.claim_account_deletion_job(
+    '00000000-0000-0000-0000-000000000719', FALSE
+  ) $$,
+  $$ VALUES (TRUE) $$,
+  'claims a failed job after its retry time'
+);
+
+UPDATE public.account_deletion_jobs
+SET status = 'in_progress', updated_at = NOW() - INTERVAL '16 minutes'
+WHERE user_id = '00000000-0000-0000-0000-000000000719';
+SELECT results_eq(
+  $$ SELECT claimed FROM public.claim_account_deletion_job(
+    '00000000-0000-0000-0000-000000000719', FALSE
+  ) $$,
+  $$ VALUES (TRUE) $$,
+  'recovers a deletion job after its lease expires'
+);
+
+SELECT ok(
+  NOT has_function_privilege(
+    'anon',
+    'public.consume_account_deletion_attempt(uuid,text,text)',
+    'EXECUTE'
+  ),
+  'anonymous callers cannot consume deletion attempts'
+);
+SELECT ok(
+  NOT has_function_privilege(
+    'authenticated',
+    'public.claim_account_deletion_job(uuid,boolean)',
+    'EXECUTE'
+  ),
+  'authenticated callers cannot claim deletion jobs'
+);
+SELECT ok(
+  has_function_privilege(
+    'service_role',
+    'public.claim_account_deletion_job(uuid,boolean)',
+    'EXECUTE'
+  ),
+  'the service role can claim deletion jobs'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/supabase/tests/database/account_deletion_concurrency.test.sql
+++ b/supabase/tests/database/account_deletion_concurrency.test.sql
@@ -2,117 +2,137 @@ BEGIN;
 
 SELECT plan(18);
 
-\set rate_user '00000000-0000-0000-0000-000000000718'
-\set job_user '00000000-0000-0000-0000-000000000719'
-\set fence_user '00000000-0000-0000-0000-000000000720'
-\set request_ip '127.0.0.1'
-\set test_agent 'pgTAP'
-\set execute_privilege 'EXECUTE'
+CREATE TEMP TABLE deletion_test_fixture AS
+SELECT
+  '00000000-0000-0000-0000-000000000718'::UUID AS rate_user,
+  '00000000-0000-0000-0000-000000000719'::UUID AS job_user,
+  '00000000-0000-0000-0000-000000000720'::UUID AS fence_user,
+  '127.0.0.1'::TEXT AS request_ip,
+  'pgTAP'::TEXT AS test_agent,
+  'EXECUTE'::TEXT AS execute_privilege;
 
 INSERT INTO auth.users (id, email)
 VALUES
-  (:'rate_user', 'account-delete-718@example.invalid'),
-  (:'job_user', 'account-delete-719@example.invalid'),
-  (:'fence_user', 'account-delete-720@example.invalid');
+  ((SELECT rate_user FROM deletion_test_fixture), 'account-delete-718@example.invalid'),
+  ((SELECT job_user FROM deletion_test_fixture), 'account-delete-719@example.invalid'),
+  ((SELECT fence_user FROM deletion_test_fixture), 'account-delete-720@example.invalid');
 
-SELECT results_eq(
-  FORMAT(
-    'SELECT allowed FROM public.consume_account_deletion_attempt(%L, %L, %L)',
-    :'rate_user', :'request_ip', :'test_agent'
-  ),
-  $$ VALUES (TRUE) $$,
+SELECT is(
+  (SELECT allowed FROM public.consume_account_deletion_attempt(
+    (SELECT rate_user FROM deletion_test_fixture),
+    (SELECT request_ip FROM deletion_test_fixture),
+    (SELECT test_agent FROM deletion_test_fixture)
+  )),
+  TRUE,
   'allows the first deletion attempt'
 );
-SELECT results_eq(
-  FORMAT(
-    'SELECT allowed FROM public.consume_account_deletion_attempt(%L, %L, %L)',
-    :'rate_user', :'request_ip', :'test_agent'
-  ),
-  $$ VALUES (TRUE) $$,
+SELECT is(
+  (SELECT allowed FROM public.consume_account_deletion_attempt(
+    (SELECT rate_user FROM deletion_test_fixture),
+    (SELECT request_ip FROM deletion_test_fixture),
+    (SELECT test_agent FROM deletion_test_fixture)
+  )),
+  TRUE,
   'allows the second deletion attempt'
 );
-SELECT results_eq(
-  FORMAT(
-    'SELECT allowed FROM public.consume_account_deletion_attempt(%L, %L, %L)',
-    :'rate_user', :'request_ip', :'test_agent'
-  ),
-  $$ VALUES (TRUE) $$,
+SELECT is(
+  (SELECT allowed FROM public.consume_account_deletion_attempt(
+    (SELECT rate_user FROM deletion_test_fixture),
+    (SELECT request_ip FROM deletion_test_fixture),
+    (SELECT test_agent FROM deletion_test_fixture)
+  )),
+  TRUE,
   'allows the third deletion attempt'
 );
-SELECT results_eq(
-  FORMAT(
-    'SELECT allowed FROM public.consume_account_deletion_attempt(%L, %L, %L)',
-    :'rate_user', :'request_ip', :'test_agent'
-  ),
-  $$ VALUES (FALSE) $$,
+SELECT is(
+  (SELECT allowed FROM public.consume_account_deletion_attempt(
+    (SELECT rate_user FROM deletion_test_fixture),
+    (SELECT request_ip FROM deletion_test_fixture),
+    (SELECT test_agent FROM deletion_test_fixture)
+  )),
+  FALSE,
   'rejects a fourth deletion attempt in the same minute'
 );
 SELECT is(
   (
     SELECT COUNT(*)::INTEGER
     FROM public.account_deletion_attempts
-    WHERE user_id = :'rate_user'
+    WHERE user_id = (SELECT rate_user FROM deletion_test_fixture)
   ),
   3,
   'records only allowed deletion attempts'
 );
 
-SELECT results_eq(
-  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, TRUE)', :'job_user'),
-  $$ VALUES (TRUE) $$,
+SELECT is(
+  (SELECT claimed FROM public.claim_account_deletion_job(
+    (SELECT job_user FROM deletion_test_fixture), TRUE
+  )),
+  TRUE,
   'creates and claims a missing deletion job'
 );
-SELECT results_eq(
-  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, TRUE)', :'job_user'),
-  $$ VALUES (FALSE) $$,
+SELECT is(
+  (SELECT claimed FROM public.claim_account_deletion_job(
+    (SELECT job_user FROM deletion_test_fixture), TRUE
+  )),
+  FALSE,
   'does not claim a job with an active lease twice'
 );
 
 UPDATE public.account_deletion_jobs
 SET status = 'failed', next_run_at = NOW() + INTERVAL '1 minute'
-WHERE user_id = :'job_user';
-SELECT results_eq(
-  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, FALSE)', :'job_user'),
-  $$ VALUES (FALSE) $$,
+WHERE user_id = (SELECT job_user FROM deletion_test_fixture);
+SELECT is(
+  (SELECT claimed FROM public.claim_account_deletion_job(
+    (SELECT job_user FROM deletion_test_fixture), FALSE
+  )),
+  FALSE,
   'does not claim a failed job before its retry time'
 );
 
 UPDATE public.account_deletion_jobs
 SET next_run_at = NOW() - INTERVAL '1 second'
-WHERE user_id = :'job_user';
-SELECT results_eq(
-  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, FALSE)', :'job_user'),
-  $$ VALUES (TRUE) $$,
+WHERE user_id = (SELECT job_user FROM deletion_test_fixture);
+SELECT is(
+  (SELECT claimed FROM public.claim_account_deletion_job(
+    (SELECT job_user FROM deletion_test_fixture), FALSE
+  )),
+  TRUE,
   'claims a failed job after its retry time'
 );
 
 UPDATE public.account_deletion_jobs
 SET status = 'in_progress', updated_at = NOW() - INTERVAL '16 minutes'
-WHERE user_id = :'job_user';
-SELECT results_eq(
-  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, FALSE)', :'job_user'),
-  $$ VALUES (TRUE) $$,
+WHERE user_id = (SELECT job_user FROM deletion_test_fixture);
+SELECT is(
+  (SELECT claimed FROM public.claim_account_deletion_job(
+    (SELECT job_user FROM deletion_test_fixture), FALSE
+  )),
+  TRUE,
   'recovers a deletion job after its lease expires'
 );
 
 UPDATE public.account_deletion_jobs
 SET status = 'dead_lettered', attempts = 5, dead_lettered_at = NOW()
-WHERE user_id = :'job_user';
-SELECT results_eq(
-  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, FALSE)', :'job_user'),
-  $$ VALUES (FALSE) $$,
+WHERE user_id = (SELECT job_user FROM deletion_test_fixture);
+SELECT is(
+  (SELECT claimed FROM public.claim_account_deletion_job(
+    (SELECT job_user FROM deletion_test_fixture), FALSE
+  )),
+  FALSE,
   'the reconciler cannot revive a dead-lettered job'
 );
-SELECT results_eq(
-  FORMAT('SELECT claimed FROM public.claim_account_deletion_job(%L, TRUE)', :'job_user'),
-  $$ VALUES (TRUE) $$,
+SELECT is(
+  (SELECT claimed FROM public.claim_account_deletion_job(
+    (SELECT job_user FROM deletion_test_fixture), TRUE
+  )),
+  TRUE,
   'an explicit user request revives a dead-lettered job'
 );
 SELECT is(
   (
     SELECT attempts
     FROM public.account_deletion_jobs
-    WHERE user_id = :'job_user'
+    WHERE user_id = (SELECT job_user FROM deletion_test_fixture)
   ),
   0,
   'reviving a dead-lettered job resets its attempt budget'
@@ -121,16 +141,16 @@ SELECT is(
 CREATE TEMP TABLE first_claim AS
 SELECT claim_token
 FROM public.claim_account_deletion_job(
-  :'fence_user',
+  (SELECT fence_user FROM deletion_test_fixture),
   TRUE
 );
 UPDATE public.account_deletion_jobs
 SET updated_at = NOW() - INTERVAL '16 minutes'
-WHERE user_id = :'fence_user';
+WHERE user_id = (SELECT fence_user FROM deletion_test_fixture);
 CREATE TEMP TABLE second_claim AS
 SELECT claim_token
 FROM public.claim_account_deletion_job(
-  :'fence_user',
+  (SELECT fence_user FROM deletion_test_fixture),
   FALSE
 );
 SELECT isnt(
@@ -142,7 +162,7 @@ CREATE TEMP TABLE stale_update_result AS
 WITH stale_update AS (
   UPDATE public.account_deletion_jobs
   SET status = 'completed'
-  WHERE user_id = :'fence_user'
+  WHERE user_id = (SELECT fence_user FROM deletion_test_fixture)
     AND claim_token = (SELECT claim_token FROM first_claim)
   RETURNING 1
 )
@@ -157,7 +177,7 @@ SELECT ok(
   NOT has_function_privilege(
     'anon',
     'public.consume_account_deletion_attempt(uuid,text,text)',
-    :'execute_privilege'
+    (SELECT execute_privilege FROM deletion_test_fixture)
   ),
   'anonymous callers cannot consume deletion attempts'
 );
@@ -165,7 +185,7 @@ SELECT ok(
   NOT has_function_privilege(
     'authenticated',
     'public.claim_account_deletion_job(uuid,boolean)',
-    :'execute_privilege'
+    (SELECT execute_privilege FROM deletion_test_fixture)
   ),
   'authenticated callers cannot claim deletion jobs'
 );
@@ -173,7 +193,7 @@ SELECT ok(
   has_function_privilege(
     'service_role',
     'public.claim_account_deletion_job(uuid,boolean)',
-    :'execute_privilege'
+    (SELECT execute_privilege FROM deletion_test_fixture)
   ),
   'the service role can claim deletion jobs'
 );

--- a/supabase/tests/database/account_deletion_concurrency.test.sql
+++ b/supabase/tests/database/account_deletion_concurrency.test.sql
@@ -1,11 +1,12 @@
 BEGIN;
 
-SELECT plan(13);
+SELECT plan(18);
 
 INSERT INTO auth.users (id, email)
 VALUES
   ('00000000-0000-0000-0000-000000000718', 'account-delete-718@example.invalid'),
-  ('00000000-0000-0000-0000-000000000719', 'account-delete-719@example.invalid');
+  ('00000000-0000-0000-0000-000000000719', 'account-delete-719@example.invalid'),
+  ('00000000-0000-0000-0000-000000000720', 'account-delete-720@example.invalid');
 
 SELECT results_eq(
   $$ SELECT allowed FROM public.consume_account_deletion_attempt(
@@ -91,6 +92,68 @@ SELECT results_eq(
   ) $$,
   $$ VALUES (TRUE) $$,
   'recovers a deletion job after its lease expires'
+);
+
+UPDATE public.account_deletion_jobs
+SET status = 'dead_lettered', attempts = 5, dead_lettered_at = NOW()
+WHERE user_id = '00000000-0000-0000-0000-000000000719';
+SELECT results_eq(
+  $$ SELECT claimed FROM public.claim_account_deletion_job(
+    '00000000-0000-0000-0000-000000000719', FALSE
+  ) $$,
+  $$ VALUES (FALSE) $$,
+  'the reconciler cannot revive a dead-lettered job'
+);
+SELECT results_eq(
+  $$ SELECT claimed FROM public.claim_account_deletion_job(
+    '00000000-0000-0000-0000-000000000719', TRUE
+  ) $$,
+  $$ VALUES (TRUE) $$,
+  'an explicit user request revives a dead-lettered job'
+);
+SELECT is(
+  (
+    SELECT attempts
+    FROM public.account_deletion_jobs
+    WHERE user_id = '00000000-0000-0000-0000-000000000719'
+  ),
+  0,
+  'reviving a dead-lettered job resets its attempt budget'
+);
+
+CREATE TEMP TABLE first_claim AS
+SELECT claim_token
+FROM public.claim_account_deletion_job(
+  '00000000-0000-0000-0000-000000000720',
+  TRUE
+);
+UPDATE public.account_deletion_jobs
+SET updated_at = NOW() - INTERVAL '16 minutes'
+WHERE user_id = '00000000-0000-0000-0000-000000000720';
+CREATE TEMP TABLE second_claim AS
+SELECT claim_token
+FROM public.claim_account_deletion_job(
+  '00000000-0000-0000-0000-000000000720',
+  FALSE
+);
+SELECT isnt(
+  (SELECT claim_token FROM first_claim),
+  (SELECT claim_token FROM second_claim),
+  'reclaiming stale work rotates the fencing token'
+);
+CREATE TEMP TABLE stale_update_result AS
+WITH stale_update AS (
+  UPDATE public.account_deletion_jobs
+  SET status = 'completed'
+  WHERE user_id = '00000000-0000-0000-0000-000000000720'
+    AND claim_token = (SELECT claim_token FROM first_claim)
+  RETURNING 1
+)
+SELECT COUNT(*)::INTEGER AS updated_rows FROM stale_update;
+SELECT is(
+  (SELECT updated_rows FROM stale_update_result),
+  0,
+  'a stale fencing token cannot update reclaimed work'
 );
 
 SELECT ok(


### PR DESCRIPTION
## Summary

- atomically enforce and record account-deletion attempts in PostgreSQL
- atomically claim deletion jobs with a 15-minute stale-work lease
- extract shared deletion retry, cleanup, failure, and completion helpers
- add Deno unit coverage and pgTAP database regressions to the Supabase CI check
- document the dedicated limiter and job-claim invariants

## Verification

- `pnpm run supabase:check`
- `deno test --config supabase/functions/deno.json supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts`
- `deno check --config supabase/functions/deno.json supabase/functions/account-delete/index.ts supabase/functions/account-delete-reconcile/index.ts`
- `deno lint --config supabase/functions/deno.json supabase/functions/_shared/account-deletion-lifecycle.ts supabase/functions/_shared/account-deletion-lifecycle.deno.test.ts supabase/functions/account-delete/index.ts supabase/functions/account-delete-reconcile/index.ts`
- targeted Prettier and blank-line lint

Closes #618
Implements the extraction originally tracked by #718.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Account deletion requests are limited to three attempts per user per minute.
  * Deletion jobs are claimed atomically, with 15-minute recovery leases and fencing protection against stale workers.
  * Failed deletions retry with backoff and may enter a dead-letter state; revival requires an explicit request.
  * Cleanup operations provide more consistent error handling and completion tracking.

* **Testing**
  * Expanded coverage for concurrency, rate limits, retries, leases, recovery, and access controls.

* **Documentation**
  * Updated workflow and rate-limiting guidance.
  * Database checks now include pgTAP regressions alongside migration validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->













<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR hardens account deletion by adding atomic rate-limit consumption, leased job claims, and fencing tokens for completion and failure transitions.

- Extracts shared retry, cleanup, claim, failure, and completion helpers used by both deletion workers.
- Distinguishes persisted transitions, lost leases, and database errors in worker outcomes.
- Adds Deno and pgTAP regressions and runs database tests in the Supabase CI check.
- Documents the deletion limiter, lease, fencing, and dead-letter revival invariants.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| supabase/functions/_shared/account-deletion-lifecycle.ts | Centralizes deletion lifecycle behavior and fences terminal state updates with the current claim token. |
| supabase/functions/account-delete/index.ts | Uses atomic rate-limit and job-claim RPCs and maps lost leases without falsely reporting a persisted transition. |
| supabase/functions/account-delete-reconcile/index.ts | Claims due work atomically and reports lost leases or transition failures distinctly. |
| supabase/migrations/20260825131739_harden_account_deletion_concurrency.sql | Adds transactional attempt consumption and leased job claims with rotating UUID fencing tokens. |
| supabase/tests/database/account_deletion_concurrency.test.sql | Covers rate limiting, lease recovery, dead-letter revival, token rotation, stale-token fencing, and RPC privileges. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Request as Deletion worker
    participant DB as PostgreSQL
    participant Auth as Supabase Auth
    Request->>DB: claim_account_deletion_job(user_id)
    DB-->>Request: claimed + fencing token
    Request->>Auth: Delete auth user
    Request->>DB: Clean user-owned records
    alt Worker still owns lease
        Request->>DB: "Complete/fail WHERE claim_token = token"
        DB-->>Request: Persisted row
    else Lease was reclaimed
        Request->>DB: Complete/fail with stale token
        DB-->>Request: Zero rows updated
        Request-->>Request: Report lease_lost
    end
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(api): distinguish deletion transitio..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/6e2fc04696c1ac770bcd8cbba1946d3776c7482c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56654982)</sub>

**Context used:**

- Knowledge Base — [Account deletion](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/account-deletion.md)

<!-- /greptile_comment -->