### PR TITLE
fix(ci): preserve Nuxt context in Fallow audits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
           fi
           echo "base=$BASE" >> "$GITHUB_OUTPUT"
       - name: Audit changed files
-        run: pnpm exec fallow audit --base "${{ steps.fallow-base.outputs.base }}" --gate new-only --quiet
+        run: pnpm run lint:fallow --base "${{ steps.fallow-base.outputs.base }}"
   lint-format:
     name: Lint & Format
     runs-on: ubuntu-latest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,10 @@ Test: `pnpm run test` | API gateway: `pnpm run test:api-gateway` | Supabase: `pn
 
 Lint: `pnpm run lint` | Blank lines: `pnpm run lint:blank-lines` | Typecheck: `pnpm run typecheck`
 
+Fallow: `pnpm run lint:fallow` (optional `--base <ref>` and `--format json`). Use this command
+locally and in CI so generated Nuxt context is materialized consistently in both audit snapshots.
+It preserves Fallow's native new-only gate; see `docs/WORKFLOW_AUTOMATION.md`.
+
 i18n: `pnpm run i18n:check` | OpenAPI: `pnpm run validate:openapi` | Dependencies: `pnpm run deps`
 
 Use the single-file Vitest command from `package.json` for focused tests. Do not run the full suite

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -40,6 +40,8 @@ and have an agent verify the answer against the code.
 12. [Map objective visibility and required items](#12-map-objective-visibility-and-required-items) —
     map marker categories and split pinned/active requirements
 
+13. [Fallow audit snapshots](#13-fallow-audit-snapshots) — consistent generated context and local source attribution
+
 ---
 
 ## 1. Tarkov.dev data integration
@@ -1193,3 +1195,25 @@ If you read something here that does not match the code, the disagreement is a b
 code (fix the code) or in this doc (fix the doc in the same PR). `AGENTS.md`'s Maintenance Contract
 requires updating this file whenever one of these systems changes. When in doubt, the code is the
 source of truth and this doc is the explanation of it.
+
+## 13. Fallow audit snapshots
+
+**Summary.** Local and CI `lint:fallow` commands use `scripts/fallow-audit.mjs` to create a
+disposable clone with two analysis commits. The merge-base source and current working source
+both receive physical copies of the same generated `.nuxt` context, so relative aliases resolve
+consistently in Fallow's base snapshot. Installed dependencies are linked into the clone.
+
+Candidate source files come from the original checkout's Git index and non-ignored untracked
+file list. This retains staged and unstaged source content, honors repository-local and configured
+exclusions, and includes force-tracked ignored files. A separate temporary index constructs the
+analysis head. Native new-only attribution and configured severities determine the exit status.
+See [the workflow guide](WORKFLOW_AUTOMATION.md#fallow-changed-file-gate) for usage and report IDs.
+
+**Invariants**
+
+- Source files, the source index, branches, and worktree registrations remain unchanged.
+- Both analysis commits contain the same physical generated context; no persistent finding
+  baseline or suppression changes the gate.
+- Invalid refs, missing setup, and analyzer errors fail explicitly; temporary snapshots are
+  removed on success and handled failure.
+- Local Git exclusions apply to untracked candidates without dropping tracked source files.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1189,13 +1189,6 @@ items and keys from pinned tasks and active tasks so pinned requirements remain 
   `required_items` / `required_keys` labels; an untitled standalone group keeps the `h3` level and
   the longer `*_summary` labels.
 
-## When this doc is wrong
-
-If you read something here that does not match the code, the disagreement is a bug — either in the
-code (fix the code) or in this doc (fix the doc in the same PR). `AGENTS.md`'s Maintenance Contract
-requires updating this file whenever one of these systems changes. When in doubt, the code is the
-source of truth and this doc is the explanation of it.
-
 ## 13. Fallow audit snapshots
 
 **Summary.** Local and CI `lint:fallow` commands use `scripts/fallow-audit.mjs` to create a
@@ -1217,3 +1210,10 @@ See [the workflow guide](WORKFLOW_AUTOMATION.md#fallow-changed-file-gate) for us
 - Invalid refs, missing setup, and analyzer errors fail explicitly; temporary snapshots are
   removed in a `finally` block on success or failure.
 - Local Git exclusions apply to untracked candidates without dropping tracked source files.
+
+## When this doc is wrong
+
+If you read something here that does not match the code, the disagreement is a bug — either in the
+code (fix the code) or in this doc (fix the doc in the same PR). `AGENTS.md`'s Maintenance Contract
+requires updating this file whenever one of these systems changes. When in doubt, the code is the
+source of truth and this doc is the explanation of it.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1215,5 +1215,5 @@ See [the workflow guide](WORKFLOW_AUTOMATION.md#fallow-changed-file-gate) for us
 - Both analysis commits contain the same physical generated context; no persistent finding
   baseline or suppression changes the gate.
 - Invalid refs, missing setup, and analyzer errors fail explicitly; temporary snapshots are
-  removed on success and handled failure.
+  removed in a `finally` block on success or failure.
 - Local Git exclusions apply to untracked candidates without dropping tracked source files.

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -30,6 +30,29 @@ Runs on every push and PR:
 
 **Triggers:** Push to `main`, `develop`, `wip/**` branches and all PRs
 
+#### Fallow changed-file gate
+
+Run `pnpm run lint:fallow` locally; CI uses the same command with `--base <event-base-sha>`.
+The default base is `origin/main`. The command resolves the merge base with the current HEAD,
+includes staged, unstaged, and non-ignored untracked files, and keeps Fallow's native
+`--gate new-only` behavior and configured severities. New error findings fail; inherited findings
+and warning-only findings do not. No persistent finding baseline is maintained.
+
+`scripts/fallow-audit.mjs` creates a temporary local clone and two analysis commits. Both contain
+a physical copy of the current generated `.nuxt` context; the second contains the current source
+tree. This prevents Fallow's internal base snapshot from symlinking the generated tsconfig and
+resolving its relative `@/` aliases against the wrong directory. Dependencies are linked from the
+installed checkout. Neither the source index, source files, branches, nor Git worktree registrations
+are modified, and the temporary clone is removed after success or failure. Run `pnpm install`
+first, as usual, to prepare dependencies and Nuxt types.
+
+Use `--format json` for structured findings. Each run uses fresh analysis without reusable caches.
+The report's Git IDs belong to the temporary analysis commits; the original source base and HEAD
+are printed on stderr. Invalid refs and setup/analyzer failures exit nonzero instead of skipping the gate.
+
+Regression checks live in `scripts/fallow-audit.test.mjs` and run with the regular test suite or
+`pnpm exec vitest run scripts/fallow-audit.test.mjs`.
+
 ### 2. Security Scanning (`.github/workflows/security.yml`)
 
 Weekly security audits:

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -34,7 +34,8 @@ Runs on every push and PR:
 
 Run `pnpm run lint:fallow` locally; CI uses the same command with `--base <event-base-sha>`.
 The default base is `origin/main`. The command resolves the merge base with the current HEAD,
-includes staged, unstaged, and non-ignored untracked files, and keeps Fallow's native
+includes staged, unstaged, and non-ignored untracked files (respecting the source checkout's
+local and configured Git exclusions, while retaining force-tracked files), and keeps Fallow's native
 `--gate new-only` behavior and configured severities. New error findings fail; inherited findings
 and warning-only findings do not. No persistent finding baseline is maintained.
 

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "design:lint": "design.md lint DESIGN.md",
     "deps": "taze --r --I",
     "dev": "nuxt dev",
-    "lint:fallow": "fallow audit --base origin/main --gate new-only --quiet",
+    "lint:fallow": "node scripts/fallow-audit.mjs",
     "format": "pnpm run format:prettier && NODE_ENV=development nuxt prepare && eslint app --fix && pnpm run format:blank-lines",
     "format:blank-lines": "node scripts/lint-blank-lines.mjs --fix",
     "format:check": "pnpm run format:check:prettier && pnpm run lint:blank-lines",

--- a/scripts/fallow-audit.mjs
+++ b/scripts/fallow-audit.mjs
@@ -2,6 +2,7 @@ import { execFileSync, spawnSync } from 'node:child_process';
 import {
   cpSync,
   existsSync,
+  lstatSync,
   mkdirSync,
   mkdtempSync,
   realpathSync,
@@ -12,11 +13,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { parseArgs } from 'node:util';
-const fallow = fileURLToPath(import.meta.resolve('fallow/bin/fallow'));
 const gitEnvironment = Object.fromEntries(
   Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_'))
 );
-const git = (args, environment = gitEnvironment, input) =>
+const git = (args, environment = gitEnvironment, input = undefined) =>
   execFileSync(
     'git',
     [
@@ -44,13 +44,29 @@ const materializeContext = (source, destination) => {
 const createHead = (source, destination, base, directory) => {
   const environment = { ...gitEnvironment, GIT_INDEX_FILE: join(directory, 'head.index') };
   const location = ['--git-dir', join(destination, '.git'), '--work-tree', source];
-  const tracked = execFileSync('git', ['-C', source, 'ls-files', '--cached', '-z'], {
-    env: gitEnvironment,
-    maxBuffer: 16 * 1024 * 1024,
-  });
+  const candidates = execFileSync(
+    'git',
+    ['-C', source, 'ls-files', '--cached', '--others', '--exclude-standard', '-z'],
+    {
+      env: gitEnvironment,
+      maxBuffer: 16 * 1024 * 1024,
+    }
+  );
+  // A tracked file may now be a directory. Only its current children belong in
+  // the empty snapshot index; replaying the old filename would fail Git staging.
+  const paths = candidates
+    .toString('utf8')
+    .split('\0')
+    .filter(Boolean)
+    .filter((path) => {
+      return !lstatSync(join(source, path), { throwIfNoEntry: false })?.isDirectory();
+    });
   git([...location, 'read-tree', '--empty'], environment);
-  git([...location, 'add', '--all'], environment);
-  git([...location, 'update-index', '--add', '--remove', '-z', '--stdin'], environment, tracked);
+  git(
+    [...location, 'update-index', '--add', '--remove', '-z', '--stdin'],
+    environment,
+    paths.map((path) => `${path}\0`).join('')
+  );
   git(['-C', destination, 'add', '--force', '--', '.nuxt'], environment);
   const tree = git([...location, 'write-tree'], environment);
   return git(
@@ -59,6 +75,7 @@ const createHead = (source, destination, base, directory) => {
   );
 };
 const runFallow = (destination, base, format) => {
+  const fallow = fileURLToPath(import.meta.resolve('fallow/bin/fallow'));
   const result = spawnSync(
     process.execPath,
     [
@@ -79,7 +96,7 @@ const runFallow = (destination, base, format) => {
   );
   if (result.error) throw result.error;
   if (!Number.isInteger(result.status)) {
-    throw new Error('Fallow did not complete');
+    throw new TypeError('Fallow did not complete');
   }
   return result.status;
 };
@@ -106,6 +123,8 @@ const validateContext = (source) => {
 const audit = () => {
   const values = readOptions();
   const source = git(['rev-parse', '--show-toplevel']);
+  // Keep the option terminator: caller-supplied commit-ish expressions are data,
+  // and only Git-verified commit IDs reach subsequent commands.
   const requestedBase = git([
     'rev-parse',
     '--verify',

--- a/scripts/fallow-audit.mjs
+++ b/scripts/fallow-audit.mjs
@@ -1,0 +1,166 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  symlinkSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { parseArgs } from 'node:util';
+const fallow = fileURLToPath(import.meta.resolve('fallow/bin/fallow'));
+const gitEnvironment = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_'))
+);
+const git = (args, environment = gitEnvironment, input) =>
+  execFileSync(
+    'git',
+    [
+      '-c',
+      'user.name=Fallow audit',
+      '-c',
+      'user.email=fallow-audit@example.invalid',
+      '-c',
+      'commit.gpgsign=false',
+      ...args,
+    ],
+    {
+      encoding: 'utf8',
+      env: environment,
+      input,
+      maxBuffer: 16 * 1024 * 1024,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }
+  ).trim();
+const materializeContext = (source, destination) => {
+  const generated = join(source, '.nuxt');
+  cpSync(realpathSync(generated), join(destination, '.nuxt'), { recursive: true });
+  git(['-C', destination, 'add', '--force', '--', '.nuxt']);
+};
+const createHead = (source, destination, base, directory) => {
+  const environment = { ...gitEnvironment, GIT_INDEX_FILE: join(directory, 'head.index') };
+  const location = ['--git-dir', join(destination, '.git'), '--work-tree', source];
+  const tracked = execFileSync('git', ['-C', source, 'ls-files', '--cached', '-z'], {
+    env: gitEnvironment,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  git([...location, 'read-tree', '--empty'], environment);
+  git([...location, 'add', '--all'], environment);
+  git([...location, 'update-index', '--add', '--remove', '-z', '--stdin'], environment, tracked);
+  git(['-C', destination, 'add', '--force', '--', '.nuxt'], environment);
+  const tree = git([...location, 'write-tree'], environment);
+  return git(
+    [...location, 'commit-tree', tree, '-p', base, '-m', 'Materialize audit head'],
+    environment
+  );
+};
+const runFallow = (destination, base, format) => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      fallow,
+      'audit',
+      '--root',
+      destination,
+      '--base',
+      base,
+      '--gate',
+      'new-only',
+      '--format',
+      format,
+      '--quiet',
+      '--no-cache',
+    ],
+    { cwd: destination, env: gitEnvironment, stdio: 'inherit' }
+  );
+  if (result.error) throw result.error;
+  if (!Number.isInteger(result.status)) {
+    throw new Error('Fallow did not complete');
+  }
+  return result.status;
+};
+const readOptions = () => {
+  const { values } = parseArgs({
+    options: {
+      base: { type: 'string', default: 'origin/main' },
+      format: { type: 'string', default: 'human' },
+    },
+  });
+  if (!['human', 'json'].includes(values.format)) {
+    throw new Error('--format must be human or json');
+  }
+  return values;
+};
+const validateContext = (source) => {
+  if (!existsSync(join(source, '.nuxt/tsconfig.json'))) {
+    throw new Error('Missing generated Nuxt tsconfig; run pnpm install or pnpm exec nuxt prepare');
+  }
+  if (!existsSync(join(source, 'node_modules'))) {
+    throw new Error('Missing node_modules; run pnpm install');
+  }
+};
+const audit = () => {
+  const values = readOptions();
+  const source = git(['rev-parse', '--show-toplevel']);
+  const requestedBase = git([
+    'rev-parse',
+    '--verify',
+    '--end-of-options',
+    `${values.base}^{commit}`,
+  ]);
+  const base = git(['merge-base', 'HEAD', requestedBase]);
+  const sourceHead = git(['rev-parse', 'HEAD']);
+  validateContext(source);
+  const directory = mkdtempSync(join(tmpdir(), 'tarkovtracker-fallow-'));
+  const destination = join(directory, 'repository');
+  const hooks = join(directory, 'hooks');
+  try {
+    mkdirSync(hooks);
+    git([
+      '-c',
+      `core.hooksPath=${hooks}`,
+      'clone',
+      '--shared',
+      '--no-checkout',
+      '--quiet',
+      '--',
+      source,
+      destination,
+    ]);
+    git(['-C', destination, 'config', 'core.hooksPath', hooks]);
+    git(['-C', destination, 'checkout', '--quiet', '--detach', base]);
+    materializeContext(source, destination);
+    git([
+      '-C',
+      destination,
+      'commit',
+      '--quiet',
+      '--allow-empty',
+      '-m',
+      'Materialize audit base context',
+    ]);
+    const analysisBase = git(['-C', destination, 'rev-parse', 'HEAD']);
+    const analysisHead = createHead(source, destination, analysisBase, directory);
+    git(['-C', destination, 'checkout', '--quiet', '--detach', analysisHead]);
+    const modules = join(source, 'node_modules');
+    if (!existsSync(join(destination, 'node_modules'))) {
+      symlinkSync(realpathSync(modules), join(destination, 'node_modules'), 'junction');
+    }
+    console.error(
+      `Fallow source base: ${base}; source HEAD: ${sourceHead} (including local changes)`
+    );
+    return runFallow(destination, analysisBase, values.format);
+  } finally {
+    rmSync(directory, { recursive: true, force: true });
+  }
+};
+try {
+  process.exitCode = audit();
+} catch (error) {
+  console.error(`[fallow audit] ${error instanceof Error ? error.message : String(error)}`);
+  process.exitCode = 2;
+}

--- a/scripts/fallow-audit.mjs
+++ b/scripts/fallow-audit.mjs
@@ -54,18 +54,21 @@ const createHead = (source, destination, base, directory) => {
   );
   // A tracked file may now be a directory. Only its current children belong in
   // the empty snapshot index; replaying the old filename would fail Git staging.
-  const paths = candidates
-    .toString('utf8')
-    .split('\0')
-    .filter(Boolean)
-    .filter((path) => {
-      return !lstatSync(join(source, path), { throwIfNoEntry: false })?.isDirectory();
-    });
+  const paths = [];
+  const prefix = Buffer.from(`${source}/`);
+  let start = 0;
+  for (let end = candidates.indexOf(0); end !== -1; end = candidates.indexOf(0, start)) {
+    const path = candidates.subarray(start, end);
+    if (!lstatSync(Buffer.concat([prefix, path]), { throwIfNoEntry: false })?.isDirectory()) {
+      paths.push(candidates.subarray(start, end + 1));
+    }
+    start = end + 1;
+  }
   git([...location, 'read-tree', '--empty'], environment);
   git(
     [...location, 'update-index', '--add', '--remove', '-z', '--stdin'],
     environment,
-    paths.map((path) => `${path}\0`).join('')
+    Buffer.concat(paths)
   );
   git(['-C', destination, 'add', '--force', '--', '.nuxt'], environment);
   const tree = git([...location, 'write-tree'], environment);

--- a/scripts/fallow-audit.test.mjs
+++ b/scripts/fallow-audit.test.mjs
@@ -211,6 +211,18 @@ describe('Fallow audit context', () => {
     expect(result.attribution.dead_code_introduced).toBe(0);
     expect(result.attribution.complexity_introduced).toBe(0);
   });
+  it.skipIf(process.platform === 'win32')('preserves non-UTF-8 filename bytes', () => {
+    const path = Buffer.concat([
+      Buffer.from(`${repository}/app/`),
+      Buffer.from([255]),
+      Buffer.from('.ts'),
+    ]);
+    writeFileSync(path, 'export const byteNamedValue = 1;\n');
+    const result = report(run(), 1);
+    expect(result.dead_code.unused_files).toEqual(
+      expect.arrayContaining([expect.objectContaining({ introduced: true })])
+    );
+  });
   it('handles a tracked file replaced by a directory', () => {
     rmSync(join(repository, 'app/logic.ts'));
     write('app/logic.ts/index.ts', files['app/logic.ts']);

--- a/scripts/fallow-audit.test.mjs
+++ b/scripts/fallow-audit.test.mjs
@@ -1,0 +1,295 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { afterAll, beforeAll, beforeEach, describe, expect, it } from 'vitest';
+const rootUrl = new URL('..', import.meta.url);
+const root = rootUrl.protocol === 'file:' ? fileURLToPath(rootUrl) : process.cwd();
+const script = join(root, 'scripts/fallow-audit.mjs');
+const fallow = join(root, 'node_modules/fallow/bin/fallow');
+const directory = mkdtempSync(join(tmpdir(), 'fallow-audit-test-'));
+const repository = join(directory, 'repository with spaces');
+const scratch = join(directory, 'scratch');
+const git = (...args) => execFileSync('git', args, { cwd: repository, encoding: 'utf8' }).trim();
+const complex = (name) =>
+  `export function ${name}(value) {\nlet result = 0;\n${Array.from(
+    { length: 25 },
+    (_, index) => `if (value > ${index}) result += ${index + 1};`
+  ).join('\n')}\nreturn result;\n}\n`;
+const clone = `const output = [];
+for (const value of values) {
+  const scaled = value * 2;
+  const shifted = scaled + 3;
+  const normalized = Math.abs(shifted);
+  const rounded = Math.round(normalized);
+  const clamped = Math.min(rounded, 100);
+  const formatted = Number(clamped.toFixed(2));
+  output.push(formatted);
+}
+return output;
+`;
+const files = {
+  '.gitignore': '.nuxt\nnode_modules\n.fallow\n',
+  '.fallowrc.json': JSON.stringify({
+    entry: ['index.ts'],
+    autoImports: true,
+    rules: { 'circular-dependency': 'warn' },
+    duplicates: { minTokens: 80, minLines: 8, skipLocal: true },
+  }),
+  'package.json': JSON.stringify({
+    name: 'fallow-audit-fixture',
+    private: true,
+    type: 'module',
+    devDependencies: { nuxt: '*' },
+  }),
+  'nuxt.config.ts':
+    "const appDir = fileURLToPath(new URL('./app', import.meta.url));\nexport default defineNuxtConfig({ srcDir: 'app', alias: { '@': appDir }, imports: { dirs: ['.'] } });\n",
+  'tsconfig.json': JSON.stringify({
+    extends: './.nuxt/tsconfig.json',
+    compilerOptions: { types: ['node', 'vitest'] },
+    exclude: ['supabase/functions/**/*', 'workers/**/*'],
+  }),
+  'index.ts': `import { heavy, simple, value } from '@/logic';
+import { left } from './left/a';
+import { right } from './right/b';
+import { cycleA } from './cycle/a';
+import { freshA } from './fresh/a';
+console.log(heavy(2), simple(1), value(), left([1]), right([2]), cycleA(0), freshA(0));
+`,
+  'app/logic.ts': `${complex('heavy')}
+export function simple(value) { return value + 1; }
+export interface LocalOnly { value: number }
+export function value() { const local: LocalOnly = { value: 1 }; return local.value; }
+`,
+  'left/a.ts': `export function left(values) {\n${clone}}\n`,
+  'right/b.ts': `export function right(values) {\n${clone}}\n`,
+  'cycle/a.ts': `import { cycleB } from './b';
+export function cycleA(n) { return n > 0 ? cycleB(n - 1) : 0; }
+`,
+  'cycle/b.ts': `import { cycleA } from './a';
+export function cycleB(n) { return n > 0 ? cycleA(n - 1) : 0; }
+`,
+  'fresh/a.ts': "import { freshB } from './b';\nexport function freshA(n) { return freshB(n); }\n",
+  'fresh/b.ts': 'export function freshB(n) { return n; }\n',
+};
+const write = (path, content) => {
+  const target = join(repository, path);
+  mkdirSync(join(target, '..'), { recursive: true });
+  writeFileSync(target, content);
+};
+const run = (args = [], environment = {}) =>
+  spawnSync(process.execPath, [script, '--base', 'HEAD', '--format', 'json', ...args], {
+    cwd: repository,
+    encoding: 'utf8',
+    env: { ...process.env, TMPDIR: scratch, TMP: scratch, TEMP: scratch, ...environment },
+    maxBuffer: 8 * 1024 * 1024,
+  });
+const report = (result, status) => {
+  expect(result.error).toBeUndefined();
+  expect(result.status, result.stderr).toBe(status);
+  expect(readdirSync(scratch)).toEqual([]);
+  return JSON.parse(result.stdout);
+};
+beforeAll(() => {
+  mkdirSync(scratch, { recursive: true });
+  for (const [path, content] of Object.entries(files)) write(path, content);
+  git('init', '--quiet');
+  git('config', 'user.name', 'Fixture');
+  git('config', 'user.email', 'fixture@example.invalid');
+  git('config', 'core.hooksPath', scratch);
+  git('add', '.');
+  git('-c', 'commit.gpgsign=false', 'commit', '--quiet', '-m', 'Fixture baseline');
+  write(
+    '.nuxt/tsconfig.json',
+    JSON.stringify({
+      compilerOptions: { paths: { '@/*': ['../app/*'], '#imports': ['./imports'] } },
+    })
+  );
+  write('.nuxt/imports.d.ts', "export { value, LocalOnly } from '../app/logic';\n");
+  symlinkSync(join(root, 'node_modules'), join(repository, 'node_modules'), 'junction');
+});
+beforeEach(() => {
+  for (const [path, content] of Object.entries(files)) write(path, content);
+  rmSync(join(repository, 'app/new.ts'), { force: true });
+  rmSync(join(repository, 'app/renamed.ts'), { force: true });
+  git('read-tree', 'HEAD');
+});
+afterAll(() => rmSync(directory, { recursive: true, force: true }));
+describe('Fallow audit context', () => {
+  it('fixes the native Nuxt alias reproduction without hiding inherited findings', () => {
+    write('app/logic.ts', `\n${files['app/logic.ts']}`);
+    write('.gitignore', `\n${files['.gitignore']}`);
+    const native = spawnSync(
+      process.execPath,
+      [
+        fallow,
+        'audit',
+        '--base',
+        'HEAD',
+        '--gate',
+        'new-only',
+        '--format',
+        'json',
+        '--quiet',
+        '--no-cache',
+      ],
+      { cwd: repository, encoding: 'utf8', maxBuffer: 8 * 1024 * 1024 }
+    );
+    expect(native.status, native.stderr + native.stdout).toBe(1);
+    expect(JSON.parse(native.stdout).dead_code.unused_types).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ export_name: 'LocalOnly', introduced: true }),
+      ])
+    );
+    const status = git('status', '--porcelain');
+    const index = readFileSync(join(repository, '.git/index'));
+    const result = report(run(), 0);
+    expect(result.attribution.dead_code_introduced).toBe(0);
+    expect(result.attribution.dead_code_inherited).toBeGreaterThan(0);
+    expect(result.attribution.complexity_introduced).toBe(0);
+    expect(result.attribution.complexity_inherited).toBeGreaterThan(0);
+    expect(readFileSync(join(repository, '.git/index'))).toEqual(index);
+    expect(git('status', '--porcelain')).toBe(status);
+    expect(readFileSync(join(repository, 'app/logic.ts'), 'utf8')).toBe(
+      `\n${files['app/logic.ts']}`
+    );
+  });
+  it('inherits unchanged findings across a broad touched-file diff', () => {
+    for (const [path, content] of Object.entries(files)) {
+      if (path.endsWith('.ts')) write(path, `\n${content}`);
+    }
+    const result = report(run(), 0);
+    expect(result.attribution.dead_code_introduced).toBe(0);
+    expect(result.attribution.complexity_introduced).toBe(0);
+    expect(result.attribution.duplication_introduced).toBe(0);
+    expect(result.attribution.duplication_inherited).toBeGreaterThan(0);
+  });
+  it('passes an unrelated edit in a complex file', () => {
+    write('app/logic.ts', files['app/logic.ts'].replace('return value + 1;', 'return value + 2;'));
+    expect(report(run(), 0).attribution.complexity_introduced).toBe(0);
+  });
+  it.each([
+    ['unused export', 'export const unusedValue = 42;'],
+    ['unused type', 'export type UnusedType = { id: string };'],
+  ])('fails a new %s', (_, addition) => {
+    write('app/logic.ts', `${files['app/logic.ts']}\n${addition}\n`);
+    expect(report(run(), 1).attribution.dead_code_introduced).toBe(1);
+  });
+  it('fails a newly complex function even when the finding count stays equal', () => {
+    write(
+      'app/logic.ts',
+      files['app/logic.ts']
+        .replace(complex('heavy'), 'export function heavy(value) { return value; }\n')
+        .replace('export function simple(value) { return value + 1; }', complex('simple'))
+    );
+    expect(report(run(), 1).attribution.complexity_introduced).toBeGreaterThan(0);
+  });
+  it('fails a new complexity finding alongside inherited complexity', () => {
+    write(
+      'app/logic.ts',
+      files['app/logic.ts'].replace(
+        'export function simple(value) { return value + 1; }',
+        complex('simple')
+      )
+    );
+    const result = report(run(), 1);
+    expect(result.attribution.complexity_introduced).toBeGreaterThan(0);
+    expect(result.attribution.complexity_inherited).toBeGreaterThan(0);
+  });
+  it('inherits findings after a pure file rename', () => {
+    renameSync(join(repository, 'app/logic.ts'), join(repository, 'app/renamed.ts'));
+    write('index.ts', files['index.ts'].replace('@/logic', '@/renamed'));
+    const result = report(run(), 0);
+    expect(result.attribution.dead_code_introduced).toBe(0);
+    expect(result.attribution.complexity_introduced).toBe(0);
+  });
+  it('keeps a genuinely new warning-only cycle nonblocking', () => {
+    write(
+      'fresh/b.ts',
+      "import { freshA } from './a';\nexport function freshB(n) { return n > 0 ? freshA(n - 1) : n; }\n"
+    );
+    const result = report(run(), 0);
+    expect(result.verdict).toBe('warn');
+    expect(result.attribution.dead_code_introduced).toBeGreaterThan(0);
+  });
+  it('includes staged, unstaged, and untracked changes without modifying the source index', () => {
+    write('app/logic.ts', `${files['app/logic.ts']}\nexport const stagedValue = 1;\n`);
+    git('add', 'app/logic.ts');
+    write(
+      'app/logic.ts',
+      `${files['app/logic.ts']}\nexport const stagedValue = 1;\nexport const unstagedValue = 2;\n`
+    );
+    write('app/new.ts', 'export const untrackedValue = 3;\n');
+    const status = git('status', '--porcelain');
+    const index = readFileSync(join(repository, '.git/index'));
+    const result = report(run(), 1);
+    expect(result.dead_code.unused_exports.map((finding) => finding.export_name)).toEqual(
+      expect.arrayContaining(['stagedValue', 'unstagedValue'])
+    );
+    expect(result.dead_code.unused_files).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: 'app/new.ts', introduced: true })])
+    );
+    expect(readFileSync(join(repository, '.git/index'))).toEqual(index);
+    expect(git('status', '--porcelain')).toBe(status);
+  });
+  it('rejects invalid refs instead of passing an empty audit', () => {
+    const result = run(['--base', 'missing-ref']);
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('[fallow audit]');
+    expect(readdirSync(scratch)).toEqual([]);
+  });
+  it('ignores inherited Git location and index overrides', () => {
+    write('app/logic.ts', `\n${files['app/logic.ts']}`);
+    report(
+      run([], {
+        GIT_DIR: join(directory, 'missing'),
+        GIT_WORK_TREE: directory,
+        GIT_INDEX_FILE: join(repository, '.git/index'),
+      }),
+      0
+    );
+    expect(git('diff', '--cached')).toBe('');
+  });
+  it('materializes generated context even when the source directory is a symlink', () => {
+    const generated = join(repository, '.nuxt');
+    const target = join(directory, 'generated');
+    renameSync(generated, target);
+    symlinkSync(target, generated, 'junction');
+    try {
+      write('app/logic.ts', `\n${files['app/logic.ts']}`);
+      report(run(), 0);
+    } finally {
+      rmSync(generated);
+      renameSync(target, generated);
+    }
+  });
+  it('fails explicitly when generated Nuxt context is missing', () => {
+    const config = join(repository, '.nuxt/tsconfig.json');
+    const original = readFileSync(config);
+    rmSync(config);
+    try {
+      const result = run();
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('Missing generated Nuxt tsconfig');
+      expect(readdirSync(scratch)).toEqual([]);
+    } finally {
+      writeFileSync(config, original);
+    }
+  });
+  it('cleans up after an analyzer configuration failure', () => {
+    write('.fallowrc.json', '{ invalid json');
+    const result = run();
+    expect(result.status).toBe(2);
+    expect(readdirSync(scratch)).toEqual([]);
+  });
+});

--- a/scripts/fallow-audit.test.mjs
+++ b/scripts/fallow-audit.test.mjs
@@ -211,13 +211,20 @@ describe('Fallow audit context', () => {
     expect(result.attribution.dead_code_introduced).toBe(0);
     expect(result.attribution.complexity_introduced).toBe(0);
   });
-  it.skipIf(process.platform === 'win32')('preserves non-UTF-8 filename bytes', () => {
+  it.skipIf(process.platform === 'win32')('preserves non-UTF-8 filename bytes', ({ skip }) => {
     const path = Buffer.concat([
       Buffer.from(`${repository}/app/`),
       Buffer.from([255]),
       Buffer.from('.ts'),
     ]);
-    writeFileSync(path, 'export const byteNamedValue = 1;\n');
+    try {
+      writeFileSync(path, 'export const byteNamedValue = 1;\n');
+    } catch (error) {
+      if (error.code === 'EINVAL' || error.code === 'EILSEQ') {
+        skip('The fixture filesystem requires valid UTF-8 filenames');
+      }
+      throw error;
+    }
     const result = report(run(), 1);
     expect(result.dead_code.unused_files).toEqual(
       expect.arrayContaining([expect.objectContaining({ introduced: true })])

--- a/scripts/fallow-audit.test.mjs
+++ b/scripts/fallow-audit.test.mjs
@@ -119,10 +119,8 @@ beforeAll(() => {
   symlinkSync(join(root, 'node_modules'), join(repository, 'node_modules'), 'junction');
 });
 beforeEach(() => {
-  for (const [path, content] of Object.entries(files)) write(path, content);
-  rmSync(join(repository, 'app/new.ts'), { force: true });
-  rmSync(join(repository, 'app/renamed.ts'), { force: true });
-  git('read-tree', 'HEAD');
+  git('reset', '--hard', 'HEAD');
+  git('clean', '-fd');
 });
 afterAll(() => rmSync(directory, { recursive: true, force: true }));
 describe('Fallow audit context', () => {
@@ -213,6 +211,15 @@ describe('Fallow audit context', () => {
     expect(result.attribution.dead_code_introduced).toBe(0);
     expect(result.attribution.complexity_introduced).toBe(0);
   });
+  it('handles a tracked file replaced by a directory', () => {
+    rmSync(join(repository, 'app/logic.ts'));
+    write('app/logic.ts/index.ts', files['app/logic.ts']);
+    write('index.ts', files['index.ts'].replace('@/logic', '@/logic.ts/index'));
+    const result = run();
+    expect(result.status, result.stderr).not.toBe(2);
+    expect(JSON.parse(result.stdout).attribution).toBeDefined();
+    expect(readdirSync(scratch)).toEqual([]);
+  });
   it('keeps a genuinely new warning-only cycle nonblocking', () => {
     write(
       'fresh/b.ts',
@@ -242,11 +249,55 @@ describe('Fallow audit context', () => {
     expect(readFileSync(join(repository, '.git/index'))).toEqual(index);
     expect(git('status', '--porcelain')).toBe(status);
   });
+  it('respects local excludes while retaining force-tracked ignored files', () => {
+    const exclude = join(repository, '.git/info/exclude');
+    const original = readFileSync(exclude);
+    writeFileSync(exclude, 'app/local.ts\napp/tracked.ts\n');
+    write('app/local.ts', 'export const localValue = 1;\n');
+    write('app/tracked.ts', 'export const trackedValue = 2;\n');
+    git('add', '--force', 'app/tracked.ts');
+    try {
+      const result = report(run(), 1);
+      const paths = result.dead_code.unused_files.map((finding) => finding.path);
+      expect(paths).not.toContain('app/local.ts');
+      expect(paths).toContain('app/tracked.ts');
+    } finally {
+      writeFileSync(exclude, original);
+    }
+  });
+  it('reports missing dependencies before resolving the analyzer', () => {
+    const isolatedScript = join(repository, 'fallow-audit.mjs');
+    writeFileSync(isolatedScript, readFileSync(script));
+    rmSync(join(repository, 'node_modules'));
+    try {
+      const result = spawnSync(process.execPath, [isolatedScript, '--base', 'HEAD'], {
+        cwd: repository,
+        encoding: 'utf8',
+      });
+      expect(result.status).toBe(2);
+      expect(result.stderr).toContain('Missing node_modules');
+      expect(result.stderr).not.toContain('ERR_MODULE_NOT_FOUND');
+    } finally {
+      symlinkSync(join(root, 'node_modules'), join(repository, 'node_modules'), 'junction');
+    }
+  });
   it('rejects invalid refs instead of passing an empty audit', () => {
     const result = run(['--base', 'missing-ref']);
     expect(result.status).toBe(2);
     expect(result.stderr).toContain('[fallow audit]');
     expect(readdirSync(scratch)).toEqual([]);
+  });
+  it.each(['--help', '-c alias.audit=!touch injected', 'HEAD;touch injected', '$(touch injected)'])(
+    'rejects hostile base input %s without executing it',
+    (base) => {
+      const result = run(['--base', base]);
+      expect(result.status).toBe(2);
+      expect(readdirSync(repository)).not.toContain('injected');
+      expect(readdirSync(scratch)).toEqual([]);
+    }
+  );
+  it.each(['HEAD^{commit}', 'HEAD@{0}'])('preserves valid commit-ish base %s', (base) => {
+    report(run(['--base', base]), 0);
   });
   it('ignores inherited Git location and index overrides', () => {
     write('app/logic.ts', `\n${files['app/logic.ts']}`);


### PR DESCRIPTION
## Summary

Broad, whitespace-only changes can make Fallow report an existing unused type as newly introduced and fail the gate. Its internal base snapshot symlinks `.nuxt`, causing generated tsconfig aliases to resolve differently from the current checkout. Materialize the same Nuxt context in both analysis snapshots so unchanged findings remain inherited while genuine new errors still fail.

The issue's older complexity description is no longer current: pinned Fallow 3.17.0 already matches complexity by identity. This change preserves that native matching, clone attribution, configured severities, and the `new-only` gate without adding a persistent finding baseline or suppressions.

## Changes

- Route local and CI audits through one Node wrapper using a disposable local clone and two temporary analysis commits with physical `.nuxt` context.
- Include current staged, unstaged, and non-ignored untracked source changes without modifying the source index, files, branches, or worktree registrations.
- Fail explicitly on invalid refs, missing context, and analyzer failures; remove temporary analysis files after success or failure.
- Add 15 real-binary integration regressions and document the command and its temporary report IDs.

## Related Issues

Closes #640

## Testing

- [x] Tested locally
- [x] Added integration regression tests
- [x] Reproduced the original failure and verified the correction against the real repository

### Test Plan

1. A blank-line-only edit across 13 progress/store files fails raw Fallow but passes the wrapper, with zero introduced findings and inherited dead-code, complexity, and clone findings retained. New unused exports and types still exit 1.
2. Integration tests cover the native alias failure, broad edits, unrelated edits inside complex files, unchanged clones, renames, new complexity even at an unchanged total count, warning-only cycles, staged/unstaged/untracked changes, source index preservation, inherited Git environment overrides, symlinked generated context, invalid refs, missing context, and analyzer failure cleanup.
3. Required production-review checks passed in order: `pnpm run typecheck`, `pnpm run lint`, `pnpm run test` (276 files, 2,724 tests), `pnpm run i18n:check`, and `pnpm run validate:openapi`.
4. `pnpm run format:check`, `pnpm run lint:fallow`, and commit hooks passed. Direct full-diff self-review found no remaining blocking issues.

The localization check retains existing non-fatal Crowdin drift diagnostics (689 missing keys, 344 extra keys, and Korean value-similarity warning). No locale files changed.

GitHub also reported five existing default-branch dependency alerts during push (four high, one moderate). They were not introduced or remediated by this tooling-only PR.

## Documentation impact

- [x] Behavior changed — documentation was updated in this PR
- [x] Contributor documentation reviewed: `AGENTS.md` and `docs/WORKFLOW_AUTOMATION.md`

## Checklist

- [x] Follows repository coding conventions
- [x] Self-review completed
- [x] No new blocking warnings or errors
- [x] Existing tests pass
- [x] Breaking changes checked

## Additional Notes

Tooling-only change; no application runtime, dependency, database, environment, or deployment configuration changes. Native JSON report Git IDs refer to temporary analysis commits; original source base and HEAD are printed on stderr. Each audit performs fresh analysis, with installed dependencies linked into the temporary clone. Reverting this PR restores the former audit command. Existing store-cycle and clone refactors remain outside this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a streamlined Fallow audit command for local and CI checks, supporting human-readable and JSON output.

* **Bug Fixes**
  * Improved auditing for staged, unstaged, untracked, renamed, ignored, and generated files.
  * Audits now provide clearer failure reporting while preserving the repository’s working state.

* **Documentation**
  * Added guidance for running Fallow audits locally and in CI, including configuration options and audit behavior.

* **Tests**
  * Added comprehensive coverage for audit findings, generated context, invalid references, cleanup, environment isolation, and failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->









<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR replaces direct Fallow invocation with a shared Node wrapper that constructs disposable base and working-tree audit snapshots with consistent generated Nuxt context.
- Routes local and CI audits through `scripts/fallow-audit.mjs`.
- Includes staged, unstaged, and eligible untracked files without modifying the source checkout.
- Adds integration coverage for attribution, file transitions, Git environment isolation, invalid inputs, and cleanup.
- Documents the audit workflow and temporary report identities.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/fallow-audit.mjs | Adds the disposable-clone audit wrapper, temporary Git-tree construction, generated-context materialization, analyzer invocation, validation, and cleanup. |
| scripts/fallow-audit.test.mjs | Adds real-binary regression coverage for finding attribution, local changes, unusual filenames and transitions, environment isolation, validation failures, and cleanup. |
| .github/workflows/ci.yml | Routes the CI changed-file audit through the new shared package command. |
| package.json | Replaces the direct Fallow command with the Node wrapper entry point. |
| docs/WORKFLOW_AUTOMATION.md | Documents the changed-file gate, snapshot construction, supported options, report identities, and failure behavior. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant User as Local or CI caller
    participant Wrapper as fallow-audit.mjs
    participant Source as Source checkout
    participant Clone as Disposable clone
    participant Fallow
    User->>Wrapper: lint:fallow --base ref
    Wrapper->>Source: Resolve merge base and current tree
    Wrapper->>Clone: Clone and checkout base
    Wrapper->>Clone: Copy physical .nuxt context
    Wrapper->>Clone: Commit analysis base
    Wrapper->>Source: Read tracked and eligible untracked files
    Wrapper->>Clone: Build analysis-head commit
    Wrapper->>Fallow: Audit head against analysis base
    Fallow-->>User: Native new-only verdict
    Wrapper->>Clone: Remove temporary workspace
```
</details>

<sub>Reviews (5): Last reviewed commit: ["test(ci): handle filesystem filename res..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/0621d1487fdc085811ae10c8903ce743a0b1afcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60883062)</sub>

<!-- /greptile_comment -->