### PR TITLE
perf(tasks): avoid premature rendering during startup

### DIFF
--- a/app/composables/__tests__/useInfiniteScroll.test.ts
+++ b/app/composables/__tests__/useInfiniteScroll.test.ts
@@ -18,9 +18,14 @@ class MockIntersectionObserver {
   takeRecords: IntersectionObserver['takeRecords'] = vi.fn(() => []);
   unobserve: IntersectionObserver['unobserve'] = vi.fn();
 }
+const createClientRects = (rects: DOMRect[]): DOMRectList =>
+  Object.assign(rects, { item: (index: number) => rects[index] ?? null });
+const sentinels: HTMLElement[] = [];
 const createSentinelElement = () => {
   const sentinel = document.createElement('div');
+  sentinels.push(sentinel);
   sentinel.getBoundingClientRect = () => new DOMRect(0, 100, 100, 20);
+  sentinel.getClientRects = () => createClientRects([sentinel.getBoundingClientRect()]);
   return sentinel;
 };
 const flushMicrotasks = async (cycles = 8) => {
@@ -33,7 +38,9 @@ const mountHarness = async (
   onLoadMore: () => void | Promise<void>,
   options: UseInfiniteScrollOptions
 ) => {
-  const sentinelRef = ref<HTMLElement | null>(createSentinelElement());
+  const sentinel = createSentinelElement();
+  document.body.append(sentinel);
+  const sentinelRef = ref<HTMLElement | null>(sentinel);
   let result: ReturnType<typeof useInfiniteScroll> | undefined;
   const wrapper = mount(
     defineComponent({
@@ -47,7 +54,7 @@ const mountHarness = async (
   if (!result) {
     throw new Error('Failed to initialize useInfiniteScroll harness');
   }
-  return { result, wrapper };
+  return { result, wrapper, sentinel };
 };
 describe('useInfiniteScroll', () => {
   beforeEach(() => {
@@ -56,6 +63,55 @@ describe('useInfiniteScroll', () => {
   });
   afterEach(() => {
     vi.unstubAllGlobals();
+    for (const sentinel of sentinels.splice(0)) sentinel.remove();
+  });
+  it.each(['detached', 'hidden'] as const)(
+    'waits for a %s sentinel to have layout before consuming the auto-load budget',
+    async (state) => {
+      const onLoadMore = vi.fn();
+      const { result, wrapper, sentinel } = await mountHarness(onLoadMore, {
+        autoLoadOnReady: false,
+        maxAutoLoads: 1,
+      });
+      const getClientRects = sentinel.getClientRects;
+      if (state === 'detached') sentinel.remove();
+      else sentinel.getClientRects = () => createClientRects([]);
+      await result.checkAndLoadMore();
+      await flushMicrotasks();
+      expect(onLoadMore).not.toHaveBeenCalled();
+      expect(logger.warn).not.toHaveBeenCalled();
+      document.body.append(sentinel);
+      sentinel.getClientRects = getClientRects;
+      await result.checkAndLoadMore(true);
+      await flushMicrotasks();
+      expect(onLoadMore).toHaveBeenCalledTimes(1);
+      wrapper.unmount();
+    }
+  );
+  it('stops queued auto-fill when the sentinel loses its layout box', async () => {
+    const onLoadMore = vi.fn(() => {
+      sentinel.getClientRects = () => createClientRects([]);
+    });
+    const { result, wrapper, sentinel } = await mountHarness(onLoadMore, {
+      autoLoadOnReady: false,
+      maxAutoLoads: 8,
+    });
+    await result.checkAndLoadMore();
+    await flushMicrotasks(12);
+    expect(onLoadMore).toHaveBeenCalledTimes(1);
+    expect(logger.warn).not.toHaveBeenCalled();
+    wrapper.unmount();
+  });
+  it('does not load when a rendered sentinel is outside the preload range', async () => {
+    const onLoadMore = vi.fn();
+    const { result, wrapper, sentinel } = await mountHarness(onLoadMore, {
+      autoLoadOnReady: false,
+      rootMargin: '700px',
+    });
+    sentinel.getBoundingClientRect = () => new DOMRect(0, window.innerHeight + 701, 100, 20);
+    await result.checkAndLoadMore();
+    expect(onLoadMore).not.toHaveBeenCalled();
+    wrapper.unmount();
   });
   it('starts a fresh auto-load cycle on external checks', async () => {
     const onLoadMore = vi.fn();

--- a/app/composables/useInfiniteScroll.ts
+++ b/app/composables/useInfiniteScroll.ts
@@ -19,6 +19,11 @@ export interface UseInfiniteScrollReturn {
   start: () => void;
   checkAndLoadMore: (scrollTriggered?: boolean) => Promise<void>;
 }
+/**
+ * Load bounded batches when a rendered sentinel approaches the viewport.
+ * Detached or hidden sentinels wait for an observer, scroll, or explicit check
+ * after layout becomes available, without consuming the auto-load budget.
+ */
 export function useInfiniteScroll(
   sentinelRef: Ref<HTMLElement | null> | ComputedRef<HTMLElement | null>,
   onLoadMore: () => void | Promise<void>,

--- a/app/composables/useInfiniteScroll.ts
+++ b/app/composables/useInfiniteScroll.ts
@@ -81,6 +81,12 @@ export function useInfiniteScroll(
       logDebug('skip', { reason: 'missing-window', scrollTriggered });
       return;
     }
+    // Suspense can mount the list in a detached tree. Its zero bounding rect is
+    // not evidence that the sentinel is near the viewport; wait for real layout.
+    if (!sentinelRef.value.isConnected || sentinelRef.value.getClientRects().length === 0) {
+      logDebug('skip', { reason: 'sentinel-without-layout', scrollTriggered });
+      return;
+    }
     if (autoFill && resetAutoLoadCycle) {
       resetAutoLoadState('manual-check');
     }

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -66,7 +66,7 @@ const preferencesStoreMock = {
   togglePinnedTask: vi.fn(),
   setHideCompletedMapObjectives: vi.fn(),
 };
-const metadataStoreMock = {
+const metadataStoreMock = reactive({
   tasks: [defaultTask],
   loading: false,
   hasInitialized: true,
@@ -77,8 +77,9 @@ const metadataStoreMock = {
   objectiveMaps: {},
   objectiveGPS: {},
   fetchMapSpawnsData: vi.fn(() => Promise.resolve()),
-  getTaskById: (taskId: string) => metadataStoreMock.tasks.find((task) => task.id === taskId),
-};
+  getTaskById: (taskId: string): Task | undefined =>
+    metadataStoreMock.tasks.find((task) => task.id === taskId),
+});
 const mapTaskCountsMock = {
   withHide: 0,
   withoutHide: 1,
@@ -108,7 +109,7 @@ vi.mock('pinia', async () => {
     storeToRefs: (store: Record<string, unknown>) => {
       const refs: Record<string, unknown> = {};
       Object.entries(store).forEach(([key, value]) => {
-        refs[key] = value !== null && isRef(value) ? value : ref(value);
+        refs[key] = value !== null && isRef(value) ? value : toRef(store, key);
       });
       return refs;
     },
@@ -300,9 +301,11 @@ describe('tasks page', () => {
   let wrapper: Awaited<ReturnType<typeof mountSuspended>>;
   let TasksPage: typeof import('@/pages/tasks.vue').default;
   const mountPage = async () => {
+    wrapper?.unmount();
     wrapper = await mountSuspended(TasksPage, {
       global: { stubs: defaultGlobalStubs },
     });
+    await vi.waitFor(() => expect(wrapper.find('task-loading-state-stub').exists()).toBe(false));
   };
   const mountAttachedPage = async () => {
     wrapper?.unmount();
@@ -310,6 +313,7 @@ describe('tasks page', () => {
       attachTo: document.body,
       global: { stubs: defaultGlobalStubs },
     });
+    await vi.waitFor(() => expect(wrapper.find('task-loading-state-stub').exists()).toBe(false));
   };
   const getLeafletMarks = (): MapObjectiveMark[] => {
     const raw = wrapper.find('[data-testid="leaflet-map"]').attributes('data-marks') ?? '[]';
@@ -329,6 +333,8 @@ describe('tasks page', () => {
     return false;
   };
   beforeEach(async () => {
+    metadataStoreMock.hasInitialized = true;
+    metadataStoreMock.loading = false;
     visibleTasksRef.value = [defaultTask];
     focusedTaskRef.value = null;
     updateVisibleTasksMock.mockReset();
@@ -367,6 +373,62 @@ describe('tasks page', () => {
   });
   afterEach(() => {
     wrapper?.unmount();
+  });
+  it.each([true, false])(
+    'keeps the loading state until the initial filter refresh finishes (has tasks: %s)',
+    async (hasTasks) => {
+      wrapper.unmount();
+      visibleTasksRef.value = [];
+      updateVisibleTasksMock.mockClear();
+      let finishRefresh: () => void = () => {};
+      updateVisibleTasksMock.mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            finishRefresh = resolve;
+          })
+      );
+      wrapper = await mountSuspended(TasksPage, {
+        global: { stubs: defaultGlobalStubs },
+      });
+      await vi.waitFor(() => expect(updateVisibleTasksMock).toHaveBeenCalled());
+      expect(wrapper.find('task-loading-state-stub').exists()).toBe(true);
+      expect(wrapper.find('task-empty-state-stub').exists()).toBe(false);
+      visibleTasksRef.value = hasTasks ? [defaultTask] : [];
+      finishRefresh();
+      await vi.waitFor(() => expect(wrapper.find('task-loading-state-stub').exists()).toBe(false));
+      expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(hasTasks);
+      expect(wrapper.find('task-empty-state-stub').exists()).toBe(!hasTasks);
+    }
+  );
+  it('refreshes after initialization changes even when the task array is unchanged', async () => {
+    metadataStoreMock.hasInitialized = false;
+    await nextTick();
+    expect(wrapper.find('task-loading-state-stub').exists()).toBe(true);
+    updateVisibleTasksMock.mockClear();
+    metadataStoreMock.hasInitialized = true;
+    await vi.waitFor(() => expect(updateVisibleTasksMock).toHaveBeenCalled());
+    await vi.waitFor(() => expect(wrapper.find('task-loading-state-stub').exists()).toBe(false));
+    expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true);
+  });
+  it('keeps the loading state across a metadata reload until the new refresh finishes', async () => {
+    metadataStoreMock.loading = true;
+    await nextTick();
+    visibleTasksRef.value = [];
+    updateVisibleTasksMock.mockClear();
+    let finishRefresh: () => void = () => {};
+    updateVisibleTasksMock.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRefresh = resolve;
+        })
+    );
+    metadataStoreMock.loading = false;
+    await vi.waitFor(() => expect(updateVisibleTasksMock).toHaveBeenCalled());
+    expect(wrapper.find('task-loading-state-stub').exists()).toBe(true);
+    expect(wrapper.find('task-empty-state-stub').exists()).toBe(false);
+    visibleTasksRef.value = [defaultTask];
+    finishRefresh();
+    await vi.waitFor(() => expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true));
   });
   it('renders task cards when tasks are available', async () => {
     expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true);
@@ -458,6 +520,7 @@ describe('tasks page', () => {
     preferencesStoreMock.getTaskPrimaryView = 'maps';
     preferencesStoreMock.getTaskMapView = 'map-1';
     metadataStoreMock.mapsWithSvg = [{ id: 'map-1', name: 'Map One' }];
+    wrapper?.unmount();
     wrapper = await mountSuspended(TasksPage, {
       global: {
         stubs: {
@@ -466,6 +529,7 @@ describe('tasks page', () => {
         },
       },
     });
+    await vi.waitFor(() => expect(wrapper.find('task-loading-state-stub').exists()).toBe(false));
     const toggleButton = wrapper.find('[data-testid="map-panel-toggle"]');
     expect(toggleButton.attributes('aria-expanded')).toBe('false');
     const jumpButton = wrapper.find('[data-testid="jump-to-map-objective"]');

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -906,6 +906,7 @@
   useTaskRouteSync({ maps, traders: sortedTraders });
   // Metadata readiness can precede the first debounced filter refresh.
   const hasRefreshedVisibleTasks = ref(false);
+  /** Refresh filters before allowing initial results to replace the loading state. */
   const refreshVisibleTasks = async () => {
     try {
       await updateVisibleTasks(mapTaskVisibilityFilterOptions.value, tasksLoading.value);

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -904,21 +904,23 @@
   };
   const route = useRoute();
   useTaskRouteSync({ maps, traders: sortedTraders });
-  const refreshVisibleTasks = () => {
+  // Metadata readiness can precede the first debounced filter refresh.
+  const hasRefreshedVisibleTasks = ref(false);
+  const refreshVisibleTasks = async () => {
     try {
-      updateVisibleTasks(mapTaskVisibilityFilterOptions.value, tasksLoading.value);
+      await updateVisibleTasks(mapTaskVisibilityFilterOptions.value, tasksLoading.value);
     } catch (error) {
       logger.error('[Tasks] Failed to refresh tasks:', error);
+    } finally {
+      hasRefreshedVisibleTasks.value = metadataStore.hasInitialized && !tasksLoading.value;
     }
   };
-  const debouncedRefreshVisibleTasks = debounce(() => {
-    refreshVisibleTasks();
-  }, 50);
+  const debouncedRefreshVisibleTasks = debounce(refreshVisibleTasks, 50);
   const handleTaskAction = (payload: TaskActionPayload) => {
     onTaskAction(payload);
     trackFocusedTaskAction(payload);
     void nextTick(() => {
-      refreshVisibleTasks();
+      void refreshVisibleTasks();
       debouncedRefreshVisibleTasks.cancel();
     });
   };
@@ -956,6 +958,7 @@
       getHideGlobalTasks,
       getHideCompletedMapObjectives,
       getPinnedTaskIds,
+      () => metadataStore.hasInitialized,
       tasksLoading,
       tasks,
       maps,
@@ -967,6 +970,11 @@
       editions,
     ],
     () => {
+      if (!metadataStore.hasInitialized || tasksLoading.value) {
+        hasRefreshedVisibleTasks.value = false;
+        debouncedRefreshVisibleTasks.cancel();
+        return;
+      }
       void debouncedRefreshVisibleTasks().catch((error) => {
         if (isDebounceRejection(error)) return;
         logger.error('[Tasks] Debounced refresh failed:', error);
@@ -974,7 +982,9 @@
     },
     { immediate: true, flush: 'post' }
   );
-  const isLoading = computed(() => !metadataStore.hasInitialized || tasksLoading.value);
+  const isLoading = computed(
+    () => !metadataStore.hasInitialized || tasksLoading.value || !hasRefreshedVisibleTasks.value
+  );
   const {
     activeSearchCount,
     cleanup: cleanupTaskFilters,

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1252,6 +1252,25 @@ code (fix the code) or in this doc (fix the doc in the same PR). `AGENTS.md`'s M
 requires updating this file whenever one of these systems changes. When in doubt, the code is the
 source of truth and this doc is the explanation of it.
 
+### Task list loading
+
+`app/composables/useInfiniteScroll.ts` loads another batch only when the sentinel is connected
+to the document and has a layout box. Nuxt Suspense can mount a warm-cache task list in a
+detached tree; its zero bounding rectangle must not trigger auto-fill. Hidden or detached
+sentinels consume no auto-load budget. The existing intersection observer checks again when
+the list becomes visible; configured scroll fallback and explicit checks use the same guard.
+
+The tasks page retains its loading state until metadata is ready and the first visible-task
+refresh settles. Reset that readiness when metadata starts loading again. Metadata readiness
+alone must not expose the empty state during the debounced filter refresh; a completed refresh
+with no matching tasks still shows the normal empty state. Subsequent filter changes retain
+the existing debounce and task actions still request an immediate refresh.
+
+Keep the tasks page's eight-card batches, preload margin, and auto-load caps. Do not defer
+critical metadata or change task filters, progress state, or card expansion to mask mounting
+cost. Performance validation and the issue #444 baseline are documented in
+`docs/task-performance-validation.md`.
+
 ### Task card layout and legacy density preferences
 
 Task cards always use compact spacing. There is no density selector or persisted density

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -113,3 +113,14 @@ why the broader CLS work in #444 remains open despite the low Lighthouse CLS.
   collapse/expand, pin/unpin, search/clear, task deep links, and completion/undo.
 - Authenticated team synchronization was not exercised in the offline preview. Existing team
   filtering and teammate map-marker regressions are covered by the focused tests.
+
+Additional browser checks passed for Hideout scrolling (14 → 20 stations), Needed Items
+scrolling (36 → 60 entries), graph and map routes, and PvP → PvE → Seasonal → PvP transitions.
+Paired real-time mobile traces reproduced the same cold layout-shift values on both revisions
+(0.2204 and 0.2586, in different run order); warm layout-shift sum remained 0.1075. The fixed
+mobile runs rendered eight initial cards rather than the baseline's 72, without empty-state
+flashes. These checks produced no uncaught browser exceptions.
+
+The Cloudflare build/deployment also passed. Its hosted preview requires Cloudflare Access;
+the interaction checks above used the local production build, not an authenticated hosted
+preview session.

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -1,0 +1,115 @@
+# Task performance validation (#444)
+
+## Scope
+
+This change fixes two task-page startup races. Nuxt Suspense mounts the
+list in a detached tree. The sentinel's bounding rectangle is then zero, which previously
+looked like a visible sentinel and exhausted eight auto-fill cycles before the first paint:
+8 initial cards became 72. The layout guard preserves eight-card batches and resumes through
+the existing intersection observer when the sentinel is actually rendered.
+
+Separately, metadata can become ready before the debounced task filter refresh completes.
+The page now keeps its loading state until that refresh settles, preventing a transient
+"No tasks found" message and footer jump. Real empty results still render the empty state.
+
+It does not change filtering, sorting, progress persistence, metadata scheduling, card defaults,
+or Lighthouse CI thresholds. No migration, dependency, or deployment ordering is required.
+Reverting the composable change restores the previous behavior.
+
+## Reproduction and method
+
+- Base: `1571da2182ef30d78a979d8a74a448e623dda414`, September 6, 2026.
+- Build both revisions with Node 24.19.0, the frozen lockfile, `CI=true`,
+  `NUXT_PUBLIC_PROMOTED_TWITCH_ENABLED=false`, and the same `APP_URL`; run `pnpm run build`.
+- Serve each built `dist` locally. The comparison used a static preview with gzip and a replay
+  proxy for public `/api/tarkov/*` responses captured from production on September 6. Keep
+  exactly the same response bodies across revisions; do not benchmark empty/error screens.
+- Use an isolated Chrome 149.0.7827.200 profile and a local `*.pages.dev` hostname mapped to loopback to
+  exercise the existing offline preview fallback. This measures guest progress; it does not
+  exercise authenticated Supabase synchronization. No production credentials are needed.
+- Desktop trace: 1440 × 900, 4× CPU throttling, unthrottled network. First visit primes the
+  browser's metadata cache; reload without clearing it for the warm sample. Wait 15 seconds
+  after cards appear, recording `longtask`, `layout-shift`, and first rendered card count.
+  Repeat with three independent profiles for each revision, without builds/tests competing
+  for CPU. Also check a 412 × 823 mobile viewport.
+- Lighthouse: version 13.4.1, three fresh profiles per revision, default simulated mobile
+  throttling, performance category. These cold-load scores are not comparable to the original
+  issue's historical report or to a different GitHub runner.
+- Instrumenting the baseline's `getBoundingClientRect` confirmed nine consecutive warm-cache
+  sentinel checks with `isConnected=false`, no client rectangles, and `top=0` before paint.
+
+Useful response fingerprints (SHA-256 prefixes): tasks-core `6d8940f89f17`, items-lite
+`625c4c63ec7e`, regular objectives `c925244c5d21`, rewards `84fc091370f6`.
+
+## Acceptance policy
+
+For this fix, a warm-cache page must not spend its auto-load budget on a detached or hidden
+sentinel, or flash an empty result before the first filter refresh settles. At the desktop test viewport with default expanded cards, initial rendering must
+remain eight cards; scrolling must load further batches. Compare repeated warm-load blocking
+work and first-card appearance, not only a cold navigation score.
+
+The cold-load non-regression budget is median TBT no more than the baseline plus the greater
+of 100 ms or 10%, LCP within 10%, and mobile Lighthouse CLS below 0.1. This is a controlled
+comparison budget, not a new universal performance floor. Keep the existing warning-only
+0.20 performance floor and single-run collection in PR CI; dedicated investigations use
+repeated runs. The historical 0.55 threshold is not a closure test for this patch.
+
+Issue #444 should remain open for cold-load investigation: expanded desktop cards still shift
+as deferred objectives/rewards arrive. A complete resolution needs those shifts addressed,
+representative persisted/team progress measurements, and a broader performance budget. Passing
+CI or this warm-cache regression check does not prove those remaining goals are complete.
+
+## Measured results
+
+Three independent warm-cache desktop profiles per revision:
+
+| Metric                                        | Baseline runs            | Fixed runs               | Median change |
+| --------------------------------------------- | ------------------------ | ------------------------ | ------------- |
+| Initial cards                                 | 72 / 72 / 72             | 8 / 8 / 8                | 89% fewer     |
+| First frame with cards (ms)                   | 3211 / 3192 / 3490       | 1170 / 1113 / 1324       | 64% earlier   |
+| Blocking portions of observed long tasks (ms) | 6896 / 6480 / 6945       | 1061 / 1044 / 1128       | 85% lower     |
+| Longest main-thread task (ms)                 | 2150 / 2133 / 2378       | 383 / 372 / 453          | 82% shorter   |
+| Observed layout-shift sum                     | 0.0361 / 0.0361 / 0.0361 | 0.0361 / 0.0361 / 0.0361 | Unchanged     |
+
+“Blocking portions” sums `max(duration - 50, 0)` across observed long tasks through the
+15-second settling window after cards first appear. It is **not Lighthouse TBT**, which has
+its own measurement window and simulated throttling. First-card appearance is a DOM/animation
+frame observation, not LCP or a guarantee that all deferred objectives have loaded.
+
+An intermediate build with only the sentinel guard exposed the independent empty-state race:
+one warm desktop run showed the footer at 516 px before the first cards and layout-shift sum
+0.3964; mobile showed 0.4020. The final readiness gate removed that transient empty state in
+all three final desktop runs. These intermediate values are diagnostic observations, not
+additional baseline samples.
+
+The method follows Chrome's guidance to investigate actual layout-shift sources and compare
+performance distributions under consistent conditions:
+[layout shift diagnosis](https://web.dev/articles/optimize-cls) and
+[Lighthouse score variability](https://developer.chrome.com/docs/lighthouse/performance/performance-scoring).
+
+Cold mobile Lighthouse runs:
+
+| Metric            | Baseline runs               | Fixed runs                  |
+| ----------------- | --------------------------- | --------------------------- |
+| Performance score | 0.45 / 0.48 / 0.45          | 0.48 / 0.48 / 0.46          |
+| TBT (ms)          | 723 / 552 / 709             | 582 / 572 / 652             |
+| LCP (ms)          | 9273 / 9270 / 9279          | 9274 / 9273 / 9270          |
+| CLS               | 0.00205 / 0.00205 / 0.00205 | 0.00205 / 0.00205 / 0.00205 |
+
+Median Lighthouse TBT fell from 709 to 582 ms; LCP was effectively unchanged. These pass the
+comparison budgets above. The real-time 4× CPU traces still show deferred-content movement:
+final cold desktop layout-shift sums were 0.1010, 0.1319, and 0.1010; the final mobile probe
+was 0.2586 cold and 0.1075 warm. None of the final probes flashed the empty state. These are
+why the broader CLS work in #444 remains open despite the low Lighthouse CLS.
+
+## Functional validation
+
+- Production build, repository lint, typecheck, and systems drift check passed.
+- Nine focused Vitest files passed (129 tests), covering infinite scroll, tasks/Hideout/Needed
+  Items pages, task filtering, page effects, task actions, deep links, and objective visibility.
+- The new infinite-scroll tests failed on the original implementation for detached/hidden
+  sentinels and for losing layout during auto-fill, then passed with the guard.
+- Browser interaction checks passed for warm initial rendering, scroll loading (8 → 16 cards),
+  collapse/expand, pin/unpin, search/clear, task deep links, and completion/undo.
+- Authenticated team synchronization was not exercised in the offline preview. Existing team
+  filtering and teammate map-marker regressions are covered by the focused tests.


### PR DESCRIPTION
## Summary

Warm-cache task visits could mount 72 cards before the first paint because Nuxt Suspense mounted the infinite-scroll sentinel in a detached tree. Metadata could also expose a transient “No tasks found” state before the first filter refresh. This PR waits for real sentinel layout and keeps the loading state until that refresh settles.

Three controlled warm-cache runs retained eight initial cards, rendered them 64% earlier, and reduced observed long-task blocking by 85%. Cold mobile Lighthouse median TBT improved from 709 ms to 582 ms, with LCP effectively unchanged.

## Changes

- Ignore detached or hidden sentinels without consuming the auto-load budget; preserve normal intersection-triggered paging.
- Track initial visible-task readiness separately from metadata readiness, including metadata reloads and genuinely empty results.
- Add regression coverage and document measurements, comparison budgets, and remaining limitations in [task performance validation](https://github.com/tarkovtracker-org/TarkovTracker/blob/4baf3401cf2be8c26df8cc33950c10ba83c56480/docs/task-performance-validation.md).

## Related Issues

Related to #444. This fixes two confirmed startup defects, but does not close the broader issue: deferred objectives/rewards still cause layout shifts in real-time cold-load traces. The historical 0.55 Lighthouse threshold is not used as a closure claim.

## Testing

- [x] Tested locally
- [x] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed (automated real-browser interaction probes)

### Test Plan

1. Production build, repository lint, typecheck, and systems drift checks passed.
2. Nine focused Vitest files passed: 129 tests across infinite scrolling, task/Hideout/Needed Items pages, filtering, actions, deep links, page effects, and objective visibility. New sentinel regressions failed before the fix.
3. Three fresh-profile Lighthouse runs per revision; three independent cold/warm desktop profiles and a mobile probe for the final implementation. See the linked validation document for exact results and limitations.
4. Browser checks passed for warm initial rendering, scrolling from 8 to 16 cards, collapse/expand, pin/unpin, search/clear, deep links, and completion/undo. Hideout scrolling (14 → 20), Needed Items scrolling (36 → 60), graph/map routes, and PvP → PvE → Seasonal → PvP transitions also passed without uncaught browser exceptions.

## Screenshots/Videos

Desktop/mobile browser screenshots were inspected locally. There is no visual redesign; the validation document records frame observations and the eliminated transient empty-state transition.

## Documentation impact

- [x] Behavior changed — documentation was updated in this PR
- [x] SYSTEMS or architecture
- [x] Contributor documentation (performance validation procedure)

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] Local validation generates no new warnings or errors
- [x] I have tested my changes with focused tests and browser probes
- [x] All hosted CI and automated reviews pass
- [x] I have checked for breaking changes

## Additional Notes

No dependency, schema, API, or deployment-order changes. Filtering, progress storage, batch sizes, and CI thresholds are preserved. The local preview used public game-data responses and offline guest progress; authenticated team synchronization was not exercised. Existing teammate filtering and map-marker regression tests passed.

Additional paired mobile traces reproduced the same pre-existing cold layout-shift values (0.2204 and 0.2586) on baseline and fixed builds; warm initial cards fell from 72 to eight. Cloudflare built and deployed this commit successfully. Its hosted preview is protected by Cloudflare Access, so runtime interaction checks used the local production build.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved task-list loading so pages remain in a loading state until metadata and refreshed filters are ready.
  - Prevented infinite scrolling from loading additional tasks when sentinel elements are detached, lack layout, or fall outside the preload range.
  - Ensured task updates wait for visible-task refreshes to complete, reducing stale or incomplete task displays.

- **Documentation**
  - Added guidance on task-list loading behavior and performance validation, including testing results and known layout-shift limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Merge handoff

Final head: `4baf3401cf2be8c26df8cc33950c10ba83c56480`. All 30 reported checks pass; the two expected skips are Supabase Preview (no database changes) and Dependabot auto-merge (not a Dependabot PR). Codex, CodeRabbit, Greptile, and Cubic completed without actionable findings. The CodeRabbit docstring advisory was fixed; its final pre-merge checks all pass. There are no unresolved review threads or merge conflicts.

Maintainer approval is still required by the repository PR policy. This PR has not been merged, and #444 remains open for the documented cold-load work.

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR prevents premature task-list rendering during startup and keeps the loading state active until the initial visible-task refresh settles.
- Ignores detached or hidden infinite-scroll sentinels without consuming the automatic-load budget.
- Separates metadata readiness from visible-task readiness across initial loads and metadata reloads.
- Adds focused regression tests and documents the task-page performance-validation procedure.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/composables/useInfiniteScroll.ts | Adds a layout-presence guard so detached or hidden sentinels cannot trigger premature automatic paging. |
| app/composables/__tests__/useInfiniteScroll.test.ts | Adds regression coverage for detached, hidden, layout-losing, and out-of-range sentinels. |
| app/pages/tasks.vue | Tracks visible-task refresh readiness independently and retains loading UI through initialization and metadata reloads. |
| app/pages/__tests__/tasks.page.test.ts | Adds reactive metadata and loading-state coverage for initial refreshes, empty results, and reloads. |
| docs/SYSTEMS.md | Documents task-list loading invariants and infinite-scroll sentinel behavior. |
| docs/task-performance-validation.md | Records the performance methodology, acceptance budgets, measured results, and remaining limitations. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Task page starts] --> B{Metadata initialized and idle?}
  B -- No --> C[Keep loading state]
  B -- Yes --> D[Refresh visible tasks]
  D --> E[Mark visible tasks ready]
  E --> F[Render task results or empty state]
  F --> G{Sentinel connected with layout?}
  G -- No --> H[Wait without consuming auto-load budget]
  G -- Yes --> I{Within preload range?}
  I -- Yes --> J[Load next bounded batch]
  I -- No --> K[Wait for observer, scroll, or explicit check]
```
</details>

<sub>Reviews (2): Last reviewed commit: ["docs(tasks): clarify loading contracts a..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/4baf3401cf2be8c26df8cc33950c10ba83c56480) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60985508)</sub>

<!-- /greptile_comment -->
