### PR TITLE
docs: fix linked project ref source

### DIFF
--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -296,8 +296,10 @@ These show up in Supabase logs / query performance and are expected. Do not trea
   pnpm exec supabase db push --linked --dry-run
   ```
 
-  Confirm the project ref in `projects list` matches the linked ref from `supabase/config.toml` and
-  every evidence record names it, so output cannot be mistaken for another project's history.
+  Confirm the remote project ref in `projects list` matches the linked ref stored in the gitignored
+  `supabase/.temp/project-ref` (written by `supabase link`), and every evidence record names it, so
+  output cannot be mistaken for another project's history. `project_id` in `supabase/config.toml` is
+  a local host-level identifier, not the remote project ref.
 
   A local-only version is pending; a remote-only version is missing from the checkout. Stop on
   unexpected versions or ordering differences and reconcile against deployment records before any


### PR DESCRIPTION
## Summary

One-line follow-up to #799: cubic flagged that the new migration-evidence procedure told operators to compare `projects list` against `project_id` in `supabase/config.toml`, but that value is a local host-level identifier (`TarkovTrackerNuxt`), not the remote project ref (a UUID). The linked ref actually lives in the gitignored `supabase/.temp/project-ref` written by `supabase link` (currently `knptqelvsodccnoehmbj`). The comparison now points there and explicitly warns that `config.toml` `project_id` is not the remote ref.

## Deployment

Docs-only; no migration, code, or production impact.

## Validation

- `prettier --check docs/runbook.md` passes.
- `pnpm run lint:blank-lines` and `git diff --check` pass.
- Verified the referenced file exists locally and contains the remote ref matching the Supabase project used by CI.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This docs-only change corrects the migration-evidence procedure so operators compare the Supabase project list with the actual linked remote project reference.

- Points operators to the gitignored `supabase/.temp/project-ref` written by `supabase link`.
- Clarifies that `project_id` in `supabase/config.toml` is a local host-level identifier rather than the remote project reference.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge with no actionable issues identified.

The corrected guidance matches the repository’s Supabase configuration and the linked workflow described by the surrounding procedure.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| docs/runbook.md | Correctly updates the linked-project validation instructions and clarifies the distinct purpose of the local `project_id`. |

</details>

<sub>Reviews (1): Last reviewed commit: ["docs: fix linked project ref source"](https://github.com/tarkovtracker-org/tarkovtracker/commit/dcbb187fe278eba5a468fe96e2c4c67fc4f64dcb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60883454)</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated migration verification guidance to compare the remote project reference with the linked project reference.
  * Clarified that the local configuration file contains only a host-level identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->