### PR TITLE
fix(ci): reuse validated main CI for releases

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -67,8 +67,12 @@ workflow files, or `app/locales/en.json` still run the normal checks.
 
 ### Release (`release.yml`)
 
-**Trigger:** Push to main (excluding `**.md`, `docs/**`)
-**Jobs:** `Release` (build + semantic-release)
+**Trigger:** Successful completion of `CI` for a same-repository push to `main`.
+**Jobs:** `Release` (validate the CI run and current main SHA, build, recheck, semantic-release).
+The workflow reuses CI's test shards and database checks. It rejects stale commits and CI attempts,
+PR/fork events, and automation-skip directives before publishing. Documentation-only pushes can
+reach the gate; conventional commits determine whether a version is warranted. Publication is
+serialized without cancelling an active release. See `docs/WORKFLOW_AUTOMATION.md` for details.
 
 ### PR Checks (`pr-checks.yml`)
 
@@ -112,7 +116,9 @@ introduce a new pinned SHA.
 | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | PR            | ~15 (Fallow audit, Lint & Format, Type Check, Test ×4 shards, Validate, Supabase DB, Systems drift check, Workers, PR Meta, Security Scan, CodeQL, Lighthouse\*) |
 | Dependabot PR | ~16 (standard PR checks plus Dependabot Auto Merge when allowlisted)                                                                                             |
-| Main push     | ~14 (Fallow audit, Lint & Format, Type Check, Test ×4 shards, Validate, Supabase DB, Systems drift check, Workers, Security Scan, CodeQL, Release)               |
+| Main push     | ~13 (Fallow audit, Lint & Format, Type Check, Test ×4 shards, Validate, Supabase DB, Systems drift check, Workers, Security Scan, CodeQL)                        |
+
+Successful main CI completion separately triggers the gated `Release` workflow.
 
 \*Lighthouse runs only when the PR touches UI paths or already carries `performance`/`ui`
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,57 +1,68 @@
 name: Release
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+permissions:
+  contents: read
 jobs:
   release:
     name: Release
-    runs-on: ubuntu-24.04
-    timeout-minutes: 30
-    # GitHub natively skips push-triggered workflows for all five of these markers, so this guard is
-    # belt-and-braces. It is kept explicit because skip markers do not apply to every event type,
-    # and because semantic-release tags its own version-bump commit with '[skip actions]' to avoid
-    # re-triggering this workflow. See docs/WORKFLOW_AUTOMATION.md for why that marker, not
-    # '[skip ci]'.
+    # workflow_run can receive privileged credentials; only trusted main push CI may release.
     if: >-
-      !contains(github.event.head_commit.message, '[skip ci]') &&
-      !contains(github.event.head_commit.message, '[ci skip]') &&
-      !contains(github.event.head_commit.message, '[no ci]') &&
-      !contains(github.event.head_commit.message, '[skip actions]') &&
-      !contains(github.event.head_commit.message, '[actions skip]')
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main' &&
+      github.event.workflow_run.head_repository.id == github.event.repository.id
+    concurrency:
+      group: release-main
+      cancel-in-progress: false
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     permissions:
+      actions: read
       contents: write
       issues: write
       pull-requests: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
+          # workflow_run's default SHA can differ from the commit that passed CI.
+          ref: ${{ github.event.workflow_run.head_sha }}
           fetch-depth: 0
+          persist-credentials: false
+      - name: Check validated commit before setup
+        id: eligible
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const { pathToFileURL } = require('node:url');
+            const { releaseEligibility } = await import(pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/release-gate.mjs`));
+            const result = await releaseEligibility({ github, context });
+            core.info(result.reason);
+            core.setOutput('release', String(result.release));
       - name: Setup Node.js
+        if: steps.eligible.outputs.release == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version-file: .nvmrc
       - name: Install pnpm
+        if: steps.eligible.outputs.release == 'true'
         run: |
           corepack enable
           corepack prepare pnpm@11.14.0 --activate
       - name: Setup pnpm cache
+        if: steps.eligible.outputs.release == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version-file: .nvmrc
           cache: 'pnpm'
       - name: Install dependencies
+        if: steps.eligible.outputs.release == 'true'
         run: pnpm install --frozen-lockfile
-      - name: Run tests
-        run: pnpm run test
-      - name: Validate Supabase migrations
-        run: pnpm run supabase:check
       - name: Build
+        if: steps.eligible.outputs.release == 'true'
         run: pnpm run build
         env:
           NODE_ENV: production
@@ -60,7 +71,19 @@ jobs:
           GA_MEASUREMENT_ID: ${{ vars.GA_MEASUREMENT_ID }}
           SUPABASE_URL: ${{ vars.SUPABASE_URL || secrets.SUPABASE_URL }}
           SUPABASE_ANON_KEY: ${{ vars.SUPABASE_ANON_KEY || secrets.SUPABASE_ANON_KEY }}
+      - name: Recheck validated commit before publishing
+        id: publish
+        if: steps.eligible.outputs.release == 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3
+        with:
+          script: |
+            const { pathToFileURL } = require('node:url');
+            const { releaseEligibility } = await import(pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/release-gate.mjs`));
+            const result = await releaseEligibility({ github, context });
+            core.info(result.reason);
+            core.setOutput('release', String(result.release));
       - name: Semantic Release
+        if: steps.publish.outputs.release == 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm exec semantic-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,10 @@ jobs:
         with:
           script: |
             const { pathToFileURL } = require('node:url');
-            const { releaseEligibility } = await import(pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/release-gate.mjs`));
+            const { copyFile } = require('node:fs/promises');
+            const gatePath = `${process.env.RUNNER_TEMP}/release-gate.mjs`;
+            await copyFile(`${process.env.GITHUB_WORKSPACE}/scripts/release-gate.mjs`, gatePath);
+            const { releaseEligibility } = await import(pathToFileURL(gatePath));
             const result = await releaseEligibility({ github, context });
             core.info(result.reason);
             core.setOutput('release', String(result.release));
@@ -86,7 +89,7 @@ jobs:
         with:
           script: |
             const { pathToFileURL } = require('node:url');
-            const { releaseEligibility } = await import(pathToFileURL(`${process.env.GITHUB_WORKSPACE}/scripts/release-gate.mjs`));
+            const { releaseEligibility } = await import(pathToFileURL(`${process.env.RUNNER_TEMP}/release-gate.mjs`));
             const result = await releaseEligibility({ github, context });
             core.info(result.reason);
             core.setOutput('release', String(result.release));

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,8 +28,8 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
         with:
-          # workflow_run's default SHA can differ from the commit that passed CI.
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # Load the gate from trusted default-branch code, not the event's candidate.
+          ref: ${{ github.sha }}
           fetch-depth: 0
           persist-credentials: false
       - name: Check validated commit before setup
@@ -42,6 +42,14 @@ jobs:
             const result = await releaseEligibility({ github, context });
             core.info(result.reason);
             core.setOutput('release', String(result.release));
+            core.setOutput('sha', result.sha || '');
+      - name: Checkout validated release commit
+        if: steps.eligible.outputs.release == 'true'
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: ${{ steps.eligible.outputs.sha }}
+          fetch-depth: 0
+          persist-credentials: false
       - name: Setup Node.js
         if: steps.eligible.outputs.release == 'true'
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1224,6 +1224,26 @@ See [the workflow guide](WORKFLOW_AUTOMATION.md#fallow-changed-file-gate) for us
   removed in a `finally` block on success or failure.
 - Local Git exclusions apply to untracked candidates without dropping tracked source files.
 
+## 14. Release validation and publication
+
+Release starts after successful main-push CI, reusing its test shards and database validation.
+`scripts/release-gate.mjs` checks live workflow identity, repository, conclusion, attempt, and SHA
+against the triggering event and current main before setup and immediately before publishing.
+The checkout stays pinned to the validated SHA. The production build still runs in Release.
+
+### Invariants
+
+- PR, fork, unsuccessful, superseded, and stale CI-attempt events cannot authorize publication.
+- Never replace the validated checkout with a newer main commit to make publishing succeed.
+- CI cancellation must not cancel a publisher; only release jobs share `release-main` with
+  `cancel-in-progress: false`. Git non-fast-forward protection and semantic-release's upstream
+  check remain the final safeguards if main advances after the last eligibility check.
+- Release version commits retain the existing skip marker behavior and Cloudflare rebuild.
+- A green workflow run must continue to mean the test shards and Supabase validation passed;
+  making those jobs optional requires reconsidering this release gate.
+
+See `docs/WORKFLOW_AUTOMATION.md` for triggering, retry, and deployment behavior.
+
 ## When this doc is wrong
 
 If you read something here that does not match the code, the disagreement is a bug — either in the

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -86,7 +86,8 @@ semantic-release still decides whether the accumulated conventional commits warr
 `release-gate.mjs` re-reads the triggering run and `refs/heads/main` before dependency setup and
 again immediately before publishing. It verifies the CI workflow path, conclusion, SHA, and run
 attempt. Superseded commits skip; release never substitutes a newer, unvalidated checkout.
-`actions/checkout` pins the triggering CI SHA rather than the default SHA of `workflow_run`.
+The gate initially loads from the trusted default-branch SHA. Only after validation does a second
+checkout pin the triggering CI SHA for building and publishing; it never executes a fork candidate.
 
 Only release jobs share the non-cancelling `release-main` concurrency group. CI can cancel obsolete
 validation independently; an active publisher is not cancelled by a newer merge. A merge in the

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -71,14 +71,31 @@ Semantic versioning with automated releases:
 
 **Jobs:**
 
-- Runs tests and build
-- Resets and lints local Supabase migrations and runs pgTAP database regressions with
-  `pnpm run supabase:check`
+- Reuses the successful `CI` run for the exact `main` push commit, including all four test shards
+  and the Supabase reset, lint, and pgTAP checks
+- Runs the production build before publishing
 - Generates changelog from conventional commits
 - Creates GitHub releases
 - Updates version in package.json
 
-**Triggers:** Push to `main` (non-docs changes)
+**Triggers:** Completion of `CI` for a successful same-repository push to `main`. PR runs, failed
+or cancelled CI, and fork runs cannot publish. Successful CI reruns can retry release eligibility;
+there is no manual bypass of the CI gate. Documentation-only pushes may reach the gate, but
+semantic-release still decides whether the accumulated conventional commits warrant a version.
+
+`release-gate.mjs` re-reads the triggering run and `refs/heads/main` before dependency setup and
+again immediately before publishing. It verifies the CI workflow path, conclusion, SHA, and run
+attempt. Superseded commits skip; release never substitutes a newer, unvalidated checkout.
+`actions/checkout` pins the triggering CI SHA rather than the default SHA of `workflow_run`.
+
+Only release jobs share the non-cancelling `release-main` concurrency group. CI can cancel obsolete
+validation independently; an active publisher is not cancelled by a newer merge. A merge in the
+small interval after the last check remains subject to semantic-release's upstream check and git's
+non-fast-forward push protection. No force push or rebase onto an unvalidated commit is permitted.
+
+This removes the duplicate full test suite and database reset from the serialized release path.
+The production build remains a release check. Cloudflare deployments continue independently;
+this workflow controls release/version publication, not when the initial deployment starts.
 
 **Version-bump commit:** `@semantic-release/git` commits the bumped `package.json` and `CHANGELOG.md`
 as `chore(release): <version> [skip actions]`. The marker is deliberately `[skip actions]` rather

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -86,8 +86,10 @@ semantic-release still decides whether the accumulated conventional commits warr
 `release-gate.mjs` re-reads the triggering run and `refs/heads/main` before dependency setup and
 again immediately before publishing. It verifies the CI workflow path, conclusion, SHA, and run
 attempt. Superseded commits skip; release never substitutes a newer, unvalidated checkout.
-The gate initially loads from the trusted default-branch SHA. Only after validation does a second
-checkout pin the triggering CI SHA for building and publishing; it never executes a fork candidate.
+The gate initially loads from the trusted default-branch SHA and is copied to `RUNNER_TEMP` so
+both checks use the same source even after checkout replacement. Only after validation does a
+second checkout pin the triggering CI SHA for building and publishing; it never executes a fork
+candidate.
 
 Only release jobs share the non-cancelling `release-main` concurrency group. CI can cancel obsolete
 validation independently; an active publisher is not cancelled by a newer merge. A merge in the

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -1,35 +1,51 @@
+function successfulMainPush(run) {
+  return run?.event === 'push' && run.head_branch === 'main';
+}
+function trustedRun(run, repositoryId) {
+  if (!successfulMainPush(run)) return false;
+  return run.head_repository?.id === repositoryId && completedSuccessfully(run);
+}
+function completedSuccessfully(run) {
+  return run.status === 'completed' && run.conclusion === 'success';
+}
+function matchesEvent(run, eventRun, repositoryId) {
+  return (
+    trustedRun(run, repositoryId) &&
+    run.path === '.github/workflows/ci.yml' &&
+    run.head_sha === eventRun.head_sha &&
+    run.run_attempt === eventRun.run_attempt
+  );
+}
+function explicitlySkipsAutomation(run) {
+  const message = run.head_commit?.message ?? '';
+  return /\[(skip ci|ci skip|no ci|skip actions|actions skip)\]/i.test(message);
+}
+function eligibleEvidence(run, eventRun, repositoryId) {
+  return matchesEvent(run, eventRun, repositoryId) && !explicitlySkipsAutomation(run);
+}
 // Re-read CI and main each time: a queued release or a CI rerun can supersede the event.
 export async function releaseEligibility({ github, context }) {
   const eventRun = context.payload.workflow_run;
   const repositoryId = context.payload.repository.id;
-  const trusted = (run) =>
-    run?.event === 'push' &&
-    run.head_branch === 'main' &&
-    run.head_repository?.id === repositoryId &&
-    run.status === 'completed' &&
-    run.conclusion === 'success';
   const skip = (reason) => ({ release: false, reason });
-  if (!trusted(eventRun)) return skip('Only successful CI for a main push may release.');
+  if (!trustedRun(eventRun, repositoryId))
+    return skip('Only successful CI for a main push may release.');
   const { data: run } = await github.rest.actions.getWorkflowRun({
     ...context.repo,
     run_id: eventRun.id,
   });
-  if (
-    !trusted(run) ||
-    run.path !== '.github/workflows/ci.yml' ||
-    run.head_sha !== eventRun.head_sha ||
-    run.run_attempt !== eventRun.run_attempt
-  ) {
-    return skip('CI evidence changed after the completion event; wait for its latest result.');
-  }
-  if (
-    /\[(skip ci|ci skip|no ci|skip actions|actions skip)\]/i.test(run.head_commit?.message ?? '')
-  ) {
-    return skip('The validated commit explicitly skips automation.');
+  if (!eligibleEvidence(run, eventRun, repositoryId)) {
+    return skip(
+      'CI evidence changed or the commit skips automation; publication is not authorized.'
+    );
   }
   const { data: main } = await github.rest.git.getRef({ ...context.repo, ref: 'heads/main' });
   if (main.object.sha !== run.head_sha) {
     return skip('Validated commit is no longer main; its successor must pass CI before release.');
   }
-  return { release: true, reason: `Release validated main commit ${run.head_sha}.` };
+  return {
+    release: true,
+    sha: run.head_sha,
+    reason: `Release validated main commit ${run.head_sha}.`,
+  };
 }

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -18,7 +18,10 @@ function matchesEvent(run, eventRun, repositoryId) {
 }
 function explicitlySkipsAutomation(run) {
   const message = run.head_commit?.message ?? '';
-  return /\[(skip ci|ci skip|no ci|skip actions|actions skip)\]/i.test(message);
+  return (
+    /\[(skip ci|ci skip|no ci|skip actions|actions skip)\]/i.test(message) ||
+    /^skip-checks:[ \t]*true[ \t]*\r?$/im.test(message)
+  );
 }
 function eligibleEvidence(run, eventRun, repositoryId) {
   return matchesEvent(run, eventRun, repositoryId) && !explicitlySkipsAutomation(run);

--- a/scripts/release-gate.mjs
+++ b/scripts/release-gate.mjs
@@ -1,0 +1,35 @@
+// Re-read CI and main each time: a queued release or a CI rerun can supersede the event.
+export async function releaseEligibility({ github, context }) {
+  const eventRun = context.payload.workflow_run;
+  const repositoryId = context.payload.repository.id;
+  const trusted = (run) =>
+    run?.event === 'push' &&
+    run.head_branch === 'main' &&
+    run.head_repository?.id === repositoryId &&
+    run.status === 'completed' &&
+    run.conclusion === 'success';
+  const skip = (reason) => ({ release: false, reason });
+  if (!trusted(eventRun)) return skip('Only successful CI for a main push may release.');
+  const { data: run } = await github.rest.actions.getWorkflowRun({
+    ...context.repo,
+    run_id: eventRun.id,
+  });
+  if (
+    !trusted(run) ||
+    run.path !== '.github/workflows/ci.yml' ||
+    run.head_sha !== eventRun.head_sha ||
+    run.run_attempt !== eventRun.run_attempt
+  ) {
+    return skip('CI evidence changed after the completion event; wait for its latest result.');
+  }
+  if (
+    /\[(skip ci|ci skip|no ci|skip actions|actions skip)\]/i.test(run.head_commit?.message ?? '')
+  ) {
+    return skip('The validated commit explicitly skips automation.');
+  }
+  const { data: main } = await github.rest.git.getRef({ ...context.repo, ref: 'heads/main' });
+  if (main.object.sha !== run.head_sha) {
+    return skip('Validated commit is no longer main; its successor must pass CI before release.');
+  }
+  return { release: true, reason: `Release validated main commit ${run.head_sha}.` };
+}

--- a/scripts/release-gate.test.mjs
+++ b/scripts/release-gate.test.mjs
@@ -1,0 +1,92 @@
+// @vitest-environment node
+import { describe, expect, it, vi } from 'vitest';
+import { releaseEligibility } from './release-gate.mjs';
+function fixture() {
+  const run = {
+    id: 123,
+    event: 'push',
+    head_branch: 'main',
+    head_repository: { id: 456 },
+    path: '.github/workflows/ci.yml',
+    status: 'completed',
+    conclusion: 'success',
+    head_sha: 'a'.repeat(40),
+    run_attempt: 1,
+    head_commit: { message: 'fix(api): reject malformed state' },
+  };
+  const context = {
+    repo: { owner: 'owner', repo: 'repo' },
+    payload: { repository: { id: 456 }, workflow_run: structuredClone(run) },
+  };
+  const main = { object: { sha: run.head_sha } };
+  const github = {
+    rest: {
+      actions: { getWorkflowRun: vi.fn().mockResolvedValue({ data: run }) },
+      git: { getRef: vi.fn().mockResolvedValue({ data: main }) },
+    },
+  };
+  return { run, main, context, github };
+}
+describe('release eligibility', () => {
+  it('releases only the successful CI commit still at main', async () => {
+    const f = fixture();
+    // Webhook payloads need not include the workflow path; verify it through the API.
+    delete f.context.payload.workflow_run.path;
+    expect((await releaseEligibility(f)).release).toBe(true);
+    expect(f.github.rest.actions.getWorkflowRun).toHaveBeenCalledWith({
+      owner: 'owner',
+      repo: 'repo',
+      run_id: 123,
+    });
+  });
+  it.each([
+    { event: 'pull_request' },
+    { head_branch: 'develop' },
+    { head_repository: { id: 999 } },
+    { head_repository: null },
+    { conclusion: 'failure' },
+    { conclusion: 'cancelled' },
+    { status: 'in_progress' },
+  ])('rejects untrusted or unsuccessful events: %o', async (changes) => {
+    const f = fixture();
+    Object.assign(f.context.payload.workflow_run, changes);
+    expect((await releaseEligibility(f)).release).toBe(false);
+    expect(f.github.rest.actions.getWorkflowRun).not.toHaveBeenCalled();
+  });
+  it.each([
+    { conclusion: 'failure' },
+    { status: 'in_progress', conclusion: null },
+    { run_attempt: 2 },
+    { head_sha: 'b'.repeat(40) },
+    { path: '.github/workflows/unrelated.yml' },
+    { head_repository: { id: 999 } },
+  ])('rejects stale or mismatched live CI evidence: %o', async (changes) => {
+    const f = fixture();
+    Object.assign(f.run, changes);
+    expect((await releaseEligibility(f)).release).toBe(false);
+  });
+  it('skips a newer unvalidated main instead of checking it out', async () => {
+    const f = fixture();
+    f.main.object.sha = 'b'.repeat(40);
+    expect((await releaseEligibility(f)).release).toBe(false);
+  });
+  it('detects main advancing during setup/build, including a release version commit', async () => {
+    const f = fixture();
+    expect((await releaseEligibility(f)).release).toBe(true);
+    f.main.object.sha = 'c'.repeat(40);
+    expect((await releaseEligibility(f)).release).toBe(false);
+  });
+  it.each(['skip ci', 'ci skip', 'no ci', 'skip actions', 'actions skip'])(
+    'preserves the %s marker even when CI is rerun manually',
+    async (marker) => {
+      const f = fixture();
+      f.run.head_commit.message = `chore(release): 1.2.3 [${marker}]`;
+      expect((await releaseEligibility(f)).release).toBe(false);
+    }
+  );
+  it('fails closed on API errors', async () => {
+    const f = fixture();
+    f.github.rest.git.getRef.mockRejectedValue(new Error('GitHub unavailable'));
+    await expect(releaseEligibility(f)).rejects.toThrow('GitHub unavailable');
+  });
+});

--- a/scripts/release-gate.test.mjs
+++ b/scripts/release-gate.test.mjs
@@ -86,6 +86,19 @@ describe('release freshness and failures', () => {
       expect((await releaseEligibility(f)).release).toBe(false);
     }
   );
+  it.each(['skip-checks: true', 'skip-checks:true', 'skip-checks: true\r'])(
+    'rejects a rerun with trailer %s',
+    async (trailer) => {
+      const f = fixture();
+      f.run.head_commit.message = `chore: update metadata\n\n\n${trailer}`;
+      expect((await releaseEligibility(f)).release).toBe(false);
+    }
+  );
+  it('does not treat a false trailer or an inline mention as a skip directive', async () => {
+    const f = fixture();
+    f.run.head_commit.message = 'fix: explain skip-checks: true usage\n\n\nskip-checks: false';
+    expect((await releaseEligibility(f)).release).toBe(true);
+  });
   it('fails closed on API errors', async () => {
     const f = fixture();
     f.github.rest.git.getRef.mockRejectedValue(new Error('GitHub unavailable'));

--- a/scripts/release-gate.test.mjs
+++ b/scripts/release-gate.test.mjs
@@ -32,7 +32,7 @@ describe('release eligibility', () => {
     const f = fixture();
     // Webhook payloads need not include the workflow path; verify it through the API.
     delete f.context.payload.workflow_run.path;
-    expect((await releaseEligibility(f)).release).toBe(true);
+    expect(await releaseEligibility(f)).toMatchObject({ release: true, sha: f.run.head_sha });
     expect(f.github.rest.actions.getWorkflowRun).toHaveBeenCalledWith({
       owner: 'owner',
       repo: 'repo',
@@ -65,6 +65,8 @@ describe('release eligibility', () => {
     Object.assign(f.run, changes);
     expect((await releaseEligibility(f)).release).toBe(false);
   });
+});
+describe('release freshness and failures', () => {
   it('skips a newer unvalidated main instead of checking it out', async () => {
     const f = fixture();
     f.main.object.sha = 'b'.repeat(40);


### PR DESCRIPTION
Release currently repeats the full test suite (~6m43s) and database validation (~2m02s) inside a serialized workflow. When main advances, that work finishes only for semantic-release to skip publication; queued releases repeat the same checks.

Start Release after successful main-push CI and reuse that exact run’s validation. Load the gate from trusted default-branch code, then pin the release checkout to the SHA it validates, re-read CI identity/attempt and current main before setup and again before publication, and skip superseded candidates. PR/fork/failed/cancelled CI cannot authorize release. Keep the production build, existing release plugins/version-commit behavior, and non-cancelling publication serialization. Cloudflare deployment triggers are unchanged.

Validation: 26 focused regression tests pass, covering event provenance, stale CI attempts, newer main commits, skip markers, and API failures. Repository lint, focused ESLint, Prettier, actionlint 1.7.12, system drift checks, and a read-only check against a superseded real GitHub CI run pass.

This removes approximately 8½ minutes of duplicated validation from each release job; it does not remove validation from CI. The workflow_run publishing path is intentionally restricted to successful main CI and cannot be exercised end to end on this PR. After merge, verify that the triggering CI SHA equals the release checkout, the build and publication succeed, and the version commit gets its normal Cloudflare deployment. A successful main CI rerun is the recovery path; there is no manual bypass of validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Release Process**
  - Releases are published only after successful, trusted CI validation for pushes to the default branch.
  - Builds and publication use the validated commit, with eligibility rechecked before release.
  - Concurrent release runs are controlled to prevent conflicting publications.
  - Release automation uses restricted permissions and excludes untrusted fork candidates.
  - Releases are blocked when CI-skip markers are detected or validation evidence is stale or mismatched.

- **Documentation**
  - Added and updated documentation covering release validation, commit verification, cancellation behavior, version commits, and publication safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR changes releases to run after successful main-branch CI and reuse that run’s validation while retaining the production build.
- Adds a gate that verifies workflow identity, repository, status, attempt, commit SHA, skip directives, and current main.
- Pins build and publication to the validated commit and rechecks eligibility before semantic-release.
- Serializes publication without cancelling active release jobs.
- Adds focused gate tests and documents the revised release lifecycle.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge because no blocking failure remains within the eligible follow-up-review scope.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/release.yml | Replaces push-triggered release validation with a gated workflow-run flow, validated-SHA checkout, and pre-publication recheck. |
| scripts/release-gate.mjs | Implements fail-closed validation of the triggering CI run and current main commit. |
| scripts/release-gate.test.mjs | Covers trusted provenance, stale attempts and SHAs, superseded main commits, skip directives, and API failures. |
| docs/WORKFLOW_AUTOMATION.md | Documents the new CI evidence reuse, serialization, retry, publication, and deployment behavior. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant CI as Main CI
    participant WR as Release workflow
    participant API as GitHub API
    participant SR as semantic-release
    CI->>WR: Successful workflow_run event
    WR->>API: Re-read CI run and refs/heads/main
    API-->>WR: Run identity, attempt, status, and main SHA
    alt Eligible validated commit
        WR->>WR: Checkout validated SHA
        WR->>WR: Install and production build
        WR->>API: Recheck CI run and current main
        API-->>WR: Eligibility result
        alt Still eligible
            WR->>SR: Publish release
        else Superseded or stale
            WR-->>WR: Skip publication
        end
    else Untrusted, unsuccessful, stale, or skipped
        WR-->>WR: Skip release setup
    end
```
</details>

<sub>Reviews (4): Last reviewed commit: ["fix(ci): preserve trusted gate across re..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/aee9e40022ff579348b1da0053b9301af26f7fa1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60945202)</sub>

<!-- /greptile_comment -->