### PR TITLE
ci: migrate Crowdin sync to GitHub Actions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,7 +45,7 @@ Before enabling this workflow on `main`:
 3. Review and merge or close any existing `locales` PR authored by a personal account. The Action
    reuses open PRs and cannot change their author. Keep the branch when disposing of the old PR.
 4. Ensure Actions may create PRs and the repository's selected-action policy permits
-   `crowdin/github-action@v3` and `actions/checkout@v7`.
+   the pinned `crowdin/github-action` v3 commit and `actions/checkout@v7`.
 
 After merging, inspect the first sync run and the next translation PR: verify its author, base,
 and that its diff contains only expected non-English locale exports. The Action creates a PR

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -22,6 +22,37 @@ Automated CI/CD and maintenance workflows for TarkovTracker.
 
 All jobs run in parallel; the `Workers` job no longer waits for `Validate` to finish.
 
+### Crowdin Sync (`crowdin.yml`)
+
+**Triggers:** English source, Crowdin config, or sync workflow changes on `main`; every six hours
+at minute 17 UTC; manual dispatch on `main`. Runs are serialized without cancelling an active sync.
+The workflow uploads `app/locales/en.json` to the Crowdin `main` branch and downloads translations
+to `app/locales/%two_letters_code%.json`, preserving the directory hierarchy. It never uploads
+local translations. The existing `locales` branch supplies translation PRs targeting `main`.
+
+Repository secrets `CROWDIN_PROJECT_ID` and `CROWDIN_PERSONAL_TOKEN` authenticate to Crowdin only.
+GitHub writes use the automatic `secrets.GITHUB_TOKEN`, with only `contents: write` and
+`pull-requests: write`, so newly created PRs are authored by `github-actions[bot]`.
+
+Before enabling this workflow on `main`:
+
+1. Confirm the existing Crowdin source is under the Crowdin branch `main` at
+   `app/locales/en.json`. Crowdin branches are separate from GitHub branches; if the source lives
+   at the Crowdin project root, omit `crowdin_branch_name` before the first run.
+2. Disable the native Crowdin GitHub integration's synchronization for this repository so both
+   integrations cannot write concurrently. Preserve the Crowdin project, translations, and GitHub
+   `locales` branch.
+3. Review and merge or close any existing `locales` PR authored by a personal account. The Action
+   reuses open PRs and cannot change their author. Keep the branch when disposing of the old PR.
+4. Ensure Actions may create PRs and the repository's selected-action policy permits
+   `crowdin/github-action@v3` and `actions/checkout@v7`.
+
+After merging, inspect the first sync run and the next translation PR: verify its author, base,
+and that its diff contains only expected non-English locale exports. The Action creates a PR
+when it commits changed translations; a no-change run may create no PR. If necessary, dispatch
+`Crowdin Sync` on `main` after new translations are available. Do not enable runner debug logging
+for this workflow: the upstream Action prints its environment in debug mode.
+
 ### Crowdin locale PRs
 
 PRs whose changes are limited to the non-English locale exports in `app/locales/` do not trigger

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -1,0 +1,47 @@
+name: Crowdin Sync
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'app/locales/en.json'
+      - 'crowdin.yml'
+      - '.github/workflows/crowdin.yml'
+  schedule:
+    - cron: '17 */6 * * *'
+  workflow_dispatch:
+permissions:
+  contents: write
+  pull-requests: write
+# All triggers share the same Crowdin project and localization branch.
+concurrency:
+  group: crowdin-sync
+  cancel-in-progress: false
+jobs:
+  sync:
+    if: github.repository == 'tarkovtracker-org/TarkovTracker' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          ref: main
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Synchronize Crowdin translations
+        uses: crowdin/github-action@v3
+        with:
+          upload_sources: true
+          upload_translations: false
+          download_translations: true
+          crowdin_branch_name: main
+          localization_branch_name: locales
+          create_pull_request: true
+          pull_request_base_branch_name: main
+          pull_request_title: 'New Crowdin updates'
+          pull_request_body: 'Automated translation updates from Crowdin.'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CROWDIN_PROJECT_ID: ${{ secrets.CROWDIN_PROJECT_ID }}
+          CROWDIN_PERSONAL_TOKEN: ${{ secrets.CROWDIN_PERSONAL_TOKEN }}

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -30,7 +30,7 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
       - name: Synchronize Crowdin translations
-        uses: crowdin/github-action@v3
+        uses: crowdin/github-action@0d5670f539973aea2f01abce61a8989934df0025 # v3
         with:
           upload_sources: true
           upload_translations: false

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,3 +1,6 @@
+project_id_env: CROWDIN_PROJECT_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
+preserve_hierarchy: true
 files:
   - source: /app/locales/en.json
     translation: /app/locales/%two_letters_code%.json


### PR DESCRIPTION
## Summary
Move Crowdin synchronization from the paused native GitHub connector to the official GitHub Action. New translation PRs use github-actions[bot] through the automatic GITHUB_TOKEN.

## Changes
- Keep the existing Crowdin main/app/locales/en.json source, locale export paths, locales branch, and main PR target.
- Use actions/checkout@v7 and crowdin/github-action v3 pinned to 0d5670f539973aea2f01abce61a8989934df0025 with only contents: write and pull-requests: write. Crowdin secrets authenticate only to Crowdin.
- Serialize syncs, restrict execution to main in this repository, and run on relevant pushes, every six hours, or manual dispatch.
- Document cutover and verification; preserve existing locale-only CI exclusions.

## Testing
- [x] Both YAML files parsed and configuration invariants asserted.
- [x] Action inputs checked against official v7/v3 metadata.
- [x] Actionlint, focused Prettier check, blank-line lint, and git diff --check passed.
- [ ] Post-merge Crowdin Sync and bot-authored translation PR verification.

## Documentation impact
- [x] Behavior changed — documentation was updated in this PR
- [x] Contributor documentation

## Additional Notes
The operator confirmed the Crowdin main/app/locales/en.json hierarchy and paused the native GitHub connector. The previous personally authored locale PR #797 has been merged; the locales branch is preserved. No GitHub PAT or user-owned GitHub token is used.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR migrates Crowdin synchronization to a serialized GitHub Actions workflow while retaining the existing source, export paths, localization branch, and PR target.
- Adds push, six-hour schedule, and manual triggers restricted to the canonical repository’s `main` branch.
- Uses narrowly scoped GitHub write permissions and Crowdin-only credentials.
- Adds Crowdin environment credential configuration and hierarchy preservation.
- Documents cutover prerequisites and post-merge verification.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The workflow’s triggers, branch restrictions, credentials, permissions, Crowdin paths, and PR flow are internally consistent with the documented and confirmed migration assumptions.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/crowdin.yml | Adds the serialized, repository-restricted Crowdin synchronization workflow with scoped permissions and explicit branch behavior. |
| crowdin.yml | Configures environment-based Crowdin authentication and preserves the confirmed locale source hierarchy. |
| .github/workflows/README.md | Documents workflow triggers, credentials, cutover prerequisites, and post-merge verification steps. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Trigger as Push / Schedule / Manual
    participant GHA as Crowdin Sync Workflow
    participant Crowdin as Crowdin
    participant Locales as GitHub locales branch
    participant Main as GitHub main branch
    Trigger->>GHA: Start serialized sync on main
    GHA->>Crowdin: Upload app/locales/en.json
    Crowdin-->>GHA: Download translated locale files
    GHA->>Locales: Commit translation updates
    GHA->>Main: Open or update translation PR
```
</details>

<sub>Reviews (1): Last reviewed commit: ["ci: pin Crowdin v3 action to immutable c..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/66b7d96876861c0a5b10463057da5a60906c15f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60943238)</sub>

<!-- /greptile_comment -->