### PR TITLE
fix(ci): deploy the version-bump commit so the footer shows the real version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,17 @@ jobs:
     name: Release
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    # GitHub natively skips push-triggered workflows for all five of these markers, so this guard is
+    # belt-and-braces. It is kept explicit because skip markers do not apply to every event type,
+    # and because semantic-release tags its own version-bump commit with '[skip actions]' to avoid
+    # re-triggering this workflow. See docs/WORKFLOW_AUTOMATION.md for why that marker, not
+    # '[skip ci]'.
     if: >-
       !contains(github.event.head_commit.message, '[skip ci]') &&
       !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[no ci]')
+      !contains(github.event.head_commit.message, '[no ci]') &&
+      !contains(github.event.head_commit.message, '[skip actions]') &&
+      !contains(github.event.head_commit.message, '[actions skip]')
     permissions:
       contents: write
       issues: write

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -47,7 +47,7 @@
       "@semantic-release/git",
       {
         "assets": ["CHANGELOG.md", "package.json"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version} [skip actions]\n\n${nextRelease.notes}"
       }
     ],
     "@semantic-release/github"

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -56,6 +56,30 @@ Semantic versioning with automated releases:
 
 **Triggers:** Push to `main` (non-docs changes)
 
+**Version-bump commit:** `@semantic-release/git` commits the bumped `package.json` and `CHANGELOG.md`
+as `chore(release): <version> [skip actions]`. The marker is deliberately `[skip actions]` rather
+than `[skip ci]`:
+
+- GitHub Actions treats `[skip actions]` as a skip marker, so this workflow does not re-trigger
+  itself. ([Skipping workflow runs](https://docs.github.com/en/actions/managing-workflow-runs/skipping-workflow-runs))
+- Cloudflare Pages does **not** recognize `[skip actions]`. Its skip markers are `[CI Skip]`,
+  `[CI-Skip]`, `[Skip CI]`, `[Skip-CI]`, and `[CF-Pages-Skip]`.
+  ([GitHub integration](https://developers.cloudflare.com/pages/configuration/git-integration/github-integration/))
+
+That asymmetry is the point. The footer version comes from `packageJson.version` in
+`nuxt.config.ts`, which is baked into the bundle at build time and surfaced through
+`runtimeConfig.public.appVersion`. The merge commit is built _before_ semantic-release bumps
+`package.json`, so if Cloudflare also skipped the bump commit the deployed site would advertise the
+previous version until the next unrelated push to `main`. Letting Pages build the bump commit costs
+one extra deploy per release and keeps the displayed version honest.
+
+> [!WARNING]
+> Both providers match these markers **anywhere** in the commit message, not just as a prefix. Never
+> write a bracketed skip marker verbatim in a commit message or PR title — including when merely
+> describing one — or you will silently skip CI, Release, and the deploy for that commit. Refer to
+> them unbracketed (`skip ci`, `skip actions`) in commit messages instead. Prose inside repository
+> files is safe; only commit messages and PR titles are scanned.
+
 **Commit Convention:**
 
 - `feat:` → minor version bump
@@ -282,6 +306,11 @@ Push to `main` triggers:
 
 GitHub Actions itself deploys nothing; items 2-4 are separate Git integrations. See the Deployment
 section of [`runbook.md`](./runbook.md) for what to verify after each merge.
+
+A releasing merge deploys twice: once for the merge commit, then again for the
+`chore(release): <version> [skip actions]` commit that carries the bumped `package.json`. The second
+deploy is what makes the footer version match the release, so treat it as part of the merge rather
+than a stray build.
 
 ### Manual Deployment
 

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -74,11 +74,17 @@ previous version until the next unrelated push to `main`. Letting Pages build th
 one extra deploy per release and keeps the displayed version honest.
 
 > [!WARNING]
-> Both providers match these markers **anywhere** in the commit message, not just as a prefix. Never
-> write a bracketed skip marker verbatim in a commit message or PR title — including when merely
+> Never write a bracketed skip marker verbatim in a commit message — including when merely
 > describing one — or you will silently skip CI, Release, and the deploy for that commit. Refer to
-> them unbracketed (`skip ci`, `skip actions`) in commit messages instead. Prose inside repository
-> files is safe; only commit messages and PR titles are scanned.
+> them unbracketed (`skip ci`, `skip actions`) instead.
+>
+> GitHub scans the commit message of a push and the HEAD commit of a pull request. It does **not**
+> scan PR titles. Cloudflare's docs describe its markers as a commit-message _prefix_, but observed
+> behaviour in this repository is broader — both `chore(release): 1.75.0 [skip ci]` (marker trailing
+> the subject) and a commit carrying `[skip ci]` only in its body produced no Pages deploy at all.
+> Assume any position matches.
+>
+> Prose inside repository files, such as this paragraph, is not scanned by either provider.
 
 **Commit Convention:**
 


### PR DESCRIPTION
## Summary

The version in the site footer is one release behind. Right now tarkovtracker.org runs v1.75.0 code
but displays **v1.74.1**.

The version is baked at build time — `nuxt.config.ts` reads `packageJson.version` and exposes it as
`runtimeConfig.public.appVersion`, which `AppFooter.vue` renders. Cloudflare Pages builds the *merge*
commit, where `package.json` still holds the previous version. `@semantic-release/git` bumps it
afterwards in a commit tagged `[skip ci]` — and Cloudflare honours `[Skip CI]` too, so that commit
never gets built. The displayed version only catches up when some later, unrelated push to `main`
happens to trigger a rebuild.

Fix: tag the version-bump commit with `[skip actions]` instead. GitHub Actions honours it; Cloudflare
Pages does not.

## Changes

- `.releaserc.json` — `@semantic-release/git` commit message marker `[skip ci]` → `[skip actions]`.
- `.github/workflows/release.yml` — add `[skip actions]` / `[actions skip]` to the Release job's
  `if:` guard. Redundant while the trigger is `push` (GitHub skips natively), but skip markers do not
  apply to every event type, so the intent is stated explicitly rather than assumed.
- `docs/WORKFLOW_AUTOMATION.md` — document the marker asymmetry, why it exists, that a releasing
  merge now deploys twice, and a warning that these markers match **anywhere** in a commit message.

## Related Issues

Follow-up from #748, where this was observed. No existing issue.

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [ ] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. **Reproduced on the live site.** Deployed build ID timestamped 05:09:37Z, i.e. 67s after merge
   commit `c4704b18` (`package.json` = 1.74.1). Bump commit `189f4b31` landed 05:18:04Z and produced
   **no Cloudflare check run at all** — the documented signature of a skipped build
   ([Monorepos](https://developers.cloudflare.com/pages/configuration/monorepos/): "If a build skips
   for any reason … the check run/commit status will not appear"). Live footer read v1.74.1 while
   `gh release list` showed v1.75.0 as latest.
2. **Verified the marker asymmetry against upstream docs.** GitHub's skip list is `[skip ci]`,
   `[ci skip]`, `[no ci]`, `[skip actions]`, `[actions skip]`. Cloudflare Pages' list is `[CI Skip]`,
   `[CI-Skip]`, `[Skip CI]`, `[Skip-CI]`, `[CF-Pages-Skip]`. `[skip actions]` is on the first and not
   the second. Both pages cited inline in the doc change.
3. **Validated the config files.** `.releaserc.json` parses and the `@semantic-release/git` plugin
   entry carries the new message; `release.yml` parses as YAML with the extended `if:` guard intact.
4. `pnpm run systems:check`, `pnpm run lint:blank-lines`, and `prettier --check` on all three files
   pass. Both new external doc links return 200.

No loop risk: the bump commit only triggers a Cloudflare build. GitHub Actions is still skipped, so
semantic-release does not re-run and cannot create a second release.

## Documentation impact

Select one:

- [ ] No behavior changed — no documentation review needed
- [ ] Behavior changed — existing documentation remains accurate
- [x] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [x] Contributor documentation
- [ ] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [ ] Screenshots or diagrams

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

**This PR demonstrated the footgun it documents.** The first push of this branch had a commit message
that spelled out the bracketed markers verbatim while explaining them. GitHub matched them and
skipped every workflow — only `Dependabot Auto Merge` ran, because `pull_request_target` is immune to
skip markers. The commit message was reworded to reference them unbracketed and force-pushed; the
full 24-check suite then ran and passed. Hence the new warning in the docs.

> [!IMPORTANT]
> When merging this PR, do not paste a bracketed skip marker into the squash commit message. Doing so
> would skip CI, Release, and the deploy on `main`.

**Verification after merge:** this PR is a `fix:`, so it will cut a patch release and exercise the
new path immediately. Expect two Cloudflare deploys — one for the merge commit, one for
`chore(release): 1.75.1 [skip actions]` — after which the footer should read v1.75.1.

**Considered and rejected:** a Cloudflare Deploy Hook called from `release.yml` after
semantic-release succeeds. It works, but needs a new repository secret and adds a moving part, where
this achieves the same result with a one-word config change.

**Trade-off:** one extra Pages build per release. The Supabase Git integration will also see the bump
commit now; it touches only `package.json` and `CHANGELOG.md`, so there are no migrations or Edge
Functions to apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated release handling so version updates no longer trigger unnecessary workflow runs.
  * Ensured deployed site version information remains up to date after automatic releases.

* **Documentation**
  * Clarified the automated release and deployment process, including the additional deployment used to refresh displayed version details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
