### PR TITLE
fix(api): validate token permissions in token-create

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -232,6 +232,9 @@ Naming:
   unauthenticated or over-quota client answers `401`/`429`, never `400`. Pass `auth.rlHeaders` into
   the resulting `400` responses so validation errors carry the same `X-RateLimit-*` headers as
   successful ones (empty on the fail-open path, where no quota decision exists).
+- The `token-create` Edge Function accepts `permissions` only as a non-empty array of supported
+  values (`GP`/`TP`/`WP`, matching the api-gateway `Permission` enum and the frontend
+  `API_PERMISSIONS` map); any other shape is rejected with `400` before token insertion.
 - API token renames update only `api_tokens.note` through authenticated owner-scoped RLS. They
   must never rotate or replace the token or change its ID, value or hash, permissions, game mode,
   or usage data.

--- a/docs/API.md
+++ b/docs/API.md
@@ -420,7 +420,7 @@ Polling integrators (TarkovMonitor, tarkov.dev, RatScanner) should poll read end
 
 ### Active Token Cap
 
-Each account may have at most **3 active API tokens**. This is enforced by a database trigger, so token rotation cannot bypass it. The `token-create` Edge Function returns `409` with `error: "Token limit reached (3 active)"` when the cap is reached. Revoke an existing token before creating a new one. Token creation is only allowed through the `token-create` Edge Function (authenticated clients cannot insert into `api_tokens` directly) and is rate-limited to 3 creates per hour per account.
+Each account may have at most **3 active API tokens**. This is enforced by a database trigger, so token rotation cannot bypass it. The `token-create` Edge Function returns `409` with `error: "Token limit reached (3 active)"` when the cap is reached. Revoke an existing token before creating a new one. Token creation is only allowed through the `token-create` Edge Function (authenticated clients cannot insert into `api_tokens` directly) and is rate-limited to 3 creates per hour per account. The `permissions` field must be a non-empty array of `GP`/`TP`/`WP`; any other shape or value is rejected with `400` before insertion.
 
 Token names can be changed from Settings → API Tokens without rotating the token. Renaming updates
 only the token's optional `note`: authenticated users receive column-level `UPDATE (note)` permission,

--- a/supabase/functions/token-create/index.ts
+++ b/supabase/functions/token-create/index.ts
@@ -7,6 +7,7 @@ import {
   type AuthSuccess,
 } from '../_shared/auth.ts';
 import { enforceUserMutationRateLimit } from '../_shared/rate-limit.ts';
+import { parseTokenPermissions, TOKEN_PERMISSIONS } from './permissions.ts';
 import {
   generateToken,
   isTokenGameMode,
@@ -44,12 +45,19 @@ Deno.serve(async (req) => {
     } catch {
       // ignore, handled below
     }
-    const permissions = (body.permissions as string[]) || [];
+    const permissions = parseTokenPermissions(body.permissions);
     const gameMode = (body.gameMode as string) || '';
     const note = (body.note as string | null) || null;
     let tokenValue = (body.tokenValue as string | undefined) || '';
-    if (!permissions.length || !gameMode) {
+    if (!gameMode) {
       return createErrorResponse('gameMode and permissions are required', 400, req);
+    }
+    if (!permissions) {
+      return createErrorResponse(
+        `permissions must be a non-empty array of: ${TOKEN_PERMISSIONS.join(', ')}`,
+        400,
+        req
+      );
     }
     if (!isTokenGameMode(gameMode)) {
       return createErrorResponse(

--- a/supabase/functions/token-create/index.ts
+++ b/supabase/functions/token-create/index.ts
@@ -34,9 +34,12 @@ type ValidatedTokenFields = TokenRequestFields & {
 };
 type MutationGuard =
   { response: Response } | { user: AuthSuccess['user']; supabase: SupabaseClient };
+const isJsonObject = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
 const parseJsonBody = async (req: Request): Promise<Record<string, unknown>> => {
   try {
-    return (await req.json()) as Record<string, unknown>;
+    const body: unknown = await req.json();
+    return isJsonObject(body) ? body : {};
   } catch {
     return {};
   }
@@ -48,7 +51,7 @@ const parseRequestFields = (body: Record<string, unknown>): TokenRequestFields =
   tokenValue: (body.tokenValue as string | undefined) || '',
 });
 const gameModePresenceError = (gameMode: string): string | null =>
-  gameMode ? null : 'gameMode and permissions are required';
+  gameMode ? null : 'gameMode is required';
 const permissionsError = (permissions: TokenPermission[] | null): string | null =>
   permissions ? null : `permissions must be a non-empty array of: ${TOKEN_PERMISSIONS.join(', ')}`;
 const gameModeValueError = (gameMode: string): string | null =>

--- a/supabase/functions/token-create/index.ts
+++ b/supabase/functions/token-create/index.ts
@@ -1,3 +1,4 @@
+import type { SupabaseClient } from 'npm:@supabase/supabase-js@2';
 import {
   authenticateUser,
   createErrorResponse,
@@ -7,12 +8,13 @@ import {
   type AuthSuccess,
 } from '../_shared/auth.ts';
 import { enforceUserMutationRateLimit } from '../_shared/rate-limit.ts';
-import { parseTokenPermissions, TOKEN_PERMISSIONS } from './permissions.ts';
+import { parseTokenPermissions, TOKEN_PERMISSIONS, type TokenPermission } from './permissions.ts';
 import {
   generateToken,
   isTokenGameMode,
   isTokenValueForGameMode,
   TOKEN_GAME_MODES,
+  type TokenGameMode,
 } from './tokenValue.ts';
 const hashToken = async (token: string) => {
   const buffer = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(token));
@@ -20,85 +22,147 @@ const hashToken = async (token: string) => {
     .map((b) => b.toString(16).padStart(2, '0'))
     .join('');
 };
+interface TokenRequestFields {
+  permissions: TokenPermission[] | null;
+  gameMode: string;
+  note: string | null;
+  tokenValue: string;
+}
+type ValidatedTokenFields = TokenRequestFields & {
+  permissions: TokenPermission[];
+  gameMode: TokenGameMode;
+};
+type MutationGuard =
+  { response: Response } | { user: AuthSuccess['user']; supabase: SupabaseClient };
+const parseJsonBody = async (req: Request): Promise<Record<string, unknown>> => {
+  try {
+    return (await req.json()) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+};
+const parseRequestFields = (body: Record<string, unknown>): TokenRequestFields => ({
+  permissions: parseTokenPermissions(body.permissions),
+  gameMode: (body.gameMode as string) || '',
+  note: (body.note as string | null) || null,
+  tokenValue: (body.tokenValue as string | undefined) || '',
+});
+const gameModePresenceError = (gameMode: string): string | null =>
+  gameMode ? null : 'gameMode and permissions are required';
+const permissionsError = (permissions: TokenPermission[] | null): string | null =>
+  permissions ? null : `permissions must be a non-empty array of: ${TOKEN_PERMISSIONS.join(', ')}`;
+const gameModeValueError = (gameMode: string): string | null =>
+  isTokenGameMode(gameMode) ? null : `gameMode must be one of: ${TOKEN_GAME_MODES.join(', ')}`;
+const tokenValueTypeError = (body: Record<string, unknown>): string | null =>
+  body.tokenValue !== undefined && typeof body.tokenValue !== 'string'
+    ? 'tokenValue must be a string'
+    : null;
+const tokenValuePrefixError = (fields: TokenRequestFields): string | null => {
+  if (!fields.tokenValue || !isTokenGameMode(fields.gameMode)) return null;
+  return isTokenValueForGameMode(fields.tokenValue, fields.gameMode)
+    ? null
+    : 'tokenValue prefix must match gameMode';
+};
+const asValidatedFields = (fields: TokenRequestFields): ValidatedTokenFields | null => {
+  if (!fields.permissions || !isTokenGameMode(fields.gameMode)) return null;
+  return { ...fields, permissions: fields.permissions, gameMode: fields.gameMode };
+};
+const validationError = (
+  body: Record<string, unknown>,
+  fields: TokenRequestFields
+): string | null =>
+  [
+    gameModePresenceError(fields.gameMode),
+    permissionsError(fields.permissions),
+    gameModeValueError(fields.gameMode),
+    tokenValueTypeError(body),
+    tokenValuePrefixError(fields),
+  ].find((error) => error !== null) ?? null;
+const isTokenLimitError = (error: { code?: string; message?: string }): boolean =>
+  error.code === '23514' || (error.message?.includes('Token limit reached') ?? false);
+const insertFailureResponse = (
+  req: Request,
+  error: { code?: string; message?: string }
+): Response => {
+  if (isTokenLimitError(error)) {
+    return createErrorResponse('Token limit reached (3 active)', 409, req);
+  }
+  console.error('token-create insert failed:', error);
+  return createErrorResponse('Failed to create token', 500, req);
+};
+const insertTokenRow = async (
+  supabase: SupabaseClient,
+  insertBody: Record<string, unknown>
+): Promise<{ data: unknown; error: { code?: string; message?: string } | null }> => {
+  const attemptInsert = () =>
+    supabase.from('api_tokens').insert(insertBody).select('token_id').single();
+  let { data, error } = await attemptInsert();
+  if (error?.code === '42703') {
+    // Column token_value not present (old schema): retry without it
+    delete insertBody.token_value;
+    ({ data, error } = await attemptInsert());
+  }
+  return { data, error };
+};
+const tokenIdFrom = (data: unknown): string | null =>
+  (data as { token_id?: string } | null)?.token_id || null;
+const respondWithCreatedToken = async (
+  req: Request,
+  supabase: SupabaseClient,
+  userId: string,
+  fields: ValidatedTokenFields
+): Promise<Response> => {
+  const tokenValue = fields.tokenValue || generateToken(fields.gameMode);
+  const tokenHash = await hashToken(tokenValue);
+  const { data, error } = await insertTokenRow(supabase, {
+    user_id: userId,
+    token_hash: tokenHash,
+    token_value: tokenValue,
+    permissions: fields.permissions,
+    game_mode: fields.gameMode,
+    note: fields.note,
+  });
+  if (error) return insertFailureResponse(req, error);
+  return createSuccessResponse({ success: true, tokenId: tokenIdFrom(data), tokenValue }, 200, req);
+};
+const handleCreateToken = async (
+  req: Request,
+  user: AuthSuccess['user'],
+  supabase: SupabaseClient
+): Promise<Response> => {
+  const body = await parseJsonBody(req);
+  const fields = parseRequestFields(body);
+  const error = validationError(body, fields);
+  if (error) return createErrorResponse(error, 400, req);
+  const validated = asValidatedFields(fields);
+  if (!validated) return createErrorResponse('Internal server error', 500, req);
+  return respondWithCreatedToken(req, supabase, user.id, validated);
+};
+const authorizeTokenMutation = async (req: Request): Promise<MutationGuard> => {
+  const methodError = validateMethod(req, ['POST']);
+  if (methodError) return { response: methodError };
+  const authResult = await authenticateUser(req);
+  if ('error' in authResult) {
+    return { response: createErrorResponse(authResult.error, authResult.status, req) };
+  }
+  const { user, supabase } = authResult as AuthSuccess;
+  const rateLimitResponse = await enforceUserMutationRateLimit(
+    req,
+    supabase,
+    user.id,
+    'token-create'
+  );
+  if (rateLimitResponse) return { response: rateLimitResponse };
+  return { user, supabase };
+};
 Deno.serve(async (req) => {
   // CORS preflight
   const cors = handleCorsPreflight(req);
   if (cors) return cors;
   try {
-    const methodError = validateMethod(req, ['POST']);
-    if (methodError) return methodError;
-    const authResult = await authenticateUser(req);
-    if ('error' in authResult) {
-      return createErrorResponse(authResult.error, authResult.status, req);
-    }
-    const { user, supabase } = authResult as AuthSuccess;
-    const rateLimitResponse = await enforceUserMutationRateLimit(
-      req,
-      supabase,
-      user.id,
-      'token-create'
-    );
-    if (rateLimitResponse) return rateLimitResponse;
-    let body: Record<string, unknown> = {};
-    try {
-      body = (await req.json()) as Record<string, unknown>;
-    } catch {
-      // ignore, handled below
-    }
-    const permissions = parseTokenPermissions(body.permissions);
-    const gameMode = (body.gameMode as string) || '';
-    const note = (body.note as string | null) || null;
-    let tokenValue = (body.tokenValue as string | undefined) || '';
-    if (!gameMode) {
-      return createErrorResponse('gameMode and permissions are required', 400, req);
-    }
-    if (!permissions) {
-      return createErrorResponse(
-        `permissions must be a non-empty array of: ${TOKEN_PERMISSIONS.join(', ')}`,
-        400,
-        req
-      );
-    }
-    if (!isTokenGameMode(gameMode)) {
-      return createErrorResponse(
-        `gameMode must be one of: ${TOKEN_GAME_MODES.join(', ')}`,
-        400,
-        req
-      );
-    }
-    if (body.tokenValue !== undefined && typeof body.tokenValue !== 'string') {
-      return createErrorResponse('tokenValue must be a string', 400, req);
-    }
-    if (tokenValue && !isTokenValueForGameMode(tokenValue, gameMode)) {
-      return createErrorResponse('tokenValue prefix must match gameMode', 400, req);
-    }
-    if (!tokenValue) tokenValue = generateToken(gameMode);
-    const tokenHash = await hashToken(tokenValue);
-    const insertBody: Record<string, unknown> = {
-      user_id: user.id,
-      token_hash: tokenHash,
-      token_value: tokenValue,
-      permissions,
-      game_mode: gameMode,
-      note,
-    };
-    const attemptInsert = () =>
-      supabase.from('api_tokens').insert(insertBody).select('token_id').single();
-    let { data, error } = await attemptInsert();
-    if (error?.code === '42703') {
-      // Column token_value not present (old schema): retry without it
-      delete insertBody.token_value;
-      ({ data, error } = await attemptInsert());
-    }
-    if (error) {
-      if (error.code === '23514' || error.message?.includes('Token limit reached')) {
-        return createErrorResponse('Token limit reached (3 active)', 409, req);
-      }
-      console.error('token-create insert failed:', error);
-      return createErrorResponse('Failed to create token', 500, req);
-    }
-    const tokenId = (data as { token_id?: string } | null)?.token_id || null;
-    return createSuccessResponse({ success: true, tokenId, tokenValue }, 200, req);
+    const guard = await authorizeTokenMutation(req);
+    if ('response' in guard) return guard.response;
+    return await handleCreateToken(req, guard.user, guard.supabase);
   } catch (error) {
     console.error('token-create error:', error);
     return createErrorResponse('Internal server error', 500, req);

--- a/supabase/functions/token-create/permissions.test.ts
+++ b/supabase/functions/token-create/permissions.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { isTokenPermission, parseTokenPermissions, TOKEN_PERMISSIONS } from './permissions.ts';
+describe('isTokenPermission', () => {
+  it('accepts only the supported permission values', () => {
+    for (const permission of TOKEN_PERMISSIONS) {
+      expect(isTokenPermission(permission)).toBe(true);
+    }
+  });
+  it('rejects unknown and non-string values', () => {
+    expect(isTokenPermission('XX')).toBe(false);
+    expect(isTokenPermission('gp')).toBe(false);
+    expect(isTokenPermission('')).toBe(false);
+    expect(isTokenPermission(123)).toBe(false);
+    expect(isTokenPermission(null)).toBe(false);
+    expect(isTokenPermission(undefined)).toBe(false);
+  });
+});
+describe('parseTokenPermissions', () => {
+  it('accepts non-empty arrays of supported permissions', () => {
+    expect(parseTokenPermissions(['GP'])).toEqual(['GP']);
+    expect(parseTokenPermissions(['WP', 'GP'])).toEqual(['WP', 'GP']);
+    expect(parseTokenPermissions([...TOKEN_PERMISSIONS])).toEqual(['GP', 'TP', 'WP']);
+  });
+  it('rejects permission-like strings instead of coercing them', () => {
+    expect(parseTokenPermissions('GP')).toBeNull();
+    expect(parseTokenPermissions('GP,TP')).toBeNull();
+    expect(parseTokenPermissions('')).toBeNull();
+  });
+  it('rejects non-array and missing values', () => {
+    expect(parseTokenPermissions(undefined)).toBeNull();
+    expect(parseTokenPermissions(null)).toBeNull();
+    expect(parseTokenPermissions({ 0: 'GP', length: 1 })).toBeNull();
+  });
+  it('rejects empty arrays', () => {
+    expect(parseTokenPermissions([])).toBeNull();
+  });
+  it('rejects mixed arrays containing unsupported values', () => {
+    expect(parseTokenPermissions(['GP', 'XX'])).toBeNull();
+    expect(parseTokenPermissions(['XX', 'GP'])).toBeNull();
+    expect(parseTokenPermissions(['GP', 123])).toBeNull();
+    expect(parseTokenPermissions(['GP', null])).toBeNull();
+  });
+  it('rejects arrays containing only unknown permissions', () => {
+    expect(parseTokenPermissions(['XX'])).toBeNull();
+    expect(parseTokenPermissions(['gp'])).toBeNull();
+  });
+});

--- a/supabase/functions/token-create/permissions.ts
+++ b/supabase/functions/token-create/permissions.ts
@@ -2,12 +2,7 @@ export const TOKEN_PERMISSIONS = ['GP', 'TP', 'WP'] as const;
 export type TokenPermission = (typeof TOKEN_PERMISSIONS)[number];
 export const isTokenPermission = (value: unknown): value is TokenPermission =>
   typeof value === 'string' && (TOKEN_PERMISSIONS as readonly string[]).includes(value);
-export const parseTokenPermissions = (value: unknown): TokenPermission[] | null => {
-  if (!Array.isArray(value) || value.length === 0) return null;
-  const permissions: TokenPermission[] = [];
-  for (const permission of value) {
-    if (!isTokenPermission(permission)) return null;
-    permissions.push(permission);
-  }
-  return permissions;
-};
+const isSupportedPermissionList = (value: unknown): value is readonly TokenPermission[] =>
+  Array.isArray(value) && value.length > 0 && value.every(isTokenPermission);
+export const parseTokenPermissions = (value: unknown): TokenPermission[] | null =>
+  isSupportedPermissionList(value) ? [...value] : null;

--- a/supabase/functions/token-create/permissions.ts
+++ b/supabase/functions/token-create/permissions.ts
@@ -1,0 +1,13 @@
+export const TOKEN_PERMISSIONS = ['GP', 'TP', 'WP'] as const;
+export type TokenPermission = (typeof TOKEN_PERMISSIONS)[number];
+export const isTokenPermission = (value: unknown): value is TokenPermission =>
+  typeof value === 'string' && (TOKEN_PERMISSIONS as readonly string[]).includes(value);
+export const parseTokenPermissions = (value: unknown): TokenPermission[] | null => {
+  if (!Array.isArray(value) || value.length === 0) return null;
+  const permissions: TokenPermission[] = [];
+  for (const permission of value) {
+    if (!isTokenPermission(permission)) return null;
+    permissions.push(permission);
+  }
+  return permissions;
+};


### PR DESCRIPTION
## Summary
- Add `parseTokenPermissions` to the `token-create` Edge Function: `permissions` must be a non-empty array whose elements are all supported permission values (`GP`/`TP`/`WP`), matching the api-gateway `Permission` enum and the frontend `API_PERMISSIONS` map
- Malformed input (a bare string like `"GP"`, mixed arrays, empty arrays, unknown values) now returns `400 permissions must be a non-empty array of: GP, TP, WP` before insertion, instead of a database error/`500` — or inserting permissions the gateway can never honor
- Document the validation in `docs/API.md` (Active Token Cap section)

Closes #620

## Test plan
- [x] New `permissions.test.ts` covers the issue's negative cases — strings, mixed arrays, empty arrays, unknown permissions — plus valid arrays (8 tests)
- [x] `pnpm exec vitest run supabase/functions/token-create/` — 15/15 pass (8 new + 7 existing)
- [x] `deno check token-create/index.ts token-create/permissions.ts` — clean
- [x] Prettier and blank-line lint clean on all touched files

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Token creation now supports validated permission settings using `GP`, `TP`, and `WP`.
  - Permissions must be provided as a non-empty array containing only supported values.

- **Bug Fixes**
  - Invalid permission formats, empty arrays, mixed values, and unsupported permissions are rejected with a clear `400` error before token creation.
  - Invalid request bodies and missing game mode values now receive clearer validation errors.
  - Token creation applies consistent validation and error handling.

- **Documentation**
  - Updated API documentation to explain the required permission format and accepted values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR validates token permissions before token insertion and synchronizes the public and canonical API documentation.

- Accepts only non-empty arrays containing `GP`, `TP`, or `WP`.
- Returns a clear `400` response for malformed or unsupported permissions.
- Adds focused validation tests and updates `docs/API.md` and `AGENTS.md`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains, and the previously reported canonical API guidance issue is fixed at the current head.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds the canonical token-create permission contract requested by the previous review thread. |
| docs/API.md | Documents the accepted permission shape, supported values, and validation response. |
| supabase/functions/token-create/index.ts | Integrates permission validation before insertion while preserving authentication, rate limiting, and token creation behavior. |
| supabase/functions/token-create/permissions.ts | Defines the permission allowlist and rejects empty, malformed, or unsupported permission inputs. |
| supabase/functions/token-create/permissions.test.ts | Covers valid permission arrays and malformed, empty, mixed, or unsupported inputs. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Authenticated token-create request] --> B[Apply mutation rate limit]
  B --> C[Parse request body]
  C --> D{Permissions are a non-empty allowlisted array?}
  D -- No --> E[Return 400]
  D -- Yes --> F[Validate game mode and token value]
  F --> G[Insert token]
  G --> H[Return created token]
```
</details>

<sub>Reviews (3): Last reviewed commit: ["fix(api): harden token body parsing and ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/d26a72baa7adcd9d15f112e18a2d842aa59e9269) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56686637)</sub>

**Context used:**

- Knowledge Base — [API access and gateway](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/api-access-and-gateway.md)

<!-- /greptile_comment -->