### PR TITLE
fix(api): bound profile reads and localize cache purge errors

### DIFF
--- a/app/composables/__tests__/useEdgeFunctions.test.ts
+++ b/app/composables/__tests__/useEdgeFunctions.test.ts
@@ -283,6 +283,23 @@ describe('useEdgeFunctions.createToken', () => {
     expect(mockSupabaseClient.auth.refreshSession).toHaveBeenCalledTimes(1);
     expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledTimes(2);
   });
+  it('preserves cache purge error codes for localized admin messages', async () => {
+    mockSupabaseClient.functions.invoke.mockResolvedValueOnce({
+      data: null,
+      error: {
+        context: new Response(
+          JSON.stringify({ error: 'cache_purge_failed', code: 'cache_purge_failed' }),
+          { status: 502 }
+        ),
+        message: 'Edge Function returned a non-2xx status code',
+      },
+    });
+    const { useEdgeFunctions } = await import('@/composables/api/useEdgeFunctions');
+    await expect(useEdgeFunctions().purgeCache('tarkov-data')).rejects.toMatchObject({
+      status: 502,
+      data: { code: 'cache_purge_failed' },
+    });
+  });
   it('normalizes Supabase function HTTP errors with response details', async () => {
     const rateLimitError = {
       context: new Response(JSON.stringify({ message: 'Too many requests' }), {

--- a/app/composables/__tests__/useEdgeFunctions.test.ts
+++ b/app/composables/__tests__/useEdgeFunctions.test.ts
@@ -283,23 +283,6 @@ describe('useEdgeFunctions.createToken', () => {
     expect(mockSupabaseClient.auth.refreshSession).toHaveBeenCalledTimes(1);
     expect(mockSupabaseClient.functions.invoke).toHaveBeenCalledTimes(2);
   });
-  it('preserves cache purge error codes for localized admin messages', async () => {
-    mockSupabaseClient.functions.invoke.mockResolvedValueOnce({
-      data: null,
-      error: {
-        context: new Response(
-          JSON.stringify({ error: 'cache_purge_failed', code: 'cache_purge_failed' }),
-          { status: 502 }
-        ),
-        message: 'Edge Function returned a non-2xx status code',
-      },
-    });
-    const { useEdgeFunctions } = await import('@/composables/api/useEdgeFunctions');
-    await expect(useEdgeFunctions().purgeCache('tarkov-data')).rejects.toMatchObject({
-      status: 502,
-      data: { code: 'cache_purge_failed' },
-    });
-  });
   it('normalizes Supabase function HTTP errors with response details', async () => {
     const rateLimitError = {
       context: new Response(JSON.stringify({ message: 'Too many requests' }), {
@@ -367,5 +350,29 @@ describe('useEdgeFunctions.createToken', () => {
     expect(mockSupabaseClient.from).toHaveBeenCalledWith('api_tokens');
     expect(deleteFn).toHaveBeenCalledTimes(1);
     expect(deleteEq).toHaveBeenCalledWith('token_id', 'token-1');
+  });
+});
+describe('useEdgeFunctions.purgeCache', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.resetAllMocks();
+    mockSupabaseReady.mockResolvedValue({ access_token: 'token-1' });
+  });
+  it('preserves cache purge error codes for localized admin messages', async () => {
+    mockSupabaseClient.functions.invoke.mockResolvedValueOnce({
+      data: null,
+      error: {
+        context: new Response(
+          JSON.stringify({ error: 'cache_purge_failed', code: 'cache_purge_failed' }),
+          { status: 502 }
+        ),
+        message: 'Edge Function returned a non-2xx status code',
+      },
+    });
+    const { useEdgeFunctions } = await import('@/composables/api/useEdgeFunctions');
+    await expect(useEdgeFunctions().purgeCache('tarkov-data')).rejects.toMatchObject({
+      status: 502,
+      data: { code: 'cache_purge_failed' },
+    });
   });
 });

--- a/app/features/admin/AdminCacheCard.vue
+++ b/app/features/admin/AdminCacheCard.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
   import { useEdgeFunctions } from '@/composables/api/useEdgeFunctions';
   import { useSystemStoreWithSupabase } from '@/stores/useSystemStore';
+  import { ADMIN_ERROR_LOCALE_KEYS, getAdminErrorCode } from '@/utils/adminErrors';
   import { logger } from '@/utils/logger';
   import { STORAGE_KEYS } from '@/utils/storageKeys';
   import type { PurgeCacheResponse } from '@/types/edge';
@@ -149,6 +150,10 @@
       logger.warn('[AdminCacheCard] Failed to fetch last purge record', error);
     }
   };
+  const getPurgeErrorMessage = (error: unknown): string => {
+    const code = getAdminErrorCode(error);
+    return t(code ? ADMIN_ERROR_LOCALE_KEYS[code] : 'admin.purge_failed_description');
+  };
   const handlePurgeTarkovData = async () => {
     if (!$supabase.user.loggedIn) {
       toast.add({
@@ -176,7 +181,7 @@
     } catch (error) {
       toast.add({
         title: t('admin.purge_failed_title'),
-        description: error instanceof Error ? error.message : t('admin.purge_failed_description'),
+        description: getPurgeErrorMessage(error),
         color: 'error',
         icon: 'i-mdi-alert-circle',
       });
@@ -212,7 +217,7 @@
     } catch (error) {
       toast.add({
         title: t('admin.purge_failed_title'),
-        description: error instanceof Error ? error.message : t('admin.purge_failed_description'),
+        description: getPurgeErrorMessage(error),
         color: 'error',
         icon: 'i-mdi-alert-circle',
       });

--- a/app/features/admin/__tests__/AdminCacheCard.test.ts
+++ b/app/features/admin/__tests__/AdminCacheCard.test.ts
@@ -1,4 +1,6 @@
-import { mount } from '@vue/test-utils';
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { flushPromises, mount } from '@vue/test-utils';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { reactive, ref } from 'vue';
 import AdminCacheCard from '@/features/admin/AdminCacheCard.vue';
@@ -42,54 +44,48 @@ vi.mock('vue-i18n', async (importOriginal) => ({
       )[key] ?? key,
   }),
 }));
-vi.mock('#imports', async (importOriginal) => ({
-  ...(await importOriginal<typeof import('#imports')>()),
-  useNuxtApp: () => ({
-    $supabase: {
-      client: {
-        from: () => ({
-          select: () => ({
-            eq: () => ({
-              order: () => ({
-                limit: async () => ({ data: [], error: null }),
-              }),
-            }),
-          }),
+mockNuxtImport('useNuxtApp', () => () => ({
+  $supabase: {
+    client: {
+      from: () => ({
+        select: () => ({
+          eq: () => ({ order: () => ({ limit: async () => ({ data: [], error: null }) }) }),
         }),
-      },
-      user: supabaseUser,
+      }),
     },
-  }),
-  useToast: () => ({
-    add: toastAddMock,
-  }),
+    user: supabaseUser,
+  },
 }));
+mockNuxtImport('useToast', () => () => ({ add: toastAddMock }));
+const mountCard = () => {
+  return mount(AdminCacheCard, {
+    global: {
+      stubs: {
+        GenericCard: {
+          template: '<div><slot name="content" /></div>',
+        },
+        UAlert: true,
+        UButton: {
+          emits: ['click'],
+          template: '<button @click="$emit(\'click\')"><slot /></button>',
+        },
+        UIcon: true,
+        UModal: {
+          props: ['open'],
+          template: '<div v-if="open"><slot name="content" /></div>',
+        },
+      },
+    },
+  });
+};
 describe('AdminCacheCard', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     systemStoreState.isAdmin = true;
     supabaseUser.loggedIn = true;
   });
-  it('purges tarkov cache from the action button', async () => {
-    const wrapper = mount(AdminCacheCard, {
-      global: {
-        stubs: {
-          GenericCard: {
-            template: '<div><slot name="content" /></div>',
-          },
-          UAlert: true,
-          UButton: {
-            emits: ['click'],
-            template: '<button @click="$emit(\'click\')"><slot /></button>',
-          },
-          UIcon: true,
-          UModal: {
-            props: ['open'],
-            template: '<div v-if="open"><slot name="content" /></div>',
-          },
-        },
-      },
-    });
+  it('requires confirmation before purging all cache', async () => {
+    const wrapper = mountCard();
     expect(wrapper.text()).not.toContain('Confirm Full Cache Purge');
     const purgeEverythingButton = wrapper
       .findAll('button')
@@ -97,5 +93,34 @@ describe('AdminCacheCard', () => {
     expect(purgeEverythingButton).toBeDefined();
     await purgeEverythingButton!.trigger('click');
     expect(wrapper.text()).toContain('Confirm Full Cache Purge');
+    expect(purgeCacheMock).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+  it.each([
+    [{ data: { code: 'cache_purge_failed' } }, 'admin.error.cache_purge_failed'],
+    [{ data: { code: 'service_config_missing' } }, 'admin.error.service_config_missing'],
+    [{ data: { code: 'admin_privileges_required' } }, 'admin.error.admin_privileges_required'],
+    [
+      { data: { code: 'unrecognized', error: 'private upstream detail' } },
+      'admin.purge_failed_description',
+    ],
+    [new Error('private upstream detail'), 'admin.purge_failed_description'],
+  ])('localizes purge errors and hides unknown upstream messages', async (error, expectedKey) => {
+    purgeCacheMock.mockRejectedValueOnce(error);
+    const wrapper = mountCard();
+    const button = wrapper
+      .findAll('button')
+      .find((item) => item.text() === 'admin.purge_game_data_button');
+    await button!.trigger('click');
+    await flushPromises();
+    expect(purgeCacheMock).toHaveBeenCalledWith('tarkov-data');
+    expect(toastAddMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        description: expectedKey,
+        color: 'error',
+      })
+    );
+    expect(JSON.stringify(toastAddMock.mock.calls)).not.toContain('private upstream detail');
+    wrapper.unmount();
   });
 });

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -5,6 +5,9 @@
     "load_error_description": "Failed to load admin data. Please refresh or contact support. Reference: {reference}",
     "no_reference": "N/A",
     "error": {
+      "cache_purge_failed": "Could not purge the cache. Please try again.",
+      "invalid_purge_type": "Select a valid cache purge type.",
+      "method_not_allowed": "This request method is not supported.",
       "admin_privileges_required": "You do not have permission to perform this action.",
       "authentication_required": "You must be signed in to continue.",
       "invalid_channel": "Enter a valid Twitch channel name.",

--- a/app/server/api/profile/[userId]/[mode].get.ts
+++ b/app/server/api/profile/[userId]/[mode].get.ts
@@ -5,6 +5,7 @@ import {
   getRouterParam,
   setResponseHeader,
 } from 'h3';
+import { normalizeSupabaseUrl } from '@/server/utils/adminSupabase';
 import { fetchWithTimeout, isAbortError } from '@/server/utils/fetchWithTimeout';
 import { createLogger } from '@/server/utils/logger';
 import { getProxyAwareClientIdentifier } from '@/server/utils/requestIdentity';
@@ -545,7 +546,8 @@ export default defineEventHandler(async (event) => {
   }
   const typedConfig = useRuntimeConfig(event) as ReturnType<typeof useRuntimeConfig> &
     ApiProtectionConfig;
-  const { supabaseAnonKey, supabaseUrl } = typedConfig;
+  const { supabaseAnonKey } = typedConfig;
+  const supabaseUrl = normalizeSupabaseUrl(typedConfig.supabaseUrl);
   const supabaseServiceKey =
     typeof typedConfig.supabaseServiceKey === 'string' ? typedConfig.supabaseServiceKey : '';
   if (

--- a/app/server/api/profile/[userId]/[mode].get.ts
+++ b/app/server/api/profile/[userId]/[mode].get.ts
@@ -619,30 +619,22 @@ export default defineEventHandler(async (event) => {
   if (!restAuthorization) {
     throw createError({ statusCode: 401, statusMessage: 'Missing auth token' });
   }
-  const restFetch = async (path: string, signal?: AbortSignal) => {
-    const url = `${supabaseUrl}/rest/v1/${path}`;
-    return fetch(url, {
-      headers: {
-        Accept: 'application/json',
-        Authorization: restAuthorization,
-        'Content-Type': 'application/json',
-        apikey: restApiKey,
+  const resourcesController = new AbortController();
+  const restFetch = (path: string) =>
+    fetchWithTimeout(
+      `${supabaseUrl}/rest/v1/${path}`,
+      {
+        headers: {
+          Accept: 'application/json',
+          Authorization: restAuthorization,
+          'Content-Type': 'application/json',
+          apikey: restApiKey,
+        },
+        signal: resourcesController.signal,
       },
-      signal,
-    });
-  };
-  const progressController = new AbortController();
-  const modeProgressController = new AbortController();
-  const preferencesController = new AbortController();
-  const progressTimeout = setTimeout(() => {
-    progressController.abort();
-  }, REST_FETCH_TIMEOUT_MS);
-  const preferencesTimeout = setTimeout(() => {
-    preferencesController.abort();
-  }, REST_FETCH_TIMEOUT_MS);
-  const modeProgressTimeout = setTimeout(() => {
-    modeProgressController.abort();
-  }, REST_FETCH_TIMEOUT_MS);
+      REST_FETCH_TIMEOUT_MS,
+      'Timed out while loading shared profile data'
+    );
   let progressResponse: Response;
   let modeProgressResponse: Response;
   let preferencesResponse: Response;
@@ -650,23 +642,17 @@ export default defineEventHandler(async (event) => {
   const progressSelect = ['user_id', 'game_edition', legacyProgressField].filter(Boolean).join(',');
   try {
     [progressResponse, modeProgressResponse, preferencesResponse] = await Promise.all([
+      restFetch(`user_progress?select=${progressSelect}&user_id=eq.${userId}&limit=1`),
       restFetch(
-        `user_progress?select=${progressSelect}&user_id=eq.${userId}&limit=1`,
-        progressController.signal
+        `user_game_mode_progress?select=user_id,progress_data,profile_public&user_id=eq.${userId}&game_mode=eq.${mode}&season_number=eq.${getGameModeSeasonNumber(mode)}&limit=1`
       ),
       restFetch(
-        `user_game_mode_progress?select=user_id,progress_data,profile_public&user_id=eq.${userId}&game_mode=eq.${mode}&season_number=eq.${getGameModeSeasonNumber(mode)}&limit=1`,
-        modeProgressController.signal
-      ),
-      restFetch(
-        `user_preferences?select=streamer_mode,profile_share_pvp_public,profile_share_pve_public&user_id=eq.${userId}&limit=1`,
-        preferencesController.signal
+        `user_preferences?select=streamer_mode,profile_share_pvp_public,profile_share_pve_public&user_id=eq.${userId}&limit=1`
       ),
     ]);
   } catch (error) {
-    progressController.abort();
-    modeProgressController.abort();
-    preferencesController.abort();
+    resourcesController.abort();
+    if (Object(error).statusCode === 504) throw error;
     if (isAbortError(error)) {
       throw createError({
         statusCode: 504,
@@ -678,10 +664,6 @@ export default defineEventHandler(async (event) => {
       statusCode: 502,
       statusMessage: 'Failed to load shared profile data',
     });
-  } finally {
-    clearTimeout(progressTimeout);
-    clearTimeout(modeProgressTimeout);
-    clearTimeout(preferencesTimeout);
   }
   if (!progressResponse.ok || !modeProgressResponse.ok) {
     throw createError({ statusCode: 500, statusMessage: 'Failed to load profile data' });

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -195,6 +195,40 @@ describe('Shared Profile API', () => {
       statusMessage: 'Timed out while loading shared profile data',
     });
   });
+  it.each(['user_progress?', 'user_game_mode_progress?', 'user_preferences?'])(
+    'returns 504 when the %s response body stalls after headers',
+    async (stalledPath) => {
+      vi.useFakeTimers();
+      const signals: AbortSignal[] = [];
+      mockFetch.mockImplementation(async (url: string, init: RequestInit) => {
+        const signal = init.signal!;
+        signals.push(signal);
+        if (url.includes(stalledPath)) {
+          return {
+            ok: true,
+            arrayBuffer: () =>
+              new Promise((_, reject) => {
+                signal.addEventListener('abort', () => reject(createAbortError()), { once: true });
+              }),
+            json: () => new Promise(() => {}),
+          };
+        }
+        if (url.includes('user_game_mode_progress?')) return modeProgressResponse({ level: 24 });
+        if (url.includes('user_preferences?')) return preferencesResponse();
+        return progressResponse();
+      });
+      const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
+      const expectation = expect(handler(mockEvent as H3Event)).rejects.toMatchObject({
+        statusCode: 504,
+        statusMessage: 'Timed out while loading shared profile data',
+      });
+      await vi.advanceTimersByTimeAsync(8000);
+      await expectation;
+      expect(signals).toHaveLength(3);
+      expect(signals.every((signal) => signal.aborted)).toBe(true);
+      expect(vi.getTimerCount()).toBe(0);
+    }
+  );
   it('returns 502 when shared profile resources cannot be loaded', async () => {
     mockFetch.mockRejectedValueOnce(new Error('upstream failure'));
     const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -143,6 +143,39 @@ describe('Shared Profile API', () => {
       statusMessage: 'Missing Supabase configuration for shared profiles',
     });
   });
+  it.each(['not-a-url', 'ftp://test.supabase.co', '   '])(
+    'rejects invalid Supabase URL %s before fetching',
+    async (url) => {
+      runtimeConfig.supabaseUrl = url;
+      const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
+      await expect(handler(mockEvent as H3Event)).rejects.toMatchObject({ statusCode: 500 });
+      expect(mockFetch).not.toHaveBeenCalled();
+    }
+  );
+  it('normalizes the Supabase URL for authentication and all profile reads', async () => {
+    runtimeConfig.supabaseUrl = ' https://test.supabase.co/?source=config#fragment ';
+    mockGetRequestHeader.mockReturnValue('Bearer user-token');
+    mockFetch.mockImplementation(async (url: string) => {
+      if (url.endsWith('/auth/v1/user')) {
+        return new Response(JSON.stringify({ id: '11111111-1111-4111-8111-111111111111' }));
+      }
+      if (url.includes('/rest/v1/user_game_mode_progress?'))
+        return modeProgressResponse({ level: 24 });
+      if (url.includes('/rest/v1/user_preferences?')) return preferencesResponse();
+      return progressResponse();
+    });
+    const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
+    await handler(mockEvent as H3Event);
+    const urls = mockFetch.mock.calls.map(([url]) => url as string);
+    expect(urls).toContain('https://test.supabase.co/auth/v1/user');
+    const restUrls = urls.filter((url) => url.includes('/rest/v1/'));
+    expect(restUrls).toHaveLength(3);
+    for (const url of urls) {
+      expect(url).not.toContain('source=config');
+      expect(url).not.toContain('#fragment');
+      expect(url).toMatch(/^https:\/\/test\.supabase\.co\/(auth|rest)\/v1\//);
+    }
+  });
   it('serves shared profiles in production mode', async () => {
     const originalNodeEnv = process.env.NODE_ENV;
     process.env.NODE_ENV = 'production';

--- a/app/utils/adminErrors.ts
+++ b/app/utils/adminErrors.ts
@@ -1,4 +1,7 @@
 export const ADMIN_ERROR_CODES = {
+  CACHE_PURGE_FAILED: 'cache_purge_failed',
+  INVALID_PURGE_TYPE: 'invalid_purge_type',
+  METHOD_NOT_ALLOWED: 'method_not_allowed',
   ADMIN_PRIVILEGES_REQUIRED: 'admin_privileges_required',
   AUTHENTICATION_REQUIRED: 'authentication_required',
   INVALID_CHANNEL: 'invalid_channel',
@@ -14,6 +17,9 @@ export const ADMIN_ERROR_CODES = {
 } as const;
 export type AdminErrorCode = (typeof ADMIN_ERROR_CODES)[keyof typeof ADMIN_ERROR_CODES];
 export const ADMIN_ERROR_LOCALE_KEYS: Record<AdminErrorCode, string> = {
+  [ADMIN_ERROR_CODES.CACHE_PURGE_FAILED]: 'admin.error.cache_purge_failed',
+  [ADMIN_ERROR_CODES.INVALID_PURGE_TYPE]: 'admin.error.invalid_purge_type',
+  [ADMIN_ERROR_CODES.METHOD_NOT_ALLOWED]: 'admin.error.method_not_allowed',
   [ADMIN_ERROR_CODES.ADMIN_PRIVILEGES_REQUIRED]: 'admin.error.admin_privileges_required',
   [ADMIN_ERROR_CODES.AUTHENTICATION_REQUIRED]: 'admin.error.authentication_required',
   [ADMIN_ERROR_CODES.INVALID_CHANNEL]: 'admin.error.invalid_channel',

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -637,6 +637,8 @@ flowchart LR
    A missing normalized row is treated as private rather than missing.
    Shared-profile REST reads use `fetchWithTimeout` with an eight-second deadline covering headers
    and the complete response body. A failed read cancels the sibling reads; timeouts return 504.
+   The configured Supabase URL is normalized before auth and REST paths are appended, removing
+   query strings, fragments, and the trailing slash; invalid or non-HTTPS URLs fail closed.
 5. Team identity comes from `team_memberships` for all modes. Team joins use a database transaction
    that locks the team while checking capacity and persists membership, user-system state, and the
    audit event together. `user_system` keeps legacy persistent PvP/PvE columns plus the active

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -635,6 +635,8 @@ flowchart LR
    `user_preferences.profile_share_*` columns, and a trigger mirrors legacy writes forward into
    `profile_public`, so a cached older client can still turn sharing off during a rolling deploy.
    A missing normalized row is treated as private rather than missing.
+   Shared-profile REST reads use `fetchWithTimeout` with an eight-second deadline covering headers
+   and the complete response body. A failed read cancels the sibling reads; timeouts return 504.
 5. Team identity comes from `team_memberships` for all modes. Team joins use a database transaction
    that locks the team while checking capacity and persists membership, user-system state, and the
    audit event together. `user_system` keeps legacy persistent PvP/PvE columns plus the active
@@ -1074,6 +1076,12 @@ flowchart LR
 - Twitch-only invalidations must use the `twitch_config_cache_purge` audit action. The `cache_purge`
   action is reserved for `all` and `tarkov-data` purges because `/api/tarkov/cache-meta` treats its
   latest successful row as a signal to clear browser game-data caches.
+
+The `admin-cache-purge` Edge Function returns `{ error: code, code }` for failures while retaining
+HTTP status and CORS headers. Authentication, authorization, method, purge-type, configuration, and
+upstream failures have stable codes. `useEdgeFunctions` preserves the response envelope in error
+`data`; `AdminCacheCard` maps recognized codes through `admin.error.*` and uses a generic localized
+fallback for older or unknown errors. Upstream purge details remain in server logs.
 
 ## 11. Boot-time asset-failure recovery
 

--- a/supabase/functions/admin-cache-purge/index.ts
+++ b/supabase/functions/admin-cache-purge/index.ts
@@ -2,10 +2,18 @@ import {
   authenticateUser,
   handleCorsPreflight,
   validateMethod,
-  createErrorResponse,
   createSuccessResponse,
   type AuthSuccess,
 } from 'shared/auth';
+type CachePurgeErrorCode =
+  | 'authentication_required'
+  | 'admin_privileges_required'
+  | 'invalid_purge_type'
+  | 'method_not_allowed'
+  | 'service_config_missing'
+  | 'cache_purge_failed';
+const createPurgeError = (code: CachePurgeErrorCode, status: number, req: Request): Response =>
+  createSuccessResponse({ error: code, code }, status, req);
 // Cloudflare API configuration
 const CLOUDFLARE_API_URL = 'https://api.cloudflare.com/client/v4';
 const EDGE_CACHE_PATH = '/__edge-cache/tarkov';
@@ -327,17 +335,17 @@ Deno.serve(async (req) => {
   try {
     // Validate HTTP method
     const methodError = validateMethod(req, ['POST']);
-    if (methodError) return methodError;
+    if (methodError) return createPurgeError('method_not_allowed', 405, req);
     // Authenticate user
     const authResult = await authenticateUser(req);
     if ('error' in authResult) {
-      return createErrorResponse(authResult.error, authResult.status, req);
+      return createPurgeError('authentication_required', authResult.status, req);
     }
     const { user, supabase } = authResult as AuthSuccess;
     // Verify admin status
     const isAdmin = await verifyAdminStatus(supabase, user.id);
     if (!isAdmin) {
-      return createErrorResponse('Admin access required', 403, req);
+      return createPurgeError('admin_privileges_required', 403, req);
     }
     // Parse request body
     const rawBody = await req.text();
@@ -363,24 +371,20 @@ Deno.serve(async (req) => {
     const purgeType = body.purgeType!;
     // Validate purge type
     if (!['all', 'tarkov-data', 'twitch-config'].includes(purgeType)) {
-      return createErrorResponse(
-        "Invalid purgeType. Must be 'all', 'tarkov-data', or 'twitch-config'",
-        400,
-        req
-      );
+      return createPurgeError('invalid_purge_type', 400, req);
     }
     // Get Cloudflare credentials
     const zoneId = Deno.env.get('CLOUDFLARE_ZONE_ID');
     const apiToken = Deno.env.get('CLOUDFLARE_API_TOKEN');
     if (!zoneId || !apiToken) {
       console.error('[admin-cache-purge] Missing Cloudflare credentials');
-      return createErrorResponse('Cloudflare credentials not configured', 500, req);
+      return createPurgeError('service_config_missing', 500, req);
     }
     const baseUrl = Deno.env.get('APP_URL')?.trim() ?? '';
     if (purgeType === 'tarkov-data') {
       if (!baseUrl) {
         console.error('[admin-cache-purge] Missing APP_URL');
-        return createErrorResponse('Application URL not configured', 500, req);
+        return createPurgeError('service_config_missing', 500, req);
       }
       try {
         const protocol = new URL(baseUrl).protocol;
@@ -389,7 +393,7 @@ Deno.serve(async (req) => {
         }
       } catch {
         console.error('[admin-cache-purge] Invalid APP_URL');
-        return createErrorResponse('Application URL invalid', 500, req);
+        return createPurgeError('service_config_missing', 500, req);
       }
     }
     // Execute cache purge
@@ -425,7 +429,7 @@ Deno.serve(async (req) => {
           ? errors.map((e) => e.message).join(', ')
           : 'Unknown error (no details provided by Cloudflare)';
       console.error('[admin-cache-purge] Cloudflare purge failed:', errorMessages);
-      return createErrorResponse(`Cache purge failed: ${errorMessages}`, 502, req);
+      return createPurgeError('cache_purge_failed', 502, req);
     }
     return createSuccessResponse(
       {
@@ -440,6 +444,6 @@ Deno.serve(async (req) => {
     );
   } catch (error) {
     console.error('[admin-cache-purge] Error:', error);
-    return createErrorResponse('Internal server error', 500, req);
+    return createPurgeError('cache_purge_failed', 500, req);
   }
 });


### PR DESCRIPTION
## Summary

Shared-profile REST requests could hang after headers because their timeout ended before the response body was read. They now enforce the existing eight-second deadline through body download and cancel sibling requests on failure, retaining 504 timeout and 502 upstream-failure responses.

Admin cache-purge failures now return stable error codes. The cache card maps the codes preserved by the existing Edge Function composable to localized messages, with a generic fallback for older or unknown errors. Detailed upstream purge failures remain in server logs.

## Changes

- Use `fetchWithTimeout` for all three shared-profile REST reads.
- Normalize the configured Supabase URL before auth and REST requests; reject invalid or non-HTTPS configuration.
- Add a stable `{ error: code, code }` purge failure envelope while retaining status codes and CORS behavior.
- Localize both admin purge actions through the existing admin error-code map.
- Add regression coverage and document both contracts in `docs/SYSTEMS.md`.

## Related Issues

Partially addresses #643 (profile response-body timeout only; team-members egress remains open)
Fixes #777

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Tested in production-like environment
- [ ] Manual browser testing performed

60 focused tests passed across the shared-profile endpoint, timeout helper, admin cache card, Edge Function composable, and admin error utility. Coverage includes each profile response body stalling after headers, sibling cancellation, normalized auth/REST URLs, invalid URL rejection, preserved status codes, known localized purge errors, and generic fallbacks without upstream detail.

Also passed: `pnpm run lint`, `pnpm run typecheck`, `pnpm run i18n:check`, `pnpm run format:check`, `pnpm run systems:check`, `pnpm run lint:fallow`, `git diff --check`, and Deno typechecking of `admin-cache-purge`.

The i18n check reports expected English fallbacks and existing Crowdin drift. Fallow's new-only gate passes while still reporting existing large/complex functions. No live cache purge or database mutation was performed.

## Documentation impact

- [x] Behavior changed — documentation was updated in this PR
- [x] SYSTEMS or architecture reviewed

## Checklist

- [x] Follows repository conventions
- [x] Self-reviewed
- [x] Relevant local validation passed
- [x] Compatibility considered: old or unknown purge errors use a localized fallback

## Additional Notes

The Supabase `admin-cache-purge` function must be deployed through the normal release workflow for the new server codes to be emitted. The frontend safely falls back until that deployment.

This PR does not complete the progression/overlay epic (#727–#730). The cache purge mode/URL inventory also needs a separate invalidation audit under #729: it currently omits Seasonal and contains unversioned URLs. Purge behavior is unchanged here.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Admin cache purge failures now show clear, localized error messages without exposing sensitive upstream details.
  - Cache purge errors preserve standardized error information for reliable handling.
  - Shared profile requests now validate and normalize service URLs, time out consistently, cancel related requests, and return appropriate responses.
  - Invalid or unsupported service URLs now fail safely without making requests.

- **Documentation**
  - Added documentation for profile request timeouts, cancellation, cache purge error handling, localization, and server-side logging.

- **Tests**
  - Expanded coverage for cache purge failures, confirmation flows, localized notifications, URL validation, and profile request timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR bounds all shared-profile REST response downloads with the existing eight-second timeout and cancels sibling requests after failure. It also standardizes cache-purge error envelopes, maps recognized codes to localized admin messages, hides upstream details behind a generic fallback, and documents and tests these contracts.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/server/api/profile/[userId]/[mode].get.ts | Applies normalized Supabase URLs and full-response timeout handling to the three concurrent shared-profile reads, with sibling cancellation and preserved 504/502 behavior. |
| supabase/functions/admin-cache-purge/index.ts | Replaces detailed client-facing purge errors with stable machine-readable codes while preserving HTTP statuses, JSON content type, CORS headers, and server-side diagnostics. |
| app/features/admin/AdminCacheCard.vue | Converts recognized purge error codes into localized messages and safely falls back to a generic localized description. |
| app/utils/adminErrors.ts | Extends the shared admin error-code allowlist and locale mapping for cache-purge failures. |
| app/server/api/profile/__tests__/shared-profile.test.ts | Covers invalid and normalized Supabase URLs, stalled response bodies, timeout status handling, sibling cancellation, and timer cleanup. |
| app/features/admin/__tests__/AdminCacheCard.test.ts | Covers purge confirmation, known-code localization, generic fallbacks, and suppression of private upstream details. |
| app/composables/__tests__/useEdgeFunctions.test.ts | Verifies that non-success Edge Function responses preserve cache-purge codes for downstream localization. |
| app/locales/en.json | Adds English messages for the new cache-purge, invalid-type, and unsupported-method codes. |
| docs/SYSTEMS.md | Documents shared-profile timeout and URL-normalization guarantees plus the cache-purge error contract. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fix(api): address shared profile review ..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/d5dcfab59240da68d8909f5b444956033a30486f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60900625)</sub>

<!-- /greptile_comment -->