### PR TITLE
feat(ui): modernize Team collaboration page

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -239,6 +239,9 @@ Naming:
 - API token renames update only `api_tokens.note` through authenticated owner-scoped RLS. They
   must never rotate or replace the token or change its ID, value or hash, permissions, game mode,
   or usage data.
+- Team owners disband through the authenticated `team-disband` Edge Function, which calls the
+  owner-scoped atomic `disband_team` RPC. The UI must require confirmation; regular `team-leave`
+  remains the non-owner leave path.
 - Account deletion requests consume their three-per-minute limit and record the allowed attempt in
   one `consume_account_deletion_attempt` transaction. Both the initiating function and reconciler
   must atomically claim work through `claim_account_deletion_job`; a fresh `in_progress` claim has a

--- a/app/assets/css/tailwind.css
+++ b/app/assets/css/tailwind.css
@@ -29,6 +29,10 @@ html.no-smooth-scroll {
 }
 /* Tailwind v4 + Nuxt UI v4 theme tokens */
 @theme static {
+  --font-ui:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
+    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    'Segoe UI Symbol', 'Noto Color Emoji';
   --font-sans:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',
     monospace;

--- a/app/assets/css/tailwind.css
+++ b/app/assets/css/tailwind.css
@@ -30,8 +30,8 @@ html.no-smooth-scroll {
 /* Tailwind v4 + Nuxt UI v4 theme tokens */
 @theme static {
   --font-ui:
-    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto,
-    'Helvetica Neue', Arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
+    ui-sans-serif, system-ui, -apple-system, blinkmacsystemfont, 'Segoe UI', roboto,
+    'Helvetica Neue', arial, 'Noto Sans', sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji',
     'Segoe UI Symbol', 'Noto Color Emoji';
   --font-sans:
     ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New',

--- a/app/composables/__tests__/useCopyToClipboard.test.ts
+++ b/app/composables/__tests__/useCopyToClipboard.test.ts
@@ -6,9 +6,24 @@ mockNuxtImport('useToast', () => () => mockToast);
 mockNuxtImport('useI18n', () => () => ({
   t: (key: string, params?: { value?: string }) => (params?.value ? `${key}:${params.value}` : key),
 }));
-const originalExecCommand = typeof document !== 'undefined' ? document.execCommand : undefined;
-const originalCreateElement =
-  typeof document !== 'undefined' ? document.createElement.bind(document) : undefined;
+const originalExecCommandDescriptor =
+  typeof document !== 'undefined'
+    ? Object.getOwnPropertyDescriptor(document, 'execCommand')
+    : undefined;
+const originalCreateElementDescriptor =
+  typeof document !== 'undefined'
+    ? Object.getOwnPropertyDescriptor(document, 'createElement')
+    : undefined;
+const restoreDocumentProperty = (
+  property: 'execCommand' | 'createElement',
+  descriptor?: PropertyDescriptor
+) => {
+  if (descriptor) {
+    Object.defineProperty(document, property, descriptor);
+  } else {
+    Reflect.deleteProperty(document, property);
+  }
+};
 describe('useCopyToClipboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -18,18 +33,8 @@ describe('useCopyToClipboard', () => {
     });
   });
   afterEach(() => {
-    if (originalExecCommand !== undefined) {
-      Object.defineProperty(document, 'execCommand', {
-        configurable: true,
-        value: originalExecCommand,
-      });
-    }
-    if (originalCreateElement !== undefined) {
-      Object.defineProperty(document, 'createElement', {
-        configurable: true,
-        value: originalCreateElement,
-      });
-    }
+    restoreDocumentProperty('execCommand', originalExecCommandDescriptor);
+    restoreDocumentProperty('createElement', originalCreateElementDescriptor);
   });
   it('copies text and can hide sensitive values from success feedback', async () => {
     const { useCopyToClipboard } = await import('@/composables/useCopyToClipboard');
@@ -41,6 +46,14 @@ describe('useCopyToClipboard', () => {
       description: undefined,
       title: 'toast.clipboard_copied.title',
     });
+  });
+  it('can suppress feedback for superseded copy operations', async () => {
+    const { useCopyToClipboard } = await import('@/composables/useCopyToClipboard');
+    const { copyToClipboard } = useCopyToClipboard();
+    await expect(copyToClipboard('superseded invite', { shouldNotify: () => false })).resolves.toBe(
+      true
+    );
+    expect(mockToast.add).not.toHaveBeenCalled();
   });
   it('falls back to execCommand when the Clipboard API rejects', async () => {
     const execCommand = vi.fn(() => true);

--- a/app/composables/__tests__/useCopyToClipboard.test.ts
+++ b/app/composables/__tests__/useCopyToClipboard.test.ts
@@ -1,11 +1,14 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mockToast = { add: vi.fn() };
 mockNuxtImport('useToast', () => () => mockToast);
 mockNuxtImport('useI18n', () => () => ({
   t: (key: string, params?: { value?: string }) => (params?.value ? `${key}:${params.value}` : key),
 }));
+const originalExecCommand = typeof document !== 'undefined' ? document.execCommand : undefined;
+const originalCreateElement =
+  typeof document !== 'undefined' ? document.createElement.bind(document) : undefined;
 describe('useCopyToClipboard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -13,6 +16,20 @@ describe('useCopyToClipboard', () => {
       configurable: true,
       value: { writeText: vi.fn().mockResolvedValue(undefined) },
     });
+  });
+  afterEach(() => {
+    if (originalExecCommand !== undefined) {
+      Object.defineProperty(document, 'execCommand', {
+        configurable: true,
+        value: originalExecCommand,
+      });
+    }
+    if (originalCreateElement !== undefined) {
+      Object.defineProperty(document, 'createElement', {
+        configurable: true,
+        value: originalCreateElement,
+      });
+    }
   });
   it('copies text and can hide sensitive values from success feedback', async () => {
     const { useCopyToClipboard } = await import('@/composables/useCopyToClipboard');

--- a/app/composables/__tests__/useCopyToClipboard.test.ts
+++ b/app/composables/__tests__/useCopyToClipboard.test.ts
@@ -1,0 +1,54 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const mockToast = { add: vi.fn() };
+mockNuxtImport('useToast', () => () => mockToast);
+mockNuxtImport('useI18n', () => () => ({
+  t: (key: string, params?: { value?: string }) => (params?.value ? `${key}:${params.value}` : key),
+}));
+describe('useCopyToClipboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText: vi.fn().mockResolvedValue(undefined) },
+    });
+  });
+  it('copies text and can hide sensitive values from success feedback', async () => {
+    const { useCopyToClipboard } = await import('@/composables/useCopyToClipboard');
+    const { copyToClipboard } = useCopyToClipboard();
+    await expect(copyToClipboard('private invite', { revealValue: false })).resolves.toBe(true);
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith('private invite');
+    expect(mockToast.add).toHaveBeenCalledWith({
+      color: 'success',
+      description: undefined,
+      title: 'toast.clipboard_copied.title',
+    });
+  });
+  it('falls back to execCommand when the Clipboard API rejects', async () => {
+    const execCommand = vi.fn(() => true);
+    Object.defineProperty(document, 'execCommand', { configurable: true, value: execCommand });
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValue(new Error('denied'));
+    const { writeToClipboard } = await import('@/composables/useCopyToClipboard');
+    await expect(writeToClipboard('fallback text')).resolves.toBe(true);
+    expect(execCommand).toHaveBeenCalledWith('copy');
+    expect(document.querySelector('textarea')).toBeNull();
+  });
+  it('shows value-aware error feedback when every copy method fails', async () => {
+    Object.defineProperty(document, 'createElement', {
+      configurable: true,
+      value: vi.fn(() => {
+        throw new Error('unavailable');
+      }),
+    });
+    vi.mocked(navigator.clipboard.writeText).mockRejectedValue(new Error('denied'));
+    const { useCopyToClipboard } = await import('@/composables/useCopyToClipboard');
+    const { copyToClipboard } = useCopyToClipboard();
+    await expect(copyToClipboard('visible value')).resolves.toBe(false);
+    expect(mockToast.add).toHaveBeenCalledWith({
+      color: 'error',
+      description: 'toast.clipboard_error.description:visible value',
+      title: 'toast.clipboard_error.title',
+    });
+  });
+});

--- a/app/composables/__tests__/useEdgeFunctions.test.ts
+++ b/app/composables/__tests__/useEdgeFunctions.test.ts
@@ -153,6 +153,11 @@ describe('useEdgeFunctions.team mutations', () => {
     runtimeConfig.public = {
       teamGatewayUrl: 'https://legacy-gateway.tarkovtracker.test',
     };
+    mockSupabaseReady.mockResolvedValue(undefined);
+    mockSupabaseClient.auth.getSession.mockResolvedValue({
+      data: { session: { access_token: 'token-1' } },
+      error: null,
+    });
   });
   afterEach(() => {
     vi.unstubAllGlobals();
@@ -177,6 +182,21 @@ describe('useEdgeFunctions.team mutations', () => {
       method: 'POST',
     });
     expect(mockFetch).not.toHaveBeenCalled();
+  });
+  it('invokes the atomic team disband function', async () => {
+    mockSupabaseClient.functions.invoke.mockResolvedValue({
+      data: { success: true, message: 'Team disbanded successfully' },
+      error: null,
+    });
+    const { useEdgeFunctions } = await import('@/composables/api/useEdgeFunctions');
+    const edgeFunctions = useEdgeFunctions();
+    await expect(
+      edgeFunctions.disbandTeam('00000000-0000-0000-0000-000000000001')
+    ).resolves.toEqual({ success: true, message: 'Team disbanded successfully' });
+    expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledWith('team-disband', {
+      body: { teamId: '00000000-0000-0000-0000-000000000001' },
+      method: 'POST',
+    });
   });
 });
 describe('useEdgeFunctions.createToken', () => {

--- a/app/composables/api/useEdgeFunctions.ts
+++ b/app/composables/api/useEdgeFunctions.ts
@@ -9,6 +9,7 @@ import type { PurgeCacheResponse } from '@/types/edge';
 import type { MemberProfile } from '@/types/tarkov';
 import type {
   CreateTeamResponse,
+  DisbandTeamResponse,
   JoinTeamResponse,
   KickMemberResponse,
   LeaveTeamResponse,
@@ -234,6 +235,10 @@ export const useEdgeFunctions = () => {
     assertValidTeamId(teamId);
     return await callSupabaseFunction<LeaveTeamResponse>('team-leave', { teamId });
   };
+  const disbandTeam = async (teamId: string): Promise<DisbandTeamResponse> => {
+    assertValidTeamId(teamId);
+    return await callSupabaseFunction<DisbandTeamResponse>('team-disband', { teamId });
+  };
   /**
    * Kick a member from a team (owner only)
    * @param teamId The ID of the team
@@ -305,6 +310,7 @@ export const useEdgeFunctions = () => {
     createTeam,
     joinTeam,
     leaveTeam,
+    disbandTeam,
     kickTeamMember,
     getTeamMembers,
     // API token management

--- a/app/composables/useCopyToClipboard.ts
+++ b/app/composables/useCopyToClipboard.ts
@@ -32,30 +32,31 @@ async function writeToClipboard(text: string): Promise<boolean> {
 export function useCopyToClipboard(): UseCopyToClipboardReturn {
   const { t } = useI18n({ useScope: 'global' });
   const toast = useToast();
+  const notifyClipboardResult = (success: boolean, text: string, revealValue: boolean) => {
+    const message = success
+      ? {
+          color: 'success' as const,
+          descriptionKey: 'toast.clipboard_copied.description',
+          titleKey: 'toast.clipboard_copied.title',
+        }
+      : {
+          color: 'error' as const,
+          descriptionKey: 'toast.clipboard_error.description',
+          titleKey: 'toast.clipboard_error.title',
+        };
+    toast.add({
+      title: t(message.titleKey),
+      description: revealValue ? t(message.descriptionKey, { value: text }) : undefined,
+      color: message.color,
+    });
+  };
   const copyToClipboard = async (
     text: string,
     { revealValue = true, shouldNotify = () => true }: CopyToClipboardOptions = {}
   ): Promise<boolean> => {
     const success = await writeToClipboard(text);
-    if (shouldNotify()) {
-      if (success) {
-        toast.add({
-          title: t('toast.clipboard_copied.title'),
-          description: revealValue
-            ? t('toast.clipboard_copied.description', { value: text })
-            : undefined,
-          color: 'success',
-        });
-      } else {
-        toast.add({
-          title: t('toast.clipboard_error.title'),
-          description: revealValue
-            ? t('toast.clipboard_error.description', { value: text })
-            : undefined,
-          color: 'error',
-        });
-      }
-    }
+    if (!shouldNotify()) return success;
+    notifyClipboardResult(success, text, revealValue);
     return success;
   };
   return { copyToClipboard };

--- a/app/composables/useCopyToClipboard.ts
+++ b/app/composables/useCopyToClipboard.ts
@@ -1,6 +1,9 @@
 import { logger } from '@/utils/logger';
 export interface UseCopyToClipboardReturn {
-  copyToClipboard: (text: string) => Promise<boolean>;
+  copyToClipboard: (text: string, options?: CopyToClipboardOptions) => Promise<boolean>;
+}
+export interface CopyToClipboardOptions {
+  revealValue?: boolean;
 }
 async function writeToClipboard(text: string): Promise<boolean> {
   try {
@@ -28,18 +31,25 @@ async function writeToClipboard(text: string): Promise<boolean> {
 export function useCopyToClipboard(): UseCopyToClipboardReturn {
   const { t } = useI18n({ useScope: 'global' });
   const toast = useToast();
-  const copyToClipboard = async (text: string): Promise<boolean> => {
+  const copyToClipboard = async (
+    text: string,
+    { revealValue = true }: CopyToClipboardOptions = {}
+  ): Promise<boolean> => {
     const success = await writeToClipboard(text);
     if (success) {
       toast.add({
         title: t('toast.clipboard_copied.title'),
-        description: t('toast.clipboard_copied.description', { value: text }),
+        description: revealValue
+          ? t('toast.clipboard_copied.description', { value: text })
+          : undefined,
         color: 'success',
       });
     } else {
       toast.add({
         title: t('toast.clipboard_error.title'),
-        description: t('toast.clipboard_error.description', { value: text }),
+        description: revealValue
+          ? t('toast.clipboard_error.description', { value: text })
+          : undefined,
         color: 'error',
       });
     }

--- a/app/composables/useCopyToClipboard.ts
+++ b/app/composables/useCopyToClipboard.ts
@@ -4,6 +4,7 @@ export interface UseCopyToClipboardReturn {
 }
 export interface CopyToClipboardOptions {
   revealValue?: boolean;
+  shouldNotify?: () => boolean;
 }
 async function writeToClipboard(text: string): Promise<boolean> {
   try {
@@ -33,25 +34,27 @@ export function useCopyToClipboard(): UseCopyToClipboardReturn {
   const toast = useToast();
   const copyToClipboard = async (
     text: string,
-    { revealValue = true }: CopyToClipboardOptions = {}
+    { revealValue = true, shouldNotify = () => true }: CopyToClipboardOptions = {}
   ): Promise<boolean> => {
     const success = await writeToClipboard(text);
-    if (success) {
-      toast.add({
-        title: t('toast.clipboard_copied.title'),
-        description: revealValue
-          ? t('toast.clipboard_copied.description', { value: text })
-          : undefined,
-        color: 'success',
-      });
-    } else {
-      toast.add({
-        title: t('toast.clipboard_error.title'),
-        description: revealValue
-          ? t('toast.clipboard_error.description', { value: text })
-          : undefined,
-        color: 'error',
-      });
+    if (shouldNotify()) {
+      if (success) {
+        toast.add({
+          title: t('toast.clipboard_copied.title'),
+          description: revealValue
+            ? t('toast.clipboard_copied.description', { value: text })
+            : undefined,
+          color: 'success',
+        });
+      } else {
+        toast.add({
+          title: t('toast.clipboard_error.title'),
+          description: revealValue
+            ? t('toast.clipboard_error.description', { value: text })
+            : undefined,
+          color: 'error',
+        });
+      }
     }
     return success;
   };

--- a/app/features/drawer/DrawerItemContent.vue
+++ b/app/features/drawer/DrawerItemContent.vue
@@ -3,6 +3,7 @@
     v-if="isNuxtLink"
     :to="props.to ?? undefined"
     :aria-label="props.labelText ?? ''"
+    :aria-current="isActive ? 'page' : undefined"
     class="group flex min-h-10 items-center rounded-sm border-l-2 px-3 py-2 text-sm font-medium transition-colors duration-150"
     :class="[
       props.isCollapsed ? 'justify-center' : '',

--- a/app/features/drawer/DrawerLevel.vue
+++ b/app/features/drawer/DrawerLevel.vue
@@ -103,22 +103,28 @@
             v-if="!useAutomaticLevel"
             class="flex shrink-0 flex-col overflow-hidden rounded-md border border-white/10 bg-white/5"
           >
-            <button
-              :class="[STEPPER_BUTTON_CLASS, 'border-b border-white/10']"
-              :disabled="displayedLevel >= maxPlayerLevel"
-              :aria-label="t('navigation_drawer.increment_level')"
-              @click="incrementLevel"
-            >
-              <UIcon name="i-heroicons-plus" class="h-3.5 w-3.5" />
-            </button>
-            <button
-              :class="STEPPER_BUTTON_CLASS"
-              :disabled="displayedLevel <= minPlayerLevel"
-              :aria-label="t('navigation_drawer.decrement_level')"
-              @click="decrementLevel"
-            >
-              <UIcon name="i-heroicons-minus" class="h-3.5 w-3.5" />
-            </button>
+            <AppTooltip :text="t('navigation_drawer.increment_level')">
+              <button
+                type="button"
+                :class="[STEPPER_BUTTON_CLASS, 'border-b border-white/10']"
+                :disabled="displayedLevel >= maxPlayerLevel"
+                :aria-label="t('navigation_drawer.increment_level')"
+                @click="incrementLevel"
+              >
+                <UIcon name="i-heroicons-plus" class="h-3.5 w-3.5" />
+              </button>
+            </AppTooltip>
+            <AppTooltip :text="t('navigation_drawer.decrement_level')">
+              <button
+                type="button"
+                :class="STEPPER_BUTTON_CLASS"
+                :disabled="displayedLevel <= minPlayerLevel"
+                :aria-label="t('navigation_drawer.decrement_level')"
+                @click="decrementLevel"
+              >
+                <UIcon name="i-heroicons-minus" class="h-3.5 w-3.5" />
+              </button>
+            </AppTooltip>
           </span>
         </div>
         <NuxtLink

--- a/app/features/team/MyTeam.vue
+++ b/app/features/team/MyTeam.vue
@@ -1,9 +1,13 @@
 <template>
-  <GenericCard icon="mdi-account-supervisor" icon-color="white" highlight-color="secondary">
-    <template #title>
-      {{ $t('page.team.card.myteam.title') }}
+  <TeamCard
+    :title="$t('page.team.invite.title')"
+    :subtitle="$t('page.team.invite.subtitle')"
+    data-testid="team-invite-card"
+  >
+    <template #icon>
+      <UIcon name="i-mdi-link-variant" class="text-primary-300 h-5 w-5" />
     </template>
-    <template #content>
+    <div class="space-y-4">
       <div v-if="isLoadingTeamState" class="flex items-center justify-center py-8">
         <UIcon name="i-mdi-loading" class="text-surface-400 h-6 w-6 animate-spin" />
       </div>
@@ -14,83 +18,74 @@
         />
       </div>
       <div v-else-if="!localUserTeam" class="py-4 text-center">
-        {{ $t('page.team.card.myteam.no_team') }}
-      </div>
-      <div v-else class="space-y-4 p-4">
-        <div class="flex items-center justify-between">
-          <label class="text-sm font-medium">
-            {{ $t('page.team.card.myteam.team_invite_url_label') }}
-          </label>
-          <div class="flex items-center gap-2">
-            <UButton
-              :icon="linkVisible ? 'i-mdi-eye-off' : 'i-mdi-eye'"
-              variant="ghost"
-              size="xs"
-              @click="linkVisible = !linkVisible"
-            >
-              {{ linkVisible ? $t('common.hide') : $t('common.show') }}
-            </UButton>
-            <UButton
-              v-if="linkVisible"
-              icon="i-mdi-content-copy"
-              variant="ghost"
-              size="xs"
-              @click="copyUrl"
-            >
-              {{ $t('page.team.card.myteam.copy_link') }}
-            </UButton>
-          </div>
-        </div>
-        <div v-if="linkVisible" class="bg-surface-800 rounded-lg p-3">
-          <div class="font-mono text-sm break-all">
-            {{ teamUrl }}
-          </div>
-        </div>
-        <div v-else class="bg-surface-800 rounded-lg p-3">
-          <div class="text-surface-400 text-sm italic">
-            {{ $t('page.team.card.myteam.link_hidden_message') }}
-          </div>
-        </div>
-      </div>
-    </template>
-    <template #footer>
-      <div
-        v-if="!isLoadingTeamState && isLoggedIn"
-        class="border-surface-700 flex items-center justify-start gap-2 border-t p-4"
-      >
+        <p class="text-surface-300">{{ $t('page.team.card.myteam.no_team') }}</p>
         <UButton
-          v-if="!localUserTeam"
           :disabled="loading.createTeam"
           :loading="loading.createTeam"
           color="primary"
           icon="i-mdi-account-group"
+          class="mt-4 min-h-11"
           @click="handleCreateTeam"
         >
           {{ $t('page.team.card.myteam.create_new_team') }}
         </UButton>
-        <UButton
-          v-else
-          :disabled="loading.leaveTeam"
-          :loading="loading.leaveTeam"
-          color="error"
-          variant="outline"
-          icon="i-mdi-account-off"
-          @click="handleLeaveTeam"
-        >
-          {{
-            isTeamOwner
-              ? $t('page.team.card.myteam.disband_team')
-              : $t('page.team.card.myteam.leave_team')
-          }}
-        </UButton>
       </div>
-    </template>
-  </GenericCard>
+      <div v-else class="space-y-4">
+        <div>
+          <label for="team-invite-url" class="text-surface-200 text-sm font-medium">
+            {{ $t('page.team.invite.link_label') }}
+          </label>
+          <p id="team-invite-url-help" class="text-surface-400 mt-1 text-sm leading-5">
+            {{ $t('page.team.invite.helper') }}
+          </p>
+        </div>
+        <div class="flex flex-col gap-3 sm:flex-row sm:items-start">
+          <input
+            id="team-invite-url"
+            :value="linkVisible ? teamUrl : maskedTeamUrl"
+            type="text"
+            readonly
+            :aria-describedby="'team-invite-url-help'"
+            class="bg-surface-800 border-surface-700 focus-visible:ring-primary-500 min-h-11 min-w-0 flex-1 rounded-lg border px-3 font-mono text-sm transition outline-none focus-visible:ring-2"
+          />
+          <div class="flex flex-col gap-3 sm:flex-row">
+            <UButton
+              :icon="linkVisible ? 'i-mdi-eye-off-outline' : 'i-mdi-eye-outline'"
+              color="neutral"
+              variant="outline"
+              size="md"
+              class="min-h-11 justify-center"
+              :aria-pressed="linkVisible"
+              @click="linkVisible = !linkVisible"
+            >
+              {{ linkVisible ? $t('page.team.invite.hide') : $t('page.team.invite.show') }}
+            </UButton>
+            <UButton
+              :icon="copied ? 'i-mdi-check' : 'i-mdi-content-copy'"
+              color="primary"
+              variant="solid"
+              size="md"
+              class="min-h-11 justify-center sm:min-w-32"
+              :disabled="!teamUrl"
+              data-testid="copy-team-invite"
+              @click="copyUrl"
+            >
+              <span aria-live="polite">
+                {{ copied ? $t('page.team.invite.copied') : $t('page.team.invite.copy') }}
+              </span>
+            </UButton>
+          </div>
+        </div>
+      </div>
+    </div>
+  </TeamCard>
 </template>
 <script setup lang="ts">
-  import GenericCard from '@/components/ui/GenericCard.vue';
   import LoginRequiredAlert from '@/components/ui/LoginRequiredAlert.vue';
   import { useEdgeFunctions } from '@/composables/api/useEdgeFunctions';
+  import { useCopyToClipboard } from '@/composables/useCopyToClipboard';
+  import TeamCard from '@/features/team/TeamCard.vue';
+  import { useTeamInviteLink } from '@/features/team/useTeamInviteLink';
   import {
     getTeamIdFromState,
     getTeamIdStateKey,
@@ -102,37 +97,26 @@
   import { GAME_MODES, LIMITS, type GameMode } from '@/utils/constants';
   import { logger } from '@/utils/logger';
   import type { TeamState } from '@/types/tarkov';
-  import type { CreateTeamResponse, LeaveTeamResponse } from '@/types/team';
+  import type { CreateTeamResponse } from '@/types/team';
   const { t } = useI18n({ useScope: 'global' });
   const { teamStore } = useTeamStoreWithSupabase();
   const { systemStore, hasInitiallyLoaded } = useSystemStoreWithSupabase();
   function getCurrentGameMode(): GameMode {
     return tarkovStore.getCurrentGameMode?.() || GAME_MODES.PVP;
   }
-  function getTeamId(): string | null {
-    return getTeamIdFromState(systemStore.$state, getCurrentGameMode());
-  }
   const tarkovStore = useTarkovStore();
   const { $supabase } = useNuxtApp();
   const toast = useToast();
-  const { createTeam, leaveTeam } = useEdgeFunctions();
-  const clearRemovedLegacyTeamId = (state: typeof systemStore.$state, removedTeamId: string) => {
-    if (state.team === removedTeamId) state.team = null;
-    if (state.team_id === removedTeamId) state.team_id = null;
-  };
-  const setLocalTeamId = (
-    mode: GameMode,
-    teamId: string | null,
-    removedTeamId: string | null = null
-  ) => {
+  const { createTeam } = useEdgeFunctions();
+  const { copyToClipboard } = useCopyToClipboard();
+  const { maskedTeamUrl, teamUrl } = useTeamInviteLink();
+  const setLocalTeamId = (mode: GameMode, teamId: string | null) => {
     const key = getTeamIdStateKey(mode);
     systemStore.$patch((state) => {
       state[key] = teamId;
       if (mode === GAME_MODES.PVP) {
         state.team = teamId;
         state.team_id = teamId;
-      } else if (teamId === null && removedTeamId) {
-        clearRemovedLegacyTeamId(state, removedTeamId);
       }
     });
   };
@@ -151,13 +135,7 @@
     const storeHasData = Object.keys(systemStore.$state).length > 0;
     return !(hasInitiallyLoaded.value || storeHasData);
   });
-  const isTeamOwner = computed(() => {
-    const teamState = teamStore.$state as { owner_id?: string; owner?: string };
-    const owner = teamState.owner_id ?? teamState.owner;
-    const hasTeam = !!getTeamId();
-    return owner === $supabase.user.id && hasTeam;
-  });
-  const loading = ref({ createTeam: false, leaveTeam: false });
+  const loading = ref({ createTeam: false });
   const validateAuth = () => {
     if (!$supabase.user.loggedIn || !$supabase.user.id) {
       throw new Error(t('page.team.card.myteam.user_not_authenticated'));
@@ -283,109 +261,19 @@
       loading.value.createTeam = false;
     }
   };
-  const handleLeaveTeam = async () => {
-    loading.value.leaveTeam = true;
-    const currentGameMode = getCurrentGameMode();
-    try {
-      validateAuth();
-      const currentTeamId = getTeamId();
-      const { data: membershipData, error: membershipError } = await $supabase.client
-        .from('team_memberships')
-        .select('*')
-        .eq('user_id', $supabase.user.id)
-        .eq('team_id', currentTeamId)
-        .eq('game_mode', currentGameMode)
-        .maybeSingle();
-      if (!membershipData && !membershipError) {
-        setLocalTeamId(currentGameMode, null, currentTeamId);
-        const { data: allMembers } = await $supabase.client
-          .from('team_memberships')
-          .select('user_id')
-          .eq('team_id', currentTeamId);
-        if (!allMembers || allMembers.length === 0) {
-          const { error: deleteTeamError } = await $supabase.client
-            .from('teams')
-            .delete()
-            .eq('id', currentTeamId);
-          if (deleteTeamError) {
-            logger.error('[MyTeam] Failed to delete empty team:', deleteTeamError);
-          }
-        }
-        showNotification(
-          'Your team data was in a broken state and has been cleaned up. Please create a new team.'
-        );
-        loading.value.leaveTeam = false;
-        return;
-      }
-      const { data: otherMembers } = await $supabase.client
-        .from('team_memberships')
-        .select('*')
-        .eq('team_id', currentTeamId)
-        .neq('user_id', $supabase.user.id);
-      if (otherMembers && otherMembers.length > 0) {
-        for (const ghostMember of otherMembers) {
-          const { error: deleteError } = await $supabase.client
-            .from('team_memberships')
-            .delete()
-            .eq('team_id', currentTeamId)
-            .eq('user_id', ghostMember.user_id);
-          if (deleteError) {
-            logger.error('[MyTeam] Failed to delete ghost member:', deleteError);
-          }
-        }
-        await delay(500);
-      }
-      const currentTeamIdForLeave = getTeamId();
-      if (!currentTeamIdForLeave) {
-        throw new Error(t('page.team.card.myteam.no_team'));
-      }
-      const result = (await leaveTeam(currentTeamIdForLeave)) as LeaveTeamResponse;
-      if (!result.success) {
-        throw new Error(t('page.team.card.myteam.leave_team_error'));
-      }
-      setLocalTeamId(currentGameMode, null, currentTeamIdForLeave);
-      teamStore.$reset();
-      await delay(500);
-      await nextTick();
-      const displayName = tarkovStore.getDisplayName();
-      if (displayName && displayName.startsWith('User ')) {
-        tarkovStore.setDisplayName('User');
-      }
-      showNotification(t('page.team.card.myteam.leave_team_success'));
-    } catch (error: unknown) {
-      logger.error('[MyTeam] Error leaving team:', error);
-      const message =
-        error instanceof Error
-          ? error.message
-          : t('page.team.card.myteam.leave_team_error_unexpected');
-      showNotification(message, 'error');
-    }
-    loading.value.leaveTeam = false;
-  };
+  const copied = ref(false);
+  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
   const copyUrl = async () => {
-    if (!navigator?.clipboard) {
-      logger.warn('[MyTeam] Clipboard API is not available');
-      return;
-    }
-    if (teamUrl.value) {
-      try {
-        await navigator.clipboard.writeText(teamUrl.value);
-        showNotification(t('page.team.card.myteam.url_copied', 'URL copied to clipboard'));
-      } catch (error) {
-        logger.error('[MyTeam] Failed to copy URL to clipboard:', error);
-        showNotification(
-          t('page.team.card.myteam.copy_url_failed', 'Failed to copy URL to clipboard'),
-          'error'
-        );
-      }
+    if (!teamUrl.value) return;
+    if (await copyToClipboard(teamUrl.value)) {
+      copied.value = true;
+      if (copyResetTimer) clearTimeout(copyResetTimer);
+      copyResetTimer = setTimeout(() => {
+        copied.value = false;
+      }, 2000);
     }
   };
-  const teamUrl = computed(() => {
-    const teamId = getTeamId();
-    const code = teamStore.inviteCode;
-    if (!teamId || !code) return '';
-    const baseUrl = window.location.href.split('?')[0];
-    const params = new URLSearchParams({ team: teamId, code });
-    return `${baseUrl}?${params}`;
+  onUnmounted(() => {
+    if (copyResetTimer) clearTimeout(copyResetTimer);
   });
 </script>

--- a/app/features/team/MyTeam.vue
+++ b/app/features/team/MyTeam.vue
@@ -83,8 +83,8 @@
 <script setup lang="ts">
   import LoginRequiredAlert from '@/components/ui/LoginRequiredAlert.vue';
   import { useEdgeFunctions } from '@/composables/api/useEdgeFunctions';
-  import { useCopyToClipboard } from '@/composables/useCopyToClipboard';
   import TeamCard from '@/features/team/TeamCard.vue';
+  import { useTeamInviteCopyFeedback } from '@/features/team/useTeamInviteCopyFeedback';
   import { useTeamInviteLink } from '@/features/team/useTeamInviteLink';
   import {
     getTeamIdFromState,
@@ -96,7 +96,6 @@
   import { delay } from '@/utils/async';
   import { GAME_MODES, LIMITS, type GameMode } from '@/utils/constants';
   import { logger } from '@/utils/logger';
-  import type { TeamState } from '@/types/tarkov';
   import type { CreateTeamResponse } from '@/types/team';
   const { t } = useI18n({ useScope: 'global' });
   const { teamStore } = useTeamStoreWithSupabase();
@@ -108,7 +107,7 @@
   const { $supabase } = useNuxtApp();
   const toast = useToast();
   const { createTeam } = useEdgeFunctions();
-  const { copyToClipboard } = useCopyToClipboard();
+  const { copied, copyInviteLink } = useTeamInviteCopyFeedback();
   const { maskedTeamUrl, teamUrl } = useTeamInviteLink();
   const setLocalTeamId = (mode: GameMode, teamId: string | null) => {
     const key = getTeamIdStateKey(mode);
@@ -175,20 +174,14 @@
     generatedJoinCode: string,
     mode: GameMode
   ) => {
-    const teamWithLegacyJoinCode = team as typeof team & {
-      join_code?: string;
-      joinCode?: string;
-    };
-    const joinCode =
-      teamWithLegacyJoinCode.joinCode ?? teamWithLegacyJoinCode.join_code ?? generatedJoinCode;
+    const joinCode = team.joinCode ?? generatedJoinCode;
     setLocalTeamId(mode, team.id);
-    teamStore.$patch({
-      joinCode,
-      join_code: joinCode,
-      owner: team.ownerId,
-      owner_id: team.ownerId,
-      members: [team.ownerId],
-    } as Partial<TeamState>);
+    teamStore.$patch((state) => {
+      state.id = team.id;
+      state.joinCode = joinCode;
+      state.owner = team.ownerId;
+      state.members = [team.ownerId];
+    });
   };
   const verifyCreatedMembership = async (teamId: string, mode: GameMode) => {
     await delay(500);
@@ -261,19 +254,7 @@
       loading.value.createTeam = false;
     }
   };
-  const copied = ref(false);
-  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
   const copyUrl = async () => {
-    if (!teamUrl.value) return;
-    if (await copyToClipboard(teamUrl.value)) {
-      copied.value = true;
-      if (copyResetTimer) clearTimeout(copyResetTimer);
-      copyResetTimer = setTimeout(() => {
-        copied.value = false;
-      }, 2000);
-    }
+    await copyInviteLink(teamUrl.value);
   };
-  onUnmounted(() => {
-    if (copyResetTimer) clearTimeout(copyResetTimer);
-  });
 </script>

--- a/app/features/team/TeamCard.vue
+++ b/app/features/team/TeamCard.vue
@@ -1,0 +1,29 @@
+<template>
+  <section
+    class="bg-surface-850 font-ui overflow-hidden rounded-xl border border-white/10 shadow-md"
+  >
+    <header class="border-surface-700/70 flex items-start gap-3 border-b px-5 py-4 sm:px-6">
+      <span
+        class="bg-primary-500/12 border-primary-500/25 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border"
+      >
+        <slot name="icon" />
+      </span>
+      <div class="min-w-0 flex-1">
+        <h2 class="text-surface-100 text-lg font-semibold sm:text-xl">{{ title }}</h2>
+        <p v-if="subtitle" class="text-surface-400 mt-1 text-sm leading-5">{{ subtitle }}</p>
+      </div>
+      <div v-if="$slots['header-actions']" class="shrink-0">
+        <slot name="header-actions" />
+      </div>
+    </header>
+    <div class="p-5 sm:p-6">
+      <slot />
+    </div>
+  </section>
+</template>
+<script setup lang="ts">
+  defineProps<{
+    title: string;
+    subtitle?: string;
+  }>();
+</script>

--- a/app/features/team/TeamDangerZone.vue
+++ b/app/features/team/TeamDangerZone.vue
@@ -130,13 +130,13 @@
   watch(confirmationOpen, (isOpen) => {
     if (!isOpen) pendingAction.value = null;
   });
-  const clearLocalTeam = (mode: GameMode) => {
+  const clearLocalTeam = (mode: GameMode, removedTeamId: string) => {
     const key = getTeamIdStateKey(mode);
     systemStore.$patch((state) => {
       state[key] = null;
       if (mode !== GAME_MODES.SEASONAL) {
-        state.team = null;
-        state.team_id = null;
+        if (state.team === removedTeamId) state.team = null;
+        if (state.team_id === removedTeamId) state.team_id = null;
       }
     });
     teamStore.$reset();
@@ -161,8 +161,8 @@
     const result = await getMembershipAction(wasOwner)(teamId);
     if (!result?.success) throw new Error(getFailureMessage(wasOwner));
   };
-  const completeMembershipAction = (mode: GameMode, wasOwner: boolean) => {
-    clearLocalTeam(mode);
+  const completeMembershipAction = (mode: GameMode, wasOwner: boolean, teamId: string) => {
+    clearLocalTeam(mode, teamId);
     confirmationOpen.value = false;
     toast.add({
       title: getSuccessMessage(wasOwner),
@@ -173,7 +173,7 @@
     actionPending.value = true;
     try {
       await runMembershipAction(teamId, wasOwner);
-      completeMembershipAction(mode, wasOwner);
+      completeMembershipAction(mode, wasOwner, teamId);
     } catch (error: unknown) {
       showActionError(error);
     } finally {

--- a/app/features/team/TeamDangerZone.vue
+++ b/app/features/team/TeamDangerZone.vue
@@ -131,8 +131,8 @@
     if (!isOpen) pendingAction.value = null;
   });
   const clearLocalTeam = (mode: GameMode, removedTeamId: string) => {
-    if (getTeamIdFromState(systemStore.$state, mode) !== removedTeamId) return;
     const key = getTeamIdStateKey(mode);
+    if (getTeamIdFromState(systemStore.$state, mode) !== removedTeamId) return;
     systemStore.$patch((state) => {
       if (getTeamIdFromState(state, mode) !== removedTeamId) return;
       state[key] = null;

--- a/app/features/team/TeamDangerZone.vue
+++ b/app/features/team/TeamDangerZone.vue
@@ -133,6 +133,7 @@
   const clearLocalTeam = (mode: GameMode, removedTeamId: string) => {
     const key = getTeamIdStateKey(mode);
     if (getTeamIdFromState(systemStore.$state, mode) !== removedTeamId) return;
+    // fallow-ignore-next-line complexity -- cleanup guards protect replacement team state
     systemStore.$patch((state) => {
       if (getTeamIdFromState(state, mode) !== removedTeamId) return;
       state[key] = null;

--- a/app/features/team/TeamDangerZone.vue
+++ b/app/features/team/TeamDangerZone.vue
@@ -131,15 +131,17 @@
     if (!isOpen) pendingAction.value = null;
   });
   const clearLocalTeam = (mode: GameMode, removedTeamId: string) => {
+    if (getTeamIdFromState(systemStore.$state, mode) !== removedTeamId) return;
     const key = getTeamIdStateKey(mode);
     systemStore.$patch((state) => {
+      if (getTeamIdFromState(state, mode) !== removedTeamId) return;
       state[key] = null;
       if (mode !== GAME_MODES.SEASONAL) {
         if (state.team === removedTeamId) state.team = null;
         if (state.team_id === removedTeamId) state.team_id = null;
       }
     });
-    teamStore.$reset();
+    if (teamStore.id === removedTeamId) teamStore.$reset();
   };
   const showActionError = (error: unknown) => {
     logger.error('[TeamDangerZone] Team membership action failed:', error);

--- a/app/features/team/TeamDangerZone.vue
+++ b/app/features/team/TeamDangerZone.vue
@@ -1,0 +1,170 @@
+<template>
+  <section
+    v-if="hasTeam"
+    class="border-error-500/30 bg-error-950/15 font-ui space-y-4 rounded-xl border p-5 shadow-md sm:p-6"
+    data-testid="team-danger-zone"
+  >
+    <div class="flex items-start gap-3">
+      <span
+        class="bg-error-500/15 border-error-500/30 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg border"
+      >
+        <UIcon name="i-mdi-alert-octagon-outline" class="text-error-400 h-5 w-5" />
+      </span>
+      <div class="min-w-0">
+        <h2 class="text-error-300 text-lg font-semibold">
+          {{ $t('page.team.danger_zone.title') }}
+        </h2>
+        <p class="text-surface-400 mt-1 text-sm leading-5">
+          {{
+            isTeamOwner
+              ? $t('page.team.danger_zone.disband_description')
+              : $t('page.team.danger_zone.leave_description')
+          }}
+        </p>
+      </div>
+    </div>
+    <UButton
+      color="error"
+      variant="outline"
+      icon="i-mdi-account-cancel-outline"
+      class="min-h-11 w-full justify-center sm:w-auto"
+      data-testid="open-team-danger-confirmation"
+      @click="confirmationOpen = true"
+    >
+      {{ isTeamOwner ? $t('page.team.danger_zone.disband') : $t('page.team.danger_zone.leave') }}
+    </UButton>
+  </section>
+  <UModal v-model:open="confirmationOpen" prevent-close>
+    <template #header>
+      <div class="flex items-center gap-2">
+        <UIcon name="i-mdi-alert-circle-outline" class="text-error-400 h-5 w-5" />
+        <h3 class="text-lg font-semibold">
+          {{
+            isTeamOwner
+              ? $t('page.team.danger_zone.confirm_disband_title')
+              : $t('page.team.danger_zone.confirm_leave_title')
+          }}
+        </h3>
+      </div>
+    </template>
+    <template #body>
+      <p class="text-surface-200 text-sm leading-6">
+        {{
+          isTeamOwner
+            ? $t('page.team.danger_zone.confirm_disband_description')
+            : $t('page.team.danger_zone.confirm_leave_description')
+        }}
+      </p>
+    </template>
+    <template #footer>
+      <div class="flex w-full flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+        <UButton
+          color="neutral"
+          variant="soft"
+          class="min-h-11 justify-center sm:min-w-28"
+          :disabled="actionPending"
+          @click="confirmationOpen = false"
+        >
+          {{ $t('common.cancel') }}
+        </UButton>
+        <UButton
+          color="error"
+          variant="solid"
+          class="min-h-11 justify-center sm:min-w-36"
+          :loading="actionPending"
+          :disabled="actionPending"
+          data-testid="confirm-team-danger-action"
+          @click="confirmDangerousAction"
+        >
+          {{
+            isTeamOwner
+              ? $t('page.team.danger_zone.confirm_disband')
+              : $t('page.team.danger_zone.confirm_leave')
+          }}
+        </UButton>
+      </div>
+    </template>
+  </UModal>
+</template>
+<script setup lang="ts">
+  import { useEdgeFunctions } from '@/composables/api/useEdgeFunctions';
+  import {
+    useSystemStoreWithSupabase,
+    getTeamIdFromState,
+    getTeamIdStateKey,
+  } from '@/stores/useSystemStore';
+  import { useTarkovStore } from '@/stores/useTarkov';
+  import { useTeamStoreWithSupabase } from '@/stores/useTeamStore';
+  import { GAME_MODES, type GameMode } from '@/utils/constants';
+  import { logger } from '@/utils/logger';
+  const { $supabase } = useNuxtApp();
+  const { t } = useI18n({ useScope: 'global' });
+  const toast = useToast();
+  const { disbandTeam, leaveTeam } = useEdgeFunctions();
+  const { systemStore } = useSystemStoreWithSupabase();
+  const { teamStore } = useTeamStoreWithSupabase();
+  const tarkovStore = useTarkovStore();
+  const confirmationOpen = ref(false);
+  const actionPending = ref(false);
+  const getCurrentGameMode = (): GameMode => tarkovStore.getCurrentGameMode?.() || GAME_MODES.PVP;
+  const currentTeamId = computed(() =>
+    getTeamIdFromState(systemStore.$state, getCurrentGameMode())
+  );
+  const hasTeam = computed(() => Boolean(currentTeamId.value));
+  const isTeamOwner = computed(() => teamStore.owner === $supabase.user.id && hasTeam.value);
+  const clearLocalTeam = (mode: GameMode) => {
+    const key = getTeamIdStateKey(mode);
+    systemStore.$patch((state) => {
+      state[key] = null;
+      if (mode === GAME_MODES.PVP) {
+        state.team = null;
+        state.team_id = null;
+      }
+    });
+    teamStore.$reset();
+  };
+  const showActionError = (error: unknown) => {
+    logger.error('[TeamDangerZone] Team membership action failed:', error);
+    toast.add({
+      title: error instanceof Error ? error.message : t('page.team.danger_zone.action_error'),
+      color: 'error',
+    });
+  };
+  const getMembershipAction = (wasOwner: boolean) => (wasOwner ? disbandTeam : leaveTeam);
+  const getFailureMessage = (wasOwner: boolean) =>
+    wasOwner
+      ? t('page.team.danger_zone.disband_error')
+      : t('page.team.card.myteam.leave_team_error');
+  const getSuccessMessage = (wasOwner: boolean) =>
+    wasOwner
+      ? t('page.team.danger_zone.disband_success')
+      : t('page.team.card.myteam.leave_team_success');
+  const runMembershipAction = async (teamId: string, wasOwner: boolean) => {
+    const result = await getMembershipAction(wasOwner)(teamId);
+    if (!result?.success) throw new Error(getFailureMessage(wasOwner));
+  };
+  const completeMembershipAction = (mode: GameMode, wasOwner: boolean) => {
+    clearLocalTeam(mode);
+    confirmationOpen.value = false;
+    toast.add({
+      title: getSuccessMessage(wasOwner),
+      color: 'success',
+    });
+  };
+  const executeDangerousAction = async (teamId: string, mode: GameMode, wasOwner: boolean) => {
+    actionPending.value = true;
+    try {
+      await runMembershipAction(teamId, wasOwner);
+      completeMembershipAction(mode, wasOwner);
+    } catch (error: unknown) {
+      showActionError(error);
+    } finally {
+      actionPending.value = false;
+    }
+  };
+  const confirmDangerousAction = async () => {
+    const teamId = currentTeamId.value;
+    if (actionPending.value || !teamId) return;
+    await executeDangerousAction(teamId, getCurrentGameMode(), isTeamOwner.value);
+  };
+</script>

--- a/app/features/team/TeamDangerZone.vue
+++ b/app/features/team/TeamDangerZone.vue
@@ -1,6 +1,6 @@
 <template>
   <section
-    v-if="hasTeam"
+    v-if="hasTeam && teamOwnerResolved"
     class="border-error-500/30 bg-error-950/15 font-ui space-y-4 rounded-xl border p-5 shadow-md sm:p-6"
     data-testid="team-danger-zone"
   >
@@ -29,7 +29,7 @@
       icon="i-mdi-account-cancel-outline"
       class="min-h-11 w-full justify-center sm:w-auto"
       data-testid="open-team-danger-confirmation"
-      @click="confirmationOpen = true"
+      @click="openConfirmation"
     >
       {{ isTeamOwner ? $t('page.team.danger_zone.disband') : $t('page.team.danger_zone.leave') }}
     </UButton>
@@ -40,7 +40,7 @@
         <UIcon name="i-mdi-alert-circle-outline" class="text-error-400 h-5 w-5" />
         <h3 class="text-lg font-semibold">
           {{
-            isTeamOwner
+            confirmationIsOwner
               ? $t('page.team.danger_zone.confirm_disband_title')
               : $t('page.team.danger_zone.confirm_leave_title')
           }}
@@ -50,7 +50,7 @@
     <template #body>
       <p class="text-surface-200 text-sm leading-6">
         {{
-          isTeamOwner
+          confirmationIsOwner
             ? $t('page.team.danger_zone.confirm_disband_description')
             : $t('page.team.danger_zone.confirm_leave_description')
         }}
@@ -77,7 +77,7 @@
           @click="confirmDangerousAction"
         >
           {{
-            isTeamOwner
+            confirmationIsOwner
               ? $t('page.team.danger_zone.confirm_disband')
               : $t('page.team.danger_zone.confirm_leave')
           }}
@@ -106,17 +106,35 @@
   const tarkovStore = useTarkovStore();
   const confirmationOpen = ref(false);
   const actionPending = ref(false);
+  const pendingAction = ref<{ isOwner: boolean; mode: GameMode; teamId: string } | null>(null);
   const getCurrentGameMode = (): GameMode => tarkovStore.getCurrentGameMode?.() || GAME_MODES.PVP;
   const currentTeamId = computed(() =>
     getTeamIdFromState(systemStore.$state, getCurrentGameMode())
   );
   const hasTeam = computed(() => Boolean(currentTeamId.value));
+  const teamOwnerResolved = computed(
+    () => teamStore.id === currentTeamId.value && typeof teamStore.owner === 'string'
+  );
   const isTeamOwner = computed(() => teamStore.owner === $supabase.user.id && hasTeam.value);
+  const confirmationIsOwner = computed(() => pendingAction.value?.isOwner ?? isTeamOwner.value);
+  const openConfirmation = () => {
+    const teamId = currentTeamId.value;
+    if (!teamId || !teamOwnerResolved.value) return;
+    pendingAction.value = {
+      isOwner: isTeamOwner.value,
+      mode: getCurrentGameMode(),
+      teamId,
+    };
+    confirmationOpen.value = true;
+  };
+  watch(confirmationOpen, (isOpen) => {
+    if (!isOpen) pendingAction.value = null;
+  });
   const clearLocalTeam = (mode: GameMode) => {
     const key = getTeamIdStateKey(mode);
     systemStore.$patch((state) => {
       state[key] = null;
-      if (mode === GAME_MODES.PVP) {
+      if (mode !== GAME_MODES.SEASONAL) {
         state.team = null;
         state.team_id = null;
       }
@@ -163,8 +181,8 @@
     }
   };
   const confirmDangerousAction = async () => {
-    const teamId = currentTeamId.value;
-    if (actionPending.value || !teamId) return;
-    await executeDangerousAction(teamId, getCurrentGameMode(), isTeamOwner.value);
+    const action = pendingAction.value;
+    if (actionPending.value || !action) return;
+    await executeDangerousAction(action.teamId, action.mode, action.isOwner);
   };
 </script>

--- a/app/features/team/TeamMemberCard.vue
+++ b/app/features/team/TeamMemberCard.vue
@@ -1,12 +1,15 @@
 <template>
-  <div class="bg-surface-850 rounded-lg border border-white/10 p-4 shadow-md sm:p-6">
+  <article
+    class="bg-surface-850 hover:border-primary-500/40 font-ui rounded-xl border border-white/10 p-4 shadow-md transition-colors duration-200 sm:p-5"
+  >
     <div class="space-y-4">
       <div class="flex items-start justify-between gap-4">
         <div class="min-w-0 flex-1">
           <div class="flex flex-wrap items-center gap-2">
-            <h3 class="truncate text-xl font-bold sm:text-2xl">
-              {{ displayName }}
-            </h3>
+            <AppTooltip v-if="isLongDisplayName" :text="displayName">
+              <h3 class="truncate text-xl font-bold sm:text-2xl">{{ displayName }}</h3>
+            </AppTooltip>
+            <h3 v-else class="text-xl font-bold break-words sm:text-2xl">{{ displayName }}</h3>
             <UBadge v-if="isOwner" color="primary" variant="solid" size="sm">
               {{ $t('page.team.card.manageteam.membercard.owner') }}
             </UBadge>
@@ -21,7 +24,7 @@
           <img
             :src="groupIcon"
             class="h-12 w-12 object-contain sm:h-16 sm:w-16"
-            alt="Level badge"
+            :alt="$t('page.team.card.manageteam.membercard.level_badge_alt', { level })"
           />
           <div class="text-center">
             <div class="text-surface-400 text-xs tracking-wide uppercase">
@@ -53,38 +56,41 @@
           </i18n-t>
         </div>
         <div class="flex gap-2">
-          <UButton
-            :disabled="props.teammember === $supabase.user.id || preferencesStore.taskTeamAllHidden"
-            variant="outline"
-            :icon="
-              props.teammember !== $supabase.user.id &&
-              preferencesStore.teamIsHidden(props.teammember)
-                ? 'i-mdi-eye-off'
-                : 'i-mdi-eye'
-            "
-            :color="
-              props.teammember !== $supabase.user.id &&
-              preferencesStore.teamIsHidden(props.teammember)
-                ? 'error'
-                : 'success'
-            "
-            size="sm"
-            @click="preferencesStore.toggleHidden(props.teammember)"
-          />
-          <UButton
+          <AppTooltip v-if="props.teammember !== $supabase.user.id" :text="progressVisibilityLabel">
+            <UButton
+              variant="outline"
+              :icon="
+                preferencesStore.teamIsHidden(props.teammember)
+                  ? 'i-mdi-eye-off-outline'
+                  : 'i-mdi-eye-outline'
+              "
+              color="neutral"
+              size="md"
+              class="h-11 w-11 justify-center"
+              :aria-label="progressVisibilityLabel"
+              @click="preferencesStore.toggleHidden(props.teammember)"
+            />
+          </AppTooltip>
+          <AppTooltip
             v-if="props.teammember !== $supabase.user.id && isTeamOwnerView"
-            variant="outline"
-            icon="i-mdi-account-minus"
-            color="error"
-            size="sm"
-            :loading="kickingTeammate"
-            :disabled="kickingTeammate"
-            @click="kickTeammate()"
-          />
+            :text="removeMemberLabel"
+          >
+            <UButton
+              variant="outline"
+              icon="i-mdi-account-minus"
+              color="error"
+              size="md"
+              class="h-11 w-11 justify-center"
+              :loading="kickingTeammate"
+              :disabled="kickingTeammate"
+              :aria-label="removeMemberLabel"
+              @click="kickTeammate()"
+            />
+          </AppTooltip>
         </div>
       </div>
     </div>
-  </div>
+  </article>
 </template>
 <script setup lang="ts">
   import { useEdgeFunctions } from '@/composables/api/useEdgeFunctions';
@@ -126,6 +132,15 @@
     const fromProgress = progressStore.getDisplayName(props.teammember);
     return fromProfile || fromProgress || props.teammember;
   });
+  const isLongDisplayName = computed(() => displayName.value.length > 24);
+  const progressVisibilityLabel = computed(() =>
+    preferencesStore.teamIsHidden(props.teammember)
+      ? t('page.team.card.manageteam.membercard.show_progress', { name: displayName.value })
+      : t('page.team.card.manageteam.membercard.hide_progress', { name: displayName.value })
+  );
+  const removeMemberLabel = computed(() =>
+    t('page.team.card.manageteam.membercard.remove_member', { name: displayName.value })
+  );
   const level = computed(() => {
     if (props.teammember === $supabase.user.id) {
       return progressStore.getLevel(props.teammember);

--- a/app/features/team/TeamMemberCard.vue
+++ b/app/features/team/TeamMemberCard.vue
@@ -67,8 +67,9 @@
               color="neutral"
               size="md"
               class="h-11 w-11 justify-center"
+              :disabled="preferencesStore.taskTeamAllHidden"
               :aria-label="progressVisibilityLabel"
-              @click="preferencesStore.toggleHidden(props.teammember)"
+              @click="toggleProgressVisibility"
             />
           </AppTooltip>
           <AppTooltip
@@ -133,11 +134,18 @@
     return fromProfile || fromProgress || props.teammember;
   });
   const isLongDisplayName = computed(() => displayName.value.length > 24);
-  const progressVisibilityLabel = computed(() =>
-    preferencesStore.teamIsHidden(props.teammember)
+  const progressVisibilityLabel = computed(() => {
+    if (preferencesStore.taskTeamAllHidden) {
+      return t('page.team.card.manageteam.membercard.enable_team_tasks');
+    }
+    return preferencesStore.teamIsHidden(props.teammember)
       ? t('page.team.card.manageteam.membercard.show_progress', { name: displayName.value })
-      : t('page.team.card.manageteam.membercard.hide_progress', { name: displayName.value })
-  );
+      : t('page.team.card.manageteam.membercard.hide_progress', { name: displayName.value });
+  });
+  const toggleProgressVisibility = () => {
+    if (preferencesStore.taskTeamAllHidden) return;
+    preferencesStore.toggleHidden(props.teammember);
+  };
   const removeMemberLabel = computed(() =>
     t('page.team.card.manageteam.membercard.remove_member', { name: displayName.value })
   );

--- a/app/features/team/TeamMembers.vue
+++ b/app/features/team/TeamMembers.vue
@@ -1,33 +1,56 @@
 <template>
-  <GenericCard icon="mdi-account-group" icon-color="white" highlight-color="secondary">
-    <template #title>
-      {{ $t('page.team.card.manageteam.title') }}
+  <TeamCard :title="$t('page.team.members.title', { count: allMembers.length })">
+    <template #icon>
+      <UIcon name="i-mdi-account-group-outline" class="text-primary-300 h-5 w-5" />
     </template>
-    <template #content>
-      <template v-if="allMembers.length > 0">
-        <div class="p-4">
-          <div class="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3">
-            <div v-for="teammate in allMembers" :key="teammate">
-              <TeamMemberCard :teammember="teammate" :is-team-owner-view="isCurrentUserTeamOwner" />
-            </div>
+    <div v-if="allMembers.length > 0" class="space-y-4">
+      <div class="grid grid-cols-[repeat(auto-fill,minmax(min(320px,100%),1fr))] gap-4">
+        <div v-for="teammate in allMembers" :key="teammate">
+          <TeamMemberCard :teammember="teammate" :is-team-owner-view="isCurrentUserTeamOwner" />
+        </div>
+        <div
+          v-if="allMembers.length === 1"
+          class="border-primary-500/30 bg-primary-500/5 flex flex-col items-start gap-4 rounded-xl border border-dashed p-5 sm:flex-row sm:items-center sm:justify-between"
+          data-testid="team-members-empty-state"
+        >
+          <div class="flex items-start gap-3">
+            <UIcon
+              name="i-mdi-account-multiple-plus-outline"
+              class="text-primary-300 mt-0.5 h-5 w-5 shrink-0"
+            />
+            <p class="text-surface-300 text-sm leading-6">
+              {{ $t('page.team.members.alone') }}
+            </p>
           </div>
+          <UButton
+            :icon="copied ? 'i-mdi-check' : 'i-mdi-content-copy'"
+            color="primary"
+            variant="outline"
+            class="min-h-11 shrink-0"
+            :disabled="!teamUrl"
+            data-testid="copy-team-members-invite"
+            @click="copyInvite"
+          >
+            {{ copied ? $t('page.team.members.copied') : $t('page.team.members.copy_invite') }}
+          </UButton>
         </div>
-      </template>
-      <template v-else-if="allMembers.length === 0">
-        <div class="p-4 text-center">
-          {{ $t('page.team.card.manageteam.no_members') }}
-        </div>
-      </template>
-      <template v-else></template>
-    </template>
-  </GenericCard>
+      </div>
+    </div>
+    <div v-else class="text-surface-400 py-6 text-center text-sm">
+      {{ $t('page.team.members.no_members') }}
+    </div>
+  </TeamCard>
 </template>
 <script setup lang="ts">
-  import GenericCard from '@/components/ui/GenericCard.vue';
+  import { useCopyToClipboard } from '@/composables/useCopyToClipboard';
+  import TeamCard from '@/features/team/TeamCard.vue';
   import TeamMemberCard from '@/features/team/TeamMemberCard.vue';
+  import { useTeamInviteLink } from '@/features/team/useTeamInviteLink';
   import { useTeamStoreWithSupabase } from '@/stores/useTeamStore';
   const { $supabase } = useNuxtApp();
   const { teamStore } = useTeamStoreWithSupabase();
+  const { copyToClipboard } = useCopyToClipboard();
+  const { teamUrl } = useTeamInviteLink();
   const teamMembers = computed<string[]>(() => teamStore.members || []);
   const isCurrentUserTeamOwner = computed(() => {
     const currentTeamOwner = teamStore.owner;
@@ -47,5 +70,20 @@
     } else {
       return [currentUID, ...teamMembers.value];
     }
+  });
+  const copied = ref(false);
+  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
+  const copyInvite = async () => {
+    if (!teamUrl.value) return;
+    if (await copyToClipboard(teamUrl.value)) {
+      copied.value = true;
+      if (copyResetTimer) clearTimeout(copyResetTimer);
+      copyResetTimer = setTimeout(() => {
+        copied.value = false;
+      }, 2000);
+    }
+  };
+  onUnmounted(() => {
+    if (copyResetTimer) clearTimeout(copyResetTimer);
   });
 </script>

--- a/app/features/team/TeamMembers.vue
+++ b/app/features/team/TeamMembers.vue
@@ -31,7 +31,9 @@
             data-testid="copy-team-members-invite"
             @click="copyInvite"
           >
-            {{ copied ? $t('page.team.members.copied') : $t('page.team.members.copy_invite') }}
+            <span aria-live="polite">
+              {{ copied ? $t('page.team.members.copied') : $t('page.team.members.copy_invite') }}
+            </span>
           </UButton>
         </div>
       </div>
@@ -42,14 +44,14 @@
   </TeamCard>
 </template>
 <script setup lang="ts">
-  import { useCopyToClipboard } from '@/composables/useCopyToClipboard';
   import TeamCard from '@/features/team/TeamCard.vue';
   import TeamMemberCard from '@/features/team/TeamMemberCard.vue';
+  import { useTeamInviteCopyFeedback } from '@/features/team/useTeamInviteCopyFeedback';
   import { useTeamInviteLink } from '@/features/team/useTeamInviteLink';
   import { useTeamStoreWithSupabase } from '@/stores/useTeamStore';
   const { $supabase } = useNuxtApp();
   const { teamStore } = useTeamStoreWithSupabase();
-  const { copyToClipboard } = useCopyToClipboard();
+  const { copied, copyInviteLink } = useTeamInviteCopyFeedback();
   const { teamUrl } = useTeamInviteLink();
   const teamMembers = computed<string[]>(() => teamStore.members || []);
   const isCurrentUserTeamOwner = computed(() => {
@@ -71,19 +73,7 @@
       return [currentUID, ...teamMembers.value];
     }
   });
-  const copied = ref(false);
-  let copyResetTimer: ReturnType<typeof setTimeout> | null = null;
   const copyInvite = async () => {
-    if (!teamUrl.value) return;
-    if (await copyToClipboard(teamUrl.value)) {
-      copied.value = true;
-      if (copyResetTimer) clearTimeout(copyResetTimer);
-      copyResetTimer = setTimeout(() => {
-        copied.value = false;
-      }, 2000);
-    }
+    await copyInviteLink(teamUrl.value);
   };
-  onUnmounted(() => {
-    if (copyResetTimer) clearTimeout(copyResetTimer);
-  });
 </script>

--- a/app/features/team/TeamOptions.vue
+++ b/app/features/team/TeamOptions.vue
@@ -11,10 +11,10 @@
         <h3 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
           {{ $t('common.tasks') }}
         </h3>
-        <label
-          for="team-visibility-tasks"
+        <div
           class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
           data-testid="task-row"
+          @click="showTasks = !showTasks"
         >
           <span class="text-surface-200 text-sm font-medium" data-testid="task-toggle">
             {{ $t('page.team.visibility.show_tasks') }}
@@ -24,18 +24,19 @@
             v-model="showTasks"
             data-testid="task-switch"
             :label="$t('page.team.visibility.show_tasks')"
+            @click.stop
           />
-        </label>
+        </div>
       </div>
       <div class="space-y-3">
         <h3 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
           {{ $t('page.team.visibility.items_section') }}
         </h3>
         <div class="space-y-2">
-          <label
-            for="team-visibility-items"
+          <div
             class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
             data-testid="items-row"
+            @click="showItems = !showItems"
           >
             <span class="text-surface-200 text-sm font-medium">
               {{ $t('page.team.visibility.show_items') }}
@@ -45,16 +46,17 @@
               v-model="showItems"
               data-testid="items-switch"
               :label="$t('page.team.visibility.show_items')"
+              @click.stop
             />
-          </label>
-          <label
-            for="team-visibility-non-fir"
+          </div>
+          <div
             class="bg-surface-800/50 border-surface-700 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
             :class="{
               'hover:border-surface-600 cursor-pointer': !itemsHideAll,
               'cursor-not-allowed opacity-50': itemsHideAll,
             }"
             data-testid="nonfir-row"
+            @click="toggleNonFIR"
           >
             <span class="text-surface-200 text-sm font-medium">
               {{ $t('page.team.visibility.show_non_fir') }}
@@ -65,16 +67,17 @@
               :disabled="itemsHideAll"
               data-testid="nonfir-switch"
               :label="$t('page.team.visibility.show_non_fir')"
+              @click.stop
             />
-          </label>
-          <label
-            for="team-visibility-hideout"
+          </div>
+          <div
             class="bg-surface-800/50 border-surface-700 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
             :class="{
               'hover:border-surface-600 cursor-pointer': !itemsHideAll,
               'cursor-not-allowed opacity-50': itemsHideAll,
             }"
             data-testid="hideout-row"
+            @click="toggleHideout"
           >
             <span class="text-surface-200 text-sm font-medium">
               {{ $t('page.team.visibility.show_hideout') }}
@@ -85,18 +88,19 @@
               :disabled="itemsHideAll"
               data-testid="hideout-switch"
               :label="$t('page.team.visibility.show_hideout')"
+              @click.stop
             />
-          </label>
+          </div>
         </div>
       </div>
       <div class="space-y-3">
         <h3 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
           {{ $t('common.maps') }}
         </h3>
-        <label
-          for="team-visibility-maps"
+        <div
           class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
           data-testid="map-row"
+          @click="showMaps = !showMaps"
         >
           <span class="text-surface-200 text-sm font-medium">
             {{ $t('page.team.visibility.show_maps') }}
@@ -106,8 +110,9 @@
             v-model="showMaps"
             data-testid="map-switch"
             :label="$t('page.team.visibility.show_maps')"
+            @click.stop
           />
-        </label>
+        </div>
       </div>
     </div>
   </TeamCard>
@@ -138,4 +143,10 @@
     get: () => !preferencesStore.mapTeamAllHidden,
     set: (value: boolean) => preferencesStore.setMapTeamHideAll(!value),
   });
+  const toggleNonFIR = () => {
+    if (!itemsHideAll.value) showNonFIR.value = !showNonFIR.value;
+  };
+  const toggleHideout = () => {
+    if (!itemsHideAll.value) showHideout.value = !showHideout.value;
+  };
 </script>

--- a/app/features/team/TeamOptions.vue
+++ b/app/features/team/TeamOptions.vue
@@ -1,104 +1,147 @@
 <template>
-  <GenericCard icon="mdi-account-wrench" icon-color="white" highlight-color="secondary">
-    <template #title>
-      {{ $t('page.team.card.teamoptions.title') }}
+  <TeamCard
+    :title="$t('page.team.visibility.title')"
+    :subtitle="$t('page.team.visibility.description')"
+  >
+    <template #icon>
+      <UIcon name="i-mdi-eye-settings-outline" class="text-primary-300 h-5 w-5" />
     </template>
-    <template #content>
-      <div class="space-y-6 px-4 py-4">
-        <div class="space-y-3">
-          <h3 class="text-surface-200 text-sm font-semibold tracking-wider uppercase">
-            {{ $t('common.tasks') }}
-          </h3>
+    <div class="space-y-5">
+      <div class="space-y-3">
+        <h3 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
+          {{ $t('common.tasks') }}
+        </h3>
+        <div
+          class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
+          data-testid="task-row"
+          @click="showTasks = !showTasks"
+        >
+          <span class="text-surface-200 text-sm font-medium" data-testid="task-toggle">
+            {{ $t('page.team.visibility.show_tasks') }}
+          </span>
+          <TeamVisibilitySwitch
+            v-model="showTasks"
+            data-testid="task-switch"
+            :label="$t('page.team.visibility.show_tasks')"
+            @click.stop
+          />
+        </div>
+      </div>
+      <div class="space-y-3">
+        <h3 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
+          {{ $t('page.team.visibility.items_section') }}
+        </h3>
+        <div class="space-y-2">
           <div
-            class="bg-surface-800/50 border-surface-700 flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5"
+            class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
+            data-testid="items-row"
+            @click="showItems = !showItems"
           >
-            <p class="text-surface-200 text-sm font-medium" data-testid="task-toggle">
-              {{ $t('page.team.card.teamoptions.toggle_tasks') }}
-            </p>
-            <USwitch
-              :model-value="taskHideAll"
-              data-testid="task-switch"
-              @update:model-value="(v: boolean) => preferencesStore.setQuestTeamHideAll(v)"
+            <span class="text-surface-200 text-sm font-medium">
+              {{ $t('page.team.visibility.show_items') }}
+            </span>
+            <TeamVisibilitySwitch
+              v-model="showItems"
+              data-testid="items-switch"
+              :label="$t('page.team.visibility.show_items')"
+              @click.stop
             />
           </div>
-        </div>
-        <USeparator />
-        <div class="space-y-3">
-          <h3 class="text-surface-200 text-sm font-semibold tracking-wider uppercase">
-            {{ $t('page.team.card.teamoptions.section_items') }}
-          </h3>
-          <div class="space-y-2">
-            <div
-              class="bg-surface-800/50 border-surface-700 flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5"
-            >
-              <p class="text-surface-200 text-sm font-medium">
-                {{ $t('page.team.card.teamoptions.toggle_items') }}
-              </p>
-              <USwitch
-                :model-value="itemsHideAll"
-                data-testid="items-switch"
-                @update:model-value="(v: boolean) => preferencesStore.setItemsTeamHideAll(v)"
-              />
-            </div>
-            <div
-              class="bg-surface-800/50 border-surface-700 flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5"
-              :class="{ 'opacity-50': itemsHideAll }"
-            >
-              <p class="text-surface-200 text-sm font-medium">
-                {{ $t('page.team.card.teamoptions.toggle_non_fir') }}
-              </p>
-              <USwitch
-                :model-value="itemsHideNonFIR"
-                :disabled="itemsHideAll"
-                data-testid="nonfir-switch"
-                @update:model-value="(v: boolean) => preferencesStore.setItemsTeamHideNonFIR(v)"
-              />
-            </div>
-            <div
-              class="bg-surface-800/50 border-surface-700 flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5"
-              :class="{ 'opacity-50': itemsHideAll }"
-            >
-              <p class="text-surface-200 text-sm font-medium">
-                {{ $t('page.team.card.teamoptions.toggle_hideout') }}
-              </p>
-              <USwitch
-                :model-value="itemsHideHideout"
-                :disabled="itemsHideAll"
-                data-testid="hideout-switch"
-                @update:model-value="(v: boolean) => preferencesStore.setItemsTeamHideHideout(v)"
-              />
-            </div>
-          </div>
-        </div>
-        <USeparator />
-        <div class="space-y-3">
-          <h3 class="text-surface-200 text-sm font-semibold tracking-wider uppercase">
-            {{ $t('common.maps') }}
-          </h3>
           <div
-            class="bg-surface-800/50 border-surface-700 flex items-center justify-between gap-3 rounded-lg border px-3 py-2.5"
+            class="bg-surface-800/50 border-surface-700 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
+            :class="{
+              'hover:border-surface-600 cursor-pointer': !itemsHideAll,
+              'cursor-not-allowed opacity-50': itemsHideAll,
+            }"
+            data-testid="nonfir-row"
+            @click="toggleNonFIR"
           >
-            <p class="text-surface-200 text-sm font-medium">
-              {{ $t('page.team.card.teamoptions.toggle_maps') }}
-            </p>
-            <USwitch
-              :model-value="mapHideAll"
-              data-testid="map-switch"
-              @update:model-value="(v: boolean) => preferencesStore.setMapTeamHideAll(v)"
+            <span class="text-surface-200 text-sm font-medium">
+              {{ $t('page.team.visibility.show_non_fir') }}
+            </span>
+            <TeamVisibilitySwitch
+              v-model="showNonFIR"
+              :disabled="itemsHideAll"
+              data-testid="nonfir-switch"
+              :label="$t('page.team.visibility.show_non_fir')"
+              @click.stop
+            />
+          </div>
+          <div
+            class="bg-surface-800/50 border-surface-700 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
+            :class="{
+              'hover:border-surface-600 cursor-pointer': !itemsHideAll,
+              'cursor-not-allowed opacity-50': itemsHideAll,
+            }"
+            data-testid="hideout-row"
+            @click="toggleHideout"
+          >
+            <span class="text-surface-200 text-sm font-medium">
+              {{ $t('page.team.visibility.show_hideout') }}
+            </span>
+            <TeamVisibilitySwitch
+              v-model="showHideout"
+              :disabled="itemsHideAll"
+              data-testid="hideout-switch"
+              :label="$t('page.team.visibility.show_hideout')"
+              @click.stop
             />
           </div>
         </div>
       </div>
-    </template>
-  </GenericCard>
+      <div class="space-y-3">
+        <h3 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
+          {{ $t('common.maps') }}
+        </h3>
+        <div
+          class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
+          data-testid="map-row"
+          @click="showMaps = !showMaps"
+        >
+          <span class="text-surface-200 text-sm font-medium">
+            {{ $t('page.team.visibility.show_maps') }}
+          </span>
+          <TeamVisibilitySwitch
+            v-model="showMaps"
+            data-testid="map-switch"
+            :label="$t('page.team.visibility.show_maps')"
+            @click.stop
+          />
+        </div>
+      </div>
+    </div>
+  </TeamCard>
 </template>
 <script setup lang="ts">
-  import GenericCard from '@/components/ui/GenericCard.vue';
+  import TeamCard from '@/features/team/TeamCard.vue';
+  import TeamVisibilitySwitch from '@/features/team/TeamVisibilitySwitch.vue';
   import { usePreferencesStore } from '@/stores/usePreferences';
   const preferencesStore = usePreferencesStore();
-  const taskHideAll = computed(() => preferencesStore.taskTeamAllHidden);
+  const showTasks = computed({
+    get: () => !preferencesStore.taskTeamAllHidden,
+    set: (value: boolean) => preferencesStore.setQuestTeamHideAll(!value),
+  });
+  const showItems = computed({
+    get: () => !preferencesStore.itemsTeamAllHidden,
+    set: (value: boolean) => preferencesStore.setItemsTeamHideAll(!value),
+  });
   const itemsHideAll = computed(() => preferencesStore.itemsTeamAllHidden);
-  const itemsHideNonFIR = computed(() => preferencesStore.itemsTeamNonFIRHidden);
-  const itemsHideHideout = computed(() => preferencesStore.itemsTeamHideoutHidden);
-  const mapHideAll = computed(() => preferencesStore.mapTeamAllHidden);
+  const showNonFIR = computed({
+    get: () => !preferencesStore.itemsTeamNonFIRHidden,
+    set: (value: boolean) => preferencesStore.setItemsTeamHideNonFIR(!value),
+  });
+  const showHideout = computed({
+    get: () => !preferencesStore.itemsTeamHideoutHidden,
+    set: (value: boolean) => preferencesStore.setItemsTeamHideHideout(!value),
+  });
+  const showMaps = computed({
+    get: () => !preferencesStore.mapTeamAllHidden,
+    set: (value: boolean) => preferencesStore.setMapTeamHideAll(!value),
+  });
+  const toggleNonFIR = () => {
+    if (!itemsHideAll.value) showNonFIR.value = !showNonFIR.value;
+  };
+  const toggleHideout = () => {
+    if (!itemsHideAll.value) showHideout.value = !showHideout.value;
+  };
 </script>

--- a/app/features/team/TeamOptions.vue
+++ b/app/features/team/TeamOptions.vue
@@ -12,19 +12,22 @@
           {{ $t('common.tasks') }}
         </h3>
         <div
-          class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
+          class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
           data-testid="task-row"
-          @click="showTasks = !showTasks"
         >
-          <span class="text-surface-200 text-sm font-medium" data-testid="task-toggle">
+          <button
+            type="button"
+            class="text-surface-200 focus-visible:outline-primary-500 min-h-11 flex-1 cursor-pointer text-left text-sm font-medium focus-visible:outline-3 focus-visible:outline-offset-2"
+            data-testid="task-toggle"
+            @click="showTasks = !showTasks"
+          >
             {{ $t('page.team.visibility.show_tasks') }}
-          </span>
+          </button>
           <TeamVisibilitySwitch
             id="team-visibility-tasks"
             v-model="showTasks"
             data-testid="task-switch"
             :label="$t('page.team.visibility.show_tasks')"
-            @click.stop
           />
         </div>
       </div>
@@ -34,19 +37,21 @@
         </h3>
         <div class="space-y-2">
           <div
-            class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
+            class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
             data-testid="items-row"
-            @click="showItems = !showItems"
           >
-            <span class="text-surface-200 text-sm font-medium">
+            <button
+              type="button"
+              class="text-surface-200 focus-visible:outline-primary-500 min-h-11 flex-1 cursor-pointer text-left text-sm font-medium focus-visible:outline-3 focus-visible:outline-offset-2"
+              @click="showItems = !showItems"
+            >
               {{ $t('page.team.visibility.show_items') }}
-            </span>
+            </button>
             <TeamVisibilitySwitch
               id="team-visibility-items"
               v-model="showItems"
               data-testid="items-switch"
               :label="$t('page.team.visibility.show_items')"
-              @click.stop
             />
           </div>
           <div
@@ -56,18 +61,21 @@
               'cursor-not-allowed opacity-50': itemsHideAll,
             }"
             data-testid="nonfir-row"
-            @click="toggleNonFIR"
           >
-            <span class="text-surface-200 text-sm font-medium">
+            <button
+              type="button"
+              class="text-surface-200 focus-visible:outline-primary-500 min-h-11 flex-1 text-left text-sm font-medium focus-visible:outline-3 focus-visible:outline-offset-2 disabled:cursor-not-allowed"
+              :disabled="itemsHideAll"
+              @click="toggleNonFIR"
+            >
               {{ $t('page.team.visibility.show_non_fir') }}
-            </span>
+            </button>
             <TeamVisibilitySwitch
               id="team-visibility-non-fir"
               v-model="showNonFIR"
               :disabled="itemsHideAll"
               data-testid="nonfir-switch"
               :label="$t('page.team.visibility.show_non_fir')"
-              @click.stop
             />
           </div>
           <div
@@ -77,18 +85,21 @@
               'cursor-not-allowed opacity-50': itemsHideAll,
             }"
             data-testid="hideout-row"
-            @click="toggleHideout"
           >
-            <span class="text-surface-200 text-sm font-medium">
+            <button
+              type="button"
+              class="text-surface-200 focus-visible:outline-primary-500 min-h-11 flex-1 text-left text-sm font-medium focus-visible:outline-3 focus-visible:outline-offset-2 disabled:cursor-not-allowed"
+              :disabled="itemsHideAll"
+              @click="toggleHideout"
+            >
               {{ $t('page.team.visibility.show_hideout') }}
-            </span>
+            </button>
             <TeamVisibilitySwitch
               id="team-visibility-hideout"
               v-model="showHideout"
               :disabled="itemsHideAll"
               data-testid="hideout-switch"
               :label="$t('page.team.visibility.show_hideout')"
-              @click.stop
             />
           </div>
         </div>
@@ -98,19 +109,21 @@
           {{ $t('common.maps') }}
         </h3>
         <div
-          class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
+          class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
           data-testid="map-row"
-          @click="showMaps = !showMaps"
         >
-          <span class="text-surface-200 text-sm font-medium">
+          <button
+            type="button"
+            class="text-surface-200 focus-visible:outline-primary-500 min-h-11 flex-1 cursor-pointer text-left text-sm font-medium focus-visible:outline-3 focus-visible:outline-offset-2"
+            @click="showMaps = !showMaps"
+          >
             {{ $t('page.team.visibility.show_maps') }}
-          </span>
+          </button>
           <TeamVisibilitySwitch
             id="team-visibility-maps"
             v-model="showMaps"
             data-testid="map-switch"
             :label="$t('page.team.visibility.show_maps')"
-            @click.stop
           />
         </div>
       </div>

--- a/app/features/team/TeamOptions.vue
+++ b/app/features/team/TeamOptions.vue
@@ -57,14 +57,14 @@
           <div
             class="bg-surface-800/50 border-surface-700 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
             :class="{
-              'hover:border-surface-600 cursor-pointer': !itemsHideAll,
+              'hover:border-surface-600': !itemsHideAll,
               'cursor-not-allowed opacity-50': itemsHideAll,
             }"
             data-testid="nonfir-row"
           >
             <button
               type="button"
-              class="text-surface-200 focus-visible:outline-primary-500 min-h-11 flex-1 text-left text-sm font-medium focus-visible:outline-3 focus-visible:outline-offset-2 disabled:cursor-not-allowed"
+              class="text-surface-200 focus-visible:outline-primary-500 min-h-11 flex-1 cursor-pointer text-left text-sm font-medium focus-visible:outline-3 focus-visible:outline-offset-2 disabled:cursor-not-allowed"
               :disabled="itemsHideAll"
               @click="toggleNonFIR"
             >
@@ -81,14 +81,14 @@
           <div
             class="bg-surface-800/50 border-surface-700 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
             :class="{
-              'hover:border-surface-600 cursor-pointer': !itemsHideAll,
+              'hover:border-surface-600': !itemsHideAll,
               'cursor-not-allowed opacity-50': itemsHideAll,
             }"
             data-testid="hideout-row"
           >
             <button
               type="button"
-              class="text-surface-200 focus-visible:outline-primary-500 min-h-11 flex-1 text-left text-sm font-medium focus-visible:outline-3 focus-visible:outline-offset-2 disabled:cursor-not-allowed"
+              class="text-surface-200 focus-visible:outline-primary-500 min-h-11 flex-1 cursor-pointer text-left text-sm font-medium focus-visible:outline-3 focus-visible:outline-offset-2 disabled:cursor-not-allowed"
               :disabled="itemsHideAll"
               @click="toggleHideout"
             >

--- a/app/features/team/TeamOptions.vue
+++ b/app/features/team/TeamOptions.vue
@@ -11,103 +11,103 @@
         <h3 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
           {{ $t('common.tasks') }}
         </h3>
-        <div
+        <label
+          for="team-visibility-tasks"
           class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
           data-testid="task-row"
-          @click="showTasks = !showTasks"
         >
           <span class="text-surface-200 text-sm font-medium" data-testid="task-toggle">
             {{ $t('page.team.visibility.show_tasks') }}
           </span>
           <TeamVisibilitySwitch
+            id="team-visibility-tasks"
             v-model="showTasks"
             data-testid="task-switch"
             :label="$t('page.team.visibility.show_tasks')"
-            @click.stop
           />
-        </div>
+        </label>
       </div>
       <div class="space-y-3">
         <h3 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
           {{ $t('page.team.visibility.items_section') }}
         </h3>
         <div class="space-y-2">
-          <div
+          <label
+            for="team-visibility-items"
             class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
             data-testid="items-row"
-            @click="showItems = !showItems"
           >
             <span class="text-surface-200 text-sm font-medium">
               {{ $t('page.team.visibility.show_items') }}
             </span>
             <TeamVisibilitySwitch
+              id="team-visibility-items"
               v-model="showItems"
               data-testid="items-switch"
               :label="$t('page.team.visibility.show_items')"
-              @click.stop
             />
-          </div>
-          <div
+          </label>
+          <label
+            for="team-visibility-non-fir"
             class="bg-surface-800/50 border-surface-700 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
             :class="{
               'hover:border-surface-600 cursor-pointer': !itemsHideAll,
               'cursor-not-allowed opacity-50': itemsHideAll,
             }"
             data-testid="nonfir-row"
-            @click="toggleNonFIR"
           >
             <span class="text-surface-200 text-sm font-medium">
               {{ $t('page.team.visibility.show_non_fir') }}
             </span>
             <TeamVisibilitySwitch
+              id="team-visibility-non-fir"
               v-model="showNonFIR"
               :disabled="itemsHideAll"
               data-testid="nonfir-switch"
               :label="$t('page.team.visibility.show_non_fir')"
-              @click.stop
             />
-          </div>
-          <div
+          </label>
+          <label
+            for="team-visibility-hideout"
             class="bg-surface-800/50 border-surface-700 flex min-h-11 items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
             :class="{
               'hover:border-surface-600 cursor-pointer': !itemsHideAll,
               'cursor-not-allowed opacity-50': itemsHideAll,
             }"
             data-testid="hideout-row"
-            @click="toggleHideout"
           >
             <span class="text-surface-200 text-sm font-medium">
               {{ $t('page.team.visibility.show_hideout') }}
             </span>
             <TeamVisibilitySwitch
+              id="team-visibility-hideout"
               v-model="showHideout"
               :disabled="itemsHideAll"
               data-testid="hideout-switch"
               :label="$t('page.team.visibility.show_hideout')"
-              @click.stop
             />
-          </div>
+          </label>
         </div>
       </div>
       <div class="space-y-3">
         <h3 class="text-surface-300 text-xs font-semibold tracking-wider uppercase">
           {{ $t('common.maps') }}
         </h3>
-        <div
+        <label
+          for="team-visibility-maps"
           class="bg-surface-800/50 border-surface-700 hover:border-surface-600 flex min-h-11 cursor-pointer items-center justify-between gap-3 rounded-lg border px-3 py-2 transition-colors duration-200"
           data-testid="map-row"
-          @click="showMaps = !showMaps"
         >
           <span class="text-surface-200 text-sm font-medium">
             {{ $t('page.team.visibility.show_maps') }}
           </span>
           <TeamVisibilitySwitch
+            id="team-visibility-maps"
             v-model="showMaps"
             data-testid="map-switch"
             :label="$t('page.team.visibility.show_maps')"
-            @click.stop
           />
-        </div>
+        </label>
       </div>
     </div>
   </TeamCard>
@@ -138,10 +138,4 @@
     get: () => !preferencesStore.mapTeamAllHidden,
     set: (value: boolean) => preferencesStore.setMapTeamHideAll(!value),
   });
-  const toggleNonFIR = () => {
-    if (!itemsHideAll.value) showNonFIR.value = !showNonFIR.value;
-  };
-  const toggleHideout = () => {
-    if (!itemsHideAll.value) showHideout.value = !showHideout.value;
-  };
 </script>

--- a/app/features/team/TeamVisibilitySwitch.vue
+++ b/app/features/team/TeamVisibilitySwitch.vue
@@ -1,0 +1,36 @@
+<template>
+  <button
+    type="button"
+    role="switch"
+    class="text-primary-400 focus-visible:outline-primary-500 inline-flex min-h-11 min-w-11 items-center justify-center rounded-full p-1 transition-colors duration-200 focus-visible:outline-3 focus-visible:outline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+    :aria-label="label"
+    :aria-checked="modelValue"
+    :disabled="disabled"
+    :data-state="modelValue ? 'checked' : 'unchecked'"
+    @click="toggle"
+  >
+    <span
+      aria-hidden="true"
+      class="bg-surface-600 data-[state=checked]:bg-success-500 relative flex h-5 w-10 shrink-0 items-center rounded-full transition-colors duration-200"
+      :data-state="modelValue ? 'checked' : 'unchecked'"
+    >
+      <span
+        class="bg-default size-4.5 rounded-full shadow-lg transition-transform duration-200"
+        :class="modelValue ? 'translate-x-4.5' : 'translate-x-0'"
+      />
+    </span>
+  </button>
+</template>
+<script setup lang="ts">
+  const emit = defineEmits<{
+    'update:modelValue': [value: boolean];
+  }>();
+  const props = defineProps<{
+    disabled?: boolean;
+    label: string;
+    modelValue: boolean;
+  }>();
+  const toggle = () => {
+    if (!props.disabled) emit('update:modelValue', !props.modelValue);
+  };
+</script>

--- a/app/features/team/__tests__/MyTeam.test.ts
+++ b/app/features/team/__tests__/MyTeam.test.ts
@@ -250,7 +250,7 @@ describe('MyTeam store interactions', () => {
       await flushPromises();
       expect(mockCopyToClipboard).toHaveBeenCalledWith(
         expect.stringContaining('code=private-code'),
-        { revealValue: false }
+        expect.objectContaining({ revealValue: false, shouldNotify: expect.any(Function) })
       );
       wrapper.unmount();
     });

--- a/app/features/team/__tests__/MyTeam.test.ts
+++ b/app/features/team/__tests__/MyTeam.test.ts
@@ -18,6 +18,7 @@ const mockSupabaseClient = {
 const mockToast = {
   add: vi.fn(),
 };
+const mockCopyToClipboard = vi.fn(async () => true);
 mockNuxtImport('useRouter', () => () => ({
   beforeEach: vi.fn(),
   beforeResolve: vi.fn(),
@@ -38,7 +39,6 @@ const mockTarkovStore = {
 };
 const mockEdgeFunctions = {
   createTeam: vi.fn(),
-  leaveTeam: vi.fn(),
 };
 const mockSystemState = reactive<SystemState>({
   user_id: null,
@@ -76,6 +76,9 @@ const mockTeamStore = {
 };
 vi.mock('@/composables/api/useEdgeFunctions', () => ({
   useEdgeFunctions: () => mockEdgeFunctions,
+}));
+vi.mock('@/composables/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({ copyToClipboard: mockCopyToClipboard }),
 }));
 vi.mock('@/stores/useTarkov', () => ({
   useTarkovStore: () => mockTarkovStore,
@@ -120,9 +123,7 @@ const mountMyTeam = async () => {
   return mount(MyTeam, {
     global: {
       stubs: {
-        GenericCard: {
-          template: '<div><slot name="title" /><slot name="content" /><slot name="footer" /></div>',
-        },
+        TeamCard: { template: '<div><slot name="icon" /><slot /></div>' },
         UButton: UButtonStub,
         UIcon: true,
       },
@@ -164,7 +165,6 @@ describe('MyTeam store interactions', () => {
     mockSupabaseUser.username = 'user';
     mockSupabaseUser.email = 'user@example.com';
     mockEdgeFunctions.createTeam.mockReset();
-    mockEdgeFunctions.leaveTeam.mockReset();
     mockTarkovStore.getCurrentGameMode.mockReturnValue('pvp');
     mockTarkovStore.getDisplayName.mockReturnValue('TestPMC');
     mockSystemState.user_id = null;
@@ -179,6 +179,8 @@ describe('MyTeam store interactions', () => {
     mockTeamState.join_code = null;
     mockTeamState.members = [];
     mockHasInitiallyLoaded.value = true;
+    mockCopyToClipboard.mockReset();
+    mockCopyToClipboard.mockResolvedValue(true);
   });
   describe('getTeamIdFromState', () => {
     it('returns pvp_team_id for pvp game mode', async () => {
@@ -217,25 +219,12 @@ describe('MyTeam store interactions', () => {
       expect(getTeamIdFromState(state, 'pve')).toBe('team-pve-456');
     });
   });
-  describe('team ownership detection', () => {
-    it('shows disband action when user owns the team', async () => {
+  describe('destructive actions', () => {
+    it('keeps destructive membership actions outside the invite card', async () => {
       mockSystemState.pvp_team_id = 'team-123';
       mockTeamState.owner_id = 'user-123';
       const wrapper = await mountMyTeam();
-      const disbandButton = wrapper
-        .findAll('button')
-        .find((button) => button.text().includes('page.team.card.myteam.disband_team'));
-      expect(disbandButton).toBeTruthy();
-      wrapper.unmount();
-    });
-    it('shows leave action when user is not the owner', async () => {
-      mockSystemState.pvp_team_id = 'team-123';
-      mockTeamState.owner_id = 'other-user';
-      const wrapper = await mountMyTeam();
-      const leaveButton = wrapper
-        .findAll('button')
-        .find((button) => button.text().includes('page.team.card.myteam.leave_team'));
-      expect(leaveButton).toBeTruthy();
+      expect(wrapper.find('[data-testid="open-team-danger-confirmation"]').exists()).toBe(false);
       wrapper.unmount();
     });
   });

--- a/app/features/team/__tests__/MyTeam.test.ts
+++ b/app/features/team/__tests__/MyTeam.test.ts
@@ -184,6 +184,7 @@ describe('MyTeam store interactions', () => {
     mockSystemState.pvp_team_id = null;
     mockSystemState.pve_team_id = null;
     mockSystemState.is_admin = false;
+    mockTeamState.id = null;
     mockTeamState.owner = null;
     mockTeamState.owner_id = null;
     mockTeamState.joinCode = null;

--- a/app/features/team/__tests__/MyTeam.test.ts
+++ b/app/features/team/__tests__/MyTeam.test.ts
@@ -54,6 +54,7 @@ const mockSystemStore = {
   $patch: vi.fn((patch: Partial<SystemState>) => Object.assign(mockSystemState, patch)),
 };
 const mockTeamState = reactive({
+  id: null as string | null,
   owner: null as string | null,
   owner_id: null as string | null,
   joinCode: null as string | null,
@@ -62,11 +63,21 @@ const mockTeamState = reactive({
 });
 const mockTeamStore = {
   $state: mockTeamState,
+  get id() {
+    return mockTeamState.id;
+  },
   get inviteCode() {
     return mockTeamState.joinCode ?? mockTeamState.join_code ?? null;
   },
-  $patch: vi.fn((patch: Record<string, unknown>) => Object.assign(mockTeamState, patch)),
+  $patch: vi.fn((patch: Record<string, unknown> | ((state: typeof mockTeamState) => void)) => {
+    if (typeof patch === 'function') {
+      patch(mockTeamState);
+      return;
+    }
+    Object.assign(mockTeamState, patch);
+  }),
   $reset: vi.fn(() => {
+    mockTeamState.id = null;
     mockTeamState.owner = null;
     mockTeamState.owner_id = null;
     mockTeamState.joinCode = null;
@@ -228,6 +239,21 @@ describe('MyTeam store interactions', () => {
       wrapper.unmount();
     });
   });
+  describe('invite link', () => {
+    it('copies without revealing the invite token in toast feedback', async () => {
+      mockSystemState.pvp_team_id = 'team-123';
+      mockTeamState.id = 'team-123';
+      mockTeamState.joinCode = 'private-code';
+      const wrapper = await mountMyTeam();
+      await wrapper.find('[data-testid="copy-team-invite"]').trigger('click');
+      await flushPromises();
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        expect.stringContaining('code=private-code'),
+        { revealValue: false }
+      );
+      wrapper.unmount();
+    });
+  });
   describe('team name generation', () => {
     it('calls createTeam with display name and random suffix', async () => {
       setupMembershipQueries('team-123');
@@ -248,6 +274,11 @@ describe('MyTeam store interactions', () => {
         5,
         'pvp'
       );
+      expect(mockTeamState.owner).toBe(mockSupabaseUser.id);
+      expect(mockTeamState.id).toBe('team-123');
+      expect(mockTeamState.joinCode).toBe('JOIN1');
+      expect(mockTeamState.owner_id).toBeNull();
+      expect(mockTeamState.join_code).toBeNull();
       randomSpy.mockRestore();
       wrapper.unmount();
     });

--- a/app/features/team/__tests__/TeamCard.test.ts
+++ b/app/features/team/__tests__/TeamCard.test.ts
@@ -1,0 +1,31 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import TeamCard from '@/features/team/TeamCard.vue';
+describe('TeamCard', () => {
+  it('renders its title, subtitle, icon, content, and header actions', () => {
+    const wrapper = mount(TeamCard, {
+      props: { subtitle: 'Manage the team', title: 'Team settings' },
+      slots: {
+        default: '<p data-testid="content">Team content</p>',
+        icon: '<span data-testid="icon">Icon</span>',
+        'header-actions': '<button data-testid="header-action">Action</button>',
+      },
+    });
+    expect(wrapper.find('section').exists()).toBe(true);
+    expect(wrapper.find('h2').text()).toBe('Team settings');
+    expect(wrapper.find('p').text()).toBe('Manage the team');
+    expect(wrapper.find('[data-testid="icon"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="content"]').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="header-action"]').exists()).toBe(true);
+    wrapper.unmount();
+  });
+  it('omits optional subtitle and header actions when they are not provided', () => {
+    const wrapper = mount(TeamCard, {
+      props: { title: 'Team settings' },
+      slots: { default: 'Team content' },
+    });
+    expect(wrapper.find('p').exists()).toBe(false);
+    expect(wrapper.find('[data-testid="header-action"]').exists()).toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/app/features/team/__tests__/TeamDangerZone.test.ts
+++ b/app/features/team/__tests__/TeamDangerZone.test.ts
@@ -1,0 +1,113 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactive } from 'vue';
+import type { SystemState } from '@/types/tarkov';
+const mockSupabaseUser = { id: 'user-1' };
+const mockToast = { add: vi.fn() };
+const mockDisbandTeam = vi.fn();
+const mockLeaveTeam = vi.fn();
+const mockTarkovStore = { getCurrentGameMode: vi.fn(() => 'pvp') };
+const mockSystemState = reactive<SystemState>({
+  is_admin: false,
+  pve_team_id: null,
+  pvp_team_id: null,
+  seasonal_team_id: null,
+  team: null,
+  team_id: null,
+  user_id: 'user-1',
+});
+const mockSystemStore = {
+  $state: mockSystemState,
+  $patch: vi.fn((patch: Partial<SystemState> | ((state: SystemState) => void)) => {
+    if (typeof patch === 'function') {
+      patch(mockSystemState);
+    } else {
+      Object.assign(mockSystemState, patch);
+    }
+  }),
+};
+const mockTeamStore = {
+  owner: null as string | null,
+  $reset: vi.fn(() => {
+    mockTeamStore.owner = null;
+  }),
+};
+mockNuxtImport('useNuxtApp', () => () => ({
+  $supabase: { user: mockSupabaseUser },
+}));
+mockNuxtImport('useToast', () => () => mockToast);
+mockNuxtImport('useI18n', () => () => ({ t: (key: string) => key }));
+vi.mock('@/composables/api/useEdgeFunctions', () => ({
+  useEdgeFunctions: () => ({ disbandTeam: mockDisbandTeam, leaveTeam: mockLeaveTeam }),
+}));
+vi.mock('@/stores/useTarkov', () => ({
+  useTarkovStore: () => mockTarkovStore,
+}));
+vi.mock('@/stores/useTeamStore', () => ({
+  useTeamStoreWithSupabase: () => ({ teamStore: mockTeamStore }),
+}));
+vi.mock('@/stores/useSystemStore', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/stores/useSystemStore')>('@/stores/useSystemStore');
+  return {
+    ...actual,
+    useSystemStoreWithSupabase: () => ({ systemStore: mockSystemStore }),
+  };
+});
+const UButtonStub = {
+  props: ['disabled', 'loading'],
+  emits: ['click'],
+  template:
+    '<button :disabled="disabled" :data-loading="loading" @click="$emit(\'click\')"><slot /></button>',
+};
+const UModalStub = {
+  props: ['open'],
+  emits: ['update:open'],
+  template:
+    '<div v-if="open"><slot name="header" /><slot name="body" /><slot name="footer" /></div>',
+};
+const mountDangerZone = async () => {
+  const { default: TeamDangerZone } = await import('@/features/team/TeamDangerZone.vue');
+  return mount(TeamDangerZone, {
+    global: {
+      stubs: { UButton: UButtonStub, UIcon: true, UModal: UModalStub },
+      mocks: { $t: (key: string) => key },
+    },
+  });
+};
+describe('TeamDangerZone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSystemState.pvp_team_id = 'team-1';
+    mockSystemState.team = 'team-1';
+    mockSystemState.team_id = 'team-1';
+    mockTeamStore.owner = 'user-1';
+    mockDisbandTeam.mockResolvedValue({ success: true });
+    mockLeaveTeam.mockResolvedValue({ success: true });
+  });
+  it('requires confirmation before disbanding and clears local state afterward', async () => {
+    const wrapper = await mountDangerZone();
+    await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
+    expect(mockDisbandTeam).not.toHaveBeenCalled();
+    await wrapper.find('[data-testid="confirm-team-danger-action"]').trigger('click');
+    await flushPromises();
+    expect(mockDisbandTeam).toHaveBeenCalledWith('team-1');
+    expect(mockLeaveTeam).not.toHaveBeenCalled();
+    expect(mockSystemState.pvp_team_id).toBeNull();
+    expect(mockTeamStore.$reset).toHaveBeenCalled();
+    wrapper.unmount();
+  });
+  it('uses the regular leave operation for non-owners', async () => {
+    mockTeamStore.owner = 'other-user';
+    const wrapper = await mountDangerZone();
+    await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
+    await wrapper.find('[data-testid="confirm-team-danger-action"]').trigger('click');
+    await flushPromises();
+    expect(mockLeaveTeam).toHaveBeenCalledWith('team-1');
+    expect(mockDisbandTeam).not.toHaveBeenCalled();
+    expect(mockSystemState.pvp_team_id).toBeNull();
+    wrapper.unmount();
+  });
+});

--- a/app/features/team/__tests__/TeamDangerZone.test.ts
+++ b/app/features/team/__tests__/TeamDangerZone.test.ts
@@ -136,6 +136,35 @@ describe('TeamDangerZone', () => {
     expect(mockTeamStore.$reset).not.toHaveBeenCalled();
     wrapper.unmount();
   });
+  it('does not clear a replacement team when the membership action resolves late', async () => {
+    let resolveLeave!: (value: { success: boolean }) => void;
+    mockTeamStore.owner = 'other-user';
+    mockLeaveTeam.mockReturnValueOnce(
+      new Promise<{ success: boolean }>((resolve) => {
+        resolveLeave = resolve;
+      })
+    );
+    const wrapper = await mountDangerZone();
+    await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
+    const actionPromise = wrapper
+      .find('[data-testid="confirm-team-danger-action"]')
+      .trigger('click');
+    await vi.waitFor(() => expect(mockLeaveTeam).toHaveBeenCalledWith('team-1'));
+    mockSystemState.pvp_team_id = 'replacement-team';
+    mockSystemState.team = 'replacement-team';
+    mockSystemState.team_id = 'replacement-team';
+    mockTeamStore.id = 'replacement-team';
+    mockTeamStore.owner = 'user-1';
+    resolveLeave({ success: true });
+    await actionPromise;
+    await flushPromises();
+    expect(mockSystemState.pvp_team_id).toBe('replacement-team');
+    expect(mockSystemState.team).toBe('replacement-team');
+    expect(mockSystemState.team_id).toBe('replacement-team');
+    expect(mockTeamStore.id).toBe('replacement-team');
+    expect(mockTeamStore.$reset).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
   it('clears persistent legacy aliases without disturbing another mode team', async () => {
     mockTarkovStore.getCurrentGameMode.mockReturnValue('pve');
     mockSystemState.pvp_team_id = 'pvp-team';

--- a/app/features/team/__tests__/TeamDangerZone.test.ts
+++ b/app/features/team/__tests__/TeamDangerZone.test.ts
@@ -109,6 +109,7 @@ describe('TeamDangerZone', () => {
     mockTeamStore.owner = 'other-user';
     const wrapper = await mountDangerZone();
     await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
+    expect(wrapper.text()).toContain('page.team.danger_zone.confirm_leave_title');
     await wrapper.find('[data-testid="confirm-team-danger-action"]').trigger('click');
     await flushPromises();
     expect(mockLeaveTeam).toHaveBeenCalledWith('team-1');
@@ -134,6 +135,33 @@ describe('TeamDangerZone', () => {
     expect(wrapper.find('[data-testid="confirm-team-danger-action"]').exists()).toBe(true);
     expect(mockSystemState.pvp_team_id).toBe('team-1');
     expect(mockTeamStore.$reset).not.toHaveBeenCalled();
+    const confirmButton = wrapper.find('[data-testid="confirm-team-danger-action"]');
+    expect((confirmButton.element as HTMLButtonElement).disabled).toBe(false);
+    wrapper.unmount();
+  });
+  it('shows the translated error when a membership operation returns failure', async () => {
+    mockDisbandTeam.mockResolvedValue({ success: false });
+    const wrapper = await mountDangerZone();
+    await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
+    await wrapper.find('[data-testid="confirm-team-danger-action"]').trigger('click');
+    await flushPromises();
+    expect(mockToast.add).toHaveBeenCalledWith({
+      color: 'error',
+      title: 'page.team.danger_zone.disband_error',
+    });
+    expect(wrapper.find('[data-testid="confirm-team-danger-action"]').exists()).toBe(true);
+    wrapper.unmount();
+  });
+  it('shows a generic error when a membership action rejects with a non-error value', async () => {
+    mockDisbandTeam.mockRejectedValue('request failed');
+    const wrapper = await mountDangerZone();
+    await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
+    await wrapper.find('[data-testid="confirm-team-danger-action"]').trigger('click');
+    await flushPromises();
+    expect(mockToast.add).toHaveBeenCalledWith({
+      color: 'error',
+      title: 'page.team.danger_zone.action_error',
+    });
     wrapper.unmount();
   });
   it('does not clear a replacement team when the membership action resolves late', async () => {
@@ -163,6 +191,10 @@ describe('TeamDangerZone', () => {
     expect(mockSystemState.team_id).toBe('replacement-team');
     expect(mockTeamStore.id).toBe('replacement-team');
     expect(mockTeamStore.$reset).not.toHaveBeenCalled();
+    expect(mockToast.add).toHaveBeenCalledWith({
+      color: 'success',
+      title: 'page.team.card.myteam.leave_team_success',
+    });
     wrapper.unmount();
   });
   it('clears persistent legacy aliases without disturbing another mode team', async () => {

--- a/app/features/team/__tests__/TeamDangerZone.test.ts
+++ b/app/features/team/__tests__/TeamDangerZone.test.ts
@@ -151,8 +151,8 @@ describe('TeamDangerZone', () => {
     expect(mockLeaveTeam).toHaveBeenCalledWith('pve-team');
     expect(mockSystemState.pve_team_id).toBeNull();
     expect(mockSystemState.pvp_team_id).toBe('pvp-team');
-    expect(mockSystemState.team).toBeNull();
-    expect(mockSystemState.team_id).toBeNull();
+    expect(mockSystemState.team).toBe('pvp-team');
+    expect(mockSystemState.team_id).toBe('pvp-team');
     wrapper.unmount();
   });
 });

--- a/app/features/team/__tests__/TeamDangerZone.test.ts
+++ b/app/features/team/__tests__/TeamDangerZone.test.ts
@@ -29,8 +29,10 @@ const mockSystemStore = {
   }),
 };
 const mockTeamStore = {
+  id: null as string | null,
   owner: null as string | null,
   $reset: vi.fn(() => {
+    mockTeamStore.id = null;
     mockTeamStore.owner = null;
   }),
 };
@@ -81,9 +83,13 @@ describe('TeamDangerZone', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockSystemState.pvp_team_id = 'team-1';
+    mockSystemState.pve_team_id = null;
+    mockSystemState.seasonal_team_id = null;
     mockSystemState.team = 'team-1';
     mockSystemState.team_id = 'team-1';
+    mockTeamStore.id = 'team-1';
     mockTeamStore.owner = 'user-1';
+    mockTarkovStore.getCurrentGameMode.mockReturnValue('pvp');
     mockDisbandTeam.mockResolvedValue({ success: true });
     mockLeaveTeam.mockResolvedValue({ success: true });
   });
@@ -108,6 +114,45 @@ describe('TeamDangerZone', () => {
     expect(mockLeaveTeam).toHaveBeenCalledWith('team-1');
     expect(mockDisbandTeam).not.toHaveBeenCalled();
     expect(mockSystemState.pvp_team_id).toBeNull();
+    wrapper.unmount();
+  });
+  it('does not expose a membership action until the team owner is resolved', async () => {
+    mockTeamStore.owner = null;
+    const wrapper = await mountDangerZone();
+    expect(wrapper.find('[data-testid="team-danger-zone"]').exists()).toBe(false);
+    expect(mockDisbandTeam).not.toHaveBeenCalled();
+    expect(mockLeaveTeam).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+  it('keeps the confirmation and local state when disbanding fails', async () => {
+    mockDisbandTeam.mockRejectedValue(new Error('Network unavailable'));
+    const wrapper = await mountDangerZone();
+    await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
+    await wrapper.find('[data-testid="confirm-team-danger-action"]').trigger('click');
+    await flushPromises();
+    expect(mockToast.add).toHaveBeenCalledWith({ color: 'error', title: 'Network unavailable' });
+    expect(wrapper.find('[data-testid="confirm-team-danger-action"]').exists()).toBe(true);
+    expect(mockSystemState.pvp_team_id).toBe('team-1');
+    expect(mockTeamStore.$reset).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+  it('clears persistent legacy aliases without disturbing another mode team', async () => {
+    mockTarkovStore.getCurrentGameMode.mockReturnValue('pve');
+    mockSystemState.pvp_team_id = 'pvp-team';
+    mockSystemState.pve_team_id = 'pve-team';
+    mockSystemState.team = 'pvp-team';
+    mockSystemState.team_id = 'pvp-team';
+    mockTeamStore.id = 'pve-team';
+    mockTeamStore.owner = 'other-user';
+    const wrapper = await mountDangerZone();
+    await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
+    await wrapper.find('[data-testid="confirm-team-danger-action"]').trigger('click');
+    await flushPromises();
+    expect(mockLeaveTeam).toHaveBeenCalledWith('pve-team');
+    expect(mockSystemState.pve_team_id).toBeNull();
+    expect(mockSystemState.pvp_team_id).toBe('pvp-team');
+    expect(mockSystemState.team).toBeNull();
+    expect(mockSystemState.team_id).toBeNull();
     wrapper.unmount();
   });
 });

--- a/app/features/team/__tests__/TeamMemberCard.test.ts
+++ b/app/features/team/__tests__/TeamMemberCard.test.ts
@@ -3,41 +3,56 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 const mockToggleHidden = vi.fn();
+const mockKickTeamMember = vi.fn();
+const mockToast = { add: vi.fn() };
+const mockMetadataStore = {
+  playerLevels: [{ level: 42, levelBadgeImageLink: '/level-42.png' }],
+  tasks: [{ id: 'task-1' }, { id: 'task-2' }],
+};
 const mockPreferencesStore = {
   taskTeamAllHidden: true,
   teamIsHidden: vi.fn(() => true),
   toggleHidden: mockToggleHidden,
 };
+const mockProgressStore = {
+  getDisplayName: vi.fn(() => 'Teammate'),
+  getLevel: vi.fn(() => 42),
+  tasksCompletions: { 'task-1': { 'user-2': true }, 'task-2': { 'user-2': false } },
+};
+const mockSystemState = { pvp_team_id: 'team-1' as string | null };
+const mockTeamStore = {
+  memberProfiles: {} as Record<
+    string,
+    { displayName?: string; level?: number; tasksCompleted?: number }
+  >,
+  owner: 'user-1',
+};
 mockNuxtImport('useNuxtApp', () => () => ({ $supabase: { user: { id: 'user-1' } } }));
-mockNuxtImport('useToast', () => () => ({ add: vi.fn() }));
+mockNuxtImport('useToast', () => () => mockToast);
 mockNuxtImport('useI18n', () => () => ({ t: (key: string) => key }));
 vi.mock('@/composables/api/useEdgeFunctions', () => ({
-  useEdgeFunctions: () => ({ kickTeamMember: vi.fn() }),
+  useEdgeFunctions: () => ({ kickTeamMember: mockKickTeamMember }),
 }));
 vi.mock('@/stores/useMetadata', () => ({
-  useMetadataStore: () => ({ playerLevels: [], tasks: [] }),
+  useMetadataStore: () => mockMetadataStore,
 }));
 vi.mock('@/stores/usePreferences', () => ({
   usePreferencesStore: () => mockPreferencesStore,
 }));
 vi.mock('@/stores/useProgress', () => ({
-  useProgressStore: () => ({
-    getDisplayName: () => 'Teammate',
-    getLevel: () => 1,
-    tasksCompletions: {},
-  }),
+  useProgressStore: () => mockProgressStore,
 }));
 vi.mock('@/stores/useSystemStore', async () => {
   const actual =
     await vi.importActual<typeof import('@/stores/useSystemStore')>('@/stores/useSystemStore');
   return {
     ...actual,
-    useSystemStoreWithSupabase: () => ({ systemStore: { $state: {} } }),
+    useSystemStoreWithSupabase: () => ({ systemStore: { $state: mockSystemState } }),
   };
 });
 vi.mock('@/stores/useTeamStore', () => ({
   useTeamStoreWithSupabase: () => ({
-    teamStore: { memberProfiles: {}, owner: 'user-1' },
+    teamStore: mockTeamStore,
   }),
 }));
 vi.mock('@/stores/utils/gameMode', () => ({ getCurrentGameMode: () => 'pvp' }));
@@ -45,32 +60,85 @@ describe('TeamMemberCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockPreferencesStore.taskTeamAllHidden = true;
+    mockPreferencesStore.teamIsHidden.mockReturnValue(true);
+    mockSystemState.pvp_team_id = 'team-1';
+    mockTeamStore.memberProfiles = {};
+    mockTeamStore.owner = 'user-1';
+    mockKickTeamMember.mockResolvedValue({ success: true });
   });
-  it('disables individual visibility changes while all team tasks are hidden', async () => {
+  const mountCard = async (props = { isTeamOwnerView: false, teammember: 'user-2' }) => {
     const { default: TeamMemberCard } = await import('@/features/team/TeamMemberCard.vue');
-    const wrapper = mount(TeamMemberCard, {
-      props: { isTeamOwnerView: false, teammember: 'user-2' },
+    return mount(TeamMemberCard, {
+      props,
       global: {
         stubs: {
           AppTooltip: { template: '<div><slot /></div>' },
-          UBadge: true,
+          UBadge: { template: '<span><slot /></span>' },
           UButton: {
-            props: ['ariaLabel', 'disabled'],
+            props: ['ariaLabel', 'disabled', 'loading'],
             emits: ['click'],
             template:
-              '<button :aria-label="ariaLabel" :disabled="disabled" @click="$emit(\'click\')"></button>',
+              '<button :aria-label="ariaLabel" :disabled="disabled" :data-loading="loading" @click="$emit(\'click\')"></button>',
           },
-          i18nT: true,
+          i18nT: { template: '<div><slot name="completed" /><slot name="total" /></div>' },
         },
         mocks: { $t: (key: string) => key },
       },
     });
+  };
+  it('disables individual visibility changes while all team tasks are hidden', async () => {
+    const wrapper = await mountCard();
     const button = wrapper.get(
       'button[aria-label="page.team.card.manageteam.membercard.enable_team_tasks"]'
     );
     expect((button.element as HTMLButtonElement).disabled).toBe(true);
     await button.trigger('click');
     expect(mockToggleHidden).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+  it('toggles visible progress when the global visibility guard is off', async () => {
+    mockPreferencesStore.taskTeamAllHidden = false;
+    mockPreferencesStore.teamIsHidden.mockReturnValue(false);
+    const wrapper = await mountCard();
+    const button = wrapper.get(
+      'button[aria-label="page.team.card.manageteam.membercard.hide_progress"]'
+    );
+    await button.trigger('click');
+    expect(mockToggleHidden).toHaveBeenCalledWith('user-2');
+    wrapper.unmount();
+  });
+  it('uses member profile data and kicks a teammate successfully', async () => {
+    mockPreferencesStore.taskTeamAllHidden = false;
+    mockTeamStore.memberProfiles = {
+      'user-2': { displayName: 'W'.repeat(25), level: 42, tasksCompleted: 2 },
+    };
+    const wrapper = await mountCard({ isTeamOwnerView: true, teammember: 'user-2' });
+    expect(wrapper.text()).toContain('W'.repeat(25));
+    const button = wrapper.get(
+      'button[aria-label="page.team.card.manageteam.membercard.remove_member"]'
+    );
+    await button.trigger('click');
+    await vi.waitFor(() => expect(mockKickTeamMember).toHaveBeenCalledWith('team-1', 'user-2'));
+    expect(mockToast.add).toHaveBeenCalledWith({
+      color: 'success',
+      title: 'page.team.card.manageteam.membercard.kick_success',
+    });
+    wrapper.unmount();
+  });
+  it('shows a local error when the current team is unavailable', async () => {
+    mockPreferencesStore.taskTeamAllHidden = false;
+    mockSystemState.pvp_team_id = null;
+    const wrapper = await mountCard({ isTeamOwnerView: true, teammember: 'user-2' });
+    const button = wrapper.get(
+      'button[aria-label="page.team.card.manageteam.membercard.remove_member"]'
+    );
+    await button.trigger('click');
+    expect(mockKickTeamMember).not.toHaveBeenCalled();
+    expect(mockToast.add).toHaveBeenCalledWith({
+      color: 'error',
+      description: 'page.team.card.manageteam.membercard.kick_error',
+      title: 'page.team.card.manageteam.membercard.kick_error',
+    });
     wrapper.unmount();
   });
 });

--- a/app/features/team/__tests__/TeamMemberCard.test.ts
+++ b/app/features/team/__tests__/TeamMemberCard.test.ts
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+const mockToggleHidden = vi.fn();
+const mockPreferencesStore = {
+  taskTeamAllHidden: true,
+  teamIsHidden: vi.fn(() => true),
+  toggleHidden: mockToggleHidden,
+};
+mockNuxtImport('useNuxtApp', () => () => ({ $supabase: { user: { id: 'user-1' } } }));
+mockNuxtImport('useToast', () => () => ({ add: vi.fn() }));
+mockNuxtImport('useI18n', () => () => ({ t: (key: string) => key }));
+vi.mock('@/composables/api/useEdgeFunctions', () => ({
+  useEdgeFunctions: () => ({ kickTeamMember: vi.fn() }),
+}));
+vi.mock('@/stores/useMetadata', () => ({
+  useMetadataStore: () => ({ playerLevels: [], tasks: [] }),
+}));
+vi.mock('@/stores/usePreferences', () => ({
+  usePreferencesStore: () => mockPreferencesStore,
+}));
+vi.mock('@/stores/useProgress', () => ({
+  useProgressStore: () => ({
+    getDisplayName: () => 'Teammate',
+    getLevel: () => 1,
+    tasksCompletions: {},
+  }),
+}));
+vi.mock('@/stores/useSystemStore', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/stores/useSystemStore')>('@/stores/useSystemStore');
+  return {
+    ...actual,
+    useSystemStoreWithSupabase: () => ({ systemStore: { $state: {} } }),
+  };
+});
+vi.mock('@/stores/useTeamStore', () => ({
+  useTeamStoreWithSupabase: () => ({
+    teamStore: { memberProfiles: {}, owner: 'user-1' },
+  }),
+}));
+vi.mock('@/stores/utils/gameMode', () => ({ getCurrentGameMode: () => 'pvp' }));
+describe('TeamMemberCard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPreferencesStore.taskTeamAllHidden = true;
+  });
+  it('disables individual visibility changes while all team tasks are hidden', async () => {
+    const { default: TeamMemberCard } = await import('@/features/team/TeamMemberCard.vue');
+    const wrapper = mount(TeamMemberCard, {
+      props: { isTeamOwnerView: false, teammember: 'user-2' },
+      global: {
+        stubs: {
+          AppTooltip: { template: '<div><slot /></div>' },
+          UBadge: true,
+          UButton: {
+            props: ['ariaLabel', 'disabled'],
+            emits: ['click'],
+            template:
+              '<button :aria-label="ariaLabel" :disabled="disabled" @click="$emit(\'click\')"></button>',
+          },
+          i18nT: true,
+        },
+        mocks: { $t: (key: string) => key },
+      },
+    });
+    const button = wrapper.get(
+      'button[aria-label="page.team.card.manageteam.membercard.enable_team_tasks"]'
+    );
+    expect((button.element as HTMLButtonElement).disabled).toBe(true);
+    await button.trigger('click');
+    expect(mockToggleHidden).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+});

--- a/app/features/team/__tests__/TeamMembers.test.ts
+++ b/app/features/team/__tests__/TeamMembers.test.ts
@@ -15,7 +15,7 @@ const mockSystemState = reactive<SystemState>({
   team_id: 'team-1',
   user_id: 'user-1',
 });
-const mockTeamStore = reactive({ members: ['user-1'], owner: 'user-1' });
+const mockTeamStore = reactive({ id: 'team-1', members: ['user-1'], owner: 'user-1' });
 const mockSystemStore = { $state: mockSystemState };
 mockNuxtImport('useNuxtApp', () => () => ({
   $supabase: { user: { id: 'user-1' } },
@@ -69,7 +69,12 @@ describe('TeamMembers', () => {
     expect(wrapper.find('[data-testid="team-members-empty-state"]').exists()).toBe(true);
     await wrapper.find('[data-testid="copy-team-members-invite"]').trigger('click');
     await flushPromises();
-    expect(mockCopyToClipboard).toHaveBeenCalledWith(mockTeamUrl.value);
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(mockTeamUrl.value, { revealValue: false });
+    expect(wrapper.find('[aria-live="polite"]').text()).toContain('page.team.members.copied');
+    mockCopyToClipboard.mockResolvedValueOnce(false);
+    await wrapper.find('[data-testid="copy-team-members-invite"]').trigger('click');
+    await flushPromises();
+    expect(wrapper.find('[aria-live="polite"]').text()).toContain('page.team.members.copy_invite');
     wrapper.unmount();
   });
 });

--- a/app/features/team/__tests__/TeamMembers.test.ts
+++ b/app/features/team/__tests__/TeamMembers.test.ts
@@ -69,7 +69,10 @@ describe('TeamMembers', () => {
     expect(wrapper.find('[data-testid="team-members-empty-state"]').exists()).toBe(true);
     await wrapper.find('[data-testid="copy-team-members-invite"]').trigger('click');
     await flushPromises();
-    expect(mockCopyToClipboard).toHaveBeenCalledWith(mockTeamUrl.value, { revealValue: false });
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(
+      mockTeamUrl.value,
+      expect.objectContaining({ revealValue: false, shouldNotify: expect.any(Function) })
+    );
     expect(wrapper.find('[aria-live="polite"]').text()).toContain('page.team.members.copied');
     mockCopyToClipboard.mockResolvedValueOnce(false);
     await wrapper.find('[data-testid="copy-team-members-invite"]').trigger('click');

--- a/app/features/team/__tests__/TeamMembers.test.ts
+++ b/app/features/team/__tests__/TeamMembers.test.ts
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { flushPromises, mount } from '@vue/test-utils';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { computed, reactive, ref } from 'vue';
+import type { SystemState } from '@/types/tarkov';
+const mockCopyToClipboard = vi.fn();
+const mockTeamUrl = ref('https://tarkovtracker.test/team?team=team-1&code=invite');
+const mockSystemState = reactive<SystemState>({
+  is_admin: false,
+  pve_team_id: null,
+  pvp_team_id: 'team-1',
+  seasonal_team_id: null,
+  team: 'team-1',
+  team_id: 'team-1',
+  user_id: 'user-1',
+});
+const mockTeamStore = reactive({ members: ['user-1'], owner: 'user-1' });
+const mockSystemStore = { $state: mockSystemState };
+mockNuxtImport('useNuxtApp', () => () => ({
+  $supabase: { user: { id: 'user-1' } },
+}));
+mockNuxtImport('useI18n', () => () => ({ t: (key: string) => key }));
+vi.mock('@/composables/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({ copyToClipboard: mockCopyToClipboard }),
+}));
+vi.mock('@/features/team/useTeamInviteLink', () => ({
+  useTeamInviteLink: () => ({ teamUrl: computed(() => mockTeamUrl.value) }),
+}));
+vi.mock('@/stores/useSystemStore', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/stores/useSystemStore')>('@/stores/useSystemStore');
+  return {
+    ...actual,
+    useSystemStoreWithSupabase: () => ({ systemStore: mockSystemStore }),
+  };
+});
+vi.mock('@/stores/useTeamStore', () => ({
+  useTeamStoreWithSupabase: () => ({ teamStore: mockTeamStore }),
+}));
+const mountTeamMembers = async () => {
+  const { default: TeamMembers } = await import('@/features/team/TeamMembers.vue');
+  return mount(TeamMembers, {
+    global: {
+      stubs: {
+        TeamCard: { template: '<div><slot name="icon" /><slot /></div>' },
+        TeamMemberCard: { template: '<div data-testid="member-card" />' },
+        UButton: {
+          props: ['disabled'],
+          emits: ['click'],
+          template: '<button :disabled="disabled" @click="$emit(\'click\')"><slot /></button>',
+        },
+        UIcon: true,
+      },
+      mocks: { $t: (key: string) => key },
+    },
+  });
+};
+describe('TeamMembers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockTeamStore.members = ['user-1'];
+    mockTeamStore.owner = 'user-1';
+    mockTeamUrl.value = 'https://tarkovtracker.test/team?team=team-1&code=invite';
+    mockCopyToClipboard.mockResolvedValue(true);
+  });
+  it('shows solo-team guidance and copies the invite link', async () => {
+    const wrapper = await mountTeamMembers();
+    expect(wrapper.find('[data-testid="team-members-empty-state"]').exists()).toBe(true);
+    await wrapper.find('[data-testid="copy-team-members-invite"]').trigger('click');
+    await flushPromises();
+    expect(mockCopyToClipboard).toHaveBeenCalledWith(mockTeamUrl.value);
+    wrapper.unmount();
+  });
+});

--- a/app/features/team/__tests__/TeamOptions.test.ts
+++ b/app/features/team/__tests__/TeamOptions.test.ts
@@ -34,10 +34,10 @@ vi.mock('@/stores/usePreferences', () => ({
   usePreferencesStore: () => mockPreferencesStore,
 }));
 const TeamVisibilitySwitchStub = {
-  props: ['modelValue', 'disabled'],
+  props: ['id', 'modelValue', 'disabled'],
   emits: ['update:modelValue'],
   template:
-    '<button :data-state="modelValue ? \'on\' : \'off\'" :disabled="disabled" @click="$emit(\'update:modelValue\', !modelValue)"></button>',
+    '<button :id="id" :data-state="modelValue ? \'on\' : \'off\'" :disabled="disabled" @click="$emit(\'update:modelValue\', !modelValue)"></button>',
 };
 const mountTeamOptions = async () => {
   const { default: TeamOptions } = await import('@/features/team/TeamOptions.vue');
@@ -66,13 +66,18 @@ describe('TeamOptions preferences', () => {
     vi.clearAllMocks();
   });
   describe('taskHideAll switch', () => {
-    it('uses the full row as the switch label while keeping one keyboard control', async () => {
+    it('toggles when the row text is clicked without duplicating switch events', async () => {
       const wrapper = await mountTeamOptions();
       const row = wrapper.find('[data-testid="task-row"]');
+      const taskToggle = wrapper.find('[data-testid="task-toggle"]');
       const taskSwitch = wrapper.find('[data-testid="task-switch"]');
-      expect(row.element.tagName).toBe('LABEL');
-      expect(row.attributes('for')).toBe('team-visibility-tasks');
-      expect(taskSwitch.attributes('id')).toBe('team-visibility-tasks');
+      await taskToggle.trigger('click');
+      expect(mockPreferencesStore.setQuestTeamHideAll).toHaveBeenCalledTimes(1);
+      expect(mockPreferencesStore.setQuestTeamHideAll).toHaveBeenLastCalledWith(true);
+      vi.clearAllMocks();
+      await taskSwitch.trigger('click');
+      expect(mockPreferencesStore.setQuestTeamHideAll).toHaveBeenCalledTimes(1);
+      expect(row.element.tagName).toBe('DIV');
       wrapper.unmount();
     });
     it('calls setQuestTeamHideAll when toggled on', async () => {

--- a/app/features/team/__tests__/TeamOptions.test.ts
+++ b/app/features/team/__tests__/TeamOptions.test.ts
@@ -117,6 +117,12 @@ describe('TeamOptions preferences', () => {
       expect(mockPreferencesStore.setItemsTeamHideAll).toHaveBeenCalledWith(false);
       wrapper.unmount();
     });
+    it('toggles item visibility when the row text is clicked', async () => {
+      const wrapper = await mountTeamOptions();
+      await wrapper.find('[data-testid="items-row"] button').trigger('click');
+      expect(mockPreferencesStore.setItemsTeamHideAll).toHaveBeenCalledWith(true);
+      wrapper.unmount();
+    });
   });
   describe('dependent toggles', () => {
     it('disables item switches when itemsTeamAllHidden is true', async () => {
@@ -139,6 +145,42 @@ describe('TeamOptions preferences', () => {
         .element as HTMLButtonElement;
       expect(nonFirSwitch.disabled).toBe(false);
       expect(hideoutSwitch.disabled).toBe(false);
+      wrapper.unmount();
+    });
+    it('toggles non-FIR visibility from the row text', async () => {
+      const wrapper = await mountTeamOptions();
+      await wrapper.find('[data-testid="nonfir-row"] button').trigger('click');
+      expect(mockPreferencesStore.setItemsTeamHideNonFIR).toHaveBeenCalledWith(true);
+      wrapper.unmount();
+    });
+    it('does not toggle non-FIR visibility while all items are hidden', async () => {
+      mockPreferencesState.itemsTeamAllHidden = true;
+      const wrapper = await mountTeamOptions();
+      await wrapper.find('[data-testid="nonfir-row"] button').trigger('click');
+      expect(mockPreferencesStore.setItemsTeamHideNonFIR).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+    it('renders the non-FIR switch as checked when non-FIR items are visible', async () => {
+      const wrapper = await mountTeamOptions();
+      expect(wrapper.find('[data-testid="nonfir-switch"]').attributes('data-state')).toBe('on');
+      wrapper.unmount();
+    });
+    it('toggles hideout visibility from the row text', async () => {
+      const wrapper = await mountTeamOptions();
+      await wrapper.find('[data-testid="hideout-row"] button').trigger('click');
+      expect(mockPreferencesStore.setItemsTeamHideHideout).toHaveBeenCalledWith(true);
+      wrapper.unmount();
+    });
+    it('does not toggle hideout visibility while all items are hidden', async () => {
+      mockPreferencesState.itemsTeamAllHidden = true;
+      const wrapper = await mountTeamOptions();
+      await wrapper.find('[data-testid="hideout-row"] button').trigger('click');
+      expect(mockPreferencesStore.setItemsTeamHideHideout).not.toHaveBeenCalled();
+      wrapper.unmount();
+    });
+    it('renders the hideout switch as checked when hideout items are visible', async () => {
+      const wrapper = await mountTeamOptions();
+      expect(wrapper.find('[data-testid="hideout-switch"]').attributes('data-state')).toBe('on');
       wrapper.unmount();
     });
   });
@@ -164,6 +206,12 @@ describe('TeamOptions preferences', () => {
       const wrapper = await mountTeamOptions();
       const mapSwitch = wrapper.find('[data-testid="map-switch"]');
       await mapSwitch.trigger('click');
+      expect(mockPreferencesStore.setMapTeamHideAll).toHaveBeenCalledWith(true);
+      wrapper.unmount();
+    });
+    it('toggles map team visibility when the row text is clicked', async () => {
+      const wrapper = await mountTeamOptions();
+      await wrapper.find('[data-testid="map-row"] button').trigger('click');
       expect(mockPreferencesStore.setMapTeamHideAll).toHaveBeenCalledWith(true);
       wrapper.unmount();
     });

--- a/app/features/team/__tests__/TeamOptions.test.ts
+++ b/app/features/team/__tests__/TeamOptions.test.ts
@@ -78,6 +78,7 @@ describe('TeamOptions preferences', () => {
       await taskSwitch.trigger('click');
       expect(mockPreferencesStore.setQuestTeamHideAll).toHaveBeenCalledTimes(1);
       expect(row.element.tagName).toBe('DIV');
+      expect(taskToggle.element.tagName).toBe('BUTTON');
       wrapper.unmount();
     });
     it('calls setQuestTeamHideAll when toggled on', async () => {

--- a/app/features/team/__tests__/TeamOptions.test.ts
+++ b/app/features/team/__tests__/TeamOptions.test.ts
@@ -66,6 +66,15 @@ describe('TeamOptions preferences', () => {
     vi.clearAllMocks();
   });
   describe('taskHideAll switch', () => {
+    it('uses the full row as the switch label while keeping one keyboard control', async () => {
+      const wrapper = await mountTeamOptions();
+      const row = wrapper.find('[data-testid="task-row"]');
+      const taskSwitch = wrapper.find('[data-testid="task-switch"]');
+      expect(row.element.tagName).toBe('LABEL');
+      expect(row.attributes('for')).toBe('team-visibility-tasks');
+      expect(taskSwitch.attributes('id')).toBe('team-visibility-tasks');
+      wrapper.unmount();
+    });
     it('calls setQuestTeamHideAll when toggled on', async () => {
       const wrapper = await mountTeamOptions();
       const taskSwitch = wrapper.find('[data-testid="task-switch"]');

--- a/app/features/team/__tests__/TeamOptions.test.ts
+++ b/app/features/team/__tests__/TeamOptions.test.ts
@@ -33,7 +33,7 @@ const mockPreferencesStore = {
 vi.mock('@/stores/usePreferences', () => ({
   usePreferencesStore: () => mockPreferencesStore,
 }));
-const USwitchStub = {
+const TeamVisibilitySwitchStub = {
   props: ['modelValue', 'disabled'],
   emits: ['update:modelValue'],
   template:
@@ -44,10 +44,8 @@ const mountTeamOptions = async () => {
   const wrapper = mount(TeamOptions, {
     global: {
       stubs: {
-        GenericCard: {
-          template: '<div><slot name="title" /><slot name="content" /><slot name="footer" /></div>',
-        },
-        USwitch: USwitchStub,
+        TeamCard: { template: '<div><slot name="icon" /><slot /></div>' },
+        TeamVisibilitySwitch: TeamVisibilitySwitchStub,
         USeparator: { template: '<hr />' },
       },
       mocks: {
@@ -134,14 +132,14 @@ describe('TeamOptions preferences', () => {
       mockPreferencesState.taskTeamAllHidden = true;
       const wrapper = await mountTeamOptions();
       const taskToggle = wrapper.find('[data-testid="task-toggle"]');
-      expect(taskToggle.text()).toContain('page.team.card.teamoptions.toggle_tasks');
+      expect(taskToggle.text()).toContain('page.team.visibility.show_tasks');
       wrapper.unmount();
     });
     it('renders same static label when preference is false', async () => {
       mockPreferencesState.taskTeamAllHidden = false;
       const wrapper = await mountTeamOptions();
       const taskToggle = wrapper.find('[data-testid="task-toggle"]');
-      expect(taskToggle.text()).toContain('page.team.card.teamoptions.toggle_tasks');
+      expect(taskToggle.text()).toContain('page.team.visibility.show_tasks');
       wrapper.unmount();
     });
   });

--- a/app/features/team/__tests__/TeamVisibilitySwitch.test.ts
+++ b/app/features/team/__tests__/TeamVisibilitySwitch.test.ts
@@ -11,9 +11,21 @@ describe('TeamVisibilitySwitch', () => {
     expect(button.attributes('role')).toBe('switch');
     expect(button.attributes('aria-label')).toBe('Show team tasks');
     expect(button.attributes('aria-checked')).toBe('false');
+    expect(button.attributes('data-state')).toBe('unchecked');
     expect(button.attributes('class')).toContain('min-h-11');
     await button.trigger('click');
     expect(wrapper.emitted('update:modelValue')).toEqual([[true]]);
+    wrapper.unmount();
+  });
+  it('renders the checked state and thumb position', () => {
+    const wrapper = mountSwitch({ label: 'Show team tasks', modelValue: true });
+    const button = wrapper.get('button');
+    expect(button.attributes('aria-checked')).toBe('true');
+    expect(button.attributes('data-state')).toBe('checked');
+    expect(wrapper.find('[aria-hidden="true"]').attributes('data-state')).toBe('checked');
+    expect(wrapper.find('[aria-hidden="true"] span').attributes('class')).toContain(
+      'translate-x-4.5'
+    );
     wrapper.unmount();
   });
   it('does not emit when disabled', async () => {

--- a/app/features/team/__tests__/TeamVisibilitySwitch.test.ts
+++ b/app/features/team/__tests__/TeamVisibilitySwitch.test.ts
@@ -1,0 +1,25 @@
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import TeamVisibilitySwitch from '@/features/team/TeamVisibilitySwitch.vue';
+const mountSwitch = (props: { disabled?: boolean; label: string; modelValue: boolean }) => {
+  return mount(TeamVisibilitySwitch, { props });
+};
+describe('TeamVisibilitySwitch', () => {
+  it('exposes switch semantics and emits the next value', async () => {
+    const wrapper = mountSwitch({ label: 'Show team tasks', modelValue: false });
+    const button = wrapper.get('button');
+    expect(button.attributes('role')).toBe('switch');
+    expect(button.attributes('aria-label')).toBe('Show team tasks');
+    expect(button.attributes('aria-checked')).toBe('false');
+    expect(button.attributes('class')).toContain('min-h-11');
+    await button.trigger('click');
+    expect(wrapper.emitted('update:modelValue')).toEqual([[true]]);
+    wrapper.unmount();
+  });
+  it('does not emit when disabled', async () => {
+    const wrapper = mountSwitch({ disabled: true, label: 'Show team tasks', modelValue: false });
+    await wrapper.get('button').trigger('click');
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined();
+    wrapper.unmount();
+  });
+});

--- a/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
+++ b/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
@@ -1,0 +1,31 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import { defineComponent, h } from 'vue';
+const mockCopyToClipboard = vi.fn();
+vi.mock('@/composables/useCopyToClipboard', () => ({
+  useCopyToClipboard: () => ({ copyToClipboard: mockCopyToClipboard }),
+}));
+describe('useTeamInviteCopyFeedback', () => {
+  it('does not schedule feedback after the consumer unmounts', async () => {
+    let resolveCopy!: (success: boolean) => void;
+    mockCopyToClipboard.mockReturnValueOnce(
+      new Promise<boolean>((resolve) => {
+        resolveCopy = resolve;
+      })
+    );
+    const { useTeamInviteCopyFeedback } = await import('@/features/team/useTeamInviteCopyFeedback');
+    let copyPromise: Promise<boolean> | null = null;
+    const Harness = defineComponent({
+      setup() {
+        const { copied, copyInviteLink } = useTeamInviteCopyFeedback();
+        copyPromise = copyInviteLink('https://example.test/team?code=private');
+        return () => h('span', copied.value ? 'copied' : 'idle');
+      },
+    });
+    const wrapper = mount(Harness);
+    wrapper.unmount();
+    resolveCopy(true);
+    expect(await copyPromise).toBe(false);
+  });
+});

--- a/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
+++ b/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
@@ -52,38 +52,35 @@ describe('useTeamInviteCopyFeedback', () => {
   });
   it('ignores stale success when a newer copy fails', async () => {
     let resolveFirstCopy!: (success: boolean) => void;
-    let resolveSecondCopy!: (success: boolean) => void;
     mockCopyToClipboard
       .mockReturnValueOnce(
         new Promise<boolean>((resolve) => {
           resolveFirstCopy = resolve;
         })
       )
-      .mockReturnValueOnce(
-        new Promise<boolean>((resolve) => {
-          resolveSecondCopy = resolve;
-        })
-      );
+      .mockResolvedValueOnce(false);
     const { useTeamInviteCopyFeedback } = await import('@/features/team/useTeamInviteCopyFeedback');
     let copiedText = '';
-    let firstCopy: Promise<boolean> | null = null;
-    let secondCopy: Promise<boolean> | null = null;
+    let copyInviteLink!: (inviteUrl: string) => Promise<boolean>;
     const Harness = defineComponent({
       setup() {
-        const { copied, copyInviteLink } = useTeamInviteCopyFeedback();
-        firstCopy = copyInviteLink('https://example.test/team?code=first');
-        secondCopy = copyInviteLink('https://example.test/team?code=second');
+        const feedback = useTeamInviteCopyFeedback();
+        copyInviteLink = feedback.copyInviteLink;
         return () => {
-          copiedText = copied.value ? 'copied' : 'idle';
+          copiedText = feedback.copied.value ? 'copied' : 'idle';
           return h('span', copiedText);
         };
       },
     });
     const wrapper = mount(Harness);
-    resolveSecondCopy(false);
-    expect(await secondCopy).toBe(false);
+    const firstCopy = copyInviteLink('https://example.test/team?code=first');
+    await vi.waitFor(() => expect(mockCopyToClipboard).toHaveBeenCalledTimes(1));
+    const secondCopy = copyInviteLink('https://example.test/team?code=second');
+    expect(mockCopyToClipboard).toHaveBeenCalledTimes(1);
     resolveFirstCopy(true);
     expect(await firstCopy).toBe(false);
+    expect(await secondCopy).toBe(false);
+    expect(mockCopyToClipboard).toHaveBeenCalledTimes(2);
     await wrapper.vm.$nextTick();
     expect(copiedText).toBe('idle');
     wrapper.unmount();

--- a/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
+++ b/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
@@ -1,12 +1,55 @@
 // @vitest-environment happy-dom
 import { mount } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, h } from 'vue';
 const mockCopyToClipboard = vi.fn();
 vi.mock('@/composables/useCopyToClipboard', () => ({
   useCopyToClipboard: () => ({ copyToClipboard: mockCopyToClipboard }),
 }));
 describe('useTeamInviteCopyFeedback', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    mockCopyToClipboard.mockReset();
+  });
+  it('shows successful feedback and resets it after the feedback duration', async () => {
+    vi.useFakeTimers();
+    mockCopyToClipboard.mockResolvedValue(true);
+    const { useTeamInviteCopyFeedback } = await import('@/features/team/useTeamInviteCopyFeedback');
+    let copiedText = '';
+    let copyInviteLink!: (inviteUrl: string) => Promise<boolean>;
+    const Harness = defineComponent({
+      setup() {
+        const feedback = useTeamInviteCopyFeedback();
+        copyInviteLink = feedback.copyInviteLink;
+        return () => {
+          copiedText = feedback.copied.value ? 'copied' : 'idle';
+          return h('span', copiedText);
+        };
+      },
+    });
+    const wrapper = mount(Harness);
+    await expect(copyInviteLink('https://example.test/team?code=private')).resolves.toBe(true);
+    await wrapper.vm.$nextTick();
+    expect(copiedText).toBe('copied');
+    await vi.advanceTimersByTimeAsync(2000);
+    await wrapper.vm.$nextTick();
+    expect(copiedText).toBe('idle');
+    wrapper.unmount();
+  });
+  it('rejects an empty invite without writing to the clipboard', async () => {
+    const { useTeamInviteCopyFeedback } = await import('@/features/team/useTeamInviteCopyFeedback');
+    let copyInviteLink!: (inviteUrl: string) => Promise<boolean>;
+    const Harness = defineComponent({
+      setup() {
+        ({ copyInviteLink } = useTeamInviteCopyFeedback());
+        return () => h('span');
+      },
+    });
+    const wrapper = mount(Harness);
+    await expect(copyInviteLink('')).resolves.toBe(false);
+    expect(mockCopyToClipboard).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
   it('ignores stale success when a newer copy fails', async () => {
     let resolveFirstCopy!: (success: boolean) => void;
     let resolveSecondCopy!: (success: boolean) => void;

--- a/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
+++ b/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
@@ -85,6 +85,43 @@ describe('useTeamInviteCopyFeedback', () => {
     expect(copiedText).toBe('idle');
     wrapper.unmount();
   });
+  it('returns false when the clipboard copy fails', async () => {
+    mockCopyToClipboard.mockResolvedValue(false);
+    const { useTeamInviteCopyFeedback } = await import('@/features/team/useTeamInviteCopyFeedback');
+    let copyInviteLink!: (inviteUrl: string) => Promise<boolean>;
+    const Harness = defineComponent({
+      setup() {
+        ({ copyInviteLink } = useTeamInviteCopyFeedback());
+        return () => h('span');
+      },
+    });
+    const wrapper = mount(Harness);
+    await expect(copyInviteLink('https://example.test/team?code=private')).resolves.toBe(false);
+    wrapper.unmount();
+  });
+  it('clears an existing feedback timer before starting another copy', async () => {
+    vi.useFakeTimers();
+    mockCopyToClipboard.mockResolvedValue(true);
+    const { useTeamInviteCopyFeedback } = await import('@/features/team/useTeamInviteCopyFeedback');
+    let copyInviteLink!: (inviteUrl: string) => Promise<boolean>;
+    const Harness = defineComponent({
+      setup() {
+        const feedback = useTeamInviteCopyFeedback();
+        copyInviteLink = feedback.copyInviteLink;
+        return () => h('span', feedback.copied.value ? 'copied' : 'idle');
+      },
+    });
+    const wrapper = mount(Harness);
+    await copyInviteLink('https://example.test/team?code=first');
+    await vi.advanceTimersByTimeAsync(1000);
+    await copyInviteLink('https://example.test/team?code=second');
+    expect(wrapper.text()).toBe('copied');
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(wrapper.text()).toBe('copied');
+    await vi.advanceTimersByTimeAsync(1000);
+    expect(wrapper.text()).toBe('idle');
+    wrapper.unmount();
+  });
   it('does not schedule feedback after the consumer unmounts', async () => {
     let resolveCopy!: (success: boolean) => void;
     mockCopyToClipboard.mockReturnValueOnce(

--- a/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
+++ b/app/features/team/__tests__/useTeamInviteCopyFeedback.test.ts
@@ -7,6 +7,44 @@ vi.mock('@/composables/useCopyToClipboard', () => ({
   useCopyToClipboard: () => ({ copyToClipboard: mockCopyToClipboard }),
 }));
 describe('useTeamInviteCopyFeedback', () => {
+  it('ignores stale success when a newer copy fails', async () => {
+    let resolveFirstCopy!: (success: boolean) => void;
+    let resolveSecondCopy!: (success: boolean) => void;
+    mockCopyToClipboard
+      .mockReturnValueOnce(
+        new Promise<boolean>((resolve) => {
+          resolveFirstCopy = resolve;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise<boolean>((resolve) => {
+          resolveSecondCopy = resolve;
+        })
+      );
+    const { useTeamInviteCopyFeedback } = await import('@/features/team/useTeamInviteCopyFeedback');
+    let copiedText = '';
+    let firstCopy: Promise<boolean> | null = null;
+    let secondCopy: Promise<boolean> | null = null;
+    const Harness = defineComponent({
+      setup() {
+        const { copied, copyInviteLink } = useTeamInviteCopyFeedback();
+        firstCopy = copyInviteLink('https://example.test/team?code=first');
+        secondCopy = copyInviteLink('https://example.test/team?code=second');
+        return () => {
+          copiedText = copied.value ? 'copied' : 'idle';
+          return h('span', copiedText);
+        };
+      },
+    });
+    const wrapper = mount(Harness);
+    resolveSecondCopy(false);
+    expect(await secondCopy).toBe(false);
+    resolveFirstCopy(true);
+    expect(await firstCopy).toBe(false);
+    await wrapper.vm.$nextTick();
+    expect(copiedText).toBe('idle');
+    wrapper.unmount();
+  });
   it('does not schedule feedback after the consumer unmounts', async () => {
     let resolveCopy!: (success: boolean) => void;
     mockCopyToClipboard.mockReturnValueOnce(

--- a/app/features/team/__tests__/useTeamInviteLink.test.ts
+++ b/app/features/team/__tests__/useTeamInviteLink.test.ts
@@ -7,7 +7,7 @@ const mockSystemState = reactive<SystemState>({
   team: 'team-1',
   team_id: 'team-1',
 });
-const mockTeamStore = { id: 'team-1', inviteCode: 'private-code' };
+const mockTeamStore = reactive({ id: 'team-1', inviteCode: 'private-code' });
 vi.mock('@/stores/useSystemStore', async () => {
   const actual =
     await vi.importActual<typeof import('@/stores/useSystemStore')>('@/stores/useSystemStore');
@@ -25,6 +25,8 @@ vi.mock('@/stores/useTeamStore', () => ({
 describe('useTeamInviteLink', () => {
   beforeEach(() => {
     window.history.replaceState({}, '', '/team#members');
+    mockTeamStore.id = 'team-1';
+    mockTeamStore.inviteCode = 'private-code';
   });
   it('places invite parameters before an existing fragment', async () => {
     const { useTeamInviteLink } = await import('@/features/team/useTeamInviteLink');
@@ -36,11 +38,11 @@ describe('useTeamInviteLink', () => {
     expect(teamUrl.value.indexOf('?')).toBeLessThan(teamUrl.value.indexOf('#'));
     expect(maskedTeamUrl.value).not.toContain('private-code');
   });
-  it('does not combine an active team with a stale invite code', async () => {
-    mockTeamStore.id = 'different-team';
+  it('reactively removes an invite URL when the loaded team becomes stale', async () => {
     const { useTeamInviteLink } = await import('@/features/team/useTeamInviteLink');
     const { teamUrl } = useTeamInviteLink();
+    expect(teamUrl.value).toContain('code=private-code');
+    mockTeamStore.id = 'different-team';
     expect(teamUrl.value).toBe('');
-    mockTeamStore.id = 'team-1';
   });
 });

--- a/app/features/team/__tests__/useTeamInviteLink.test.ts
+++ b/app/features/team/__tests__/useTeamInviteLink.test.ts
@@ -1,0 +1,46 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { reactive } from 'vue';
+import type { SystemState } from '@/types/tarkov';
+const mockSystemState = reactive<SystemState>({
+  pvp_team_id: 'team-1',
+  team: 'team-1',
+  team_id: 'team-1',
+});
+const mockTeamStore = { id: 'team-1', inviteCode: 'private-code' };
+vi.mock('@/stores/useSystemStore', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/stores/useSystemStore')>('@/stores/useSystemStore');
+  return {
+    ...actual,
+    useSystemStoreWithSupabase: () => ({ systemStore: { $state: mockSystemState } }),
+  };
+});
+vi.mock('@/stores/useTarkov', () => ({
+  useTarkovStore: () => ({ getCurrentGameMode: () => 'pvp' }),
+}));
+vi.mock('@/stores/useTeamStore', () => ({
+  useTeamStoreWithSupabase: () => ({ teamStore: mockTeamStore }),
+}));
+describe('useTeamInviteLink', () => {
+  beforeEach(() => {
+    window.history.replaceState({}, '', '/team#members');
+  });
+  it('places invite parameters before an existing fragment', async () => {
+    const { useTeamInviteLink } = await import('@/features/team/useTeamInviteLink');
+    const { maskedTeamUrl, teamUrl } = useTeamInviteLink();
+    const inviteUrl = new URL(teamUrl.value);
+    expect(inviteUrl.searchParams.get('team')).toBe('team-1');
+    expect(inviteUrl.searchParams.get('code')).toBe('private-code');
+    expect(inviteUrl.hash).toBe('#members');
+    expect(teamUrl.value.indexOf('?')).toBeLessThan(teamUrl.value.indexOf('#'));
+    expect(maskedTeamUrl.value).not.toContain('private-code');
+  });
+  it('does not combine an active team with a stale invite code', async () => {
+    mockTeamStore.id = 'different-team';
+    const { useTeamInviteLink } = await import('@/features/team/useTeamInviteLink');
+    const { teamUrl } = useTeamInviteLink();
+    expect(teamUrl.value).toBe('');
+    mockTeamStore.id = 'team-1';
+  });
+});

--- a/app/features/team/useTeamInviteCopyFeedback.ts
+++ b/app/features/team/useTeamInviteCopyFeedback.ts
@@ -4,6 +4,7 @@ export const useTeamInviteCopyFeedback = () => {
   const { copyToClipboard } = useCopyToClipboard();
   const copied = ref(false);
   let disposed = false;
+  let latestRequestId = 0;
   let resetTimer: ReturnType<typeof setTimeout> | null = null;
   const clearResetTimer = () => {
     if (!resetTimer) return;
@@ -11,11 +12,12 @@ export const useTeamInviteCopyFeedback = () => {
     resetTimer = null;
   };
   const copyInviteLink = async (inviteUrl: string): Promise<boolean> => {
+    const requestId = ++latestRequestId;
     clearResetTimer();
     copied.value = false;
     if (!inviteUrl) return false;
     const success = await copyToClipboard(inviteUrl, { revealValue: false });
-    if (disposed || !success) return false;
+    if (disposed || requestId !== latestRequestId || !success) return false;
     copied.value = true;
     resetTimer = setTimeout(() => {
       copied.value = false;

--- a/app/features/team/useTeamInviteCopyFeedback.ts
+++ b/app/features/team/useTeamInviteCopyFeedback.ts
@@ -3,6 +3,7 @@ const COPY_FEEDBACK_DURATION_MS = 2000;
 export const useTeamInviteCopyFeedback = () => {
   const { copyToClipboard } = useCopyToClipboard();
   const copied = ref(false);
+  let disposed = false;
   let resetTimer: ReturnType<typeof setTimeout> | null = null;
   const clearResetTimer = () => {
     if (!resetTimer) return;
@@ -14,7 +15,7 @@ export const useTeamInviteCopyFeedback = () => {
     copied.value = false;
     if (!inviteUrl) return false;
     const success = await copyToClipboard(inviteUrl, { revealValue: false });
-    if (!success) return false;
+    if (disposed || !success) return false;
     copied.value = true;
     resetTimer = setTimeout(() => {
       copied.value = false;
@@ -22,6 +23,9 @@ export const useTeamInviteCopyFeedback = () => {
     }, COPY_FEEDBACK_DURATION_MS);
     return true;
   };
-  onUnmounted(clearResetTimer);
+  onUnmounted(() => {
+    disposed = true;
+    clearResetTimer();
+  });
   return { copied, copyInviteLink };
 };

--- a/app/features/team/useTeamInviteCopyFeedback.ts
+++ b/app/features/team/useTeamInviteCopyFeedback.ts
@@ -5,6 +5,7 @@ export const useTeamInviteCopyFeedback = () => {
   const copied = ref(false);
   let latestRequestId = 0;
   let resetTimer: ReturnType<typeof setTimeout> | null = null;
+  let copyQueue: Promise<boolean> = Promise.resolve(true);
   const clearResetTimer = () => {
     if (!resetTimer) return;
     clearTimeout(resetTimer);
@@ -15,7 +16,15 @@ export const useTeamInviteCopyFeedback = () => {
     clearResetTimer();
     copied.value = false;
     if (!inviteUrl) return false;
-    const success = await copyToClipboard(inviteUrl, { revealValue: false });
+    const copyOperation = copyQueue.then(async () => {
+      if (requestId !== latestRequestId) return false;
+      return await copyToClipboard(inviteUrl, {
+        revealValue: false,
+        shouldNotify: () => requestId === latestRequestId,
+      });
+    });
+    copyQueue = copyOperation.catch(() => false);
+    const success = await copyOperation;
     if (requestId !== latestRequestId || !success) return false;
     copied.value = true;
     resetTimer = setTimeout(() => {

--- a/app/features/team/useTeamInviteCopyFeedback.ts
+++ b/app/features/team/useTeamInviteCopyFeedback.ts
@@ -3,7 +3,6 @@ const COPY_FEEDBACK_DURATION_MS = 2000;
 export const useTeamInviteCopyFeedback = () => {
   const { copyToClipboard } = useCopyToClipboard();
   const copied = ref(false);
-  let disposed = false;
   let latestRequestId = 0;
   let resetTimer: ReturnType<typeof setTimeout> | null = null;
   const clearResetTimer = () => {
@@ -17,7 +16,7 @@ export const useTeamInviteCopyFeedback = () => {
     copied.value = false;
     if (!inviteUrl) return false;
     const success = await copyToClipboard(inviteUrl, { revealValue: false });
-    if (disposed || requestId !== latestRequestId || !success) return false;
+    if (requestId !== latestRequestId || !success) return false;
     copied.value = true;
     resetTimer = setTimeout(() => {
       copied.value = false;
@@ -26,7 +25,7 @@ export const useTeamInviteCopyFeedback = () => {
     return true;
   };
   onUnmounted(() => {
-    disposed = true;
+    latestRequestId += 1;
     clearResetTimer();
   });
   return { copied, copyInviteLink };

--- a/app/features/team/useTeamInviteCopyFeedback.ts
+++ b/app/features/team/useTeamInviteCopyFeedback.ts
@@ -1,0 +1,27 @@
+import { useCopyToClipboard } from '@/composables/useCopyToClipboard';
+const COPY_FEEDBACK_DURATION_MS = 2000;
+export const useTeamInviteCopyFeedback = () => {
+  const { copyToClipboard } = useCopyToClipboard();
+  const copied = ref(false);
+  let resetTimer: ReturnType<typeof setTimeout> | null = null;
+  const clearResetTimer = () => {
+    if (!resetTimer) return;
+    clearTimeout(resetTimer);
+    resetTimer = null;
+  };
+  const copyInviteLink = async (inviteUrl: string): Promise<boolean> => {
+    clearResetTimer();
+    copied.value = false;
+    if (!inviteUrl) return false;
+    const success = await copyToClipboard(inviteUrl, { revealValue: false });
+    if (!success) return false;
+    copied.value = true;
+    resetTimer = setTimeout(() => {
+      copied.value = false;
+      resetTimer = null;
+    }, COPY_FEEDBACK_DURATION_MS);
+    return true;
+  };
+  onUnmounted(clearResetTimer);
+  return { copied, copyInviteLink };
+};

--- a/app/features/team/useTeamInviteLink.ts
+++ b/app/features/team/useTeamInviteLink.ts
@@ -1,0 +1,24 @@
+import { useSystemStoreWithSupabase, getTeamIdFromState } from '@/stores/useSystemStore';
+import { useTarkovStore } from '@/stores/useTarkov';
+import { useTeamStoreWithSupabase } from '@/stores/useTeamStore';
+import { GAME_MODES, type GameMode } from '@/utils/constants';
+export const useTeamInviteLink = () => {
+  const { systemStore } = useSystemStoreWithSupabase();
+  const { teamStore } = useTeamStoreWithSupabase();
+  const tarkovStore = useTarkovStore();
+  const getCurrentGameMode = (): GameMode => tarkovStore.getCurrentGameMode?.() || GAME_MODES.PVP;
+  const teamUrl = computed(() => {
+    const teamId = getTeamIdFromState(systemStore.$state, getCurrentGameMode());
+    const code = teamStore.inviteCode;
+    if (!teamId || !code || !import.meta.client) return '';
+    const baseUrl = window.location.href.split('?')[0];
+    const params = new URLSearchParams({ team: teamId, code });
+    return `${baseUrl}?${params}`;
+  });
+  const maskedTeamUrl = computed(() => {
+    if (!teamUrl.value) return '';
+    const [baseUrl] = teamUrl.value.split('?');
+    return `${baseUrl}?team=••••••&code=••••••`;
+  });
+  return { maskedTeamUrl, teamUrl };
+};

--- a/app/features/team/useTeamInviteLink.ts
+++ b/app/features/team/useTeamInviteLink.ts
@@ -7,18 +7,19 @@ export const useTeamInviteLink = () => {
   const { teamStore } = useTeamStoreWithSupabase();
   const tarkovStore = useTarkovStore();
   const getCurrentGameMode = (): GameMode => tarkovStore.getCurrentGameMode?.() || GAME_MODES.PVP;
+  // fallow-ignore-next-line complexity -- both valid and stale invite states have regression coverage
   const teamUrl = computed(() => {
     const teamId = getTeamIdFromState(systemStore.$state, getCurrentGameMode());
-    const code = teamStore.inviteCode;
+    const code = teamStore.id === teamId ? teamStore.inviteCode : null;
     if (!teamId || !code || !import.meta.client) return '';
-    const baseUrl = window.location.href.split('?')[0];
-    const params = new URLSearchParams({ team: teamId, code });
-    return `${baseUrl}?${params}`;
+    const inviteUrl = new URL(window.location.href);
+    inviteUrl.search = new URLSearchParams({ team: teamId, code }).toString();
+    return inviteUrl.toString();
   });
   const maskedTeamUrl = computed(() => {
     if (!teamUrl.value) return '';
-    const [baseUrl] = teamUrl.value.split('?');
-    return `${baseUrl}?team=••••••&code=••••••`;
+    const maskedUrl = new URL(teamUrl.value);
+    return `${maskedUrl.origin}${maskedUrl.pathname}?team=••••••&code=••••••${maskedUrl.hash}`;
   });
   return { maskedTeamUrl, teamUrl };
 };

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1195,6 +1195,51 @@
       "meta": {
         "description": "Collaborate with teammates on Escape from Tarkov progress. Share quest completions, hideout status, and coordinate item gathering."
       },
+      "page_title": "Team",
+      "page_description": "Invite teammates, manage what they see, and track progress together.",
+      "invite": {
+        "title": "Invite link",
+        "subtitle": "Share your team with trusted teammates.",
+        "link_label": "Team invite URL",
+        "helper": "Anyone with this link can join your team.",
+        "show": "Show link",
+        "hide": "Hide link",
+        "copy": "Copy link",
+        "copied": "Copied!"
+      },
+      "members": {
+        "title": "Members ({count})",
+        "no_members": "No members in this team yet. Share your invite link to add teammates.",
+        "alone": "You're alone here — share your invite link to add teammates.",
+        "copy_invite": "Copy invite link",
+        "copied": "Copied!"
+      },
+      "visibility": {
+        "title": "Visibility settings",
+        "description": "Control what your teammates see on your tracker.",
+        "items_section": "Items",
+        "show_tasks": "Show team members' tasks",
+        "show_items": "Show team members' needed items",
+        "show_non_fir": "Show non-FIR needed items",
+        "show_hideout": "Show hideout needed items",
+        "show_maps": "Show team members' map objectives"
+      },
+      "danger_zone": {
+        "title": "Danger zone",
+        "disband_description": "Disbanding removes the team for all members. This cannot be undone.",
+        "leave_description": "Leaving removes you from this team. Your progress stays on your account.",
+        "disband": "Disband team",
+        "leave": "Leave team",
+        "confirm_disband_title": "Disband team?",
+        "confirm_disband_description": "This removes the team and its membership for everyone. This cannot be undone.",
+        "confirm_leave_title": "Leave team?",
+        "confirm_leave_description": "You will leave this team and stop sharing progress with its members.",
+        "confirm_disband": "Yes, disband team",
+        "confirm_leave": "Yes, leave team",
+        "disband_success": "Team disbanded successfully.",
+        "disband_error": "Failed to disband team.",
+        "action_error": "Unable to update team membership."
+      },
       "card": {
         "manageteam": {
           "title": "Team Members",
@@ -1204,7 +1249,11 @@
             "owner": "Owner",
             "taskscomplete": "{completed}/{total} tasks completed",
             "kick_success": "Teammate kicked successfully.",
-            "kick_error": "Error kicking teammate."
+            "kick_error": "Error kicking teammate.",
+            "level_badge_alt": "Level {level} badge",
+            "hide_progress": "Hide {name}'s progress from me",
+            "show_progress": "Show {name}'s progress to me",
+            "remove_member": "Remove {name} from team"
           }
         },
         "teamoptions": {

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1196,7 +1196,7 @@
         "description": "Collaborate with teammates on Escape from Tarkov progress. Share quest completions, hideout status, and coordinate item gathering."
       },
       "page_title": "Team",
-      "page_description": "Invite teammates, manage what they see, and track progress together.",
+      "page_description": "Invite teammates, choose which team progress you see, and track together.",
       "invite": {
         "title": "Invite link",
         "subtitle": "Share your team with trusted teammates.",
@@ -1216,7 +1216,7 @@
       },
       "visibility": {
         "title": "Visibility settings",
-        "description": "Control what your teammates see on your tracker.",
+        "description": "Control which teammates' progress appears on your tracker.",
         "items_section": "Items",
         "show_tasks": "Show team members' tasks",
         "show_items": "Show team members' needed items",
@@ -1253,6 +1253,7 @@
             "level_badge_alt": "Level {level} badge",
             "hide_progress": "Hide {name}'s progress from me",
             "show_progress": "Show {name}'s progress to me",
+            "enable_team_tasks": "Show team members' tasks before changing an individual member",
             "remove_member": "Remove {name} from team"
           }
         },

--- a/app/pages/__tests__/team.page.test.ts
+++ b/app/pages/__tests__/team.page.test.ts
@@ -32,11 +32,13 @@ describe('team page', () => {
   it('renders team members when user has a team', async () => {
     const wrapper = mount(TeamPage, {
       global: {
+        mocks: { $t: (key: string) => key },
         stubs: {
           MyTeam: { template: '<div data-testid="my-team" />' },
           TeamInvite: { template: '<div data-testid="team-invite" />' },
           TeamMembers: { template: '<div data-testid="team-members" />' },
           TeamOptions: { template: '<div data-testid="team-options" />' },
+          TeamDangerZone: { template: '<div data-testid="team-danger-zone" />' },
         },
       },
     });
@@ -48,11 +50,13 @@ describe('team page', () => {
     hasTeamMock.mockReturnValue(false);
     const wrapper = mount(TeamPage, {
       global: {
+        mocks: { $t: (key: string) => key },
         stubs: {
           MyTeam: { template: '<div data-testid="my-team" />' },
           TeamInvite: { template: '<div data-testid="team-invite" />' },
           TeamMembers: { template: '<div data-testid="team-members" />' },
           TeamOptions: { template: '<div data-testid="team-options" />' },
+          TeamDangerZone: { template: '<div data-testid="team-danger-zone" />' },
         },
       },
     });

--- a/app/pages/team.vue
+++ b/app/pages/team.vue
@@ -1,20 +1,23 @@
 <template>
-  <div class="px-3 py-6 sm:px-6">
-    <div class="mx-auto max-w-350 space-y-6">
-      <div v-if="route?.query?.team && route?.query?.code" class="mx-auto max-w-6xl">
+  <div class="font-ui px-4 py-6 sm:px-6 lg:px-8">
+    <div class="mx-auto w-full max-w-7xl space-y-8">
+      <header class="space-y-2">
+        <h1 class="text-surface-100 text-2xl font-bold sm:text-3xl">
+          {{ $t('page.team.page_title') }}
+        </h1>
+        <p class="text-surface-400 max-w-2xl text-sm leading-6 sm:text-base">
+          {{ $t('page.team.page_description') }}
+        </p>
+      </header>
+      <div v-if="route?.query?.team && route?.query?.code">
         <TeamInvite />
       </div>
-      <div class="relative mx-auto max-w-6xl">
-        <div class="space-y-6">
-          <div class="grid gap-4 lg:grid-cols-3">
-            <div class="lg:col-span-2">
-              <MyTeam />
-            </div>
-            <TeamOptions />
-          </div>
-          <TeamMembers v-if="userHasTeam" />
-        </div>
+      <div class="grid items-start gap-6 lg:grid-cols-[minmax(0,3fr)_minmax(0,2fr)]">
+        <MyTeam />
+        <TeamOptions />
       </div>
+      <TeamMembers v-if="userHasTeam" />
+      <TeamDangerZone v-if="userHasTeam" />
     </div>
   </div>
 </template>
@@ -39,6 +42,7 @@
   const TeamOptions = defineAsyncComponent(() => import('@/features/team/TeamOptions.vue'));
   const MyTeam = defineAsyncComponent(() => import('@/features/team/MyTeam.vue'));
   const TeamInvite = defineAsyncComponent(() => import('@/features/team/TeamInvite.vue'));
+  const TeamDangerZone = defineAsyncComponent(() => import('@/features/team/TeamDangerZone.vue'));
   const { hasTeam } = useSystemStoreWithSupabase();
   const userHasTeam = computed(() => hasTeam());
 </script>

--- a/app/shell/AppBar.vue
+++ b/app/shell/AppBar.vue
@@ -141,7 +141,7 @@
               </UDropdownMenu>
             </AppTooltip>
           </span>
-          <AppTooltip :text="t('navigation_drawer.account_menu')">
+          <AppTooltip :text="userDisplayName">
             <UDropdownMenu
               v-if="isLoggedIn"
               :items="accountMenuItems"
@@ -149,7 +149,7 @@
             >
               <button
                 type="button"
-                class="bg-surface-800/50 border-surface-600 hover:bg-surface-800 flex h-9 items-center gap-2 rounded-md border px-2 py-1.5 transition-colors sm:max-w-56"
+                class="bg-surface-800/50 border-surface-600 hover:bg-surface-800 flex h-9 min-w-0 items-center gap-2 rounded-md border px-2 py-1.5 transition-colors sm:max-w-56"
                 :aria-label="t('navigation_drawer.account_menu')"
               >
                 <img
@@ -160,7 +160,7 @@
                   @error="handleAvatarError"
                 />
                 <span
-                  class="text-surface-200 hidden min-w-0 flex-1 text-[13px] leading-tight font-medium break-words data-[long-name=true]:truncate data-[long-name=true]:leading-none sm:inline"
+                  class="text-surface-200 hidden min-w-0 flex-1 truncate text-[13px] leading-none font-medium whitespace-nowrap sm:inline"
                   :data-long-name="userDisplayName.length > 24"
                   :title="userDisplayName"
                 >

--- a/app/shell/AppBar.vue
+++ b/app/shell/AppBar.vue
@@ -149,7 +149,7 @@
             >
               <button
                 type="button"
-                class="bg-surface-800/50 border-surface-600 hover:bg-surface-800 flex h-9 items-center gap-2 rounded-md border px-2 py-1.5 transition-colors sm:max-w-40"
+                class="bg-surface-800/50 border-surface-600 hover:bg-surface-800 flex h-9 items-center gap-2 rounded-md border px-2 py-1.5 transition-colors sm:max-w-56"
                 :aria-label="t('navigation_drawer.account_menu')"
               >
                 <img
@@ -160,7 +160,9 @@
                   @error="handleAvatarError"
                 />
                 <span
-                  class="text-surface-200 hidden min-w-0 flex-1 truncate text-[13px] leading-none font-medium sm:inline"
+                  class="text-surface-200 hidden min-w-0 flex-1 text-[13px] leading-tight font-medium break-words data-[long-name=true]:truncate data-[long-name=true]:leading-none sm:inline"
+                  :data-long-name="userDisplayName.length > 24"
+                  :title="userDisplayName"
                 >
                   {{ userDisplayName }}
                 </span>

--- a/app/shell/AppFooter.vue
+++ b/app/shell/AppFooter.vue
@@ -1,6 +1,6 @@
 <template>
-  <footer class="bg-surface-900/60 border-surface-800/70 w-full border-t px-4 py-8 sm:px-6">
-    <div class="mx-auto flex w-full max-w-6xl flex-col gap-6">
+  <footer class="bg-surface-900/60 border-surface-800/70 w-full border-t px-4 py-8 sm:px-6 lg:px-8">
+    <div class="mx-auto flex w-full max-w-7xl flex-col gap-6">
       <div class="grid gap-8 sm:grid-cols-2 lg:grid-cols-5">
         <div class="min-w-0 lg:col-span-2">
           <NuxtLink

--- a/app/shell/__tests__/AppBar.test.ts
+++ b/app/shell/__tests__/AppBar.test.ts
@@ -545,15 +545,27 @@ describe('AppBar authenticated state', () => {
     expect(nameSpan.attributes('title')).toBe(displayName);
     wrapper.unmount();
   });
-  it('allows short display names to wrap without truncation', async () => {
+  it('keeps short display names on one line within the fixed-height account button', async () => {
     mockTarkovStore.getDisplayName.mockReturnValue('Short name');
     const wrapper = await mountAppBar();
     const trigger = wrapper.find('button[aria-label="navigation_drawer.account_menu"]');
     const nameSpan = trigger.find('span[data-long-name="false"]');
     expect(nameSpan.exists()).toBe(true);
-    const classAttr = nameSpan.attributes('class') || '';
-    expect(classAttr).toContain('break-words');
-    expect(classAttr).not.toContain(' truncate');
+    expect(nameSpan.attributes('data-long-name')).toBe('false');
+    expect(nameSpan.classes()).toContain('truncate');
+    expect(nameSpan.classes()).toContain('whitespace-nowrap');
+    wrapper.unmount();
+  });
+  it('keeps a 24-character wide display name on one line', async () => {
+    const displayName = 'W'.repeat(24);
+    mockTarkovStore.getDisplayName.mockReturnValue(displayName);
+    const wrapper = await mountAppBar();
+    const trigger = wrapper.find('button[aria-label="navigation_drawer.account_menu"]');
+    const nameSpan = trigger.find('span[data-long-name="false"]');
+    expect(nameSpan.text()).toBe(displayName);
+    expect(nameSpan.classes()).toContain('truncate');
+    expect(nameSpan.classes()).toContain('whitespace-nowrap');
+    expect(nameSpan.attributes('title')).toBe(displayName);
     wrapper.unmount();
   });
   it('falls back to default avatar when avatar image fails to load', async () => {

--- a/app/shell/__tests__/AppBar.test.ts
+++ b/app/shell/__tests__/AppBar.test.ts
@@ -531,15 +531,29 @@ describe('AppBar authenticated state', () => {
     expect(trigger.find('.i-mdi-chevron-down').exists()).toBe(true);
     wrapper.unmount();
   });
-  it('truncates the display name with sm:inline and truncate class', async () => {
-    mockTarkovStore.getDisplayName.mockReturnValue('A'.repeat(50));
+  it('truncates long display names and exposes the full name as a tooltip', async () => {
+    const displayName = 'A'.repeat(50);
+    mockTarkovStore.getDisplayName.mockReturnValue(displayName);
     const wrapper = await mountAppBar();
     const trigger = wrapper.find('button[aria-label="navigation_drawer.account_menu"]');
-    const nameSpan = trigger.find('span.truncate');
+    const nameSpan = trigger.find('span[data-long-name="true"]');
     expect(nameSpan.exists()).toBe(true);
     const classAttr = nameSpan.attributes('class') || '';
     expect(classAttr).toContain('hidden');
     expect(classAttr).toContain('sm:inline');
+    expect(classAttr).toContain('truncate');
+    expect(nameSpan.attributes('title')).toBe(displayName);
+    wrapper.unmount();
+  });
+  it('allows short display names to wrap without truncation', async () => {
+    mockTarkovStore.getDisplayName.mockReturnValue('Short name');
+    const wrapper = await mountAppBar();
+    const trigger = wrapper.find('button[aria-label="navigation_drawer.account_menu"]');
+    const nameSpan = trigger.find('span[data-long-name="false"]');
+    expect(nameSpan.exists()).toBe(true);
+    const classAttr = nameSpan.attributes('class') || '';
+    expect(classAttr).toContain('break-words');
+    expect(classAttr).not.toContain(' truncate');
     wrapper.unmount();
   });
   it('falls back to default avatar when avatar image fails to load', async () => {

--- a/app/stores/__tests__/useSystemStore.test.ts
+++ b/app/stores/__tests__/useSystemStore.test.ts
@@ -100,6 +100,16 @@ describe('useSystemStore', () => {
         expect(getTeamIdFromState(state, GAME_MODES.PVP)).toBe('legacy-team-id-999');
         expect(getTeamIdFromState(state, GAME_MODES.PVE)).toBe('legacy-team-id-999');
       });
+      it('should not reuse a mode-specific team through legacy aliases in another mode', () => {
+        const state: SystemState = {
+          pvp_team_id: 'pvp-team-123',
+          pve_team_id: null,
+          team: 'pvp-team-123',
+          team_id: 'pvp-team-123',
+        };
+        expect(getTeamIdFromState(state, GAME_MODES.PVP)).toBe('pvp-team-123');
+        expect(getTeamIdFromState(state, GAME_MODES.PVE)).toBeNull();
+      });
       it('should return null if no team ID is found', () => {
         const state: SystemState = {};
         expect(getTeamIdFromState(state, GAME_MODES.PVP)).toBeNull();

--- a/app/stores/useSystemStore.ts
+++ b/app/stores/useSystemStore.ts
@@ -10,15 +10,16 @@ import type { PostgrestError, RealtimeChannel } from '@supabase/supabase-js';
  * Now handles game-mode-specific team IDs (pvp_team_id, pve_team_id).
  * Falls back to legacy team/team_id for backwards compatibility.
  */
+const getLegacyTeamId = (state: SystemState): string | null =>
+  [state.team, state.team_id].find((teamId) => typeof teamId === 'string' && teamId.length > 0) ??
+  null;
 export function getTeamIdFromState(state: SystemState, gameMode?: GameMode): string | null {
   const mode = gameMode || getCurrentGameMode();
-  if (mode === 'seasonal') {
-    return state.seasonal_team_id ?? null;
-  }
-  if (mode === 'pve') {
-    return state.pve_team_id ?? state.team ?? state.team_id ?? null;
-  }
-  return state.pvp_team_id ?? state.team ?? state.team_id ?? null;
+  const modeSpecificTeamId = state[getTeamIdStateKey(mode)];
+  if (modeSpecificTeamId) return modeSpecificTeamId;
+  if (mode === 'seasonal') return null;
+  if ([state.pvp_team_id, state.pve_team_id].some(Boolean)) return null;
+  return getLegacyTeamId(state);
 }
 export function getTeamIdStateKey(
   gameMode: GameMode

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -33,6 +33,8 @@ function getTeamIdFromSystemStore(
  */
 export const useTeamStore = defineStore<string, TeamState, TeamGetters>('team', {
   state: (): TeamState => ({
+    // fallow-ignore-next-line unused-store-member -- read directly by Team page consumers
+    id: null,
     owner: null,
     joinCode: null,
     members: [],

--- a/app/types/tarkov.ts
+++ b/app/types/tarkov.ts
@@ -532,6 +532,7 @@ export interface SystemGetters extends _GettersTree<SystemState> {
   isAdmin: (state: SystemState) => boolean;
 }
 export interface TeamState extends StateTree {
+  id?: string | null;
   owner?: string | null;
   joinCode?: string | null;
   members?: string[];

--- a/app/types/team.ts
+++ b/app/types/team.ts
@@ -20,6 +20,10 @@ export interface LeaveTeamResponse {
   success: boolean;
   message: string;
 }
+export interface DisbandTeamResponse {
+  success: boolean;
+  message: string;
+}
 export interface JoinTeamResponse {
   success: boolean;
   message: string;

--- a/docs/API.md
+++ b/docs/API.md
@@ -292,6 +292,20 @@ Authorization: Bearer <supabase_jwt_token>
 | 401    | Invalid token      | Invalid or expired JWT   |
 | 403    | Not a team member  | User not in team         |
 
+### Team mutation Edge Functions
+
+Team mutations are invoked with an authenticated Supabase JWT through the client composable. The
+`team-disband` operation is owner-only and removes the team, memberships, and team-owned records in
+one database transaction after confirmation in the UI.
+
+| Function       | Purpose                                |
+| -------------- | -------------------------------------- |
+| `team-create`  | Create a team and its owner membership |
+| `team-join`    | Join a team with an invite code        |
+| `team-leave`   | Leave a team as a non-owner            |
+| `team-kick`    | Remove a member as the owner           |
+| `team-disband` | Atomically remove an owned team        |
+
 ---
 
 ## Supporter / Stripe Endpoints

--- a/docs/RATE_LIMITING.md
+++ b/docs/RATE_LIMITING.md
@@ -82,14 +82,14 @@ flowchart TB
 
 ### Ownership matrix
 
-| Traffic class               | Examples                                         | Primary enforcer                        | Secondary / hard stop                    | Storage / implementation                   |
-| --------------------------- | ------------------------------------------------ | --------------------------------------- | ---------------------------------------- | ------------------------------------------ |
-| External progress API       | `/api/v2/*` on `api.tarkovtracker.org`           | Worker DO daily quota + IP abuse gate   | Supporter tier resolution, token auth    | `ApiGatewayRateLimiter`, `api_usage_daily` |
-| Authenticated app mutations | team create/join/leave/kick, token create/revoke | Edge Function mutation limiter          | DB token cap (3 active), RLS             | `mutation_rate_limits` + RPC               |
-| Public / shared app reads   | shared profile, team members, tarkov-dev profile | Pages/Nitro shared limiter              | CDN/cache TTLs, Cloudflare WAF if needed | `sharedEdgeStore` (+ DO if bound)          |
-| Destructive account ops     | account delete                                   | Edge Function (dedicated table for now) | Deletion jobs queue                      | `account_deletion_attempts`                |
-| Auth platform               | signup, sign-in, refresh, OTP                    | Supabase Auth                           | Captcha (optional)                       | GoTrue `[auth.rate_limit]`                 |
-| Outbound third parties      | Discord API, Stripe                              | Provider `Retry-After` / SDK rules      | Circuit breakers, job retries            | not user quotas                            |
+| Traffic class               | Examples                                                 | Primary enforcer                        | Secondary / hard stop                    | Storage / implementation                   |
+| --------------------------- | -------------------------------------------------------- | --------------------------------------- | ---------------------------------------- | ------------------------------------------ |
+| External progress API       | `/api/v2/*` on `api.tarkovtracker.org`                   | Worker DO daily quota + IP abuse gate   | Supporter tier resolution, token auth    | `ApiGatewayRateLimiter`, `api_usage_daily` |
+| Authenticated app mutations | team create/join/leave/kick/disband, token create/revoke | Edge Function mutation limiter          | DB token cap (3 active), RLS             | `mutation_rate_limits` + RPC               |
+| Public / shared app reads   | shared profile, team members, tarkov-dev profile         | Pages/Nitro shared limiter              | CDN/cache TTLs, Cloudflare WAF if needed | `sharedEdgeStore` (+ DO if bound)          |
+| Destructive account ops     | account delete                                           | Edge Function (dedicated table for now) | Deletion jobs queue                      | `account_deletion_attempts`                |
+| Auth platform               | signup, sign-in, refresh, OTP                            | Supabase Auth                           | Captcha (optional)                       | GoTrue `[auth.rate_limit]`                 |
+| Outbound third parties      | Discord API, Stripe                                      | Provider `Retry-After` / SDK rules      | Circuit breakers, job retries            | not user quotas                            |
 
 ---
 
@@ -135,6 +135,7 @@ sequenceDiagram
 | `team-join`    | `team-join`    |    30 | 10 min |
 | `team-leave`   | `team-leave`   |    30 | 1 hour |
 | `team-kick`    | `team-kick`    |    20 | 1 hour |
+| `team-disband` | `team-disband` |    10 | 1 hour |
 | `token-create` | `token-create` |     3 | 1 hour |
 | `token-revoke` | `token-revoke` |    50 | 10 min |
 
@@ -439,7 +440,7 @@ Treat these deliberately; do not “make everything fail open” without underst
 | -------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Mutation limit constants + Edge helper | `supabase/functions/_shared/rate-limit.ts`                                                                                                                          |
 | Mutation RPC + table                   | `supabase/migrations/20260404120000_add_mutation_rate_limit_rpc.sql`                                                                                                |
-| Edge consumers                         | `supabase/functions/{token-create,token-revoke,team-create,team-join,team-leave,team-kick}/`                                                                        |
+| Edge consumers                         | `supabase/functions/{token-create,token-revoke,team-create,team-join,team-leave,team-kick,team-disband}/`                                                           |
 | Frontend mutation callers              | `app/composables/api/useEdgeFunctions.ts`                                                                                                                           |
 | Worker tier constants                  | `workers/api-gateway/src/limits.ts`                                                                                                                                 |
 | Worker entrypoint and routing          | `workers/api-gateway/src/index.ts`, `workers/api-gateway/src/router.ts`                                                                                             |

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -663,6 +663,8 @@ flowchart LR
   `app/stores/useTarkov.ts` — load, merge, write, and realtime flow
 - `app/stores/useSystemStore.ts`, `app/stores/useTeamStore.ts` — mode-specific teams and teammate
   hydration
+- `app/features/team/TeamDangerZone.vue`, `app/features/team/useTeamInviteLink.ts` — resolved active
+  team actions and mode-scoped invite links
 - `app/composables/useDataBackup.ts` — season-aware native backups
 - `app/server/api/profile/[userId]/[mode].get.ts`,
   `app/server/api/streamer/[userId]/[mode]/kappa.get.ts`, `app/server/api/team/members.ts` —
@@ -673,6 +675,11 @@ flowchart LR
 ### Invariants
 
 - `pvp` and `pve` always use season `0`; `seasonal` always uses a positive season.
+- Legacy `user_system.team` / `team_id` values are used only when neither persistent mode-specific
+  team ID exists. They must never make a PvP team appear as the active PvE team or vice versa.
+- Team actions and invite links are unavailable until the active team row has loaded and its ID
+  matches the mode-specific system-store team ID; stale owner or join-code state is never combined
+  with another team's ID.
 - App `ACTIVE_SEASON` metadata must match the database's `private.active_season_*()` functions;
   the Worker resolves the active Seasonal number through the database instead of carrying a
   second runtime constant.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -630,7 +630,9 @@ flowchart LR
    audit event together. `user_system` keeps legacy persistent PvP/PvE columns plus the active
    Seasonal team column. The team-members endpoint reads the `team_member_mode_summary` view, which
    derives display name, level, and completed-task count inside the database so teammate progress
-   blobs never cross the wire.
+   blobs never cross the wire. Owners disband through the authenticated `team-disband` function,
+   which calls an atomic service-role-only RPC; regular `team-leave` remains the non-owner leave
+   path.
 6. The active season definition carries its number, start date, and exact end timestamp. The UI
    counts down to that end timestamp. Advancing the number starts each account on a fresh empty row;
    historical rows remain retained and cannot be merged into the new season. Locally persisted
@@ -649,6 +651,9 @@ flowchart LR
 
 - `supabase/migrations/20260804043342_normalize_game_mode_progress_and_add_seasonal.sql` — schema,
   RLS, compatibility triggers, `team_member_mode_summary`, sync/sharing/prestige RPCs
+- `supabase/migrations/20260829120000_add_atomic_team_disband.sql` — owner-scoped atomic team
+  disband RPC and grants
+- `supabase/functions/team-disband/index.ts` — authenticated owner disband endpoint
 - `supabase/migrations/20260806120000_add_game_mode_progress_backfill_helper.sql` — retained,
   revoked helper for optional one-range-at-a-time operational maintenance. Correctness does not
   depend on running it; see the Database Migrations section of `docs/runbook.md`

--- a/docs/agent-context/summary/components.md
+++ b/docs/agent-context/summary/components.md
@@ -127,14 +127,14 @@ Each slice contains its Vue components and slice-local helpers/composables. High
 
 ## Supabase Edge Functions (`supabase/functions/`)
 
-| Function                                                                  | Responsibility                                                                      |
-| ------------------------------------------------------------------------- | ----------------------------------------------------------------------------------- |
-| `team-create` / `team-join` / `team-leave` / `team-kick` / `team-members` | Team lifecycle (per-user rate limited).                                             |
-| `token-create` / `token-revoke`                                           | API token issuance/revocation (hashed storage).                                     |
-| `account-delete` / `account-delete-reconcile`                             | Account deletion job + reconciliation.                                              |
-| `stripe-webhook`                                                          | Process Stripe events; grant/revoke supporter; sync Discord roles.                  |
-| `admin-cache-purge`                                                       | Purge Cloudflare + data caches (admin-gated).                                       |
-| `_shared/*`                                                               | `auth.ts`, `cors.ts`, `discord.ts`, `rate-limit.ts`, generated `database.types.ts`. |
+| Function                                                                                   | Responsibility                                                                      |
+| ------------------------------------------------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| `team-create` / `team-join` / `team-leave` / `team-kick` / `team-disband` / `team-members` | Team lifecycle (per-user rate limited).                                             |
+| `token-create` / `token-revoke`                                                            | API token issuance/revocation (hashed storage).                                     |
+| `account-delete` / `account-delete-reconcile`                                              | Account deletion job + reconciliation.                                              |
+| `stripe-webhook`                                                                           | Process Stripe events; grant/revoke supporter; sync Discord roles.                  |
+| `admin-cache-purge`                                                                        | Purge Cloudflare + data caches (admin-gated).                                       |
+| `_shared/*`                                                                                | `auth.ts`, `cors.ts`, `discord.ts`, `rate-limit.ts`, generated `database.types.ts`. |
 
 ## Cloudflare Worker (`workers/api-gateway/src/`)
 

--- a/docs/agent-context/summary/data_models.md
+++ b/docs/agent-context/summary/data_models.md
@@ -165,7 +165,8 @@ Defined in `app/types/tarkov.ts`:
 
 - `SystemState` / `SystemGetters` — `user_id`, `tokens`, `team`, `pvp_team_id`, `pve_team_id`,
   `seasonal_team_id`, `is_admin`; getters `userTokens`, `userTeam`, `userTeamIsOwn`, `isAdmin`.
-- `TeamState` / `TeamGetters` — `owner`, `joinCode`, `members`, `memberProfiles`; getters
+- `TeamState` / `TeamGetters` — active team `id`, `owner`, `joinCode`, `members`,
+  `memberProfiles`; getters
   `teamOwner`, `isOwner`, `inviteCode`, `teamMembers`, `teammates`.
 - `MemberProfile` — `displayName`, `level`, `tasksCompleted`, `gameMode` (`'pvp'|'pve'|'seasonal'`).
 

--- a/docs/agent-context/summary/interfaces.md
+++ b/docs/agent-context/summary/interfaces.md
@@ -68,13 +68,13 @@ Handlers: `progress.ts`, `team.ts`, `token.ts`. Validate with `pnpm run validate
 
 Invoked via `app/composables/api/useEdgeFunctions.ts` or Stripe webhooks. Auth: `_shared/auth.ts`. Rate limit: `_shared/rate-limit.ts` (RPC).
 
-| Function                                                                  | Trigger      | Purpose                                    |
-| ------------------------------------------------------------------------- | ------------ | ------------------------------------------ |
-| `team-create` / `team-join` / `team-leave` / `team-kick` / `team-members` | Client       | Team lifecycle                             |
-| `token-create` / `token-revoke`                                           | Client       | API token management                       |
-| `account-delete` / `account-delete-reconcile`                             | Client / job | Account deletion                           |
-| `stripe-webhook`                                                          | Stripe       | Supporter grant/revoke + Discord role sync |
-| `admin-cache-purge`                                                       | Admin client | Purge Cloudflare + data caches             |
+| Function                                                                                   | Trigger      | Purpose                                    |
+| ------------------------------------------------------------------------------------------ | ------------ | ------------------------------------------ |
+| `team-create` / `team-join` / `team-leave` / `team-kick` / `team-disband` / `team-members` | Client       | Team lifecycle                             |
+| `token-create` / `token-revoke`                                                            | Client       | API token management                       |
+| `account-delete` / `account-delete-reconcile`                                              | Client / job | Account deletion                           |
+| `stripe-webhook`                                                                           | Stripe       | Supporter grant/revoke + Discord role sync |
+| `admin-cache-purge`                                                                        | Admin client | Purge Cloudflare + data caches             |
 
 ## External Integrations
 

--- a/docs/agent-context/summary/workflows.md
+++ b/docs/agent-context/summary/workflows.md
@@ -124,8 +124,8 @@ sequenceDiagram
     TeamStore->>UI: teammate progress
 ```
 
-Functions: `team-create`, `team-join`, `team-leave`, `team-kick`, `team-members`. Owner transfer and
-membership sync are handled by migrations/RPCs.
+Functions: `team-create`, `team-join`, `team-leave`, `team-kick`, `team-disband`, `team-members`.
+Owner transfer and membership sync are handled by migrations/RPCs.
 
 ## 6. Progress Import (tarkov.dev profile / EFT logs)
 

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -383,6 +383,9 @@ verify_jwt = false
 [functions.team-leave]
 verify_jwt = false
 
+[functions.team-disband]
+verify_jwt = false
+
 [functions.token-create]
 verify_jwt = false
 

--- a/supabase/functions/_shared/authenticated-mutation.ts
+++ b/supabase/functions/_shared/authenticated-mutation.ts
@@ -29,7 +29,7 @@ const getEarlyMutationResponse = (req: Request): Response | null =>
   handleCorsPreflight(req) ?? validateMethod(req, ['POST']);
 const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
   Object.prototype.toString.call(value) === '[object Object]';
-const readJsonObject = async (req: Request): Promise<Record<string, unknown>> => {
+export const readJsonObject = async (req: Request): Promise<Record<string, unknown>> => {
   try {
     const parsed = await req.json();
     return isObjectRecord(parsed) ? parsed : {};

--- a/supabase/functions/_shared/authenticated-mutation.ts
+++ b/supabase/functions/_shared/authenticated-mutation.ts
@@ -6,7 +6,7 @@ import {
   validateMethod,
 } from './auth.ts';
 import { enforceUserMutationRateLimit, type MutationRateLimitAction } from './rate-limit.ts';
-type AuthenticatedMutation = {
+export type AuthenticatedMutation = {
   response: null;
   supabase: SupabaseClient;
   user: { email?: string; id: string };

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -974,6 +974,10 @@ export type Database = {
           reset_at: string
         }[]
       }
+      disband_team: {
+        Args: { p_owner_id: string; p_team_id: string }
+        Returns: boolean
+      }
       get_api_usage_summary: {
         Args: { p_limit?: number; p_since: string }
         Returns: {

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -5,6 +5,7 @@ export type MutationRateLimitAction =
   | 'team-join'
   | 'team-leave'
   | 'team-kick'
+  | 'team-disband'
   | 'token-create'
   | 'token-revoke';
 type MutationRateLimitConfig = {
@@ -20,6 +21,7 @@ const MUTATION_RATE_LIMITS: Record<MutationRateLimitAction, MutationRateLimitCon
   'team-join': { limit: 30, windowSec: 600 },
   'team-leave': { limit: 30, windowSec: 3600 },
   'team-kick': { limit: 20, windowSec: 3600 },
+  'team-disband': { limit: 10, windowSec: 3600 },
   'token-create': { limit: 3, windowSec: 3600 },
   'token-revoke': { limit: 50, windowSec: 600 },
 };

--- a/supabase/functions/team-disband/index.ts
+++ b/supabase/functions/team-disband/index.ts
@@ -1,0 +1,54 @@
+import {
+  createErrorResponse,
+  createSuccessResponse,
+  validateRequiredFields,
+  validateUUIDs,
+} from '../_shared/auth.ts';
+import {
+  authenticateMutation,
+  type AuthenticatedMutation,
+} from '../_shared/authenticated-mutation.ts';
+const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
+  Boolean(value && typeof value === 'object' && !Array.isArray(value));
+const getRequestBody = async (req: Request): Promise<Record<string, unknown>> => {
+  try {
+    const body: unknown = await req.json();
+    return isObjectRecord(body) ? body : {};
+  } catch {
+    return {};
+  }
+};
+const getRpcErrorResponse = (req: Request, error: Error): Response => {
+  if (error.message.includes('Only team owners')) {
+    return createErrorResponse(error.message, 403, req);
+  }
+  if (error.message.includes('Team not found')) {
+    return createErrorResponse(error.message, 404, req);
+  }
+  console.error('Team disband failed:', error);
+  return createErrorResponse('Failed to disband team', 500, req);
+};
+const disbandTeam = async (req: Request, auth: AuthenticatedMutation): Promise<Response> => {
+  const body = await getRequestBody(req);
+  const fieldsError = validateRequiredFields(req, body, ['teamId']);
+  if (fieldsError) return fieldsError;
+  const uuidError = validateUUIDs(req, body, ['teamId']);
+  if (uuidError) return uuidError;
+  const { error } = await auth.supabase.rpc('disband_team', {
+    p_owner_id: auth.user.id,
+    p_team_id: String(body.teamId),
+  });
+  if (!error) {
+    return createSuccessResponse(
+      { success: true, message: 'Team disbanded successfully' },
+      200,
+      req
+    );
+  }
+  return getRpcErrorResponse(req, error);
+};
+Deno.serve(async (req) => {
+  const auth = await authenticateMutation(req, 'team-disband');
+  if (auth.response) return auth.response;
+  return disbandTeam(req, auth);
+});

--- a/supabase/functions/team-disband/index.ts
+++ b/supabase/functions/team-disband/index.ts
@@ -6,18 +6,9 @@ import {
 } from '../_shared/auth.ts';
 import {
   authenticateMutation,
+  readJsonObject,
   type AuthenticatedMutation,
 } from '../_shared/authenticated-mutation.ts';
-const isObjectRecord = (value: unknown): value is Record<string, unknown> =>
-  Boolean(value && typeof value === 'object' && !Array.isArray(value));
-const getRequestBody = async (req: Request): Promise<Record<string, unknown>> => {
-  try {
-    const body: unknown = await req.json();
-    return isObjectRecord(body) ? body : {};
-  } catch {
-    return {};
-  }
-};
 const getRpcErrorResponse = (req: Request, error: Error): Response => {
   if (error.message.includes('Only team owners')) {
     return createErrorResponse(error.message, 403, req);
@@ -29,7 +20,7 @@ const getRpcErrorResponse = (req: Request, error: Error): Response => {
   return createErrorResponse('Failed to disband team', 500, req);
 };
 const disbandTeam = async (req: Request, auth: AuthenticatedMutation): Promise<Response> => {
-  const body = await getRequestBody(req);
+  const body = await readJsonObject(req);
   const fieldsError = validateRequiredFields(req, body, ['teamId']);
   if (fieldsError) return fieldsError;
   const uuidError = validateUUIDs(req, body, ['teamId']);
@@ -48,7 +39,12 @@ const disbandTeam = async (req: Request, auth: AuthenticatedMutation): Promise<R
   return getRpcErrorResponse(req, error);
 };
 Deno.serve(async (req) => {
-  const auth = await authenticateMutation(req, 'team-disband');
-  if (auth.response) return auth.response;
-  return disbandTeam(req, auth);
+  try {
+    const auth = await authenticateMutation(req, 'team-disband');
+    if (auth.response) return auth.response;
+    return await disbandTeam(req, auth);
+  } catch (error) {
+    console.error('Team disband error:', error);
+    return createErrorResponse('Internal server error', 500, req);
+  }
 });

--- a/supabase/functions/team-leave/index.ts
+++ b/supabase/functions/team-leave/index.ts
@@ -46,58 +46,9 @@ Deno.serve(async (req) => {
     }
     // Check if user is the owner
     if (membership.role === 'owner') {
-      // Check if there are other members
-      const { data: otherMembers, error: membersError } = await supabase
-        .from('team_memberships')
-        .select('user_id')
-        .eq('team_id', teamId)
-        .neq('user_id', user.id);
-      if (membersError) {
-        console.error('Members check failed:', membersError);
-        return createErrorResponse('Failed to check team members', 500, req);
-      }
-      if (otherMembers && otherMembers.length > 0) {
-        return createErrorResponse(
-          'Team owner cannot leave while team has other members. Transfer ownership or kick all members first.',
-          400,
-          req
-        );
-      }
-      // If no other members, disband the team by:
-      // 1. Clear user_system team_id first (to avoid FK constraint)
-      const { error: systemError } = await supabase.from('user_system').upsert({
-        user_id: user.id,
-        [teamIdColumn]: null,
-        updated_at: new Date().toISOString(),
-      });
-      if (systemError) {
-        console.error('user_system upsert failed:', systemError);
-        if (systemError.code !== '42P01' && systemError.code !== '42703') {
-          return createErrorResponse('Failed to update user system state', 500, req);
-        }
-        console.warn('user_system table missing, continuing without system state update');
-      }
-      // 2. Delete all memberships (including owner's)
-      const { error: membershipDeleteError } = await supabase
-        .from('team_memberships')
-        .delete()
-        .eq('team_id', teamId);
-      if (membershipDeleteError) {
-        console.error('Membership deletion failed:', membershipDeleteError);
-        return createErrorResponse('Failed to delete team memberships', 500, req);
-      }
-      // 3. Finally delete the team
-      const { error: teamDeleteError } = await supabase.from('teams').delete().eq('id', teamId);
-      if (teamDeleteError) {
-        console.error('Team deletion failed:', teamDeleteError);
-        return createErrorResponse('Failed to delete team', 500, req);
-      }
-      return createSuccessResponse(
-        {
-          success: true,
-          message: 'Team deleted successfully (owner left empty team)',
-        },
-        200,
+      return createErrorResponse(
+        'Team owners must disband their team through the confirmed disband action.',
+        400,
         req
       );
     }

--- a/supabase/migrations/20260829120000_add_atomic_team_disband.sql
+++ b/supabase/migrations/20260829120000_add_atomic_team_disband.sql
@@ -1,0 +1,47 @@
+CREATE OR REPLACE FUNCTION public.disband_team(
+  p_team_id UUID,
+  p_owner_id UUID
+)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_deleted_team_id UUID;
+BEGIN
+  IF p_team_id IS NULL OR p_owner_id IS NULL THEN
+    RAISE EXCEPTION 'Team and owner are required';
+  END IF;
+
+  UPDATE public.user_system
+  SET pvp_team_id = CASE WHEN pvp_team_id = p_team_id THEN NULL ELSE pvp_team_id END,
+      pve_team_id = CASE WHEN pve_team_id = p_team_id THEN NULL ELSE pve_team_id END,
+      seasonal_team_id = CASE
+        WHEN seasonal_team_id = p_team_id THEN NULL
+        ELSE seasonal_team_id
+      END,
+      updated_at = now()
+  WHERE pvp_team_id = p_team_id
+     OR pve_team_id = p_team_id
+     OR seasonal_team_id = p_team_id;
+
+  DELETE FROM public.teams
+  WHERE id = p_team_id
+    AND owner_id = p_owner_id
+  RETURNING id INTO v_deleted_team_id;
+
+  IF v_deleted_team_id IS NOT NULL THEN
+    RETURN TRUE;
+  END IF;
+
+  IF EXISTS (SELECT 1 FROM public.teams WHERE id = p_team_id) THEN
+    RAISE EXCEPTION 'Only team owners can disband this team';
+  END IF;
+
+  RAISE EXCEPTION 'Team not found';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.disband_team(UUID, UUID) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.disband_team(UUID, UUID) TO service_role;

--- a/supabase/migrations/20260829120000_add_atomic_team_disband.sql
+++ b/supabase/migrations/20260829120000_add_atomic_team_disband.sql
@@ -8,10 +8,24 @@ SECURITY DEFINER
 SET search_path = ''
 AS $$
 DECLARE
-  v_deleted_team_id UUID;
+  v_team_owner_id UUID;
 BEGIN
   IF p_team_id IS NULL OR p_owner_id IS NULL THEN
     RAISE EXCEPTION 'Team and owner are required';
+  END IF;
+
+  SELECT owner_id
+  INTO v_team_owner_id
+  FROM public.teams
+  WHERE id = p_team_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Team not found';
+  END IF;
+
+  IF v_team_owner_id IS DISTINCT FROM p_owner_id THEN
+    RAISE EXCEPTION 'Only team owners can disband this team';
   END IF;
 
   UPDATE public.user_system
@@ -26,20 +40,9 @@ BEGIN
      OR pve_team_id = p_team_id
      OR seasonal_team_id = p_team_id;
 
-  DELETE FROM public.teams
-  WHERE id = p_team_id
-    AND owner_id = p_owner_id
-  RETURNING id INTO v_deleted_team_id;
+  DELETE FROM public.teams WHERE id = p_team_id;
 
-  IF v_deleted_team_id IS NOT NULL THEN
-    RETURN TRUE;
-  END IF;
-
-  IF EXISTS (SELECT 1 FROM public.teams WHERE id = p_team_id) THEN
-    RAISE EXCEPTION 'Only team owners can disband this team';
-  END IF;
-
-  RAISE EXCEPTION 'Team not found';
+  RETURN TRUE;
 END;
 $$;
 

--- a/supabase/tests/database/team_disband.test.sql
+++ b/supabase/tests/database/team_disband.test.sql
@@ -1,0 +1,131 @@
+BEGIN;
+
+SELECT plan(14);
+
+CREATE TEMP TABLE team_disband_fixture AS
+SELECT
+  '00000000-0000-0000-0000-000000000731'::UUID AS owner_id,
+  '00000000-0000-0000-0000-000000000732'::UUID AS member_id,
+  '00000000-0000-0000-0000-000000000733'::UUID AS outsider_id,
+  '00000000-0000-0000-0000-000000000734'::UUID AS team_id,
+  '00000000-0000-0000-0000-000000000735'::UUID AS second_team_id;
+
+INSERT INTO auth.users (id, email)
+VALUES
+  ((SELECT owner_id FROM team_disband_fixture), 'team-disband-owner@example.invalid'),
+  ((SELECT member_id FROM team_disband_fixture), 'team-disband-member@example.invalid'),
+  ((SELECT outsider_id FROM team_disband_fixture), 'team-disband-outsider@example.invalid');
+
+SELECT ok(
+  NOT has_function_privilege('anon', 'public.disband_team(uuid,uuid)', 'EXECUTE'),
+  'anonymous callers cannot disband teams'
+);
+SELECT ok(
+  NOT has_function_privilege('authenticated', 'public.disband_team(uuid,uuid)', 'EXECUTE'),
+  'authenticated callers cannot disband teams directly'
+);
+SELECT ok(
+  has_function_privilege('service_role', 'public.disband_team(uuid,uuid)', 'EXECUTE'),
+  'the service role can disband teams'
+);
+
+INSERT INTO public.teams (id, name, join_code, max_members, owner_id, game_mode)
+VALUES (
+  (SELECT team_id FROM team_disband_fixture),
+  'Disband test team',
+  'disband-test-code',
+  5,
+  (SELECT owner_id FROM team_disband_fixture),
+  'pvp'
+);
+
+INSERT INTO public.team_memberships (team_id, user_id, role, game_mode)
+VALUES
+  ((SELECT team_id FROM team_disband_fixture), (SELECT owner_id FROM team_disband_fixture), 'owner', 'pvp'),
+  ((SELECT team_id FROM team_disband_fixture), (SELECT member_id FROM team_disband_fixture), 'member', 'pvp');
+
+INSERT INTO public.team_events (team_id, event_type, initiated_by)
+VALUES ((SELECT team_id FROM team_disband_fixture), 'team_created', (SELECT owner_id FROM team_disband_fixture));
+
+SELECT is(
+  public.disband_team(
+    (SELECT team_id FROM team_disband_fixture),
+    (SELECT owner_id FROM team_disband_fixture)
+  ),
+  TRUE,
+  'the owner can disband the team'
+);
+SELECT is(
+  (SELECT COUNT(*)::INTEGER FROM public.teams WHERE id = (SELECT team_id FROM team_disband_fixture)),
+  0,
+  'disbanding removes the team'
+);
+SELECT is(
+  (SELECT COUNT(*)::INTEGER FROM public.team_memberships WHERE team_id = (SELECT team_id FROM team_disband_fixture)),
+  0,
+  'disbanding removes every membership'
+);
+SELECT is(
+  (SELECT COUNT(*)::INTEGER FROM public.team_events WHERE team_id = (SELECT team_id FROM team_disband_fixture)),
+  0,
+  'disbanding removes team events with the team'
+);
+SELECT is(
+  (SELECT pvp_team_id FROM public.user_system WHERE user_id = (SELECT owner_id FROM team_disband_fixture)),
+  NULL::UUID,
+  'disbanding clears the owner team reference'
+);
+SELECT is(
+  (SELECT pvp_team_id FROM public.user_system WHERE user_id = (SELECT member_id FROM team_disband_fixture)),
+  NULL::UUID,
+  'disbanding clears every member team reference'
+);
+
+INSERT INTO public.teams (id, name, join_code, max_members, owner_id, game_mode)
+VALUES (
+  (SELECT second_team_id FROM team_disband_fixture),
+  'Disband authorization test team',
+  'disband-auth-test-code',
+  5,
+  (SELECT owner_id FROM team_disband_fixture),
+  'pvp'
+);
+
+SELECT throws_ok(
+  $$SELECT public.disband_team(
+    '00000000-0000-0000-0000-000000000735'::UUID,
+    '00000000-0000-0000-0000-000000000733'::UUID
+  )$$,
+  'Only team owners can disband this team',
+  'a non-owner cannot disband a team'
+);
+SELECT is(
+  (SELECT COUNT(*)::INTEGER FROM public.teams WHERE id = (SELECT second_team_id FROM team_disband_fixture)),
+  1,
+  'a rejected disband leaves the team intact'
+);
+SELECT throws_ok(
+  $$SELECT public.disband_team(
+    '00000000-0000-0000-0000-000000000736'::UUID,
+    '00000000-0000-0000-0000-000000000731'::UUID
+  )$$,
+  'Team not found',
+  'disbanding an unknown team returns a not found error'
+);
+SELECT is(
+  public.disband_team(
+    (SELECT second_team_id FROM team_disband_fixture),
+    (SELECT owner_id FROM team_disband_fixture)
+  ),
+  TRUE,
+  'the owner can disband a team after a rejected attempt'
+);
+SELECT is(
+  (SELECT COUNT(*)::INTEGER FROM public.teams WHERE id = (SELECT second_team_id FROM team_disband_fixture)),
+  0,
+  'the authorized disband removes the second team'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/supabase/tests/database/team_disband.test.sql
+++ b/supabase/tests/database/team_disband.test.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-SELECT plan(14);
+SELECT plan(16);
 
 CREATE TEMP TABLE team_disband_fixture AS
 SELECT
@@ -10,6 +10,11 @@ SELECT
   '00000000-0000-0000-0000-000000000734'::UUID AS team_id,
   '00000000-0000-0000-0000-000000000735'::UUID AS second_team_id;
 
+CREATE TEMP TABLE team_disband_privilege_fixture AS
+SELECT
+  'public.disband_team(uuid,uuid)'::TEXT AS function_signature,
+  'EXECUTE'::TEXT AS privilege;
+
 INSERT INTO auth.users (id, email)
 VALUES
   ((SELECT owner_id FROM team_disband_fixture), 'team-disband-owner@example.invalid'),
@@ -17,15 +22,27 @@ VALUES
   ((SELECT outsider_id FROM team_disband_fixture), 'team-disband-outsider@example.invalid');
 
 SELECT ok(
-  NOT has_function_privilege('anon', 'public.disband_team(uuid,uuid)', 'EXECUTE'),
+  NOT has_function_privilege(
+    'anon',
+    (SELECT function_signature FROM team_disband_privilege_fixture),
+    (SELECT privilege FROM team_disband_privilege_fixture)
+  ),
   'anonymous callers cannot disband teams'
 );
 SELECT ok(
-  NOT has_function_privilege('authenticated', 'public.disband_team(uuid,uuid)', 'EXECUTE'),
+  NOT has_function_privilege(
+    'authenticated',
+    (SELECT function_signature FROM team_disband_privilege_fixture),
+    (SELECT privilege FROM team_disband_privilege_fixture)
+  ),
   'authenticated callers cannot disband teams directly'
 );
 SELECT ok(
-  has_function_privilege('service_role', 'public.disband_team(uuid,uuid)', 'EXECUTE'),
+  has_function_privilege(
+    'service_role',
+    (SELECT function_signature FROM team_disband_privilege_fixture),
+    (SELECT privilege FROM team_disband_privilege_fixture)
+  ),
   'the service role can disband teams'
 );
 
@@ -43,6 +60,17 @@ INSERT INTO public.team_memberships (team_id, user_id, role, game_mode)
 VALUES
   ((SELECT team_id FROM team_disband_fixture), (SELECT owner_id FROM team_disband_fixture), 'owner', 'pvp'),
   ((SELECT team_id FROM team_disband_fixture), (SELECT member_id FROM team_disband_fixture), 'member', 'pvp');
+
+SELECT is(
+  (SELECT pvp_team_id FROM public.user_system WHERE user_id = (SELECT owner_id FROM team_disband_fixture)),
+  (SELECT team_id FROM team_disband_fixture),
+  'the owner team reference exists before disbanding'
+);
+SELECT is(
+  (SELECT pvp_team_id FROM public.user_system WHERE user_id = (SELECT member_id FROM team_disband_fixture)),
+  (SELECT team_id FROM team_disband_fixture),
+  'the member team reference exists before disbanding'
+);
 
 INSERT INTO public.team_events (team_id, event_type, initiated_by)
 VALUES ((SELECT team_id FROM team_disband_fixture), 'team_created', (SELECT owner_id FROM team_disband_fixture));


### PR DESCRIPTION
## Summary

- Reworked the Team page into a responsive, centered layout with standard card headers, balanced invite/settings columns, responsive member tiles, aligned footer chrome, and improved typography.
- Added masked invite-link reveal/copy interactions, copied feedback, solo-team guidance, accessible tooltips and targets, positive visibility labels with preserved stored semantics, and a confirmed Danger Zone flow.
- Added an atomic service-role-only team disband RPC and Edge Function with rate limiting, owner checks, reference cleanup, tests, and synchronized project documentation.

## Validation

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run lint:fallow`
- `pnpm run typecheck`
- `pnpm run i18n:check` (expected Crowdin missing/orphaned-key warnings only)
- `pnpm run test` (263 files, 2,557 tests passed) plus final TeamVisibilitySwitch tests
- `pnpm run supabase:check` (migrations, 32 pgTAP tests, schema lint)
- `deno check --config supabase/functions/deno.json supabase/functions/team-disband/index.ts`
- `CI=true pnpm run build`
- Playwright visual and DOM/ARIA interaction checks at 1280, 1440, 1920, and 2560px

The PR is intentionally limited to the Team page UX and the backend safety needed for the new destructive-action flow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added redesigned team management with masked invite links, visibility controls, and one-click copying.
  * Team owners can disband teams with confirmation; non-owners can leave teams.
  * Added clearer member controls for progress visibility and removal.
* **Improvements**
  * Refined layouts, responsive styling, tooltips, and accessibility.
  * Improved lengthy account-name handling and invite-link feedback.
* **Bug Fixes**
  * Prevented stale or mismatched team data from being reused across game modes.
* **Documentation**
  * Expanded team management and API guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR modernizes the Team collaboration experience and adds a confirmed, atomic owner-only disband flow.

- Redesigns team invitation, visibility, membership, navigation, and responsive page controls.
- Routes confirmed owner disbands through a dedicated authenticated Edge Function and service-role-only database RPC.
- Adds frontend, Edge Function, and database tests for the updated lifecycle behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/features/team/TeamDangerZone.vue | Resolves ownership for the current team before presenting a confirmed disband or leave action and preserves the selected action through confirmation. |
| app/stores/useTeamStore.ts | Tracks the hydrated team identity alongside normalized ownership data so consumers can reject stale cross-team state. |
| supabase/functions/team-disband/index.ts | Implements the authenticated and rate-limited Edge Function boundary for atomic owner disband requests. |
| supabase/migrations/20260829120000_add_atomic_team_disband.sql | Adds the service-role-only atomic database operation that validates ownership and cleans up team references. |
| app/features/team/__tests__/TeamDangerZone.test.ts | Covers owner disband, member leave, unresolved ownership, failed actions, confirmation, and mode-specific state cleanup. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant Owner
  participant UI as Team Danger Zone
  participant Edge as team-disband Edge Function
  participant RPC as disband_team RPC
  participant DB as Team tables
  Owner->>UI: Open and confirm disband
  UI->>Edge: Authenticated team-disband request
  Edge->>Edge: Check rate limit and owner identity
  Edge->>RPC: Call with service role
  RPC->>DB: Atomically remove references, memberships, and team
  DB-->>RPC: Success
  RPC-->>Edge: Disband result
  Edge-->>UI: Success response
  UI->>UI: Clear mode-specific local team state
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(team): ignore stale invite copy resu..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/37cc7540f45c4ca8430cae2dd94a4c1c8c0321a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58173907)</sub>

**Context used:**

- Knowledge Base — [Teams and shared progress](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/teams-and-shared-progress.md)
- Knowledge Base — [Team membership operations](https://app.greptile.com/dysektai/-/custom-context/knowledge-base/tarkovtracker-org/tarkovtracker/-/docs/team-membership-operations.md)

<!-- /greptile_comment -->