### PR TITLE
fix(ui): resolve remaining shell contrast failures

### DIFF
--- a/app/features/drawer/DrawerLevel.vue
+++ b/app/features/drawer/DrawerLevel.vue
@@ -46,7 +46,7 @@
               <span class="text-surface-500 text-[0.5rem]">·</span>
               <span
                 class="text-[0.55rem]"
-                :class="useAutomaticLevel ? 'text-accent-400' : 'text-surface-500'"
+                :class="useAutomaticLevel ? 'text-accent-400' : 'text-surface-400'"
               >
                 {{ useAutomaticLevel ? t('navigation_drawer.mode_auto') : t('common.manual') }}
               </span>

--- a/app/shell/AppBar.vue
+++ b/app/shell/AppBar.vue
@@ -171,7 +171,7 @@
           <AppTooltip v-if="!isLoggedIn" :text="t('app_bar.login_aria', 'Log in to your account')">
             <NuxtLink
               to="/login"
-              class="bg-primary-600 hover:bg-primary-500 border-primary-500 flex h-9 items-center gap-1.5 rounded-md border px-3.5 text-[13px] leading-none font-semibold text-white transition-colors"
+              class="bg-primary-500 hover:bg-primary-400 border-primary-500 text-surface-950 flex h-9 items-center gap-1.5 rounded-md border px-3.5 text-[13px] leading-none font-semibold transition-colors"
               :aria-label="t('app_bar.login_aria', 'Log in to your account')"
             >
               <UIcon name="i-mdi-account-outline" class="h-4 w-4 shrink-0" />

--- a/app/shell/__tests__/AppBar.test.ts
+++ b/app/shell/__tests__/AppBar.test.ts
@@ -501,12 +501,14 @@ describe('AppBar responsive layout', () => {
     expect(classAttr).toContain('w-9');
     wrapper.unmount();
   });
-  it('renders the Log In button with a filled primary background', async () => {
+  it('renders the Log In button with an accessible primary treatment', async () => {
     const wrapper = await mountAppBar();
     const loginLink = wrapper.find('a[aria-label="app_bar.login_aria"]');
     expect(loginLink.exists()).toBe(true);
     const classAttr = loginLink.attributes('class') || '';
-    expect(classAttr).toContain('bg-primary-600');
+    expect(classAttr).toContain('bg-primary-500');
+    expect(classAttr).toContain('hover:bg-primary-400');
+    expect(classAttr).toContain('text-surface-950');
     expect(classAttr).toContain('h-9');
     wrapper.unmount();
   });


### PR DESCRIPTION
## Summary

Fix the two remaining shell contrast failures tracked in #680 while keeping the adjacent automatic-level metadata outside this PR.

## Changes

- Raise the drawer `Manual` metadata foreground from `surface-500` to `surface-400`.
- Use the established accessible primary CTA treatment for the AppBar `Log In` control.
- Update the existing AppBar assertion for the default, hover, and foreground tokens.

## Related Issues

Fixes #680

## Testing

- [x] Tested locally
- [x] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. Ran ESLint on all changed files, blank-line lint, commitlint, the Fallow new-only gate, and Prettier against the committed blobs.
2. Ran `app/shell/__tests__/AppBar.test.ts`: 32/32 tests passed after rebasing onto current `main`.
3. Built and served the Cloudflare Pages production output locally, then checked the drawer label and AppBar login control at desktop and mobile widths.
4. Ran hydrated Lighthouse snapshots: desktop and mobile both scored 0.99 for accessibility and 1.00 for color contrast, with zero contrast failures.

## Screenshots/Videos

<img width="1440" height="1682" alt="issue-680-credits-desktop" src="https://github.com/user-attachments/assets/37693ecb-f29d-487d-8463-d2d9ec451bb5" />

## Documentation impact

Select one:

- [ ] No behavior changed — no documentation review needed
- [x] Behavior changed — existing documentation remains accurate
- [ ] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [ ] Contributor documentation
- [ ] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [x] Screenshots or diagrams

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

- The adjacent automatic-level metadata finding remains out of scope, as requested by the maintainer.
- The full Windows run passed 2,530 tests; 23 unchanged tests fail locally because they exercise POSIX executable bits or assume LF-only checkout line endings. Those tests pass on Ubuntu CI. The PR's test shards are the final gate before checking "All existing tests still pass."
- Local Nuxt typecheck is affected by nested-worktree dependency resolution into the parent checkout; the changed files are absent from its diagnostics. Clean PR CI remains the final typecheck gate.
- Fork workflows skip the repository's production-build and Lighthouse jobs, so the local production build and hydrated Lighthouse results are included above.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved the visual contrast of the non-automatic level mode label.
  * Updated the login button’s background, hover, and text colors for a refreshed appearance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->