### PR TITLE
fix(app): make OAuth PKCE callback exchange explicit

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,13 +202,14 @@ Naming:
 - OAuth PKCE callback: the client treats a request as an OAuth callback only on the `/auth/callback`
   route (`readOAuthCallbackCode()`); a `code` query param on any other route — e.g. a team invite
   `/team?team=...&code=...` — is left for that feature to consume and never sent to
-  `exchangeCodeForSession`. `detectSessionInUrl` is disabled only when a real callback code is
-  present so PKCE codes are exchanged explicitly. The PKCE exchange runs inside `$supabase.ready()`
-  (deferred, exactly once), never in top-level plugin `setup()`, so an expired/replayed/invalid code
-  rejects `ready()` for `auth/callback.vue` to surface and post `OAUTH_ERROR` to the login opener
-  instead of aborting plugin initialization and stalling the popup until its abandonment timeout. A
-  successful exchange removes `code` and `sb_flow_id` from the callback URL before the page redirects
-  or closes.
+  `exchangeCodeForSession`. `detectSessionInUrl` is disabled for every query `code` so Supabase cannot
+  auto-classify a feature-specific value as PKCE; the plugin exchanges it only on the callback route.
+  The PKCE exchange runs inside `$supabase.ready()` (deferred, exactly once), never in top-level plugin
+  `setup()`, so an expired/replayed/invalid code rejects `ready()` for `auth/callback.vue` to surface
+  and post `OAUTH_ERROR` to the login opener instead of aborting plugin initialization and stalling
+  the popup until its abandonment timeout. The single exchange attempt clears the in-memory callback
+  marker when it settles; a successful exchange also removes `code` and `sb_flow_id` from the callback
+  URL so later `ready()` calls refresh the current session normally.
 - API endpoints: `app/server/api/`. Use composables for shared data access patterns.
 - Admin Pages API routes return stable machine-readable error codes in `data.code`; keep the
   English `statusMessage` as a client fallback and map known codes to localized UI copy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,6 +199,14 @@ Naming:
 
 - Pinia stores in `app/stores/`, auto-registered by Nuxt. Use `pinia-plugin-persistedstate` where applicable.
 - Supabase client: `app/plugins/supabase.client.ts`. Regenerate types: `pnpm run supabase:types`.
+- OAuth PKCE callback: the client treats a request as an OAuth callback only on the `/auth/callback`
+  route (`readOAuthCallbackCode()`); a `code` query param on any other route — e.g. a team invite
+  `/team?team=...&code=...` — is left for that feature to consume and never sent to
+  `exchangeCodeForSession`. `detectSessionInUrl` is disabled only when a real callback code is
+  present so PKCE codes are exchanged explicitly. The PKCE exchange runs inside `$supabase.ready()`
+  (deferred, exactly once), never in top-level plugin `setup()`, so an expired/replayed/invalid code
+  rejects `ready()` for `auth/callback.vue` to surface and post `OAUTH_ERROR` to the login opener
+  instead of aborting plugin initialization and stalling the popup until its abandonment timeout.
 - API endpoints: `app/server/api/`. Use composables for shared data access patterns.
 - Admin Pages API routes return stable machine-readable error codes in `data.code`; keep the
   English `statusMessage` as a client fallback and map known codes to localized UI copy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,7 +206,9 @@ Naming:
   present so PKCE codes are exchanged explicitly. The PKCE exchange runs inside `$supabase.ready()`
   (deferred, exactly once), never in top-level plugin `setup()`, so an expired/replayed/invalid code
   rejects `ready()` for `auth/callback.vue` to surface and post `OAUTH_ERROR` to the login opener
-  instead of aborting plugin initialization and stalling the popup until its abandonment timeout.
+  instead of aborting plugin initialization and stalling the popup until its abandonment timeout. A
+  successful exchange removes `code` and `sb_flow_id` from the callback URL before the page redirects
+  or closes.
 - API endpoints: `app/server/api/`. Use composables for shared data access patterns.
 - Admin Pages API routes return stable machine-readable error codes in `data.code`; keep the
   English `statusMessage` as a client fallback and map known codes to localized UI copy.

--- a/app/plugins/__tests__/supabase.client.test.ts
+++ b/app/plugins/__tests__/supabase.client.test.ts
@@ -409,6 +409,54 @@ describe('supabase plugin', () => {
     expect(localStorage.getItem(STORAGE_KEYS.progress)).toBe('progress-state');
     expect(localStorage.getItem(STORAGE_KEYS.preferences)).toBe('preferences-state');
   });
+  it('provides an offline stub when supabase config is missing', async () => {
+    localStorage.removeItem('sb-test-auth-token');
+    runtimeConfig.public.supabaseUrl = '';
+    runtimeConfig.public.supabaseAnonKey = '';
+    const plugin = (await import('@/plugins/supabase.client')).default;
+    const result = (await plugin.setup?.({} as Parameters<NonNullable<typeof plugin.setup>>[0])) as
+      SupabasePluginProvide | undefined;
+    const supabase = result?.provide.supabase;
+    expect(supabase?.isOfflineMode).toBe(true);
+    expect(supabase?.user.loggedIn).toBe(false);
+    expect(mockCreateClient).not.toHaveBeenCalled();
+    const stubClient = supabase?.client as unknown as {
+      from: (table: string) => { select?: () => unknown };
+      channel: (name: string) => { subscribe: () => unknown; unsubscribe: () => Promise<string> };
+      rpc: (fn: string) => Promise<{ data: null; error: null }>;
+      auth: {
+        getSession: () => Promise<{ data: { session: null }; error: null }>;
+        exchangeCodeForSession: () => Promise<{ error: Error }>;
+      };
+    };
+    expect(typeof stubClient.from('teams').select).toBe('function');
+    const channel = stubClient.channel('team:1');
+    expect(channel.subscribe()).toBe(channel);
+    await expect(channel.unsubscribe()).resolves.toBe('ok');
+    await expect(stubClient.rpc('noop')).resolves.toEqual({ data: null, error: null });
+    await expect(stubClient.auth.getSession()).resolves.toEqual({
+      data: { session: null },
+      error: null,
+    });
+    const exchangeResult = await stubClient.auth.exchangeCodeForSession();
+    expect(exchangeResult.error).toBeInstanceOf(Error);
+    const fullClient = stubClient as unknown as {
+      removeChannel: () => void;
+      removeAllChannels: () => void;
+      functions: { invoke: (fn: string) => Promise<{ data: null; error: null }> };
+      auth: { signOut: () => Promise<{ error: null }>; onAuthStateChange: () => unknown };
+    };
+    expect(() => fullClient.removeChannel()).not.toThrow();
+    expect(() => fullClient.removeAllChannels()).not.toThrow();
+    await expect(fullClient.functions.invoke('noop')).resolves.toEqual({ data: null, error: null });
+    await expect(fullClient.auth.signOut()).resolves.toEqual({ error: null });
+    expect(fullClient.auth.onAuthStateChange()).toBeDefined();
+    await expect(supabase?.ready()).resolves.toBeUndefined();
+    await expect(supabase?.signOut()).resolves.toBeUndefined();
+    await expect(supabase?.signInWithOAuth('github')).rejects.toThrow(
+      'Supabase not configured - login unavailable in offline mode'
+    );
+  });
   it('rejects ready when client initialization fails', async () => {
     const initError = new Error('create client failed');
     localStorage.removeItem('sb-test-auth-token');

--- a/app/plugins/__tests__/supabase.client.test.ts
+++ b/app/plugins/__tests__/supabase.client.test.ts
@@ -158,12 +158,16 @@ describe('supabase plugin', () => {
     window.history.replaceState(null, '', '/');
     try {
       window.history.replaceState(null, '', '/auth/callback?code=oauth-code');
-      const sessionDeferred = createDeferred<{
-        data: { session: ReturnType<typeof createSession> };
-      }>();
       mockCreateClient.mockReturnValue({
         auth: {
-          getSession: vi.fn(() => sessionDeferred.promise),
+          exchangeCodeForSession: vi.fn().mockResolvedValue({
+            data: { session: createSession('user-code') },
+            error: null,
+          }),
+          getSession: vi.fn().mockResolvedValue({
+            data: { session: null },
+            error: null,
+          }),
           onAuthStateChange: vi.fn(() => ({
             data: {
               subscription: {
@@ -184,12 +188,7 @@ describe('supabase plugin', () => {
         return value;
       });
       await flushPlugin();
-      expect(resolved).toBe(false);
-      sessionDeferred.resolve({
-        data: {
-          session: createSession('user-code'),
-        },
-      });
+      expect(resolved).toBe(true);
       const result = (await setupPromise) as SupabasePluginProvide | undefined;
       expect(result?.provide.supabase.user.id).toBe('user-code');
       expect(result?.provide.supabase.user.loggedIn).toBe(true);

--- a/app/plugins/__tests__/supabase.client.test.ts
+++ b/app/plugins/__tests__/supabase.client.test.ts
@@ -171,10 +171,16 @@ describe('supabase plugin', () => {
         data: { session: createSession('user-code') },
         error: null,
       });
-      const getSession = vi.fn().mockResolvedValue({
-        data: { session: null },
-        error: null,
-      });
+      const getSession = vi
+        .fn()
+        .mockResolvedValueOnce({
+          data: { session: null },
+          error: null,
+        })
+        .mockResolvedValue({
+          data: { session: createSession('user-refreshed') },
+          error: null,
+        });
       mockAuthClient({
         exchangeCodeForSession,
         getSession,
@@ -192,6 +198,18 @@ describe('supabase plugin', () => {
       expect(result?.provide.supabase.user.loggedIn).toBe(true);
       expect(window.location.pathname).toBe('/auth/callback');
       expect(window.location.search).toBe('?redirect=%2Ftasks');
+      await result?.provide.supabase.ready();
+      expect(getSession).toHaveBeenCalledTimes(2);
+      expect(result?.provide.supabase.user.id).toBe('user-refreshed');
+      vi.resetModules();
+      const reloadedPlugin = (await import('@/plugins/supabase.client')).default;
+      const reloadedResult = (await reloadedPlugin.setup?.(
+        {} as Parameters<NonNullable<typeof reloadedPlugin.setup>>[0]
+      )) as SupabasePluginProvide | undefined;
+      await flushPlugin();
+      expect(exchangeCodeForSession).toHaveBeenCalledTimes(1);
+      expect(reloadedResult?.provide.supabase.user.id).toBe('user-refreshed');
+      expect(mockCreateClient).toHaveBeenCalledTimes(2);
       expect(mockCreateClient).toHaveBeenCalledWith(
         'https://test.supabase.co',
         'test-anon-key',
@@ -216,9 +234,16 @@ describe('supabase plugin', () => {
         data: { session: null },
         error: exchangeError,
       });
+      const getSession = vi
+        .fn()
+        .mockResolvedValueOnce({ data: { session: null }, error: null })
+        .mockResolvedValue({
+          data: { session: createSession('user-after-retry') },
+          error: null,
+        });
       mockAuthClient({
         exchangeCodeForSession,
-        getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+        getSession,
       });
       const plugin = (await import('@/plugins/supabase.client')).default;
       const result = (await plugin.setup?.(
@@ -226,7 +251,11 @@ describe('supabase plugin', () => {
       )) as SupabasePluginProvide | undefined;
       await flushPlugin();
       await expect(result?.provide.supabase.ready()).rejects.toThrow('invalid_grant');
+      expect(window.location.search).toBe('?code=expired-code');
       expect(result?.provide.supabase.user.loggedIn).toBe(false);
+      await expect(result?.provide.supabase.ready()).resolves.toBeUndefined();
+      expect(getSession).toHaveBeenCalledTimes(2);
+      expect(result?.provide.supabase.user.id).toBe('user-after-retry');
     } finally {
       window.history.replaceState(null, '', '/');
     }
@@ -254,7 +283,7 @@ describe('supabase plugin', () => {
         'test-anon-key',
         expect.objectContaining({
           auth: {
-            detectSessionInUrl: true,
+            detectSessionInUrl: false,
             flowType: 'pkce',
           },
         })

--- a/app/plugins/__tests__/supabase.client.test.ts
+++ b/app/plugins/__tests__/supabase.client.test.ts
@@ -11,7 +11,7 @@ const runtimeConfig = {
     supabaseUrl: 'https://test.supabase.co',
   },
 };
-const { loggerMock, mockCreateClient } = vi.hoisted(() => ({
+const { loggerMock, mockCreateClient, offlineFallbackMock } = vi.hoisted(() => ({
   loggerMock: {
     debug: vi.fn(),
     error: vi.fn(),
@@ -19,10 +19,14 @@ const { loggerMock, mockCreateClient } = vi.hoisted(() => ({
     warn: vi.fn(),
   },
   mockCreateClient: vi.fn(),
+  offlineFallbackMock: vi.fn(() => true),
 }));
 mockNuxtImport('useRuntimeConfig', () => () => runtimeConfig);
 vi.mock('@supabase/supabase-js', () => ({
   createClient: mockCreateClient,
+}));
+vi.mock('@/utils/runtimeConfig', () => ({
+  shouldUseOfflineSupabaseFallback: offlineFallbackMock,
 }));
 vi.mock('@/utils/logger', () => ({
   logger: loggerMock,
@@ -107,6 +111,7 @@ describe('supabase plugin', () => {
     vi.clearAllMocks();
     localStorage.clear();
     sessionStorage.clear();
+    offlineFallbackMock.mockReturnValue(true);
     runtimeConfig.public.supabaseAnonKey = 'test-anon-key';
     runtimeConfig.public.supabaseUrl = 'https://test.supabase.co';
     localStorage.setItem('sb-test-auth-token', 'token');
@@ -434,6 +439,66 @@ describe('supabase plugin', () => {
     } finally {
       window.history.replaceState(null, '', '/');
     }
+  });
+  it('throws when config is missing and offline fallback is disallowed', async () => {
+    runtimeConfig.public.supabaseUrl = '';
+    runtimeConfig.public.supabaseAnonKey = '';
+    offlineFallbackMock.mockReturnValue(false);
+    const plugin = (await import('@/plugins/supabase.client')).default;
+    await expect(
+      plugin.setup?.({} as Parameters<NonNullable<typeof plugin.setup>>[0])
+    ).rejects.toThrow('Missing SUPABASE_URL or SUPABASE_ANON_KEY');
+    expect(mockCreateClient).not.toHaveBeenCalled();
+  });
+  it('hydrates from a hash-token callback and cleans the OAuth hash', async () => {
+    localStorage.removeItem('sb-test-auth-token');
+    window.history.replaceState(null, '', '/');
+    try {
+      window.history.replaceState(null, '', '/#access_token=abc&refresh_token=def');
+      mockAuthClient({
+        getSession: vi.fn().mockResolvedValue({
+          data: { session: createSession('user-hash') },
+          error: null,
+        }),
+      });
+      const plugin = (await import('@/plugins/supabase.client')).default;
+      const result = (await plugin.setup?.(
+        {} as Parameters<NonNullable<typeof plugin.setup>>[0]
+      )) as SupabasePluginProvide | undefined;
+      await flushPlugin();
+      expect(result?.provide.supabase.user.id).toBe('user-hash');
+      expect(result?.provide.supabase.user.loggedIn).toBe(true);
+      expect(window.location.hash).toBe('');
+    } finally {
+      window.history.replaceState(null, '', '/');
+    }
+  });
+  it('rejects signInWithOAuth when the client returns an error', async () => {
+    const oauthError = new Error('oauth_denied');
+    mockAuthClient({
+      getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+      signInWithOAuth: vi.fn().mockResolvedValue({ data: null, error: oauthError }),
+    });
+    const plugin = (await import('@/plugins/supabase.client')).default;
+    const result = (await plugin.setup?.({} as Parameters<NonNullable<typeof plugin.setup>>[0])) as
+      SupabasePluginProvide | undefined;
+    await flushPlugin();
+    await expect(result?.provide.supabase.signInWithOAuth('github')).rejects.toThrow(
+      'oauth_denied'
+    );
+  });
+  it('rejects signOut when the client returns an error', async () => {
+    const signOutError = new Error('signout_failed');
+    mockAuthClient({
+      getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+      signOut: vi.fn().mockResolvedValue({ error: signOutError }),
+    });
+    const plugin = (await import('@/plugins/supabase.client')).default;
+    const result = (await plugin.setup?.({} as Parameters<NonNullable<typeof plugin.setup>>[0])) as
+      SupabasePluginProvide | undefined;
+    await flushPlugin();
+    await result?.provide.supabase.ready();
+    await expect(result?.provide.supabase.signOut()).rejects.toThrow('signout_failed');
   });
   it('rejects ready when client initialization fails', async () => {
     const initError = new Error('create client failed');

--- a/app/plugins/__tests__/supabase.client.test.ts
+++ b/app/plugins/__tests__/supabase.client.test.ts
@@ -153,21 +153,23 @@ describe('supabase plugin', () => {
       })
     );
   });
-  it('waits for code-based oauth callback hydration before setup resolves', async () => {
+  it('exchanges an oauth callback code when ready is called', async () => {
     localStorage.removeItem('sb-test-auth-token');
     window.history.replaceState(null, '', '/');
     try {
       window.history.replaceState(null, '', '/auth/callback?code=oauth-code');
+      const exchangeCodeForSession = vi.fn().mockResolvedValue({
+        data: { session: createSession('user-code') },
+        error: null,
+      });
+      const getSession = vi.fn().mockResolvedValue({
+        data: { session: null },
+        error: null,
+      });
       mockCreateClient.mockReturnValue({
         auth: {
-          exchangeCodeForSession: vi.fn().mockResolvedValue({
-            data: { session: createSession('user-code') },
-            error: null,
-          }),
-          getSession: vi.fn().mockResolvedValue({
-            data: { session: null },
-            error: null,
-          }),
+          exchangeCodeForSession,
+          getSession,
           onAuthStateChange: vi.fn(() => ({
             data: {
               subscription: {
@@ -180,18 +182,105 @@ describe('supabase plugin', () => {
         },
       });
       const plugin = (await import('@/plugins/supabase.client')).default;
-      let resolved = false;
-      const setupPromise = Promise.resolve(
-        plugin.setup?.({} as Parameters<NonNullable<typeof plugin.setup>>[0])
-      ).then((value) => {
-        resolved = true;
-        return value;
-      });
+      const result = (await plugin.setup?.(
+        {} as Parameters<NonNullable<typeof plugin.setup>>[0]
+      )) as SupabasePluginProvide | undefined;
       await flushPlugin();
-      expect(resolved).toBe(true);
-      const result = (await setupPromise) as SupabasePluginProvide | undefined;
+      expect(result?.provide.supabase.user.loggedIn).toBe(false);
+      await result?.provide.supabase.ready();
+      expect(exchangeCodeForSession).toHaveBeenCalledTimes(1);
+      expect(exchangeCodeForSession).toHaveBeenCalledWith('oauth-code', undefined);
       expect(result?.provide.supabase.user.id).toBe('user-code');
       expect(result?.provide.supabase.user.loggedIn).toBe(true);
+      expect(mockCreateClient).toHaveBeenCalledWith(
+        'https://test.supabase.co',
+        'test-anon-key',
+        expect.objectContaining({
+          auth: {
+            detectSessionInUrl: false,
+            flowType: 'pkce',
+          },
+        })
+      );
+    } finally {
+      window.history.replaceState(null, '', '/');
+    }
+  });
+  it('surfaces the exchange error through ready without aborting setup', async () => {
+    localStorage.removeItem('sb-test-auth-token');
+    window.history.replaceState(null, '', '/');
+    try {
+      window.history.replaceState(null, '', '/auth/callback?code=expired-code');
+      const exchangeError = new Error('invalid_grant');
+      const exchangeCodeForSession = vi.fn().mockResolvedValue({
+        data: { session: null },
+        error: exchangeError,
+      });
+      mockCreateClient.mockReturnValue({
+        auth: {
+          exchangeCodeForSession,
+          getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
+          onAuthStateChange: vi.fn(() => ({
+            data: {
+              subscription: {
+                unsubscribe: vi.fn(),
+              },
+            },
+          })),
+          signInWithOAuth: vi.fn(),
+          signOut: vi.fn(),
+        },
+      });
+      const plugin = (await import('@/plugins/supabase.client')).default;
+      const result = (await plugin.setup?.(
+        {} as Parameters<NonNullable<typeof plugin.setup>>[0]
+      )) as SupabasePluginProvide | undefined;
+      await flushPlugin();
+      await expect(result?.provide.supabase.ready()).rejects.toThrow('invalid_grant');
+      expect(result?.provide.supabase.user.loggedIn).toBe(false);
+    } finally {
+      window.history.replaceState(null, '', '/');
+    }
+  });
+  it('ignores a team invite code outside the auth callback route', async () => {
+    localStorage.removeItem('sb-test-auth-token');
+    window.history.replaceState(null, '', '/');
+    try {
+      window.history.replaceState(null, '', '/team?team=team-1&code=invite-code');
+      const exchangeCodeForSession = vi.fn();
+      const getSession = vi.fn().mockResolvedValue({ data: { session: null }, error: null });
+      mockCreateClient.mockReturnValue({
+        auth: {
+          exchangeCodeForSession,
+          getSession,
+          onAuthStateChange: vi.fn(() => ({
+            data: {
+              subscription: {
+                unsubscribe: vi.fn(),
+              },
+            },
+          })),
+          signInWithOAuth: vi.fn(),
+          signOut: vi.fn(),
+        },
+      });
+      const plugin = (await import('@/plugins/supabase.client')).default;
+      const result = (await plugin.setup?.(
+        {} as Parameters<NonNullable<typeof plugin.setup>>[0]
+      )) as SupabasePluginProvide | undefined;
+      await flushPlugin();
+      await result?.provide.supabase.ready();
+      expect(exchangeCodeForSession).not.toHaveBeenCalled();
+      expect(mockCreateClient).toHaveBeenCalledWith(
+        'https://test.supabase.co',
+        'test-anon-key',
+        expect.objectContaining({
+          auth: {
+            detectSessionInUrl: true,
+            flowType: 'pkce',
+          },
+        })
+      );
     } finally {
       window.history.replaceState(null, '', '/');
     }

--- a/app/plugins/__tests__/supabase.client.test.ts
+++ b/app/plugins/__tests__/supabase.client.test.ts
@@ -162,7 +162,11 @@ describe('supabase plugin', () => {
     localStorage.removeItem('sb-test-auth-token');
     window.history.replaceState(null, '', '/');
     try {
-      window.history.replaceState(null, '', '/auth/callback?code=oauth-code');
+      window.history.replaceState(
+        null,
+        '',
+        '/auth/callback?code=oauth-code&sb_flow_id=flow-id&redirect=%2Ftasks'
+      );
       const exchangeCodeForSession = vi.fn().mockResolvedValue({
         data: { session: createSession('user-code') },
         error: null,
@@ -183,9 +187,11 @@ describe('supabase plugin', () => {
       expect(result?.provide.supabase.user.loggedIn).toBe(false);
       await result?.provide.supabase.ready();
       expect(exchangeCodeForSession).toHaveBeenCalledTimes(1);
-      expect(exchangeCodeForSession).toHaveBeenCalledWith('oauth-code', undefined);
+      expect(exchangeCodeForSession).toHaveBeenCalledWith('oauth-code', { flowId: 'flow-id' });
       expect(result?.provide.supabase.user.id).toBe('user-code');
       expect(result?.provide.supabase.user.loggedIn).toBe(true);
+      expect(window.location.pathname).toBe('/auth/callback');
+      expect(window.location.search).toBe('?redirect=%2Ftasks');
       expect(mockCreateClient).toHaveBeenCalledWith(
         'https://test.supabase.co',
         'test-anon-key',

--- a/app/plugins/__tests__/supabase.client.test.ts
+++ b/app/plugins/__tests__/supabase.client.test.ts
@@ -41,6 +41,23 @@ const flushPlugin = async () => {
   await flushPromises();
   await flushPromises();
 };
+const stubAuthSubscription = () => ({
+  data: {
+    subscription: {
+      unsubscribe: vi.fn(),
+    },
+  },
+});
+const mockAuthClient = (auth: Record<string, unknown>) => {
+  mockCreateClient.mockReturnValue({
+    auth: {
+      onAuthStateChange: vi.fn(() => stubAuthSubscription()),
+      signInWithOAuth: vi.fn(),
+      signOut: vi.fn(),
+      ...auth,
+    },
+  });
+};
 const createSession = (userId: string | null) => {
   if (!userId) {
     return null;
@@ -72,13 +89,7 @@ const createClientMock = (initialUserId: string) => {
       }),
       onAuthStateChange: vi.fn((callback: MockAuthStateChangeCallback) => {
         authStateChangeCallback = callback;
-        return {
-          data: {
-            subscription: {
-              unsubscribe: vi.fn(),
-            },
-          },
-        };
+        return stubAuthSubscription();
       }),
       signInWithOAuth,
       signOut,
@@ -110,19 +121,8 @@ describe('supabase plugin', () => {
     const sessionDeferred = createDeferred<{
       data: { session: ReturnType<typeof createSession> };
     }>();
-    mockCreateClient.mockReturnValue({
-      auth: {
-        getSession: vi.fn(() => sessionDeferred.promise),
-        onAuthStateChange: vi.fn(() => ({
-          data: {
-            subscription: {
-              unsubscribe: vi.fn(),
-            },
-          },
-        })),
-        signInWithOAuth: vi.fn(),
-        signOut: vi.fn(),
-      },
+    mockAuthClient({
+      getSession: vi.fn(() => sessionDeferred.promise),
     });
     const plugin = (await import('@/plugins/supabase.client')).default;
     let resolved = false;
@@ -166,20 +166,9 @@ describe('supabase plugin', () => {
         data: { session: null },
         error: null,
       });
-      mockCreateClient.mockReturnValue({
-        auth: {
-          exchangeCodeForSession,
-          getSession,
-          onAuthStateChange: vi.fn(() => ({
-            data: {
-              subscription: {
-                unsubscribe: vi.fn(),
-              },
-            },
-          })),
-          signInWithOAuth: vi.fn(),
-          signOut: vi.fn(),
-        },
+      mockAuthClient({
+        exchangeCodeForSession,
+        getSession,
       });
       const plugin = (await import('@/plugins/supabase.client')).default;
       const result = (await plugin.setup?.(
@@ -216,20 +205,9 @@ describe('supabase plugin', () => {
         data: { session: null },
         error: exchangeError,
       });
-      mockCreateClient.mockReturnValue({
-        auth: {
-          exchangeCodeForSession,
-          getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
-          onAuthStateChange: vi.fn(() => ({
-            data: {
-              subscription: {
-                unsubscribe: vi.fn(),
-              },
-            },
-          })),
-          signInWithOAuth: vi.fn(),
-          signOut: vi.fn(),
-        },
+      mockAuthClient({
+        exchangeCodeForSession,
+        getSession: vi.fn().mockResolvedValue({ data: { session: null }, error: null }),
       });
       const plugin = (await import('@/plugins/supabase.client')).default;
       const result = (await plugin.setup?.(
@@ -249,20 +227,9 @@ describe('supabase plugin', () => {
       window.history.replaceState(null, '', '/team?team=team-1&code=invite-code');
       const exchangeCodeForSession = vi.fn();
       const getSession = vi.fn().mockResolvedValue({ data: { session: null }, error: null });
-      mockCreateClient.mockReturnValue({
-        auth: {
-          exchangeCodeForSession,
-          getSession,
-          onAuthStateChange: vi.fn(() => ({
-            data: {
-              subscription: {
-                unsubscribe: vi.fn(),
-              },
-            },
-          })),
-          signInWithOAuth: vi.fn(),
-          signOut: vi.fn(),
-        },
+      mockAuthClient({
+        exchangeCodeForSession,
+        getSession,
       });
       const plugin = (await import('@/plugins/supabase.client')).default;
       const result = (await plugin.setup?.(
@@ -291,22 +258,12 @@ describe('supabase plugin', () => {
       data: { session: ReturnType<typeof createSession> };
     }>();
     let authStateChangeCallback: MockAuthStateChangeCallback | null = null;
-    mockCreateClient.mockReturnValue({
-      auth: {
-        getSession: vi.fn(() => sessionDeferred.promise),
-        onAuthStateChange: vi.fn((callback: MockAuthStateChangeCallback) => {
-          authStateChangeCallback = callback;
-          return {
-            data: {
-              subscription: {
-                unsubscribe: vi.fn(),
-              },
-            },
-          };
-        }),
-        signInWithOAuth: vi.fn(),
-        signOut: vi.fn(),
-      },
+    mockAuthClient({
+      getSession: vi.fn(() => sessionDeferred.promise),
+      onAuthStateChange: vi.fn((callback: MockAuthStateChangeCallback) => {
+        authStateChangeCallback = callback;
+        return stubAuthSubscription();
+      }),
     });
     const plugin = (await import('@/plugins/supabase.client')).default;
     let resolved = false;
@@ -373,20 +330,7 @@ describe('supabase plugin', () => {
           session: createSession('user-3'),
         },
       });
-    mockCreateClient.mockReturnValue({
-      auth: {
-        getSession,
-        onAuthStateChange: vi.fn(() => ({
-          data: {
-            subscription: {
-              unsubscribe: vi.fn(),
-            },
-          },
-        })),
-        signInWithOAuth: vi.fn(),
-        signOut: vi.fn(),
-      },
-    });
+    mockAuthClient({ getSession });
     const plugin = (await import('@/plugins/supabase.client')).default;
     const result = (await plugin.setup?.({} as Parameters<NonNullable<typeof plugin.setup>>[0])) as
       SupabasePluginProvide | undefined;

--- a/app/plugins/__tests__/supabase.client.test.ts
+++ b/app/plugins/__tests__/supabase.client.test.ts
@@ -401,6 +401,40 @@ describe('supabase plugin', () => {
       'Supabase not configured - login unavailable in offline mode'
     );
   });
+  it('shares a single exchange across concurrent ready callers', async () => {
+    localStorage.removeItem('sb-test-auth-token');
+    window.history.replaceState(null, '', '/');
+    try {
+      window.history.replaceState(null, '', '/auth/callback?code=oauth-code');
+      const exchangeDeferred = createDeferred<{
+        data: { session: ReturnType<typeof createSession> };
+        error: null;
+      }>();
+      const exchangeCodeForSession = vi.fn(() => exchangeDeferred.promise);
+      const getSession = vi.fn().mockResolvedValue({ data: { session: null }, error: null });
+      mockAuthClient({
+        exchangeCodeForSession,
+        getSession,
+      });
+      const plugin = (await import('@/plugins/supabase.client')).default;
+      const result = (await plugin.setup?.(
+        {} as Parameters<NonNullable<typeof plugin.setup>>[0]
+      )) as SupabasePluginProvide | undefined;
+      await flushPlugin();
+      const first = result?.provide.supabase.ready();
+      const second = result?.provide.supabase.ready();
+      exchangeDeferred.resolve({
+        data: { session: createSession('user-code') },
+        error: null,
+      });
+      await Promise.all([first, second]);
+      expect(exchangeCodeForSession).toHaveBeenCalledTimes(1);
+      expect(result?.provide.supabase.user.id).toBe('user-code');
+      expect(result?.provide.supabase.user.loggedIn).toBe(true);
+    } finally {
+      window.history.replaceState(null, '', '/');
+    }
+  });
   it('rejects ready when client initialization fails', async () => {
     const initError = new Error('create client failed');
     localStorage.removeItem('sb-test-auth-token');

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -19,6 +19,20 @@ type SupabaseUser = {
   providers: string[] | null; // All linked OAuth providers
 };
 type OAuthCallbackCode = { code: string; flowId?: string };
+const createSupabaseUserState = () =>
+  reactive<SupabaseUser>({
+    id: null,
+    loggedIn: false,
+    email: null,
+    displayName: null,
+    username: null,
+    avatarUrl: null,
+    photoURL: null,
+    lastLoginAt: null,
+    createdAt: null,
+    provider: null,
+    providers: null,
+  });
 const OAUTH_CALLBACK_PATH = '/auth/callback';
 const OAUTH_HASH_TOKEN_KEYS = ['access_token', 'refresh_token', 'error'] as const;
 const currentSearchParams = () => new URLSearchParams(window.location.search || '');
@@ -136,19 +150,7 @@ const buildStubClient = (): SupabaseClient => {
   } as unknown as SupabaseClient;
 };
 const buildStub = () => {
-  const stubUser = reactive<SupabaseUser>({
-    id: null,
-    loggedIn: false,
-    email: null,
-    displayName: null,
-    username: null,
-    avatarUrl: null,
-    photoURL: null,
-    lastLoginAt: null,
-    createdAt: null,
-    provider: null,
-    providers: null,
-  });
+  const stubUser = createSupabaseUserState();
   return {
     client: buildStubClient(),
     user: stubUser,
@@ -191,19 +193,7 @@ export default defineNuxtPlugin({
       const stub = buildStub();
       return { provide: { supabase: stub } };
     }
-    const user = reactive<SupabaseUser>({
-      id: null,
-      loggedIn: false,
-      email: null,
-      displayName: null,
-      username: null,
-      avatarUrl: null,
-      photoURL: null,
-      lastLoginAt: null,
-      createdAt: null,
-      provider: null,
-      providers: null,
-    });
+    const user = createSupabaseUserState();
     const stub = buildStub();
     let initPromise: Promise<void> | null = null;
     let supabaseClient: SupabaseClient | null = null;

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -245,7 +245,7 @@ export default defineNuxtPlugin({
     const initializeClientInBackground = () => {
       void ensureClientInitialized().catch(() => {});
     };
-    let oauthCodeConsumed = false;
+    let oauthExchangePromise: Promise<void> | null = null;
     const exchangeOAuthCode = async ({ code, flowId }: OAuthCallbackCode) => {
       if (!supabaseClient) {
         throw new Error('Supabase client unavailable');
@@ -267,11 +267,13 @@ export default defineNuxtPlugin({
       hydrateFromSession(sessionResult.data?.session ?? null);
     };
     const consumeOAuthCallbackCode = async () => {
-      if (!oauthCallbackCode || oauthCodeConsumed) {
+      if (!oauthCallbackCode) {
         return false;
       }
-      oauthCodeConsumed = true;
-      await exchangeOAuthCode(oauthCallbackCode);
+      if (!oauthExchangePromise) {
+        oauthExchangePromise = exchangeOAuthCode(oauthCallbackCode);
+      }
+      await oauthExchangePromise;
       return true;
     };
     const ready = async () => {

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -44,6 +44,12 @@ const readOAuthCallbackCode = (): OAuthCallbackCode | null => {
   const code = searchParams.get('code');
   return code ? { code, flowId: searchParams.get('sb_flow_id') || undefined } : null;
 };
+const clearOAuthCallbackCode = () => {
+  const url = new URL(window.location.href);
+  url.searchParams.delete('code');
+  url.searchParams.delete('sb_flow_id');
+  window.history.replaceState(window.history.state, '', url.toString());
+};
 const currentHashParams = (): URLSearchParams => {
   const rawHash = window.location.hash.replace(/^#/, '').replace(/^\?/, '');
   return new URLSearchParams(rawHash);
@@ -258,6 +264,7 @@ export default defineNuxtPlugin({
         throw result.error;
       }
       hydrateFromSession(result.data.session);
+      clearOAuthCallbackCode();
     };
     const refreshFromStoredSession = async () => {
       if (!supabaseClient) {

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -18,6 +18,155 @@ type SupabaseUser = {
   provider: string | null; // 'discord', 'twitch', etc.
   providers: string[] | null; // All linked OAuth providers
 };
+type OAuthCallbackCode = { code: string; flowId?: string };
+const OAUTH_CALLBACK_PATH = '/auth/callback';
+const OAUTH_HASH_TOKEN_KEYS = ['access_token', 'refresh_token', 'error'] as const;
+const currentSearchParams = () => new URLSearchParams(window.location.search || '');
+const readOAuthCallbackCode = (): OAuthCallbackCode | null => {
+  if (window.location.pathname !== OAUTH_CALLBACK_PATH) {
+    return null;
+  }
+  const searchParams = currentSearchParams();
+  const code = searchParams.get('code');
+  return code ? { code, flowId: searchParams.get('sb_flow_id') || undefined } : null;
+};
+const currentHashParams = (): URLSearchParams => {
+  const rawHash = window.location.hash.replace(/^#/, '').replace(/^\?/, '');
+  return new URLSearchParams(rawHash);
+};
+const hasHashCallbackTokens = (): boolean => {
+  const hashParams = currentHashParams();
+  return OAUTH_HASH_TOKEN_KEYS.some((key) => hashParams.has(key));
+};
+const hasOAuthCallbackParams = (): boolean => {
+  return (
+    Boolean(readOAuthCallbackCode()) ||
+    currentSearchParams().has('error') ||
+    hasHashCallbackTokens()
+  );
+};
+const buildStubBuilder = () => {
+  const result = Promise.resolve({ data: null, error: null });
+  const proxy = new Proxy(
+    {},
+    {
+      get(_target, prop) {
+        if (prop === 'then') {
+          return result.then.bind(result);
+        }
+        if (prop === 'catch') {
+          return result.catch.bind(result);
+        }
+        if (prop === 'finally') {
+          return result.finally.bind(result);
+        }
+        return () => proxy;
+      },
+    }
+  );
+  return proxy;
+};
+const buildStubChannel = () => {
+  return {
+    on() {
+      return this;
+    },
+    subscribe(_callback?: (status: string) => void) {
+      return this;
+    },
+    async unsubscribe() {
+      return 'ok';
+    },
+  };
+};
+const buildStubClient = (): SupabaseClient => {
+  return {
+    from(table: string) {
+      logger.debug(`[Supabase Stub] from('${table}') called in offline mode`);
+      return buildStubBuilder();
+    },
+    channel(channelName: string) {
+      logger.debug(`[Supabase Stub] channel('${channelName}') called in offline mode`);
+      return buildStubChannel();
+    },
+    async rpc(fnName: string) {
+      logger.debug(`[Supabase Stub] rpc('${fnName}') called in offline mode`);
+      return { data: null, error: null };
+    },
+    removeChannel() {
+      logger.debug('[Supabase Stub] removeChannel called in offline mode');
+    },
+    removeAllChannels() {
+      logger.debug('[Supabase Stub] removeAllChannels called in offline mode');
+    },
+    functions: {
+      async invoke(fnName: string) {
+        logger.debug(`[Supabase Stub] functions.invoke('${fnName}') called in offline mode`);
+        return { data: null, error: null };
+      },
+    },
+    auth: {
+      async getSession() {
+        logger.debug('[Supabase Stub] auth.getSession called in offline mode');
+        return { data: { session: null }, error: null };
+      },
+      async exchangeCodeForSession() {
+        logger.debug('[Supabase Stub] auth.exchangeCodeForSession called in offline mode');
+        return {
+          data: { session: null },
+          error: new Error('OAuth not available in offline mode'),
+        };
+      },
+      onAuthStateChange() {
+        logger.debug('[Supabase Stub] auth.onAuthStateChange called in offline mode');
+        return { data: { subscription: { unsubscribe() {} } } };
+      },
+      async signInWithOAuth() {
+        logger.debug('[Supabase Stub] auth.signInWithOAuth called in offline mode');
+        return {
+          data: { provider: '', url: null },
+          error: new Error('OAuth not available in offline mode'),
+        };
+      },
+      async signOut() {
+        logger.debug('[Supabase Stub] auth.signOut called in offline mode');
+        return { error: null };
+      },
+    },
+  } as unknown as SupabaseClient;
+};
+const buildStub = () => {
+  const stubUser = reactive<SupabaseUser>({
+    id: null,
+    loggedIn: false,
+    email: null,
+    displayName: null,
+    username: null,
+    avatarUrl: null,
+    photoURL: null,
+    lastLoginAt: null,
+    createdAt: null,
+    provider: null,
+    providers: null,
+  });
+  return {
+    client: buildStubClient(),
+    user: stubUser,
+    isOfflineMode: true,
+    signInWithOAuth: async (
+      _provider: OAuthProvider,
+      _options?: { skipBrowserRedirect?: boolean; redirectTo?: string }
+    ) => {
+      logger.error('[Supabase] Offline OAuth sign-in attempted', {
+        provider: _provider,
+        options: _options,
+      });
+      throw new Error('Supabase not configured - login unavailable in offline mode');
+    },
+    signOut: async () => {},
+    ready: async () => {},
+  };
+};
 export default defineNuxtPlugin({
   name: 'supabase',
   async setup() {
@@ -25,126 +174,6 @@ export default defineNuxtPlugin({
     const supabaseUrl = String(runtimeConfig.public.supabaseUrl || '').trim();
     const supabaseKey = String(runtimeConfig.public.supabaseAnonKey || '').trim();
     const missingConfigMessage = '[Supabase] Missing SUPABASE_URL or SUPABASE_ANON_KEY';
-    const buildStubBuilder = () => {
-      const result = Promise.resolve({ data: null, error: null });
-      const proxy = new Proxy(
-        {},
-        {
-          get(_target, prop) {
-            if (prop === 'then') {
-              return result.then.bind(result);
-            }
-            if (prop === 'catch') {
-              return result.catch.bind(result);
-            }
-            if (prop === 'finally') {
-              return result.finally.bind(result);
-            }
-            return () => proxy;
-          },
-        }
-      );
-      return proxy;
-    };
-    const buildStubChannel = () => {
-      return {
-        on() {
-          return this;
-        },
-        subscribe(_callback?: (status: string) => void) {
-          return this;
-        },
-        async unsubscribe() {
-          return 'ok';
-        },
-      };
-    };
-    const buildStub = () => {
-      const stubUser = reactive<SupabaseUser>({
-        id: null,
-        loggedIn: false,
-        email: null,
-        displayName: null,
-        username: null,
-        avatarUrl: null,
-        photoURL: null,
-        lastLoginAt: null,
-        createdAt: null,
-        provider: null,
-        providers: null,
-      });
-      const stubClient = {
-        from(table: string) {
-          logger.debug(`[Supabase Stub] from('${table}') called in offline mode`);
-          return buildStubBuilder();
-        },
-        channel(channelName: string) {
-          logger.debug(`[Supabase Stub] channel('${channelName}') called in offline mode`);
-          return buildStubChannel();
-        },
-        async rpc(fnName: string) {
-          logger.debug(`[Supabase Stub] rpc('${fnName}') called in offline mode`);
-          return { data: null, error: null };
-        },
-        removeChannel() {
-          logger.debug('[Supabase Stub] removeChannel called in offline mode');
-        },
-        removeAllChannels() {
-          logger.debug('[Supabase Stub] removeAllChannels called in offline mode');
-        },
-        functions: {
-          async invoke(fnName: string) {
-            logger.debug(`[Supabase Stub] functions.invoke('${fnName}') called in offline mode`);
-            return { data: null, error: null };
-          },
-        },
-        auth: {
-          async getSession() {
-            logger.debug('[Supabase Stub] auth.getSession called in offline mode');
-            return { data: { session: null }, error: null };
-          },
-          async exchangeCodeForSession() {
-            logger.debug('[Supabase Stub] auth.exchangeCodeForSession called in offline mode');
-            return {
-              data: { session: null },
-              error: new Error('OAuth not available in offline mode'),
-            };
-          },
-          onAuthStateChange() {
-            logger.debug('[Supabase Stub] auth.onAuthStateChange called in offline mode');
-            return { data: { subscription: { unsubscribe() {} } } };
-          },
-          async signInWithOAuth() {
-            logger.debug('[Supabase Stub] auth.signInWithOAuth called in offline mode');
-            return {
-              data: { provider: '', url: null },
-              error: new Error('OAuth not available in offline mode'),
-            };
-          },
-          async signOut() {
-            logger.debug('[Supabase Stub] auth.signOut called in offline mode');
-            return { error: null };
-          },
-        },
-      } as unknown as SupabaseClient;
-      return {
-        client: stubClient,
-        user: stubUser,
-        isOfflineMode: true,
-        signInWithOAuth: async (
-          _provider: OAuthProvider,
-          _options?: { skipBrowserRedirect?: boolean; redirectTo?: string }
-        ) => {
-          logger.error('[Supabase] Offline OAuth sign-in attempted', {
-            provider: _provider,
-            options: _options,
-          });
-          throw new Error('Supabase not configured - login unavailable in offline mode');
-        },
-        signOut: async () => {},
-        ready: async () => {},
-      };
-    };
     if (!supabaseUrl || !supabaseKey) {
       const allowOfflineFallback = shouldUseOfflineSupabaseFallback({
         hostname: import.meta.client ? window.location.hostname : undefined,
@@ -178,22 +207,7 @@ export default defineNuxtPlugin({
     const stub = buildStub();
     let initPromise: Promise<void> | null = null;
     let supabaseClient: SupabaseClient | null = null;
-    const hasOAuthCodeCallback = () => {
-      return new URLSearchParams(window.location.search || '').has('code');
-    };
-    const hasOAuthCallbackParams = () => {
-      const searchParams = new URLSearchParams(window.location.search || '');
-      if (searchParams.has('code') || searchParams.has('error')) {
-        return true;
-      }
-      const hash = window.location.hash.startsWith('#')
-        ? window.location.hash.slice(1)
-        : window.location.hash;
-      const hashParams = new URLSearchParams(hash.startsWith('?') ? hash.slice(1) : hash);
-      return (
-        hashParams.has('access_token') || hashParams.has('refresh_token') || hashParams.has('error')
-      );
-    };
+    const oauthCallbackCode = readOAuthCallbackCode();
     const hasStoredSession = () => {
       try {
         return hasSupabaseAuthSessionHint();
@@ -216,7 +230,7 @@ export default defineNuxtPlugin({
           const { createClient } = await import('@supabase/supabase-js');
           const client = createClient(supabaseUrl, supabaseKey, {
             auth: {
-              detectSessionInUrl: !hasOAuthCodeCallback(),
+              detectSessionInUrl: !oauthCallbackCode,
               flowType: 'pkce',
             },
           });
@@ -241,16 +255,8 @@ export default defineNuxtPlugin({
     const initializeClientInBackground = () => {
       void ensureClientInitialized().catch(() => {});
     };
-    const ready = async () => {
-      await ensureClientInitialized();
-      if (!supabaseClient) {
-        return;
-      }
-      const sessionResult = await supabaseClient.auth.getSession();
-      hydrateFromSession(sessionResult.data?.session ?? null);
-    };
-    const exchangeOAuthCode = async (code: string, flowId?: string) => {
-      await ensureClientInitialized();
+    let oauthCodeConsumed = false;
+    const exchangeOAuthCode = async ({ code, flowId }: OAuthCallbackCode) => {
       if (!supabaseClient) {
         throw new Error('Supabase client unavailable');
       }
@@ -262,6 +268,28 @@ export default defineNuxtPlugin({
         throw result.error;
       }
       hydrateFromSession(result.data.session);
+    };
+    const refreshFromStoredSession = async () => {
+      if (!supabaseClient) {
+        return;
+      }
+      const sessionResult = await supabaseClient.auth.getSession();
+      hydrateFromSession(sessionResult.data?.session ?? null);
+    };
+    const consumeOAuthCallbackCode = async () => {
+      if (!oauthCallbackCode || oauthCodeConsumed) {
+        return false;
+      }
+      oauthCodeConsumed = true;
+      await exchangeOAuthCode(oauthCallbackCode);
+      return true;
+    };
+    const ready = async () => {
+      await ensureClientInitialized();
+      if (await consumeOAuthCallbackCode()) {
+        return;
+      }
+      await refreshFromStoredSession();
     };
     const signInWithOAuth = async (
       provider: OAuthProvider,
@@ -298,16 +326,10 @@ export default defineNuxtPlugin({
       signOut,
       ready,
     });
-    if (hasOAuthCallbackParams() || hasStoredSession()) {
-      if (hasOAuthCodeCallback()) {
-        const searchParams = new URLSearchParams(window.location.search || '');
-        await exchangeOAuthCode(
-          searchParams.get('code') || '',
-          searchParams.get('sb_flow_id') || undefined
-        );
-      } else {
-        await ready();
-      }
+    if (oauthCallbackCode) {
+      initializeClientInBackground();
+    } else if (hasOAuthCallbackParams() || hasStoredSession()) {
+      await ready();
     } else {
       initializeClientInBackground();
     }

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -103,6 +103,13 @@ export default defineNuxtPlugin({
             logger.debug('[Supabase Stub] auth.getSession called in offline mode');
             return { data: { session: null }, error: null };
           },
+          async exchangeCodeForSession() {
+            logger.debug('[Supabase Stub] auth.exchangeCodeForSession called in offline mode');
+            return {
+              data: { session: null },
+              error: new Error('OAuth not available in offline mode'),
+            };
+          },
           onAuthStateChange() {
             logger.debug('[Supabase Stub] auth.onAuthStateChange called in offline mode');
             return { data: { subscription: { unsubscribe() {} } } };
@@ -171,6 +178,9 @@ export default defineNuxtPlugin({
     const stub = buildStub();
     let initPromise: Promise<void> | null = null;
     let supabaseClient: SupabaseClient | null = null;
+    const hasOAuthCodeCallback = () => {
+      return new URLSearchParams(window.location.search || '').has('code');
+    };
     const hasOAuthCallbackParams = () => {
       const searchParams = new URLSearchParams(window.location.search || '');
       if (searchParams.has('code') || searchParams.has('error')) {
@@ -206,7 +216,7 @@ export default defineNuxtPlugin({
           const { createClient } = await import('@supabase/supabase-js');
           const client = createClient(supabaseUrl, supabaseKey, {
             auth: {
-              detectSessionInUrl: true,
+              detectSessionInUrl: !hasOAuthCodeCallback(),
               flowType: 'pkce',
             },
           });
@@ -238,6 +248,20 @@ export default defineNuxtPlugin({
       }
       const sessionResult = await supabaseClient.auth.getSession();
       hydrateFromSession(sessionResult.data?.session ?? null);
+    };
+    const exchangeOAuthCode = async (code: string, flowId?: string) => {
+      await ensureClientInitialized();
+      if (!supabaseClient) {
+        throw new Error('Supabase client unavailable');
+      }
+      const result = await supabaseClient.auth.exchangeCodeForSession(
+        code,
+        flowId ? { flowId } : undefined
+      );
+      if (result.error) {
+        throw result.error;
+      }
+      hydrateFromSession(result.data.session);
     };
     const signInWithOAuth = async (
       provider: OAuthProvider,
@@ -275,7 +299,15 @@ export default defineNuxtPlugin({
       ready,
     });
     if (hasOAuthCallbackParams() || hasStoredSession()) {
-      await ready();
+      if (hasOAuthCodeCallback()) {
+        const searchParams = new URLSearchParams(window.location.search || '');
+        await exchangeOAuthCode(
+          searchParams.get('code') || '',
+          searchParams.get('sb_flow_id') || undefined
+        );
+      } else {
+        await ready();
+      }
     } else {
       initializeClientInBackground();
     }

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -203,7 +203,8 @@ export default defineNuxtPlugin({
     const stub = buildStub();
     let initPromise: Promise<void> | null = null;
     let supabaseClient: SupabaseClient | null = null;
-    const oauthCallbackCode = readOAuthCallbackCode();
+    let oauthCallbackCode = readOAuthCallbackCode();
+    const hasCodeQueryParam = currentSearchParams().has('code');
     const hasStoredSession = () => {
       try {
         return hasSupabaseAuthSessionHint();
@@ -226,7 +227,7 @@ export default defineNuxtPlugin({
           const { createClient } = await import('@supabase/supabase-js');
           const client = createClient(supabaseUrl, supabaseKey, {
             auth: {
-              detectSessionInUrl: !oauthCallbackCode,
+              detectSessionInUrl: !hasCodeQueryParam,
               flowType: 'pkce',
             },
           });
@@ -277,7 +278,9 @@ export default defineNuxtPlugin({
       if (!oauthCallbackCode) {
         return false;
       }
-      oauthExchangePromise ??= exchangeOAuthCode(oauthCallbackCode);
+      oauthExchangePromise ??= exchangeOAuthCode(oauthCallbackCode).finally(() => {
+        oauthCallbackCode = null;
+      });
       await oauthExchangePromise;
       return true;
     };

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -270,9 +270,7 @@ export default defineNuxtPlugin({
       if (!oauthCallbackCode) {
         return false;
       }
-      if (!oauthExchangePromise) {
-        oauthExchangePromise = exchangeOAuthCode(oauthCallbackCode);
-      }
+      oauthExchangePromise ??= exchangeOAuthCode(oauthCallbackCode);
       await oauthExchangePromise;
       return true;
     };


### PR DESCRIPTION
## Summary

- explicitly exchange OAuth PKCE callback codes through the Supabase readiness API
- preserve callback failures for the callback page and popup opener to surface
- prevent non-auth route query codes from being consumed as OAuth codes
- remove exchanged `code` and `sb_flow_id` parameters from the callback URL

## Changes

- scope PKCE callback-code detection to `/auth/callback`
- defer and memoize code exchange so concurrent readiness callers share one result or failure
- preserve implicit/hash callback handling and existing session restoration
- add regression coverage for success, failure, concurrency, team invites, offline mode, and URL cleanup
- document the OAuth callback invariants in `AGENTS.md`

## Related Issues

None.

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. Run `pnpm exec vitest run app/plugins/__tests__/supabase.client.test.ts` and verify all 15 focused tests pass.
2. Run `pnpm run typecheck`, `pnpm run lint`, `pnpm run test`, `pnpm run i18n:check`, and `pnpm run validate:openapi`.
3. Verify a callback code exchanges once, errors reach `ready()`, team invite codes are ignored, and successful exchange removes only OAuth callback parameters.

## Screenshots/Videos

Not applicable; this change affects auth lifecycle behavior without changing rendered UI.

## Documentation impact

Select one:

- [ ] No behavior changed — no documentation review needed
- [ ] Behavior changed — existing documentation remains accurate
- [x] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [x] Contributor documentation
- [ ] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [ ] Screenshots or diagrams

## Checklist

- [x] My code follows the project coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

Current Supabase documentation and the installed `@supabase/auth-js` implementation confirm the `exchangeCodeForSession(code, flowId ? { flowId } : undefined)` contract. Manual successful exchange now mirrors Supabase automatic callback handling by removing `code` and `sb_flow_id` while preserving unrelated query parameters.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved OAuth PKCE callback handling, including flow tracking and hash-token callbacks.
  * Added offline-mode behavior for unsupported OAuth session exchanges.
  * Preserved redirect parameters while cleaning up consumed authentication parameters.

* **Bug Fixes**
  * Prevented callback codes on unrelated routes from being exchanged automatically.
  * Ensured callback exchanges occur only once and can recover from transient failures.
  * Improved session hydration and readiness handling during authentication callbacks.
  * Ensured OAuth sign-in and sign-out errors are surfaced correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->