### PR TITLE
fix(api): safely describe invalid progress states

### DIFF
--- a/docs/CI_AUDIT.md
+++ b/docs/CI_AUDIT.md
@@ -199,6 +199,16 @@ quality gates. It is the strongest full-removal candidate:
 
 ### SonarCloud
 
+The project uses automatic analysis with a rolling 30-day new-code period
+(`sonar.leak.period=30`, `sonar.leak.period.type=days`). Do not use `previous_version` unless
+analysis supplies a reliable release version. These settings live in SonarCloud project settings.
+
+The project overrides `sonar.plsql.file.suffixes` to `tab,pkb`, removing the inherited `sql`
+suffix: repository SQL is PostgreSQL, not Oracle PL/SQL. Database validation remains owned by
+`pnpm run supabase:check` and migration review; do not exclude Supabase TypeScript from analysis.
+Applied migrations are immutable. Review historical style findings individually and document
+accepted findings in SonarCloud rather than rewriting migration history or weakening the gate.
+
 Keep provisionally if it catches maintainability or correctness issues not enforced by ESLint and
 CodeQL. Remove it if a review of recent findings shows that it only repeats local lint rules.
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -572,6 +572,9 @@ sequenceDiagram
   throttle in `api_usage_daily`.
 - The daily quota counts admitted requests, not successful responses. A Supabase 500 after
   admission consumes one slot — no refund system exists or is needed.
+- Invalid task/objective states return 400 with rate-limit headers after authentication and quota
+  checks. Error messages preserve scalar values but label arrays and objects without invoking
+  client-controlled string coercion, which could otherwise turn malformed input into a 500.
 - Progress reads select one exact `(user_id, game_mode, season_number)` row and account metadata;
   they never read another mode's progress or use `select=*`.
 - Read responses derive the `ETag` from the serialized payload (not `updated_at`), so a `304` can

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -889,6 +889,21 @@ describe('api-gateway', () => {
       'Invalid state "123" (must be completed, uncompleted, or failed)'
     );
   });
+  it.each([
+    { state: { toString: null }, display: '[object]' },
+    { state: [{ toString: null }], display: '[array]' },
+  ])('rejects an unstringifiable task state: $display', async ({ state, display }) => {
+    vi.stubGlobal('fetch', createBaseFetchMock());
+    const res = await worker.fetch(postTaskRequest('task-1', { state }), BASE_ENV);
+    await expectErrorResponse(
+      res,
+      400,
+      `Invalid state "${display}" (must be completed, uncompleted, or failed)`
+    );
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('100');
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('10');
+    expect(res.headers.get('X-RateLimit-Reset')).toMatch(/^\d+$/);
+  });
   it('accepts POST /progress/task with URL-encoded valid task ID', async () => {
     let mergePayload: MergeRpcPayload | null = null;
     const fetchMock = createBaseFetchMock({
@@ -993,6 +1008,21 @@ describe('api-gateway', () => {
     vi.stubGlobal('fetch', createBaseFetchMock());
     const res = await worker.fetch(postObjectiveRequest('obj-1', { state: 123 }), BASE_ENV);
     await expectErrorResponse(res, 400, 'Invalid state "123" (must be completed or uncompleted)');
+  });
+  it.each([
+    { state: { toString: null }, display: '[object]' },
+    { state: [{ toString: null }], display: '[array]' },
+  ])('rejects an unstringifiable objective state: $display', async ({ state, display }) => {
+    vi.stubGlobal('fetch', createBaseFetchMock());
+    const res = await worker.fetch(postObjectiveRequest('obj-1', { state }), BASE_ENV);
+    await expectErrorResponse(
+      res,
+      400,
+      `Invalid state "${display}" (must be completed or uncompleted)`
+    );
+    expect(res.headers.get('X-RateLimit-Limit')).toBe('100');
+    expect(res.headers.get('X-RateLimit-Remaining')).toBe('10');
+    expect(res.headers.get('X-RateLimit-Reset')).toMatch(/^\d+$/);
   });
   it('rejects POST /progress/task/objective with negative count', async () => {
     vi.stubGlobal('fetch', createBaseFetchMock());

--- a/workers/api-gateway/src/router.ts
+++ b/workers/api-gateway/src/router.ts
@@ -43,7 +43,9 @@ function normalizePath(pathname: string): string {
   return '/' + pathname.split('/').filter(Boolean).join('/');
 }
 function stripApiPrefix(path: string, prefixes: readonly string[]): string | null {
-  const prefix = prefixes.find((candidate) => path === candidate || path.startsWith(candidate + '/'));
+  const prefix = prefixes.find(
+    (candidate) => path === candidate || path.startsWith(candidate + '/')
+  );
   return prefix ? path.slice(prefix.length) || '/' : null;
 }
 function resolveApiPath(path: string, isApiHost: boolean): string | null {
@@ -76,11 +78,7 @@ function robotsResponse(origin?: string, reqOrigin?: string): Response {
     },
   });
 }
-function apiHostPublicResponse(
-  path: string,
-  origin?: string,
-  reqOrigin?: string
-): Response | null {
+function apiHostPublicResponse(path: string, origin?: string, reqOrigin?: string): Response | null {
   if (path === '/' || path === '/docs') return docsResponse(origin, reqOrigin);
   if (path === '/openapi.json') return openApiResponse(origin, reqOrigin);
   return path === '/robots.txt' ? robotsResponse(origin, reqOrigin) : null;
@@ -161,18 +159,25 @@ function normalizeTaskUpdates(body: unknown): BatchTaskUpdate[] | null {
   if (!body || typeof body !== 'object') return null;
   return normalizeBatchObject(body as Record<string, unknown>);
 }
+function formatInvalidState(state: unknown): string {
+  if (typeof state === 'string') return state;
+  if (state === null || state === undefined) return '';
+  if (typeof state === 'number' || typeof state === 'boolean') return String(state);
+  // JSON objects can shadow toString; never invoke their coercion hooks for an error message.
+  return Array.isArray(state) ? '[array]' : '[object]';
+}
 function objectiveStateError(state: unknown): string | null {
-  if (state === undefined || (typeof state === 'string' && ['completed', 'uncompleted'].includes(state))) {
+  if (
+    state === undefined ||
+    (typeof state === 'string' && ['completed', 'uncompleted'].includes(state))
+  ) {
     return null;
   }
-  const value = typeof state === 'string' ? state : String(state ?? '');
+  const value = formatInvalidState(state);
   return 'Invalid state "' + value + '" (must be completed or uncompleted)';
 }
 function objectiveCountError(count: unknown): string | null {
-  if (
-    count === undefined ||
-    (typeof count === 'number' && Number.isFinite(count) && count >= 0)
-  ) {
+  if (count === undefined || (typeof count === 'number' && Number.isFinite(count) && count >= 0)) {
     return null;
   }
   return 'Invalid count (must be a non-negative number)';
@@ -310,7 +315,7 @@ async function routeTask(context: RouteContext): Promise<Response | null> {
   );
   if (body instanceof Response) return body;
   if (!isTaskState(body.state)) {
-    const value = typeof body.state === 'string' ? body.state : String(body.state ?? '');
+    const value = formatInvalidState(body.state);
     return errorResponse(
       'Invalid state "' + value + '" (must be completed, uncompleted, or failed)',
       400,
@@ -392,7 +397,8 @@ export async function handleGatewayRequest(
   const response = publicResponse(request, path, isApiHost, origin, reqOrigin);
   if (response) return response;
   const apiPath = resolveApiPath(path, isApiHost);
-  if (!apiPath) return new Response('Not Found', { status: 404, headers: corsHeaders(origin, reqOrigin) });
+  if (!apiPath)
+    return new Response('Not Found', { status: 404, headers: corsHeaders(origin, reqOrigin) });
   const inboundUserAgent = normalizeInboundUserAgent(request.headers.get('User-Agent'));
   if (!inboundUserAgent || inboundUserAgent.length < INBOUND_USER_AGENT_MIN_LENGTH) {
     return errorResponse(


### PR DESCRIPTION
Invalid object or array states could throw during error-message string coercion in both progress-write endpoints, returning HTTP 500 instead of 400. Use a shared formatter that preserves scalar messages and safely labels structured values; retain authentication, quota checks, and rate-limit headers.

Four regression cases reproduced the failure before the fix. All 100 gateway tests now pass. App and Worker typechecks, lint, generated Worker types, formatting, system drift checks, and a Wrangler deployment dry run passed.

Also document the SonarCloud settings applied during this review: retain automatic analysis, use a rolling 30-day new-code baseline, and remove PostgreSQL `.sql` files from the Oracle PL/SQL suffix mapping. Four historical/style findings received individual documented dispositions; quality-gate thresholds and applied migrations are unchanged. The API finding remains open on main until this code lands and is analyzed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation error handling for invalid task and objective states, including arrays and objects that cannot be safely converted to text.
  - Preserved rate-limit headers in relevant HTTP 400 responses.
  - Standardized unmatched API-path responses.

- **Documentation**
  - Documented invalid-state responses, safe value formatting, and analysis guidance for historical findings and database migrations.

- **Tests**
  - Added coverage for invalid state values and rate-limit header preservation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->