### PR TITLE
fix(tasks): stabilize initial cards and complete performance validation

### DIFF
--- a/app/composables/__tests__/useTaskDetailReadiness.test.ts
+++ b/app/composables/__tests__/useTaskDetailReadiness.test.ts
@@ -13,15 +13,16 @@ const metadata = reactive({
   getApiGameMode: () => metadata.mode,
   fetchTaskObjectivesData: vi.fn<() => Promise<void>>(),
   fetchTaskRewardsData: vi.fn<() => Promise<void>>(),
+  fetchItemsLiteData: vi.fn<() => Promise<void>>(),
   fetchEditionsData: vi.fn<() => Promise<void>>(),
-  fetchObjectiveModeCountDifferences: vi.fn<() => Promise<void>>(),
+  fetchObjectiveModeCountDifferences: vi.fn<() => Promise<'stale' | undefined>>(),
 });
 vi.mock('@/stores/useMetadata', () => ({ useMetadataStore: () => metadata }));
 const deferred = () => {
   let resolve!: () => void;
   let reject!: (error: Error) => void;
-  const promise = new Promise<void>((done, fail) => {
-    resolve = done;
+  const promise = new Promise<undefined>((done, fail) => {
+    resolve = () => done(undefined);
     reject = fail;
   });
   return { promise, resolve, reject };
@@ -46,8 +47,9 @@ describe('useTaskDetailReadiness', () => {
     metadata.objectiveModeCountDifferencesHydrated = true;
     metadata.fetchTaskObjectivesData.mockReset().mockResolvedValue();
     metadata.fetchTaskRewardsData.mockReset().mockResolvedValue();
+    metadata.fetchItemsLiteData.mockReset().mockResolvedValue();
     metadata.fetchEditionsData.mockReset().mockResolvedValue();
-    metadata.fetchObjectiveModeCountDifferences.mockReset().mockResolvedValue();
+    metadata.fetchObjectiveModeCountDifferences.mockReset().mockResolvedValue(undefined);
   });
   afterEach(() => {
     scope.stop();
@@ -69,6 +71,23 @@ describe('useTaskDetailReadiness', () => {
     await flush();
     expect(ready.value).toBe(true);
     expect(vi.getTimerCount()).toBe(0);
+  });
+  it('waits for item-lite hydration before revealing localized cards', async () => {
+    const items = deferred();
+    metadata.fetchItemsLiteData.mockReturnValue(items.promise);
+    const ready = start();
+    await flush();
+    expect(ready.value).toBe(false);
+    items.resolve();
+    await flush();
+    expect(ready.value).toBe(true);
+  });
+  it('does not retry handled objective count failures', async () => {
+    metadata.objectiveModeCountDifferencesHydrated = false;
+    const ready = start();
+    await flush();
+    expect(ready.value).toBe(true);
+    expect(metadata.fetchObjectiveModeCountDifferences).toHaveBeenCalledTimes(1);
   });
   it('waits for core metadata before requesting details', async () => {
     metadata.hasInitialized = false;
@@ -136,7 +155,7 @@ describe('useTaskDetailReadiness', () => {
     metadata.objectiveModeCountDifferencesHydrated = false;
     const replacement = deferred();
     metadata.fetchObjectiveModeCountDifferences
-      .mockResolvedValueOnce()
+      .mockResolvedValueOnce('stale')
       .mockReturnValueOnce(replacement.promise);
     const ready = start();
     await flush();

--- a/app/composables/__tests__/useTaskDetailReadiness.test.ts
+++ b/app/composables/__tests__/useTaskDetailReadiness.test.ts
@@ -4,6 +4,7 @@ import { useTaskDetailReadiness } from '@/composables/useTaskDetailReadiness';
 const metadata = reactive({
   hasInitialized: true,
   loading: false,
+  tasksCoreRefreshing: false,
   languageCode: 'en',
   mode: 'regular',
   tasks: [{ id: 'task' }],
@@ -39,6 +40,7 @@ describe('useTaskDetailReadiness', () => {
     scope = effectScope();
     metadata.hasInitialized = true;
     metadata.loading = false;
+    metadata.tasksCoreRefreshing = false;
     metadata.languageCode = 'en';
     metadata.mode = 'regular';
     metadata.tasks = [{ id: 'task' }];
@@ -83,11 +85,28 @@ describe('useTaskDetailReadiness', () => {
     expect(ready.value).toBe(true);
   });
   it('does not retry handled objective count failures', async () => {
+    // Handled failures resolve undefined and leave hydration false; neither permits a retry.
     metadata.objectiveModeCountDifferencesHydrated = false;
+    metadata.fetchObjectiveModeCountDifferences.mockResolvedValueOnce(undefined);
     const ready = start();
     await flush();
     expect(ready.value).toBe(true);
     expect(metadata.fetchObjectiveModeCountDifferences).toHaveBeenCalledTimes(1);
+  });
+  it('keeps cached locale details hidden while bootstrap and core refresh are pending', async () => {
+    const ready = start();
+    await flush();
+    expect(ready.value).toBe(true);
+    metadata.fetchTaskRewardsData.mockClear();
+    metadata.tasksCoreRefreshing = true;
+    metadata.languageCode = 'fr';
+    await flush();
+    expect(ready.value).toBe(false);
+    expect(metadata.fetchTaskRewardsData).not.toHaveBeenCalled();
+    metadata.tasksCoreRefreshing = false;
+    metadata.tasksCoreRevision += 1;
+    await flush();
+    expect(ready.value).toBe(true);
   });
   it('waits for core metadata before requesting details', async () => {
     metadata.hasInitialized = false;

--- a/app/composables/__tests__/useTaskDetailReadiness.test.ts
+++ b/app/composables/__tests__/useTaskDetailReadiness.test.ts
@@ -7,10 +7,14 @@ const metadata = reactive({
   languageCode: 'en',
   mode: 'regular',
   tasks: [{ id: 'task' }],
+  tasksCoreRevision: 0,
+  editionsLoading: false,
+  objectiveModeCountDifferencesHydrated: true,
   getApiGameMode: () => metadata.mode,
   fetchTaskObjectivesData: vi.fn<() => Promise<void>>(),
   fetchTaskRewardsData: vi.fn<() => Promise<void>>(),
   fetchEditionsData: vi.fn<() => Promise<void>>(),
+  fetchObjectiveModeCountDifferences: vi.fn<() => Promise<void>>(),
 });
 vi.mock('@/stores/useMetadata', () => ({ useMetadataStore: () => metadata }));
 const deferred = () => {
@@ -25,8 +29,7 @@ const deferred = () => {
 let scope: ReturnType<typeof effectScope>;
 const start = () => scope.run(() => useTaskDetailReadiness())!;
 const flush = async () => {
-  await Promise.resolve();
-  await Promise.resolve();
+  await vi.advanceTimersByTimeAsync(0);
   await nextTick();
 };
 describe('useTaskDetailReadiness', () => {
@@ -38,9 +41,13 @@ describe('useTaskDetailReadiness', () => {
     metadata.languageCode = 'en';
     metadata.mode = 'regular';
     metadata.tasks = [{ id: 'task' }];
+    metadata.tasksCoreRevision = 0;
+    metadata.editionsLoading = false;
+    metadata.objectiveModeCountDifferencesHydrated = true;
     metadata.fetchTaskObjectivesData.mockReset().mockResolvedValue();
     metadata.fetchTaskRewardsData.mockReset().mockResolvedValue();
     metadata.fetchEditionsData.mockReset().mockResolvedValue();
+    metadata.fetchObjectiveModeCountDifferences.mockReset().mockResolvedValue();
   });
   afterEach(() => {
     scope.stop();
@@ -87,6 +94,66 @@ describe('useTaskDetailReadiness', () => {
     metadata.tasks = [];
     expect(start().value).toBe(true);
     expect(metadata.fetchTaskRewardsData).not.toHaveBeenCalled();
+  });
+  it.each([true, false])(
+    're-arms cached core replacement without loading (previous tasks: %s)',
+    async (hadTasks) => {
+      if (!hadTasks) metadata.tasks = [];
+      const ready = start();
+      await flush();
+      expect(ready.value).toBe(true);
+      const replacement = deferred();
+      metadata.fetchTaskObjectivesData.mockReturnValueOnce(replacement.promise);
+      metadata.tasks = [{ id: 'localized-task' }];
+      metadata.tasksCoreRevision += 1;
+      await nextTick();
+      expect(ready.value).toBe(false);
+      replacement.resolve();
+      await flush();
+      expect(ready.value).toBe(true);
+    }
+  );
+  it('waits for background edition revalidation after the cache read settles', async () => {
+    metadata.editionsLoading = true;
+    const ready = start();
+    await flush();
+    expect(ready.value).toBe(false);
+    metadata.editionsLoading = false;
+    await nextTick();
+    expect(ready.value).toBe(true);
+  });
+  it('waits for objective count differences after the objectives merge', async () => {
+    const differences = deferred();
+    metadata.fetchObjectiveModeCountDifferences.mockReturnValue(differences.promise);
+    const ready = start();
+    await flush();
+    expect(ready.value).toBe(false);
+    differences.resolve();
+    await flush();
+    expect(ready.value).toBe(true);
+  });
+  it('retries a discarded count request once after detail hydration', async () => {
+    metadata.objectiveModeCountDifferencesHydrated = false;
+    const replacement = deferred();
+    metadata.fetchObjectiveModeCountDifferences
+      .mockResolvedValueOnce()
+      .mockReturnValueOnce(replacement.promise);
+    const ready = start();
+    await flush();
+    expect(metadata.fetchObjectiveModeCountDifferences).toHaveBeenCalledTimes(2);
+    expect(ready.value).toBe(false);
+    replacement.resolve();
+    await flush();
+    expect(ready.value).toBe(true);
+    expect(metadata.fetchObjectiveModeCountDifferences).toHaveBeenCalledTimes(2);
+  });
+  it('does not let stalled edition revalidation hold the page indefinitely', async () => {
+    metadata.editionsLoading = true;
+    const ready = start();
+    await flush();
+    expect(ready.value).toBe(false);
+    await vi.advanceTimersByTimeAsync(3000);
+    expect(ready.value).toBe(true);
   });
   it('releases the page on request failure', async () => {
     metadata.fetchTaskObjectivesData.mockRejectedValue(new Error('offline'));

--- a/app/composables/__tests__/useTaskDetailReadiness.test.ts
+++ b/app/composables/__tests__/useTaskDetailReadiness.test.ts
@@ -15,7 +15,7 @@ const metadata = reactive({
   fetchTaskObjectivesData: vi.fn<() => Promise<void>>(),
   fetchTaskRewardsData: vi.fn<() => Promise<void>>(),
   fetchItemsLiteData: vi.fn<() => Promise<void>>(),
-  fetchEditionsData: vi.fn<() => Promise<void>>(),
+  ensureEditionsData: vi.fn<() => Promise<void>>(),
   fetchObjectiveModeCountDifferences: vi.fn<() => Promise<'stale' | undefined>>(),
 });
 vi.mock('@/stores/useMetadata', () => ({ useMetadataStore: () => metadata }));
@@ -50,7 +50,7 @@ describe('useTaskDetailReadiness', () => {
     metadata.fetchTaskObjectivesData.mockReset().mockResolvedValue();
     metadata.fetchTaskRewardsData.mockReset().mockResolvedValue();
     metadata.fetchItemsLiteData.mockReset().mockResolvedValue();
-    metadata.fetchEditionsData.mockReset().mockResolvedValue();
+    metadata.ensureEditionsData.mockReset().mockResolvedValue();
     metadata.fetchObjectiveModeCountDifferences.mockReset().mockResolvedValue(undefined);
   });
   afterEach(() => {
@@ -120,7 +120,7 @@ describe('useTaskDetailReadiness', () => {
   });
   it('waits for edition eligibility so the first cards use the final filters', async () => {
     const editions = deferred();
-    metadata.fetchEditionsData.mockReturnValue(editions.promise);
+    metadata.ensureEditionsData.mockReturnValue(editions.promise);
     const ready = start();
     await flush();
     expect(ready.value).toBe(false);

--- a/app/composables/__tests__/useTaskDetailReadiness.test.ts
+++ b/app/composables/__tests__/useTaskDetailReadiness.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { effectScope, nextTick, reactive } from 'vue';
+import { useTaskDetailReadiness } from '@/composables/useTaskDetailReadiness';
+const metadata = reactive({
+  hasInitialized: true,
+  loading: false,
+  languageCode: 'en',
+  mode: 'regular',
+  tasks: [{ id: 'task' }],
+  getApiGameMode: () => metadata.mode,
+  fetchTaskObjectivesData: vi.fn<() => Promise<void>>(),
+  fetchTaskRewardsData: vi.fn<() => Promise<void>>(),
+  fetchEditionsData: vi.fn<() => Promise<void>>(),
+});
+vi.mock('@/stores/useMetadata', () => ({ useMetadataStore: () => metadata }));
+const deferred = () => {
+  let resolve!: () => void;
+  let reject!: (error: Error) => void;
+  const promise = new Promise<void>((done, fail) => {
+    resolve = done;
+    reject = fail;
+  });
+  return { promise, resolve, reject };
+};
+let scope: ReturnType<typeof effectScope>;
+const start = () => scope.run(() => useTaskDetailReadiness())!;
+const flush = async () => {
+  await Promise.resolve();
+  await Promise.resolve();
+  await nextTick();
+};
+describe('useTaskDetailReadiness', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    scope = effectScope();
+    metadata.hasInitialized = true;
+    metadata.loading = false;
+    metadata.languageCode = 'en';
+    metadata.mode = 'regular';
+    metadata.tasks = [{ id: 'task' }];
+    metadata.fetchTaskObjectivesData.mockReset().mockResolvedValue();
+    metadata.fetchTaskRewardsData.mockReset().mockResolvedValue();
+    metadata.fetchEditionsData.mockReset().mockResolvedValue();
+  });
+  afterEach(() => {
+    scope.stop();
+    vi.useRealTimers();
+  });
+  it('requests both details promptly and waits for both to settle', async () => {
+    const objectives = deferred();
+    const rewards = deferred();
+    metadata.fetchTaskObjectivesData.mockReturnValue(objectives.promise);
+    metadata.fetchTaskRewardsData.mockReturnValue(rewards.promise);
+    const ready = start();
+    expect(metadata.fetchTaskObjectivesData).toHaveBeenCalledOnce();
+    expect(metadata.fetchTaskRewardsData).toHaveBeenCalledOnce();
+    expect(ready.value).toBe(false);
+    objectives.resolve();
+    await flush();
+    expect(ready.value).toBe(false);
+    rewards.resolve();
+    await flush();
+    expect(ready.value).toBe(true);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+  it('waits for core metadata before requesting details', async () => {
+    metadata.hasInitialized = false;
+    const ready = start();
+    expect(metadata.fetchTaskObjectivesData).not.toHaveBeenCalled();
+    expect(ready.value).toBe(false);
+    metadata.hasInitialized = true;
+    await nextTick();
+    await flush();
+    expect(ready.value).toBe(true);
+  });
+  it('waits for edition eligibility so the first cards use the final filters', async () => {
+    const editions = deferred();
+    metadata.fetchEditionsData.mockReturnValue(editions.promise);
+    const ready = start();
+    await flush();
+    expect(ready.value).toBe(false);
+    editions.resolve();
+    await flush();
+    expect(ready.value).toBe(true);
+  });
+  it('does not hold an empty task result for optional requests', () => {
+    metadata.tasks = [];
+    expect(start().value).toBe(true);
+    expect(metadata.fetchTaskRewardsData).not.toHaveBeenCalled();
+  });
+  it('releases the page on request failure', async () => {
+    metadata.fetchTaskObjectivesData.mockRejectedValue(new Error('offline'));
+    const ready = start();
+    await flush();
+    expect(ready.value).toBe(true);
+  });
+  it('releases stalled requests after three seconds without cancelling data loading', async () => {
+    const objectives = deferred();
+    metadata.fetchTaskObjectivesData.mockReturnValue(objectives.promise);
+    const ready = start();
+    await vi.advanceTimersByTimeAsync(2999);
+    expect(ready.value).toBe(false);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(ready.value).toBe(true);
+    objectives.resolve();
+    await flush();
+    expect(ready.value).toBe(true);
+  });
+  it.each(['mode', 'languageCode'] as const)(
+    'ignores an old request when %s changes',
+    async (key) => {
+      const old = deferred();
+      const current = deferred();
+      metadata.fetchTaskObjectivesData
+        .mockReturnValueOnce(old.promise)
+        .mockReturnValueOnce(current.promise);
+      const ready = start();
+      metadata[key] = key === 'mode' ? 'pve' : 'de';
+      await nextTick();
+      old.resolve();
+      await flush();
+      expect(ready.value).toBe(false);
+      current.resolve();
+      await flush();
+      expect(ready.value).toBe(true);
+    }
+  );
+  it('resets readiness for a core reload and ignores the previous request', async () => {
+    const old = deferred();
+    metadata.fetchTaskObjectivesData.mockReturnValueOnce(old.promise);
+    const ready = start();
+    metadata.loading = true;
+    await nextTick();
+    old.resolve();
+    await flush();
+    expect(ready.value).toBe(false);
+    metadata.loading = false;
+    await nextTick();
+    await flush();
+    expect(ready.value).toBe(true);
+    expect(metadata.fetchTaskObjectivesData).toHaveBeenCalledTimes(2);
+  });
+  it('cleans up timers and ignores settlement after leaving the page', async () => {
+    const request = deferred();
+    metadata.fetchTaskRewardsData.mockReturnValue(request.promise);
+    const ready = start();
+    scope.stop();
+    request.resolve();
+    await flush();
+    expect(ready.value).toBe(false);
+    expect(vi.getTimerCount()).toBe(0);
+  });
+});

--- a/app/composables/useTaskDetailReadiness.ts
+++ b/app/composables/useTaskDetailReadiness.ts
@@ -54,7 +54,7 @@ export const useTaskDetailReadiness = () => {
         metadataStore.fetchTaskObjectivesData(),
         metadataStore.fetchTaskRewardsData(),
         metadataStore.fetchItemsLiteData(),
-        metadataStore.fetchEditionsData(),
+        metadataStore.ensureEditionsData(),
       ]).then(async () => {
         if (active) await Promise.allSettled([settleCountDifferences()]);
         requestsSettled = true;

--- a/app/composables/useTaskDetailReadiness.ts
+++ b/app/composables/useTaskDetailReadiness.ts
@@ -40,9 +40,9 @@ export const useTaskDetailReadiness = () => {
         stopEditionsWatch();
       });
       const settleCountDifferences = async () => {
-        await metadataStore.fetchObjectiveModeCountDifferences();
+        const result = await metadataStore.fetchObjectiveModeCountDifferences();
         // A joined request may be discarded when reward/item hydration replaces tasks.
-        if (active && !metadataStore.objectiveModeCountDifferencesHydrated) {
+        if (active && result === 'stale') {
           await metadataStore.fetchObjectiveModeCountDifferences();
         }
       };
@@ -50,6 +50,7 @@ export const useTaskDetailReadiness = () => {
       void Promise.allSettled([
         metadataStore.fetchTaskObjectivesData(),
         metadataStore.fetchTaskRewardsData(),
+        metadataStore.fetchItemsLiteData(),
         metadataStore.fetchEditionsData(),
       ]).then(async () => {
         if (active) await Promise.allSettled([settleCountDifferences()]);

--- a/app/composables/useTaskDetailReadiness.ts
+++ b/app/composables/useTaskDetailReadiness.ts
@@ -13,6 +13,7 @@ export const useTaskDetailReadiness = () => {
       () => metadataStore.hasInitialized && !metadataStore.loading,
       () => metadataStore.languageCode,
       () => metadataStore.getApiGameMode(),
+      () => metadataStore.tasksCoreRevision,
     ],
     ([coreReady], _previous, onCleanup) => {
       ready.value = false;
@@ -22,22 +23,38 @@ export const useTaskDetailReadiness = () => {
         return;
       }
       let active = true;
+      let requestsSettled = false;
       const timeout = setTimeout(() => {
         if (active) ready.value = true;
       }, TASK_DETAIL_WAIT_MS);
+      const finishWhenSettled = () => {
+        if (!active || !requestsSettled || metadataStore.editionsLoading) return;
+        clearTimeout(timeout);
+        ready.value = true;
+      };
+      // A cache hit can return while edition eligibility is still being revalidated.
+      const stopEditionsWatch = watch(() => metadataStore.editionsLoading, finishWhenSettled);
       onCleanup(() => {
         active = false;
         clearTimeout(timeout);
+        stopEditionsWatch();
       });
+      const settleCountDifferences = async () => {
+        await metadataStore.fetchObjectiveModeCountDifferences();
+        // A joined request may be discarded when reward/item hydration replaces tasks.
+        if (active && !metadataStore.objectiveModeCountDifferencesHydrated) {
+          await metadataStore.fetchObjectiveModeCountDifferences();
+        }
+      };
       // These actions retain the store's cache, request deduplication, and stale-response guards.
       void Promise.allSettled([
         metadataStore.fetchTaskObjectivesData(),
         metadataStore.fetchTaskRewardsData(),
         metadataStore.fetchEditionsData(),
-      ]).then(() => {
-        if (!active) return;
-        clearTimeout(timeout);
-        ready.value = true;
+      ]).then(async () => {
+        if (active) await Promise.allSettled([settleCountDifferences()]);
+        requestsSettled = true;
+        finishWhenSettled();
       });
     },
     { immediate: true }

--- a/app/composables/useTaskDetailReadiness.ts
+++ b/app/composables/useTaskDetailReadiness.ts
@@ -10,7 +10,10 @@ export const useTaskDetailReadiness = () => {
   const ready = ref(false);
   watch(
     [
-      () => metadataStore.hasInitialized && !metadataStore.loading,
+      () =>
+        metadataStore.hasInitialized &&
+        !metadataStore.loading &&
+        !metadataStore.tasksCoreRefreshing,
       () => metadataStore.languageCode,
       () => metadataStore.getApiGameMode(),
       () => metadataStore.tasksCoreRevision,

--- a/app/composables/useTaskDetailReadiness.ts
+++ b/app/composables/useTaskDetailReadiness.ts
@@ -1,0 +1,46 @@
+import { useMetadataStore } from '@/stores/useMetadata';
+// Optional details must not prevent task navigation when a request stalls.
+const TASK_DETAIL_WAIT_MS = 3000;
+/**
+ * Request task-card details and edition eligibility before the initial list replaces loading.
+ * Release the page after settlement or a bounded wait; ignore obsolete mode/locale loads.
+ */
+export const useTaskDetailReadiness = () => {
+  const metadataStore = useMetadataStore();
+  const ready = ref(false);
+  watch(
+    [
+      () => metadataStore.hasInitialized && !metadataStore.loading,
+      () => metadataStore.languageCode,
+      () => metadataStore.getApiGameMode(),
+    ],
+    ([coreReady], _previous, onCleanup) => {
+      ready.value = false;
+      if (!coreReady) return;
+      if (!metadataStore.tasks.length) {
+        ready.value = true;
+        return;
+      }
+      let active = true;
+      const timeout = setTimeout(() => {
+        if (active) ready.value = true;
+      }, TASK_DETAIL_WAIT_MS);
+      onCleanup(() => {
+        active = false;
+        clearTimeout(timeout);
+      });
+      // These actions retain the store's cache, request deduplication, and stale-response guards.
+      void Promise.allSettled([
+        metadataStore.fetchTaskObjectivesData(),
+        metadataStore.fetchTaskRewardsData(),
+        metadataStore.fetchEditionsData(),
+      ]).then(() => {
+        if (!active) return;
+        clearTimeout(timeout);
+        ready.value = true;
+      });
+    },
+    { immediate: true }
+  );
+  return ready;
+};

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -78,6 +78,7 @@ const metadataStoreMock = reactive({
   getApiGameMode: () => 'regular',
   fetchTaskObjectivesData: vi.fn(() => Promise.resolve()),
   fetchTaskRewardsData: vi.fn(() => Promise.resolve()),
+  fetchItemsLiteData: vi.fn(() => Promise.resolve()),
   fetchEditionsData: vi.fn(() => Promise.resolve()),
   fetchObjectiveModeCountDifferences: vi.fn(() => Promise.resolve()),
   mapsWithSvg: [] as Array<{ id: string; name: string }>,
@@ -384,31 +385,50 @@ describe('tasks page', () => {
   afterEach(() => {
     wrapper?.unmount();
   });
-  it.each(['fetchTaskObjectivesData', 'fetchTaskRewardsData', 'fetchEditionsData'] as const)(
-    'filters merged details before revealing the first cards (%s)',
-    async (action) => {
-      wrapper.unmount();
-      updateVisibleTasksMock.mockClear();
-      let finishRewards: () => void = () => {};
-      metadataStoreMock[action].mockImplementationOnce(
-        () =>
-          new Promise<void>((resolve) => {
-            finishRewards = resolve;
-          })
-      );
-      wrapper = await mountSuspended(TasksPage, {
-        global: { stubs: defaultGlobalStubs },
-      });
-      await flushPromises();
-      expect(metadataStoreMock[action]).toHaveBeenCalled();
-      expect(wrapper.find('task-loading-state-stub').exists()).toBe(true);
-      expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(false);
-      expect(updateVisibleTasksMock).not.toHaveBeenCalled();
-      finishRewards();
-      await vi.waitFor(() => expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true));
-      expect(updateVisibleTasksMock).toHaveBeenCalled();
-    }
-  );
+  it('defers deep links until cached detail readiness clears with unchanged task IDs', async () => {
+    let release!: () => void;
+    metadataStoreMock.fetchTaskRewardsData.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve;
+        })
+    );
+    metadataStoreMock.tasksCoreRevision += 1;
+    await nextTick();
+    handleTaskQueryParamMock.mockClear();
+    await wrapper.vm.$router.replace({ query: { task: defaultTask.id } });
+    await nextTick();
+    expect(handleTaskQueryParamMock).not.toHaveBeenCalled();
+    release();
+    await vi.waitFor(() => expect(handleTaskQueryParamMock).toHaveBeenCalled());
+  });
+  it.each([
+    'fetchTaskObjectivesData',
+    'fetchTaskRewardsData',
+    'fetchEditionsData',
+    'fetchItemsLiteData',
+  ] as const)('filters merged details before revealing the first cards (%s)', async (action) => {
+    wrapper.unmount();
+    updateVisibleTasksMock.mockClear();
+    let finishRewards: () => void = () => {};
+    metadataStoreMock[action].mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRewards = resolve;
+        })
+    );
+    wrapper = await mountSuspended(TasksPage, {
+      global: { stubs: defaultGlobalStubs },
+    });
+    await flushPromises();
+    expect(metadataStoreMock[action]).toHaveBeenCalled();
+    expect(wrapper.find('task-loading-state-stub').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(false);
+    expect(updateVisibleTasksMock).not.toHaveBeenCalled();
+    finishRewards();
+    await vi.waitFor(() => expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true));
+    expect(updateVisibleTasksMock).toHaveBeenCalled();
+  });
   it.each([true, false])(
     'keeps the loading state until the initial filter refresh finishes (has tasks: %s)',
     async (hasTasks) => {

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -1,4 +1,5 @@
 import { mountSuspended } from '@nuxt/test-utils/runtime';
+import { flushPromises } from '@vue/test-utils';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defineComponent, inject, isRef, nextTick, ref } from 'vue';
 import { jumpToMapObjectiveKey } from '@/features/tasks/task-context';
@@ -71,10 +72,14 @@ const metadataStoreMock = reactive({
   loading: false,
   hasInitialized: true,
   languageCode: 'en',
+  tasksCoreRevision: 0,
+  editionsLoading: false,
+  objectiveModeCountDifferencesHydrated: true,
   getApiGameMode: () => 'regular',
   fetchTaskObjectivesData: vi.fn(() => Promise.resolve()),
   fetchTaskRewardsData: vi.fn(() => Promise.resolve()),
   fetchEditionsData: vi.fn(() => Promise.resolve()),
+  fetchObjectiveModeCountDifferences: vi.fn(() => Promise.resolve()),
   mapsWithSvg: [] as Array<{ id: string; name: string }>,
   objectives: [],
   sortedTraders: [],
@@ -379,27 +384,31 @@ describe('tasks page', () => {
   afterEach(() => {
     wrapper?.unmount();
   });
-  it('filters merged details before revealing the first cards', async () => {
-    wrapper.unmount();
-    updateVisibleTasksMock.mockClear();
-    let finishRewards: () => void = () => {};
-    metadataStoreMock.fetchTaskRewardsData.mockImplementationOnce(
-      () =>
-        new Promise<void>((resolve) => {
-          finishRewards = resolve;
-        })
-    );
-    wrapper = await mountSuspended(TasksPage, {
-      global: { stubs: defaultGlobalStubs },
-    });
-    await new Promise((resolve) => setTimeout(resolve, 100));
-    expect(wrapper.find('task-loading-state-stub').exists()).toBe(true);
-    expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(false);
-    expect(updateVisibleTasksMock).not.toHaveBeenCalled();
-    finishRewards();
-    await vi.waitFor(() => expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true));
-    expect(updateVisibleTasksMock).toHaveBeenCalled();
-  });
+  it.each(['fetchTaskObjectivesData', 'fetchTaskRewardsData', 'fetchEditionsData'] as const)(
+    'filters merged details before revealing the first cards (%s)',
+    async (action) => {
+      wrapper.unmount();
+      updateVisibleTasksMock.mockClear();
+      let finishRewards: () => void = () => {};
+      metadataStoreMock[action].mockImplementationOnce(
+        () =>
+          new Promise<void>((resolve) => {
+            finishRewards = resolve;
+          })
+      );
+      wrapper = await mountSuspended(TasksPage, {
+        global: { stubs: defaultGlobalStubs },
+      });
+      await flushPromises();
+      expect(metadataStoreMock[action]).toHaveBeenCalled();
+      expect(wrapper.find('task-loading-state-stub').exists()).toBe(true);
+      expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(false);
+      expect(updateVisibleTasksMock).not.toHaveBeenCalled();
+      finishRewards();
+      await vi.waitFor(() => expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true));
+      expect(updateVisibleTasksMock).toHaveBeenCalled();
+    }
+  );
   it.each([true, false])(
     'keeps the loading state until the initial filter refresh finishes (has tasks: %s)',
     async (hasTasks) => {

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -73,6 +73,7 @@ const metadataStoreMock = reactive({
   hasInitialized: true,
   languageCode: 'en',
   tasksCoreRevision: 0,
+  tasksCoreRefreshing: false,
   editionsLoading: false,
   objectiveModeCountDifferencesHydrated: true,
   getApiGameMode: () => 'regular',

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -80,7 +80,7 @@ const metadataStoreMock = reactive({
   fetchTaskObjectivesData: vi.fn(() => Promise.resolve()),
   fetchTaskRewardsData: vi.fn(() => Promise.resolve()),
   fetchItemsLiteData: vi.fn(() => Promise.resolve()),
-  fetchEditionsData: vi.fn(() => Promise.resolve()),
+  ensureEditionsData: vi.fn(() => Promise.resolve()),
   fetchObjectiveModeCountDifferences: vi.fn(() => Promise.resolve()),
   mapsWithSvg: [] as Array<{ id: string; name: string }>,
   objectives: [],
@@ -406,7 +406,7 @@ describe('tasks page', () => {
   it.each([
     'fetchTaskObjectivesData',
     'fetchTaskRewardsData',
-    'fetchEditionsData',
+    'ensureEditionsData',
     'fetchItemsLiteData',
   ] as const)('filters merged details before revealing the first cards (%s)', async (action) => {
     wrapper.unmount();

--- a/app/pages/__tests__/tasks.page.test.ts
+++ b/app/pages/__tests__/tasks.page.test.ts
@@ -70,6 +70,11 @@ const metadataStoreMock = reactive({
   tasks: [defaultTask],
   loading: false,
   hasInitialized: true,
+  languageCode: 'en',
+  getApiGameMode: () => 'regular',
+  fetchTaskObjectivesData: vi.fn(() => Promise.resolve()),
+  fetchTaskRewardsData: vi.fn(() => Promise.resolve()),
+  fetchEditionsData: vi.fn(() => Promise.resolve()),
   mapsWithSvg: [] as Array<{ id: string; name: string }>,
   objectives: [],
   sortedTraders: [],
@@ -374,6 +379,27 @@ describe('tasks page', () => {
   afterEach(() => {
     wrapper?.unmount();
   });
+  it('filters merged details before revealing the first cards', async () => {
+    wrapper.unmount();
+    updateVisibleTasksMock.mockClear();
+    let finishRewards: () => void = () => {};
+    metadataStoreMock.fetchTaskRewardsData.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishRewards = resolve;
+        })
+    );
+    wrapper = await mountSuspended(TasksPage, {
+      global: { stubs: defaultGlobalStubs },
+    });
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(wrapper.find('task-loading-state-stub').exists()).toBe(true);
+    expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(false);
+    expect(updateVisibleTasksMock).not.toHaveBeenCalled();
+    finishRewards();
+    await vi.waitFor(() => expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true));
+    expect(updateVisibleTasksMock).toHaveBeenCalled();
+  });
   it.each([true, false])(
     'keeps the loading state until the initial filter refresh finishes (has tasks: %s)',
     async (hasTasks) => {
@@ -409,6 +435,36 @@ describe('tasks page', () => {
     await vi.waitFor(() => expect(updateVisibleTasksMock).toHaveBeenCalled());
     await vi.waitFor(() => expect(wrapper.find('task-loading-state-stub').exists()).toBe(false));
     expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true);
+  });
+  it('ignores a filter refresh settling from an earlier metadata cycle', async () => {
+    let finishOld: () => void = () => {};
+    let finishCurrent: () => void = () => {};
+    updateVisibleTasksMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishOld = resolve;
+        })
+    );
+    metadataStoreMock.loading = true;
+    await nextTick();
+    updateVisibleTasksMock.mockClear();
+    metadataStoreMock.loading = false;
+    await vi.waitFor(() => expect(updateVisibleTasksMock).toHaveBeenCalledTimes(1));
+    metadataStoreMock.loading = true;
+    await nextTick();
+    updateVisibleTasksMock.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          finishCurrent = resolve;
+        })
+    );
+    metadataStoreMock.loading = false;
+    await vi.waitFor(() => expect(updateVisibleTasksMock).toHaveBeenCalledTimes(2));
+    finishOld();
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(wrapper.find('task-loading-state-stub').exists()).toBe(true);
+    finishCurrent();
+    await vi.waitFor(() => expect(wrapper.find('[data-testid="task-card"]').exists()).toBe(true));
   });
   it('keeps the loading state across a metadata reload until the new refresh finishes', async () => {
     metadataStoreMock.loading = true;

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -906,7 +906,11 @@
   const route = useRoute();
   useTaskRouteSync({ maps, traders: sortedTraders });
   const canRefreshVisibleTasks = computed(
-    () => metadataStore.hasInitialized && !tasksLoading.value && taskDetailsReady.value
+    () =>
+      metadataStore.hasInitialized &&
+      !tasksLoading.value &&
+      !metadataStore.tasksCoreRefreshing &&
+      taskDetailsReady.value
   );
   // Metadata readiness can precede the first debounced filter refresh.
   const hasRefreshedVisibleTasks = ref(false);

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -576,6 +576,7 @@
   } = storeToRefs(preferencesStore);
   const metadataStore = useMetadataStore();
   const { tasks, loading: tasksLoading } = storeToRefs(metadataStore);
+  const taskDetailsReady = useTaskDetailReadiness();
   const maps = computed(() => metadataStore.mapsWithSvg);
   const sortedTraders = computed(() => metadataStore.sortedTraders);
   const editions = computed(() => metadataStore.editions);
@@ -906,14 +907,19 @@
   useTaskRouteSync({ maps, traders: sortedTraders });
   // Metadata readiness can precede the first debounced filter refresh.
   const hasRefreshedVisibleTasks = ref(false);
+  let visibleTaskRefreshGeneration = 0;
   /** Refresh filters before allowing initial results to replace the loading state. */
   const refreshVisibleTasks = async () => {
+    const generation = ++visibleTaskRefreshGeneration;
     try {
       await updateVisibleTasks(mapTaskVisibilityFilterOptions.value, tasksLoading.value);
     } catch (error) {
       logger.error('[Tasks] Failed to refresh tasks:', error);
     } finally {
-      hasRefreshedVisibleTasks.value = metadataStore.hasInitialized && !tasksLoading.value;
+      if (generation === visibleTaskRefreshGeneration) {
+        hasRefreshedVisibleTasks.value =
+          metadataStore.hasInitialized && !tasksLoading.value && taskDetailsReady.value;
+      }
     }
   };
   const debouncedRefreshVisibleTasks = debounce(refreshVisibleTasks, 50);
@@ -960,6 +966,7 @@
       getHideCompletedMapObjectives,
       getPinnedTaskIds,
       () => metadataStore.hasInitialized,
+      taskDetailsReady,
       tasksLoading,
       tasks,
       maps,
@@ -971,7 +978,8 @@
       editions,
     ],
     () => {
-      if (!metadataStore.hasInitialized || tasksLoading.value) {
+      if (!metadataStore.hasInitialized || tasksLoading.value || !taskDetailsReady.value) {
+        visibleTaskRefreshGeneration += 1;
         hasRefreshedVisibleTasks.value = false;
         debouncedRefreshVisibleTasks.cancel();
         return;
@@ -984,7 +992,11 @@
     { immediate: true, flush: 'post' }
   );
   const isLoading = computed(
-    () => !metadataStore.hasInitialized || tasksLoading.value || !hasRefreshedVisibleTasks.value
+    () =>
+      !metadataStore.hasInitialized ||
+      tasksLoading.value ||
+      !taskDetailsReady.value ||
+      !hasRefreshedVisibleTasks.value
   );
   const {
     activeSearchCount,

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -1106,7 +1106,7 @@
     selectedMapData,
     showMapDisplay,
     stopResize,
-    tasksLoading,
+    tasksLoading: isLoading,
     visibleTaskCount,
   });
   onBeforeUnmount(() => {

--- a/app/pages/tasks.vue
+++ b/app/pages/tasks.vue
@@ -905,6 +905,9 @@
   };
   const route = useRoute();
   useTaskRouteSync({ maps, traders: sortedTraders });
+  const canRefreshVisibleTasks = computed(
+    () => metadataStore.hasInitialized && !tasksLoading.value && taskDetailsReady.value
+  );
   // Metadata readiness can precede the first debounced filter refresh.
   const hasRefreshedVisibleTasks = ref(false);
   let visibleTaskRefreshGeneration = 0;
@@ -917,8 +920,7 @@
       logger.error('[Tasks] Failed to refresh tasks:', error);
     } finally {
       if (generation === visibleTaskRefreshGeneration) {
-        hasRefreshedVisibleTasks.value =
-          metadataStore.hasInitialized && !tasksLoading.value && taskDetailsReady.value;
+        hasRefreshedVisibleTasks.value = canRefreshVisibleTasks.value;
       }
     }
   };
@@ -978,7 +980,7 @@
       editions,
     ],
     () => {
-      if (!metadataStore.hasInitialized || tasksLoading.value || !taskDetailsReady.value) {
+      if (!canRefreshVisibleTasks.value) {
         visibleTaskRefreshGeneration += 1;
         hasRefreshedVisibleTasks.value = false;
         debouncedRefreshVisibleTasks.cancel();
@@ -992,11 +994,7 @@
     { immediate: true, flush: 'post' }
   );
   const isLoading = computed(
-    () =>
-      !metadataStore.hasInitialized ||
-      tasksLoading.value ||
-      !taskDetailsReady.value ||
-      !hasRefreshedVisibleTasks.value
+    () => !canRefreshVisibleTasks.value || !hasRefreshedVisibleTasks.value
   );
   const {
     activeSearchCount,

--- a/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
+++ b/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
@@ -130,6 +130,36 @@ describe('useMetadataStore fetchEditionsData', () => {
     expect(store.editions).toEqual([latest]);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
+  it('keeps cached eligibility when malformed chapters and the network both fail', async () => {
+    const store = useMetadataStore();
+    const cached = createEdition('cached', 1, 'Cached');
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue({
+      editions: [cached],
+      storyChapters: [null],
+    });
+    vi.stubGlobal('$fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    await store.fetchEditionsData();
+    expect(store.editions).toEqual([cached]);
+    expect(store.editionsError).toBeInstanceOf(Error);
+  });
+  it('preserves eligibility and chapters when the response cannot be normalized', async () => {
+    const store = useMetadataStore();
+    const existing = createEdition('existing', 1, 'Existing');
+    const chapter = createStoryChapter('existing', 1, 'Existing');
+    store.editions = [existing];
+    store.storyChapters = [chapter];
+    vi.stubGlobal(
+      '$fetch',
+      vi.fn().mockResolvedValue({
+        editions: { replacement: createEdition('replacement', 2, 'Replacement') },
+        storyChapters: { invalid: null },
+      })
+    );
+    await store.fetchEditionsData(true);
+    expect(store.editions).toEqual([existing]);
+    expect(store.storyChapters).toEqual([chapter]);
+    expect(store.editionsError).toBeInstanceOf(TypeError);
+  });
   it('records synchronous network failures after request registration', async () => {
     const store = useMetadataStore();
     const error = new Error('synchronous failure');

--- a/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
+++ b/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
@@ -72,6 +72,33 @@ describe('useMetadataStore fetchEditionsData', () => {
     expect(store.editions).toEqual([existing]);
     expect(store.editionsError).toBeInstanceOf(Error);
   });
+  it('reuses settled editions for readiness after an active core refresh loaded them', async () => {
+    const store = useMetadataStore();
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue(null);
+    vi.spyOn(cacheUtils, 'setCachedData').mockResolvedValue();
+    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue({ editions: {}, storyChapters: {} }));
+    await store.fetchEditionsData();
+    await store.ensureEditionsData();
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+  it('starts editions for readiness when no route has requested them', async () => {
+    const store = useMetadataStore();
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue(null);
+    vi.spyOn(cacheUtils, 'setCachedData').mockResolvedValue();
+    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue({ editions: {}, storyChapters: {} }));
+    await store.ensureEditionsData();
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+  it('does not retry a settled failure for readiness but retains explicit refreshes', async () => {
+    const store = useMetadataStore();
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue(null);
+    vi.stubGlobal('$fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    await store.fetchEditionsData();
+    await store.ensureEditionsData();
+    expect($fetch).toHaveBeenCalledTimes(1);
+    await store.fetchEditionsData(true);
+    expect($fetch).toHaveBeenCalledTimes(2);
+  });
   it('keeps loading until the latest forced request settles', async () => {
     const store = useMetadataStore();
     const older = createDeferred<object>();
@@ -203,7 +230,7 @@ describe('useMetadataStore fetchEditionsData', () => {
     await firstRequest;
     expect(store.editionsLoading).toBe(true);
     let secondSettled = false;
-    const secondRequest = store.fetchEditionsData(false);
+    const secondRequest = store.ensureEditionsData();
     void secondRequest.then(() => {
       secondSettled = true;
     });

--- a/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
+++ b/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
@@ -62,6 +62,16 @@ describe('useMetadataStore fetchEditionsData', () => {
     expect(store.editions).toEqual([existingEdition]);
     expect(store.editionsError).toBeInstanceOf(Error);
   });
+  it('preserves loaded eligibility when an empty cached fallback and the network fail', async () => {
+    const store = useMetadataStore();
+    const existing = createEdition('existing', 2, 'Existing');
+    store.editions = [existing];
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue({ editions: [] });
+    vi.stubGlobal('$fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    await store.fetchEditionsData();
+    expect(store.editions).toEqual([existing]);
+    expect(store.editionsError).toBeInstanceOf(Error);
+  });
   it('keeps loading until the latest forced request settles', async () => {
     const store = useMetadataStore();
     const older = createDeferred<object>();

--- a/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
+++ b/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
@@ -62,6 +62,23 @@ describe('useMetadataStore fetchEditionsData', () => {
     expect(store.editions).toEqual([existingEdition]);
     expect(store.editionsError).toBeInstanceOf(Error);
   });
+  it('keeps loading until the latest forced request settles', async () => {
+    const store = useMetadataStore();
+    const older = createDeferred<object>();
+    const current = createDeferred<object>();
+    vi.stubGlobal(
+      '$fetch',
+      vi.fn().mockReturnValueOnce(older.promise).mockReturnValueOnce(current.promise)
+    );
+    const first = store.fetchEditionsData(true);
+    const second = store.fetchEditionsData(true);
+    older.resolve({});
+    await first;
+    expect(store.editionsLoading).toBe(true);
+    current.resolve({});
+    await second;
+    expect(store.editionsLoading).toBe(false);
+  });
   it('reuses the in-flight background editions revalidation while serving cached data', async () => {
     const store = useMetadataStore();
     const cachedEdition = createEdition('cached-edition', 1, 'Cached Edition');
@@ -79,9 +96,16 @@ describe('useMetadataStore fetchEditionsData', () => {
     const fetchMock = vi.fn().mockImplementation(() => overlayResponse.promise);
     vi.stubGlobal('$fetch', fetchMock);
     const firstRequest = store.fetchEditionsData(false);
+    await firstRequest;
+    expect(store.editionsLoading).toBe(true);
+    let secondSettled = false;
     const secondRequest = store.fetchEditionsData(false);
+    void secondRequest.then(() => {
+      secondSettled = true;
+    });
     await flushPromises();
     expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(secondSettled).toBe(false);
     overlayResponse.resolve({
       editions: {
         [refreshedEdition.id]: refreshedEdition,

--- a/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
+++ b/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
@@ -71,12 +71,76 @@ describe('useMetadataStore fetchEditionsData', () => {
       vi.fn().mockReturnValueOnce(older.promise).mockReturnValueOnce(current.promise)
     );
     const first = store.fetchEditionsData(true);
+    await flushPromises();
     const second = store.fetchEditionsData(true);
     older.resolve({});
     await first;
     expect(store.editionsLoading).toBe(true);
     current.resolve({});
     await second;
+    expect(store.editionsLoading).toBe(false);
+  });
+  it.each(['resolve', 'reject'] as const)(
+    'ignores obsolete forced responses (%s)',
+    async (outcome) => {
+      const store = useMetadataStore();
+      const older = createDeferred<object>();
+      const current = createDeferred<object>();
+      const latestEdition = createEdition('latest', 3, 'Latest');
+      const latestChapter = createStoryChapter('latest-chapter', 3, 'Latest Chapter');
+      const cacheWrite = vi.spyOn(cacheUtils, 'setCachedData').mockResolvedValue();
+      vi.stubGlobal(
+        '$fetch',
+        vi.fn().mockReturnValueOnce(older.promise).mockReturnValueOnce(current.promise)
+      );
+      const first = store.fetchEditionsData(true);
+      await flushPromises();
+      const second = store.fetchEditionsData(true);
+      current.resolve({
+        editions: { latest: latestEdition },
+        storyChapters: { latest: latestChapter },
+      });
+      await second;
+      if (outcome === 'resolve') older.resolve({ editions: {}, storyChapters: {} });
+      else older.reject(new Error('obsolete failure'));
+      await first;
+      expect(store.editions).toEqual([latestEdition]);
+      expect(store.storyChapters).toEqual([latestChapter]);
+      expect(store.editionsError).toBeNull();
+      expect(store.editionsLoading).toBe(false);
+      expect(cacheWrite).toHaveBeenCalledTimes(1);
+    }
+  );
+  it('ignores a cache read superseded by a forced refresh', async () => {
+    const store = useMetadataStore();
+    const cache = createDeferred<{ editions: GameEdition[]; storyChapters: StoryChapter[] }>();
+    const latest = createEdition('latest', 3, 'Latest');
+    vi.spyOn(cacheUtils, 'getCachedData').mockReturnValue(cache.promise);
+    vi.spyOn(cacheUtils, 'setCachedData').mockResolvedValue();
+    const fetchMock = vi.fn().mockResolvedValue({ editions: { latest } });
+    vi.stubGlobal('$fetch', fetchMock);
+    const older = store.fetchEditionsData();
+    await flushPromises();
+    await store.fetchEditionsData(true);
+    cache.resolve({
+      editions: [createEdition('old', 1, 'Old')],
+      storyChapters: [createStoryChapter('old', 1, 'Old')],
+    });
+    await older;
+    expect(store.editions).toEqual([latest]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+  it('records synchronous network failures after request registration', async () => {
+    const store = useMetadataStore();
+    const error = new Error('synchronous failure');
+    vi.stubGlobal(
+      '$fetch',
+      vi.fn(() => {
+        throw error;
+      })
+    );
+    await store.fetchEditionsData(true);
+    expect(store.editionsError).toBe(error);
     expect(store.editionsLoading).toBe(false);
   });
   it('reuses the in-flight background editions revalidation while serving cached data', async () => {

--- a/app/stores/__tests__/useMetadata.promiseTracking.test.ts
+++ b/app/stores/__tests__/useMetadata.promiseTracking.test.ts
@@ -69,6 +69,18 @@ describe('useMetadataStore promise tracking', () => {
     vi.restoreAllMocks();
     vi.unstubAllGlobals();
   });
+  it('advances the core revision on cache replacement but not detail merges', async () => {
+    const store = useMetadataStore();
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue(tasksCorePayload());
+    await store.fetchTasksCoreData();
+    expect(store.tasksCoreRevision).toBe(1);
+    expect(store.loading).toBe(false);
+    await store.fetchTasksCoreData();
+    expect(store.tasksCoreRevision).toBe(2);
+    expect(store.loading).toBe(false);
+    store.mergeTaskObjectives([{ id: 'task-1', objectives: [], failConditions: [] }]);
+    expect(store.tasksCoreRevision).toBe(2);
+  });
   it('populates tasks and hideout when JSON API responses return valid { data } envelopes', async () => {
     const store = useMetadataStore();
     const fetchMock = vi.fn(async (endpoint: string) => {

--- a/app/stores/__tests__/useMetadata.taskObjectivesHydration.test.ts
+++ b/app/stores/__tests__/useMetadata.taskObjectivesHydration.test.ts
@@ -59,6 +59,13 @@ describe('useMetadataStore fetchTaskObjectivesData', () => {
     });
     expect(store.tasksObjectivesHydrated).toBe(true);
   });
+  it('reports handled count failures without marking them stale', async () => {
+    const store = useMetadataStore();
+    store.tasks = [{ id: 'task-1', objectives: [] }] as Task[];
+    vi.stubGlobal('$fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    expect(await store.fetchObjectiveModeCountDifferences()).toBeUndefined();
+    expect(store.objectiveModeCountDifferencesHydrated).toBe(false);
+  });
   it('ignores stale objective mode differences response after mode changes', async () => {
     const store = useMetadataStore();
     store.currentGameMode = GAME_MODES.PVP;
@@ -115,7 +122,7 @@ describe('useMetadataStore fetchTaskObjectivesData', () => {
         ],
       },
     });
-    await pending;
+    expect(await pending).toBe('stale');
     expect(store.objectiveModeCountDifferences).toEqual({
       stable: { pve: 6, pvp: 5 },
     });

--- a/app/stores/__tests__/useMetadata.taskReadiness.test.ts
+++ b/app/stores/__tests__/useMetadata.taskReadiness.test.ts
@@ -94,6 +94,28 @@ describe('metadata task readiness ownership', () => {
     await second;
     expect(store.tasksCoreRefreshing).toBe(false);
   });
+  it('keeps readiness pending when the newer core refresh finishes before older bootstrap', async () => {
+    const older = createDeferred<undefined>();
+    vi.mocked(store.fetchBootstrapData).mockReturnValueOnce(older.promise);
+    const first = store.fetchAllData(false, { deferHeavy: true });
+    await store.fetchAllData(false, { deferHeavy: true });
+    expect(store.tasksCoreRefreshing).toBe(true);
+    older.resolve(undefined);
+    await first;
+    expect(store.tasksCoreRefreshing).toBe(false);
+  });
+  it('ends the initialization core phase before optional metadata settles', async () => {
+    const optional = createDeferred<undefined>();
+    vi.spyOn(store, 'updateLanguageAndGameMode').mockImplementation(() => undefined);
+    vi.spyOn(store, 'loadStaticMapData').mockResolvedValue();
+    vi.spyOn(store, 'loadCriticalCacheData').mockResolvedValue(null);
+    vi.mocked(store.fetchItemsLiteData).mockReturnValueOnce(optional.promise);
+    const initialization = store.initialize();
+    await flushPromises();
+    expect(store.tasksCoreRefreshing).toBe(false);
+    optional.resolve(undefined);
+    await initialization;
+  });
   it('clears the pending phase when core fetching fails', async () => {
     vi.mocked(store.fetchTasksCoreData).mockRejectedValueOnce(new Error('core offline'));
     await expect(store.fetchAllData(false, { deferHeavy: true })).rejects.toThrow('core offline');

--- a/app/stores/__tests__/useMetadata.taskReadiness.test.ts
+++ b/app/stores/__tests__/useMetadata.taskReadiness.test.ts
@@ -1,0 +1,129 @@
+// @vitest-environment happy-dom
+import { flushPromises } from '@vue/test-utils';
+import { createPinia, setActivePinia } from 'pinia';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useMetadataStore } from '@/stores/useMetadata';
+import { queueIdleTask } from '@/utils/idleScheduler';
+import * as cacheUtils from '@/utils/tarkovCache';
+import { createDeferred } from '@/utils/test-helpers';
+import type { Task } from '@/types/tarkov';
+vi.mock('@/utils/idleScheduler', () => ({ queueIdleTask: vi.fn(async () => undefined) }));
+vi.mock('@/utils/logger', () => ({
+  logger: { debug: vi.fn(), error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+const deferredEdition = () => {
+  const call = vi.mocked(queueIdleTask).mock.calls.find(([, options]) => options?.timeout === 3500);
+  expect(call).toBeDefined();
+  return call![0];
+};
+describe('metadata task readiness ownership', () => {
+  let store: ReturnType<typeof useMetadataStore>;
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    vi.clearAllMocks();
+    store = useMetadataStore();
+    store.initialized = true;
+    store.tasks = [{ id: 'task-1', name: 'Task', objectives: [] }] as Task[];
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue(null);
+    vi.spyOn(cacheUtils, 'setCachedData').mockResolvedValue();
+    vi.spyOn(cacheUtils, 'cleanupExpiredCache').mockResolvedValue(0);
+    for (const action of [
+      'checkCachePurge',
+      'fetchBootstrapData',
+      'fetchTasksCoreData',
+      'fetchHideoutData',
+      'fetchItemsLiteData',
+      'fetchTaskObjectivesData',
+      'fetchTaskRewardsData',
+      'fetchPrestigeData',
+    ] as const) {
+      vi.spyOn(store, action).mockResolvedValue();
+    }
+    vi.spyOn(store, 'assertCriticalMetadataReady').mockImplementation(() => undefined);
+    vi.stubGlobal('$fetch', vi.fn().mockResolvedValue({ editions: {}, storyChapters: {} }));
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+  it('holds readiness during initialization before cached core loading starts', async () => {
+    const setup = createDeferred<undefined>();
+    vi.spyOn(store, 'updateLanguageAndGameMode').mockImplementation(() => {
+      store.languageCode = 'fr';
+    });
+    vi.spyOn(store, 'loadStaticMapData').mockReturnValueOnce(setup.promise);
+    vi.spyOn(store, 'loadCriticalCacheData').mockResolvedValue(null);
+    const initialization = store.initialize();
+    expect(store.tasksCoreRefreshing).toBe(true);
+    setup.resolve(undefined);
+    await initialization;
+    expect(store.tasksCoreRefreshing).toBe(false);
+  });
+  it('clears readiness when initialization fails before fetching core data', async () => {
+    vi.spyOn(store, 'updateLanguageAndGameMode').mockImplementation(() => undefined);
+    vi.spyOn(store, 'loadStaticMapData').mockRejectedValueOnce(new Error('setup failed'));
+    await expect(store.initialize()).rejects.toThrow('setup failed');
+    expect(store.tasksCoreRefreshing).toBe(false);
+  });
+  it('marks the core refresh pending before bootstrap and clears it after core settlement', async () => {
+    const bootstrap = createDeferred<undefined>();
+    const core = createDeferred<undefined>();
+    vi.mocked(store.fetchBootstrapData).mockReturnValueOnce(bootstrap.promise);
+    vi.mocked(store.fetchTasksCoreData).mockReturnValueOnce(core.promise);
+    const pending = store.fetchAllData(false, { deferHeavy: true });
+    expect(store.tasksCoreRefreshing).toBe(true);
+    bootstrap.resolve(undefined);
+    await flushPromises();
+    expect(store.tasksCoreRefreshing).toBe(true);
+    core.resolve(undefined);
+    await pending;
+    expect(store.tasksCoreRefreshing).toBe(false);
+  });
+  it('does not let an older refresh clear the current pending phase', async () => {
+    const older = createDeferred<undefined>();
+    const current = createDeferred<undefined>();
+    vi.mocked(store.fetchBootstrapData)
+      .mockReturnValueOnce(older.promise)
+      .mockReturnValueOnce(current.promise);
+    const first = store.fetchAllData(false, { deferHeavy: true });
+    const second = store.fetchAllData(false, { deferHeavy: true });
+    older.resolve(undefined);
+    await first;
+    expect(store.tasksCoreRefreshing).toBe(true);
+    current.resolve(undefined);
+    await second;
+    expect(store.tasksCoreRefreshing).toBe(false);
+  });
+  it('clears the pending phase when core fetching fails', async () => {
+    vi.mocked(store.fetchTasksCoreData).mockRejectedValueOnce(new Error('core offline'));
+    await expect(store.fetchAllData(false, { deferHeavy: true })).rejects.toThrow('core offline');
+    expect(store.tasksCoreRefreshing).toBe(false);
+  });
+  it.each([false, true])(
+    'consumes queued editions after an eager request (forced queue: %s)',
+    async (forceRefresh) => {
+      await store.fetchAllData(forceRefresh, { deferHeavy: true });
+      await store.fetchEditionsData();
+      await deferredEdition()();
+      expect($fetch).toHaveBeenCalledTimes(1);
+    }
+  );
+  it('consumes queued editions when the eager caller joins an existing request', async () => {
+    const response = createDeferred<object>();
+    vi.mocked($fetch).mockReturnValueOnce(response.promise);
+    const first = store.fetchEditionsData();
+    await flushPromises();
+    await store.fetchAllData(false, { deferHeavy: true });
+    const joined = store.fetchEditionsData();
+    response.resolve({ editions: {}, storyChapters: {} });
+    await Promise.all([first, joined]);
+    await deferredEdition()();
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+  it('retains deferred editions when no eager request takes ownership', async () => {
+    await store.fetchAllData(false, { deferHeavy: true });
+    expect($fetch).not.toHaveBeenCalled();
+    await deferredEdition()();
+    expect($fetch).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/stores/__tests__/useMetadata.taskReadiness.test.ts
+++ b/app/stores/__tests__/useMetadata.taskReadiness.test.ts
@@ -136,11 +136,33 @@ describe('metadata task readiness ownership', () => {
     const first = store.fetchEditionsData();
     await flushPromises();
     await store.fetchAllData(false, { deferHeavy: true });
-    const joined = store.fetchEditionsData();
+    const joined = store.ensureEditionsData();
     response.resolve({ editions: {}, storyChapters: {} });
     await Promise.all([first, joined]);
     await deferredEdition()();
     expect($fetch).toHaveBeenCalledTimes(1);
+  });
+  it('consumes deferred rewards after an eager request has settled', async () => {
+    vi.mocked(store.fetchTaskRewardsData).mockRestore();
+    vi.spyOn(store, 'fetchWithCache').mockResolvedValue();
+    await store.fetchAllData(false, { deferHeavy: true });
+    await store.fetchTaskRewardsData();
+    const queued = vi
+      .mocked(queueIdleTask)
+      .mock.calls.find(([, options]) => options?.timeout === 4000);
+    expect(queued).toBeDefined();
+    await queued![0]();
+    expect(store.fetchWithCache).toHaveBeenCalledTimes(1);
+  });
+  it('retains deferred rewards without an eager owner', async () => {
+    vi.mocked(store.fetchTaskRewardsData).mockRestore();
+    vi.spyOn(store, 'fetchWithCache').mockResolvedValue();
+    await store.fetchAllData(false, { deferHeavy: true });
+    const queued = vi
+      .mocked(queueIdleTask)
+      .mock.calls.find(([, options]) => options?.timeout === 4000);
+    await queued![0]();
+    expect(store.fetchWithCache).toHaveBeenCalledTimes(1);
   });
   it('retains deferred editions when no eager request takes ownership', async () => {
     await store.fetchAllData(false, { deferHeavy: true });

--- a/app/stores/tarkov/promiseStore.ts
+++ b/app/stores/tarkov/promiseStore.ts
@@ -11,7 +11,7 @@ export interface PromiseStore {
   readonly prestigePromise: Promise<void> | null;
   readonly editionsPromise: Promise<void> | null;
   readonly editionsRequestVersion: number;
-  readonly taskCoreRefreshId: symbol | null;
+  readonly taskCoreRefreshes: Set<symbol>;
   readonly initPromise: Promise<void> | null;
   readonly isInitializing: boolean;
 }
@@ -55,7 +55,7 @@ export function getPromiseStore(storeInstance: object): MutablePromiseStore {
       prestigePromise: null,
       editionsPromise: null,
       editionsRequestVersion: 0,
-      taskCoreRefreshId: null,
+      taskCoreRefreshes: new Set(),
       initPromise: null,
       isInitializing: false,
     });

--- a/app/stores/tarkov/promiseStore.ts
+++ b/app/stores/tarkov/promiseStore.ts
@@ -5,7 +5,7 @@ export interface PromiseStore {
   readonly itemsFullPromise: Promise<void> | null;
   readonly itemsLitePromise: Promise<void> | null;
   readonly mapSpawnsPromise: Promise<void> | null;
-  readonly objectiveModeCountDifferencesPromise: Promise<void> | null;
+  readonly objectiveModeCountDifferencesPromise: Promise<'stale' | undefined> | null;
   readonly taskObjectivesPromise: Promise<void> | null;
   readonly taskRewardsPromise: Promise<void> | null;
   readonly prestigePromise: Promise<void> | null;

--- a/app/stores/tarkov/promiseStore.ts
+++ b/app/stores/tarkov/promiseStore.ts
@@ -10,6 +10,8 @@ export interface PromiseStore {
   readonly taskRewardsPromise: Promise<void> | null;
   readonly prestigePromise: Promise<void> | null;
   readonly editionsPromise: Promise<void> | null;
+  readonly editionsRequestVersion: number;
+  readonly taskCoreRefreshId: symbol | null;
   readonly initPromise: Promise<void> | null;
   readonly isInitializing: boolean;
 }
@@ -52,6 +54,8 @@ export function getPromiseStore(storeInstance: object): MutablePromiseStore {
       taskRewardsPromise: null,
       prestigePromise: null,
       editionsPromise: null,
+      editionsRequestVersion: 0,
+      taskCoreRefreshId: null,
       initPromise: null,
       isInitializing: false,
     });

--- a/app/stores/tarkov/promiseStore.ts
+++ b/app/stores/tarkov/promiseStore.ts
@@ -11,6 +11,7 @@ export interface PromiseStore {
   readonly prestigePromise: Promise<void> | null;
   readonly editionsPromise: Promise<void> | null;
   readonly editionsRequestVersion: number;
+  readonly taskRewardsRequestVersion: number;
   readonly taskCoreRefreshes: Set<symbol>;
   readonly initPromise: Promise<void> | null;
   readonly isInitializing: boolean;
@@ -55,6 +56,7 @@ export function getPromiseStore(storeInstance: object): MutablePromiseStore {
       prestigePromise: null,
       editionsPromise: null,
       editionsRequestVersion: 0,
+      taskRewardsRequestVersion: 0,
       taskCoreRefreshes: new Set(),
       initPromise: null,
       isInitializing: false,

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -947,11 +947,14 @@ export const useMetadataStore = defineStore('metadata', {
       }
       // Only defer non-critical task rewards
       if (this.tasks.length && deferHeavy) {
+        const rewardsRequestVersion = promiseStore.taskRewardsRequestVersion;
         queueIdleTask(
-          () =>
-            this.fetchTaskRewardsData(forceRefresh).catch((err) =>
+          () => {
+            if (promiseStore.taskRewardsRequestVersion !== rewardsRequestVersion) return;
+            return this.fetchTaskRewardsData(forceRefresh).catch((err) =>
               logger.error('[MetadataStore] Error fetching deferred data:', err)
-            ),
+            );
+          },
           { timeout: 4000, minTime: 8, priority: 'normal' }
         );
       } else if (this.tasks.length) {
@@ -1198,6 +1201,7 @@ export const useMetadataStore = defineStore('metadata', {
      * Fetch task rewards data
      */
     async fetchTaskRewardsData(forceRefresh = false) {
+      getPromiseStore(this).taskRewardsRequestVersion += 1;
       const requestLanguage = this.languageCode;
       const requestGameMode = this.getApiGameMode();
       const requestKey = `${requestLanguage}-${requestGameMode}`;
@@ -1405,6 +1409,15 @@ export const useMetadataStore = defineStore('metadata', {
         promiseKey: 'prestigePromise',
         promiseRequestKey: requestLanguage,
       });
+    },
+    /** Join or reuse universal edition data for task readiness. */
+    async ensureEditionsData() {
+      const promises = getPromiseStore(this);
+      if (!promises.editionsRequestVersion) return this.fetchEditionsData();
+      // Universal editions already requested this session: join or reuse their settlement.
+      // This caller also consumes a queued idle load, even when joining another request.
+      promises.editionsRequestVersion += 1;
+      return promises.editionsPromise;
     },
     /**
      * Fetch game editions data directly from GitHub overlay.

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -171,7 +171,7 @@ const deriveStaticMapKey = (mapName: string, normalizedName?: string): string =>
 };
 const beginTaskCoreRefresh = (state: Pick<MetadataState, 'tasksCoreRefreshing'>): symbol => {
   const token = Symbol('taskCoreRefresh');
-  getPromiseStore(state).taskCoreRefreshId = token;
+  getPromiseStore(state).taskCoreRefreshes.add(token);
   state.tasksCoreRefreshing = true;
   return token;
 };
@@ -180,9 +180,8 @@ const finishTaskCoreRefresh = (
   token: symbol
 ) => {
   const promises = getPromiseStore(state);
-  if (promises.taskCoreRefreshId !== token) return;
-  state.tasksCoreRefreshing = false;
-  promises.taskCoreRefreshId = null;
+  promises.taskCoreRefreshes.delete(token);
+  state.tasksCoreRefreshing = promises.taskCoreRefreshes.size > 0;
 };
 type CachedEditions = { editions?: GameEdition[]; storyChapters?: StoryChapter[] };
 const readCachedEditions = async (): Promise<CachedEditions> => {
@@ -198,8 +197,8 @@ const applyCachedEditions = async (
   state: Pick<MetadataState, 'editions' | 'storyChapters'>,
   isCurrent: () => boolean
 ): Promise<boolean> => {
-  const { editions, storyChapters = [] } = await readCachedEditions();
-  if (!isCurrent() || !editions) return false;
+  const { editions = [], storyChapters = [] } = await readCachedEditions();
+  if (!isCurrent() || !editions.length) return false;
   state.editions = markRaw(editions);
   if (!storyChapters.length) return false;
   state.storyChapters = markRaw(
@@ -436,7 +435,13 @@ export const useMetadataStore = defineStore('metadata', {
               logger.debug('[MetadataStore] Critical cache exists, skipping loading screen');
             }
           }
-          await this.fetchAllData(forceRefresh, { deferHeavy: !forceRefresh, cachedData });
+          const dataRefresh = this.fetchAllData(forceRefresh, {
+            deferHeavy: !forceRefresh,
+            cachedData,
+          });
+          // fetchAllData registers its core phase synchronously; release setup ownership now.
+          finishTaskCoreRefresh(this, taskCoreRefreshId);
+          await dataRefresh;
           this.assertCriticalMetadataReady();
           this.initialized = true;
           this.initializationFailed = false;

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -103,6 +103,7 @@ interface MetadataState {
   loading: boolean;
   // Only core replacement advances this token; detail and item merges leave it unchanged.
   tasksCoreRevision: number;
+  tasksCoreRefreshing: boolean;
   // Indicates objectives still need to be fetched (set when tasks exist but objectives not yet loaded)
   tasksObjectivesPending: boolean;
   tasksObjectivesHydrated: boolean;
@@ -168,6 +169,21 @@ const deriveStaticMapKey = (mapName: string, normalizedName?: string): string =>
   const lower = mapName.toLowerCase();
   return MAP_NAME_MAPPING[lower] ?? lower.replace(/[\s+-]/g, '');
 };
+const beginTaskCoreRefresh = (state: Pick<MetadataState, 'tasksCoreRefreshing'>): symbol => {
+  const token = Symbol('taskCoreRefresh');
+  getPromiseStore(state).taskCoreRefreshId = token;
+  state.tasksCoreRefreshing = true;
+  return token;
+};
+const finishTaskCoreRefresh = (
+  state: Pick<MetadataState, 'tasksCoreRefreshing'>,
+  token: symbol
+) => {
+  const promises = getPromiseStore(state);
+  if (promises.taskCoreRefreshId !== token) return;
+  state.tasksCoreRefreshing = false;
+  promises.taskCoreRefreshId = null;
+};
 type CachedEditions = { editions?: GameEdition[]; storyChapters?: StoryChapter[] };
 const readCachedEditions = async (): Promise<CachedEditions> => {
   if (typeof window === 'undefined') return {};
@@ -198,6 +214,7 @@ export const useMetadataStore = defineStore('metadata', {
     initializationFailed: false,
     loading: false,
     tasksCoreRevision: 0,
+    tasksCoreRefreshing: false,
     tasksObjectivesPending: false,
     tasksObjectivesHydrated: false,
     hideoutLoading: false,
@@ -407,6 +424,7 @@ export const useMetadataStore = defineStore('metadata', {
       }
       promiseStore.isInitializing = true;
       promiseStore.initPromise = (async () => {
+        const taskCoreRefreshId = beginTaskCoreRefresh(this);
         try {
           this.updateLanguageAndGameMode(undefined, options?.gameMode);
           await this.loadStaticMapData();
@@ -429,6 +447,7 @@ export const useMetadataStore = defineStore('metadata', {
           // Rethrow to allow caller (e.g. metadata plugin) to handle retries or critical failure
           throw err;
         } finally {
+          finishTaskCoreRefresh(this, taskCoreRefreshId);
           promiseStore.isInitializing = false;
           promiseStore.initPromise = null;
           perfEnd(perfTimer, {
@@ -860,45 +879,53 @@ export const useMetadataStore = defineStore('metadata', {
           logger.error('[MetadataStore] Error during cache cleanup:', err)
         );
       }
-      if (cachedData && !forceRefresh) {
-        this.applyCriticalCachedData(cachedData);
-      }
-      await this.fetchBootstrapData(forceRefresh);
-      // Use pre-loaded cache data if available, otherwise fetch
+      const promiseStore = getPromiseStore(this);
+      const taskCoreRefreshId = beginTaskCoreRefresh(this);
       let hideoutPromise: Promise<void>;
       let prestigePromise: Promise<void> = Promise.resolve();
       let editionsPromise: Promise<void> = Promise.resolve();
       let tasksCorePromise: Promise<void>;
-      if (cachedData && !forceRefresh) {
-        hideoutPromise = Promise.resolve();
-        if (!this.storyChapters.length) {
-          editionsPromise = this.fetchEditionsData(false);
+      try {
+        if (cachedData && !forceRefresh) {
+          this.applyCriticalCachedData(cachedData);
         }
-        tasksCorePromise = Promise.resolve();
-      } else {
-        hideoutPromise = this.fetchHideoutData(forceRefresh);
-        if (deferHeavy) {
-          queueIdleTask(
-            () =>
-              this.fetchPrestigeData(forceRefresh).catch((err) =>
-                logger.error('[MetadataStore] Error fetching deferred prestige data:', err)
-              ),
-            { timeout: 3000, minTime: 8, priority: 'normal' }
-          );
-          queueIdleTask(
-            () =>
-              this.fetchEditionsData(forceRefresh).catch((err) =>
-                logger.error('[MetadataStore] Error fetching deferred editions data:', err)
-              ),
-            { timeout: 3500, minTime: 8, priority: 'normal' }
-          );
+        await this.fetchBootstrapData(forceRefresh);
+        if (cachedData && !forceRefresh) {
+          hideoutPromise = Promise.resolve();
+          if (!this.storyChapters.length) {
+            editionsPromise = this.fetchEditionsData(false);
+          }
+          tasksCorePromise = Promise.resolve();
         } else {
-          prestigePromise = this.fetchPrestigeData(forceRefresh);
-          editionsPromise = this.fetchEditionsData(forceRefresh);
+          hideoutPromise = this.fetchHideoutData(forceRefresh);
+          if (deferHeavy) {
+            queueIdleTask(
+              () =>
+                this.fetchPrestigeData(forceRefresh).catch((err) =>
+                  logger.error('[MetadataStore] Error fetching deferred prestige data:', err)
+                ),
+              { timeout: 3000, minTime: 8, priority: 'normal' }
+            );
+            const editionsRequestVersion = promiseStore.editionsRequestVersion;
+            queueIdleTask(
+              () => {
+                if (promiseStore.editionsRequestVersion !== editionsRequestVersion) return;
+                return this.fetchEditionsData(forceRefresh).catch((err) =>
+                  logger.error('[MetadataStore] Error fetching deferred editions data:', err)
+                );
+              },
+              { timeout: 3500, minTime: 8, priority: 'normal' }
+            );
+          } else {
+            prestigePromise = this.fetchPrestigeData(forceRefresh);
+            editionsPromise = this.fetchEditionsData(forceRefresh);
+          }
+          tasksCorePromise = this.fetchTasksCoreData(forceRefresh);
         }
-        tasksCorePromise = this.fetchTasksCoreData(forceRefresh);
+        await tasksCorePromise;
+      } finally {
+        finishTaskCoreRefresh(this, taskCoreRefreshId);
       }
-      await tasksCorePromise;
       // Fetch critical data directly (not deferred) - needed for UI to render
       const itemsLitePromise = this.fetchItemsLiteData(forceRefresh);
       let taskObjectivesPromise: Promise<void> = Promise.resolve();
@@ -1381,6 +1408,7 @@ export const useMetadataStore = defineStore('metadata', {
      */
     async fetchEditionsData(forceRefresh = false) {
       const promiseStore = getPromiseStore(this);
+      promiseStore.editionsRequestVersion += 1;
       const existingPromise = promiseStore.editionsPromise;
       if (existingPromise && !forceRefresh) {
         return existingPromise;

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -1083,7 +1083,7 @@ export const useMetadataStore = defineStore('metadata', {
             this.languageCode !== requestLanguageCode ||
             this.tasks !== requestTasks
           ) {
-            return;
+            return 'stale' as const;
           }
           const otherModeTasks = (response.data.tasks || []).map((task) => ({
             id: task.id,
@@ -1116,7 +1116,7 @@ export const useMetadataStore = defineStore('metadata', {
             this.languageCode !== requestLanguageCode ||
             this.tasks !== requestTasks
           ) {
-            return;
+            return 'stale' as const;
           }
           this.objectiveModeCountDifferences = markRaw(differences);
           this.objectiveModeCountDifferencesHydrated = true;
@@ -1126,7 +1126,7 @@ export const useMetadataStore = defineStore('metadata', {
             this.languageCode !== requestLanguageCode ||
             this.tasks !== requestTasks
           ) {
-            return;
+            return 'stale' as const;
           }
           this.objectiveModeCountDifferences = markRaw({});
           this.objectiveModeCountDifferencesHydrated = false;
@@ -1135,7 +1135,7 @@ export const useMetadataStore = defineStore('metadata', {
       })();
       promiseStore.objectiveModeCountDifferencesPromise = promise;
       try {
-        await promise;
+        return await promise;
       } finally {
         promiseStore.objectiveModeCountDifferencesPromise = null;
       }
@@ -1363,7 +1363,8 @@ export const useMetadataStore = defineStore('metadata', {
       if (existingPromise && !forceRefresh) {
         return existingPromise;
       }
-      const promise = (async () => {
+      // Register the promise before requests can settle or throw synchronously.
+      const promise = Promise.resolve().then(async () => {
         this.editionsError = null;
         const existingEditions = this.editions;
         const existingStoryChapters = this.storyChapters;
@@ -1373,6 +1374,7 @@ export const useMetadataStore = defineStore('metadata', {
               editions: GameEdition[];
               storyChapters?: StoryChapter[];
             }>('editions' as CacheType, 'all', 'en');
+            if (promiseStore.editionsPromise !== promise) return;
             if (cached?.editions) {
               this.editions = markRaw(cached.editions);
             }
@@ -1391,6 +1393,7 @@ export const useMetadataStore = defineStore('metadata', {
             logger.warn('[MetadataStore] Editions cache read failed:', cacheErr);
           }
         }
+        if (promiseStore.editionsPromise !== promise) return;
         this.editionsLoading = true;
         try {
           const OVERLAY_URL =
@@ -1401,6 +1404,7 @@ export const useMetadataStore = defineStore('metadata', {
           }>(OVERLAY_URL, {
             parseResponse: JSON.parse,
           });
+          if (promiseStore.editionsPromise !== promise) return;
           if (overlay?.editions) {
             this.editions = markRaw(Object.values(overlay.editions));
           } else {
@@ -1426,6 +1430,7 @@ export const useMetadataStore = defineStore('metadata', {
             ).catch((err) => logger.error('[MetadataStore] Error caching editions:', err));
           }
         } catch (err) {
+          if (promiseStore.editionsPromise !== promise) return;
           logger.error('[MetadataStore] Error fetching editions data:', err);
           this.editionsError = err as Error;
           if (!this.editions.length && existingEditions.length) {
@@ -1438,7 +1443,7 @@ export const useMetadataStore = defineStore('metadata', {
             this.editions = markRaw([]);
           }
         }
-      })();
+      });
       promiseStore.editionsPromise = promise;
       try {
         await promise;

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -168,6 +168,30 @@ const deriveStaticMapKey = (mapName: string, normalizedName?: string): string =>
   const lower = mapName.toLowerCase();
   return MAP_NAME_MAPPING[lower] ?? lower.replace(/[\s+-]/g, '');
 };
+type CachedEditions = { editions?: GameEdition[]; storyChapters?: StoryChapter[] };
+const readCachedEditions = async (): Promise<CachedEditions> => {
+  if (typeof window === 'undefined') return {};
+  try {
+    return (await getCachedData<CachedEditions>('editions' as CacheType, 'all', 'en')) ?? {};
+  } catch (error) {
+    logger.warn('[MetadataStore] Editions cache read failed:', error);
+    return {};
+  }
+};
+const applyCachedEditions = async (
+  state: Pick<MetadataState, 'editions' | 'storyChapters'>,
+  isCurrent: () => boolean
+): Promise<boolean> => {
+  const { editions, storyChapters = [] } = await readCachedEditions();
+  if (!isCurrent() || !editions) return false;
+  state.editions = markRaw(editions);
+  if (!storyChapters.length) return false;
+  state.storyChapters = markRaw(
+    storyChapters.map((chapter) => normalizeStoryChapter(chapter)).sort((a, b) => a.order - b.order)
+  );
+  logger.debug('[MetadataStore] Editions loaded from cache');
+  return true;
+};
 export const useMetadataStore = defineStore('metadata', {
   state: (): MetadataState => ({
     initialized: false,
@@ -961,8 +985,6 @@ export const useMetadataStore = defineStore('metadata', {
         throwOnError: true,
       });
     },
-    // Fallow cannot follow this method through the typed composable boundary.
-    // fallow-ignore-next-line unused-store-member -- accessed through typed composable boundary
     async fetchMapSpawnsData(forceRefresh = false) {
       if (this.mapSpawnsLoaded && !forceRefresh) return;
       const requestLanguage = this.languageCode;
@@ -1364,36 +1386,23 @@ export const useMetadataStore = defineStore('metadata', {
         return existingPromise;
       }
       // Register the promise before requests can settle or throw synchronously.
+      // fallow-ignore-next-line complexity -- CRAP assumes zero coverage; measured coverage and reduced complexity are documented in docs/task-performance-validation.md
       const promise = Promise.resolve().then(async () => {
         this.editionsError = null;
-        const existingEditions = this.editions;
-        const existingStoryChapters = this.storyChapters;
-        if (!forceRefresh && typeof window !== 'undefined') {
-          try {
-            const cached = await getCachedData<{
-              editions: GameEdition[];
-              storyChapters?: StoryChapter[];
-            }>('editions' as CacheType, 'all', 'en');
-            if (promiseStore.editionsPromise !== promise) return;
-            if (cached?.editions) {
-              this.editions = markRaw(cached.editions);
-            }
-            if (cached?.editions && cached.storyChapters && cached.storyChapters.length > 0) {
-              logger.debug('[MetadataStore] Editions loaded from cache');
-              const sorted = cached.storyChapters
-                .map((chapter) => normalizeStoryChapter(chapter))
-                .sort((a, b) => a.order - b.order);
-              this.storyChapters = markRaw(sorted);
-              void this.fetchEditionsData(true).catch((err) =>
-                logger.warn('[MetadataStore] Background editions revalidation failed:', err)
-              );
-              return;
-            }
-          } catch (cacheErr) {
-            logger.warn('[MetadataStore] Editions cache read failed:', cacheErr);
-          }
+        const isCurrent = () => promiseStore.editionsPromise === promise;
+        if (
+          !forceRefresh &&
+          (await applyCachedEditions(this, isCurrent).catch((error) => {
+            logger.warn('[MetadataStore] Editions cache read failed:', error);
+            return false;
+          }))
+        ) {
+          void this.fetchEditionsData(true).catch((error) =>
+            logger.warn('[MetadataStore] Background editions revalidation failed:', error)
+          );
+          return;
         }
-        if (promiseStore.editionsPromise !== promise) return;
+        if (!isCurrent()) return;
         this.editionsLoading = true;
         try {
           const OVERLAY_URL =
@@ -1405,21 +1414,15 @@ export const useMetadataStore = defineStore('metadata', {
             parseResponse: JSON.parse,
           });
           if (promiseStore.editionsPromise !== promise) return;
-          if (overlay?.editions) {
-            this.editions = markRaw(Object.values(overlay.editions));
-          } else {
+          // Normalize both before assigning so malformed chapters cannot partially replace eligibility.
+          const editions = Object.values(overlay?.editions ?? {});
+          const chapters = Object.values(overlay?.storyChapters ?? {})
+            .map((chapter) => normalizeStoryChapter(chapter))
+            .sort((a, b) => a.order - b.order);
+          if (!overlay?.editions)
             logger.warn('[MetadataStore] No editions found in overlay response');
-            this.editions = markRaw([]);
-          }
-          if (overlay?.storyChapters) {
-            const chaptersArray = Object.values(overlay.storyChapters).map((chapter) =>
-              normalizeStoryChapter(chapter)
-            );
-            chaptersArray.sort((a, b) => a.order - b.order);
-            this.storyChapters = markRaw(chaptersArray);
-          } else {
-            this.storyChapters = markRaw([]);
-          }
+          this.editions = markRaw(editions);
+          this.storyChapters = markRaw(chapters);
           if (typeof window !== 'undefined') {
             setCachedData(
               'editions' as CacheType,
@@ -1433,15 +1436,6 @@ export const useMetadataStore = defineStore('metadata', {
           if (promiseStore.editionsPromise !== promise) return;
           logger.error('[MetadataStore] Error fetching editions data:', err);
           this.editionsError = err as Error;
-          if (!this.editions.length && existingEditions.length) {
-            this.editions = markRaw(existingEditions);
-          }
-          if (!this.storyChapters.length && existingStoryChapters.length) {
-            this.storyChapters = markRaw(existingStoryChapters);
-          }
-          if (!this.editions.length) {
-            this.editions = markRaw([]);
-          }
         }
       });
       promiseStore.editionsPromise = promise;

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -101,6 +101,8 @@ interface MetadataState {
   initialized: boolean;
   initializationFailed: boolean;
   loading: boolean;
+  // Only core replacement advances this token; detail and item merges leave it unchanged.
+  tasksCoreRevision: number;
   // Indicates objectives still need to be fetched (set when tasks exist but objectives not yet loaded)
   tasksObjectivesPending: boolean;
   tasksObjectivesHydrated: boolean;
@@ -171,6 +173,7 @@ export const useMetadataStore = defineStore('metadata', {
     initialized: false,
     initializationFailed: false,
     loading: false,
+    tasksCoreRevision: 0,
     tasksObjectivesPending: false,
     tasksObjectivesHydrated: false,
     hideoutLoading: false,
@@ -1434,15 +1437,16 @@ export const useMetadataStore = defineStore('metadata', {
           if (!this.editions.length) {
             this.editions = markRaw([]);
           }
-        } finally {
-          this.editionsLoading = false;
         }
       })();
       promiseStore.editionsPromise = promise;
       try {
         await promise;
       } finally {
-        promiseStore.editionsPromise = null;
+        if (promiseStore.editionsPromise === promise) {
+          this.editionsLoading = false;
+          promiseStore.editionsPromise = null;
+        }
       }
     },
     applyCriticalCachedData(cachedData: {
@@ -1511,6 +1515,7 @@ export const useMetadataStore = defineStore('metadata', {
         maps: data.maps || [],
         traders: data.traders || [],
       });
+      this.tasksCoreRevision += 1;
       perfEnd(perfTimer, { tasks: this.tasks.length });
     },
     mergeMapSpawns(data: TarkovMapSpawnsQueryResult) {

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1260,8 +1260,18 @@ detached tree; its zero bounding rectangle must not trigger auto-fill. Hidden or
 sentinels consume no auto-load budget. The existing intersection observer checks again when
 the list becomes visible; configured scroll fallback and explicit checks use the same guard.
 
-The tasks page retains its loading state until metadata is ready and the first visible-task
-refresh settles. Reset that readiness when metadata starts loading again. Metadata readiness
+The tasks page requests objectives, rewards, and edition eligibility together through the
+existing cached/deduplicated store actions (`useTaskDetailReadiness`). Keep its loading state
+until these requests settle and the first visible-task refresh settles. This prevents objective
+skeleton/reward reflow and an initial list filtered without edition eligibility. This eager
+request is scoped to the tasks page; other routes retain the store's idle scheduling.
+
+Optional detail requests can hold the page for at most three seconds after core readiness;
+then show the existing progressive UI while late requests continue. Failed requests also release
+the gate. Mode/locale changes, core reloads, and scope disposal invalidate earlier waits and clear
+their timers. An empty task dataset does not wait for optional requests.
+
+Reset filter readiness when metadata or task-detail readiness resets. Metadata readiness
 alone must not expose the empty state during the debounced filter refresh; a completed refresh
 with no matching tasks still shows the normal empty state. Subsequent filter changes retain
 the existing debounce and task actions still request an immediate refresh.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1270,11 +1270,12 @@ request is scoped to the tasks page; other routes retain the store's idle schedu
 responses, errors, and cleanup apply only to the current promise; superseded cache reads and
 network requests cannot overwrite current eligibility, cache payloads, or loading state.
 Normalize edition and chapter network payloads before applying either, preserving existing
-data if normalization fails.
+data if normalization fails. Empty cached editions do not replace loaded eligibility.
 
 Initialization marks `tasksCoreRefreshing` before updating locale/mode and reading caches.
-`fetchAllData` takes ownership of this phase before bootstrap and clears it after core settlement,
-including failures. A per-store token prevents an older refresh from clearing a newer phase.
+`fetchAllData` registers its phase synchronously before bootstrap; initialization then releases
+its setup phase. A per-store set retains every active phase until core settlement, including
+failures, so either completion order keeps readiness pending while another core refresh can run.
 Task readiness stays false during this phase, so locale changes cannot reveal old core data
 while bootstrap is pending. Optional requests remain outside this phase and keep their timeout.
 

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1269,6 +1269,8 @@ skeleton/reward reflow and an initial list filtered without edition eligibility.
 request is scoped to the tasks page; other routes retain the store's idle scheduling. Edition
 responses, errors, and cleanup apply only to the current promise; superseded cache reads and
 network requests cannot overwrite current eligibility, cache payloads, or loading state.
+Normalize edition and chapter network payloads before applying either, preserving existing
+data if normalization fails.
 
 Core-task replacements advance `tasksCoreRevision`, including cache hits that never raise
 `loading`; detail/item merges do not advance it. Readiness watches this revision so cached

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1260,19 +1260,21 @@ detached tree; its zero bounding rectangle must not trigger auto-fill. Hidden or
 sentinels consume no auto-load budget. The existing intersection observer checks again when
 the list becomes visible; configured scroll fallback and explicit checks use the same guard.
 
-The tasks page requests objectives, rewards, and edition eligibility together through the
-existing cached/deduplicated store actions (`useTaskDetailReadiness`). Keep its loading state
+The tasks page requests objectives, rewards, item-lite hydration, and edition eligibility through the
+readiness composable `useTaskDetailReadiness`, which invokes the existing cached/deduplicated
+metadata store actions. Keep its loading state
 until these requests, background edition revalidation, objective mode-count metadata, and the
 first visible-task refresh settle. This prevents objective
 skeleton/reward reflow and an initial list filtered without edition eligibility. This eager
 request is scoped to the tasks page; other routes retain the store's idle scheduling. Edition
-request cleanup clears loading and deduplication only for the current promise.
+responses, errors, and cleanup apply only to the current promise; superseded cache reads and
+network requests cannot overwrite current eligibility, cache payloads, or loading state.
 
 Core-task replacements advance `tasksCoreRevision`, including cache hits that never raise
 `loading`; detail/item merges do not advance it. Readiness watches this revision so cached
 locale replacements and empty-to-populated core recovery start a new wait. After objectives
-and rewards settle, await objective mode-count metadata; retry once if an already-running
-request was discarded during task replacement. The existing gate timer still bounds this wait.
+and rewards/items settle, await objective mode-count metadata; retry once only when the store
+returns `stale` for a response discarded during task replacement. Handled failures are not retried. The existing gate timer still bounds this wait.
 
 Optional detail requests use a three-second gate timer after core readiness; on expiry,
 resume filtering/rendering while late requests continue. Failed requests also release
@@ -1282,7 +1284,9 @@ their timers. An empty task dataset does not wait for optional requests.
 Reset filter readiness when metadata or task-detail readiness resets. Metadata readiness
 alone must not expose the empty state during the debounced filter refresh; a completed refresh
 with no matching tasks still shows the normal empty state. Subsequent filter changes retain
-the existing debounce and task actions still request an immediate refresh.
+the existing debounce and task actions still request an immediate refresh. Deep-link effects
+use this combined loading state so queries wait for mounted cards and retry after readiness
+clears even when the filtered task IDs have not changed.
 
 Keep the tasks page's eight-card batches, preload margin, and auto-load caps. Do not defer
 critical metadata or change task filters, progress state, or card expansion to mask mounting

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1272,6 +1272,16 @@ network requests cannot overwrite current eligibility, cache payloads, or loadin
 Normalize edition and chapter network payloads before applying either, preserving existing
 data if normalization fails.
 
+Initialization marks `tasksCoreRefreshing` before updating locale/mode and reading caches.
+`fetchAllData` takes ownership of this phase before bootstrap and clears it after core settlement,
+including failures. A per-store token prevents an older refresh from clearing a newer phase.
+Task readiness stays false during this phase, so locale changes cannot reveal old core data
+while bootstrap is pending. Optional requests remain outside this phase and keep their timeout.
+
+Deferred edition callbacks capture a request version. A later edition request, including a
+deduplicated join, consumes that queued load; the callback skips its redundant revalidation.
+Routes without an eager request retain idle edition loading.
+
 Core-task replacements advance `tasksCoreRevision`, including cache hits that never raise
 `loading`; detail/item merges do not advance it. Readiness watches this revision so cached
 locale replacements and empty-to-populated core recovery start a new wait. After objectives

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1272,6 +1272,11 @@ network requests cannot overwrite current eligibility, cache payloads, or loadin
 Normalize edition and chapter network payloads before applying either, preserving existing
 data if normalization fails. Empty cached editions do not replace loaded eligibility.
 
+Task readiness uses `ensureEditionsData` to join or reuse the session's universal edition request,
+including a request settled during bootstrap/core loading. Explicit `fetchEditionsData` calls keep
+their cache revalidation behavior. Queued reward work, like editions, is consumed by a later eager
+request; other routes retain their idle load when no caller takes ownership.
+
 Initialization marks `tasksCoreRefreshing` before updating locale/mode and reading caches.
 `fetchAllData` registers its phase synchronously before bootstrap; initialization then releases
 its setup phase. A per-store set retains every active phase until core settlement, including

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1262,12 +1262,20 @@ the list becomes visible; configured scroll fallback and explicit checks use the
 
 The tasks page requests objectives, rewards, and edition eligibility together through the
 existing cached/deduplicated store actions (`useTaskDetailReadiness`). Keep its loading state
-until these requests settle and the first visible-task refresh settles. This prevents objective
+until these requests, background edition revalidation, objective mode-count metadata, and the
+first visible-task refresh settle. This prevents objective
 skeleton/reward reflow and an initial list filtered without edition eligibility. This eager
-request is scoped to the tasks page; other routes retain the store's idle scheduling.
+request is scoped to the tasks page; other routes retain the store's idle scheduling. Edition
+request cleanup clears loading and deduplication only for the current promise.
 
-Optional detail requests can hold the page for at most three seconds after core readiness;
-then show the existing progressive UI while late requests continue. Failed requests also release
+Core-task replacements advance `tasksCoreRevision`, including cache hits that never raise
+`loading`; detail/item merges do not advance it. Readiness watches this revision so cached
+locale replacements and empty-to-populated core recovery start a new wait. After objectives
+and rewards settle, await objective mode-count metadata; retry once if an already-running
+request was discarded during task replacement. The existing gate timer still bounds this wait.
+
+Optional detail requests use a three-second gate timer after core readiness; on expiry,
+resume filtering/rendering while late requests continue. Failed requests also release
 the gate. Mode/locale changes, core reloads, and scope disposal invalidate earlier waits and clear
 their timers. An empty task dataset does not wait for optional requests.
 

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -130,8 +130,11 @@ preview session.
 ## Follow-up: complete initial task cards
 
 The follow-up compares main `8f0c63896ffa8df08d40df241474dcc0e21701c2` (the merged #808
-implementation) with this revision. The same production-build method and public API response
-replay described above are used. The subsequent main release commit changes the version only.
+implementation) with implementation commit `fa6f422b092a3b2546b6bf595304d1e71c7a5917`.
+The measurements below identify the initial implementation; the review corrections and their
+validation are recorded separately below. The same production-build method and public API
+response replay described above are used. The subsequent main release commit changes the
+version only.
 
 ### Cause and behavior
 
@@ -141,15 +144,17 @@ trace of the intermediate follow-up showed Shooting Cans replaced by Shady Contr
 edition data arrived. Waiting for objectives/rewards alone therefore did not fix cold CLS.
 
 `useTaskDetailReadiness` requests objectives, rewards, and editions concurrently once core
-metadata is ready. The tasks page filters after those requests settle and presents complete
-cards together. It uses the existing cache, deduplication, and response-context guards; other
+metadata is ready. It also waits for background edition revalidation and objective mode-count
+metadata, including one retry if hydration discarded an in-flight count request. The tasks page
+filters after these settle and presents complete cards together. It uses the existing cache, deduplication, and response-context guards; other
 routes retain deferred loading. No card expansion defaults, task eligibility rules, batch sizes,
 progress persistence, or remote data contracts change.
 
 The wait is bounded at **three seconds after core readiness**. Failures release the page;
 stalled requests continue in the background after the bound. This intentionally favors usable
 navigation over stable layout during an outage. A mode/locale change or core reload invalidates
-an earlier wait; unmount clears timers. Filter refresh generations prevent an older async
+an earlier wait, including cached core replacements tracked by `tasksCoreRevision`; unmount
+clears timers. Filter refresh generations prevent an older async
 completion from releasing a newer loading cycle. Its regression test failed before the guard.
 
 ### Measurement policy for closing #444
@@ -250,8 +255,8 @@ and settled-card budgets without changing the selected progress or task filters.
 
 ### Follow-up functional validation
 
-Production build, lint, typecheck, systems drift check, and eight focused Vitest files
-(123 tests) passed. Coverage includes readiness settlement, failures, the three-second timer,
+The initial implementation passed production build, lint, typecheck, systems drift check, and
+eight focused Vitest files (123 tests). Coverage includes readiness settlement, failures, the three-second timer,
 mode/locale changes, core reloads, unmount cleanup, and stale filter refreshes, plus existing
 filtering, actions, deep-link, infinite-scroll, and objective visibility regressions.
 
@@ -263,3 +268,46 @@ promptly. Both retained interactive cards. Teammate selection and hide/show were
 a synthetic identity on the offline client; no authenticated network access was involved.
 Desktop/mobile screenshots were inspected. Local CodeRabbit review raised one stale-refresh
 finding, which the generation guard and failing-then-passing regression test address.
+
+### Review corrections and repeated validation
+
+Review identified three additional initial-render races: cached core replacements without a
+loading transition, background edition revalidation after a cache hit, and deferred objective
+mode-count badges. Core revisions now re-arm readiness, and the gate includes edition
+revalidation and count metadata. Edition promise/loading cleanup is identity-guarded so an
+older request cannot clear the current request's tracking. Empty-to-populated core recovery is
+covered as well. The three-second availability timer still bounds all optional waits.
+
+The corrected production build was measured again on September 6 using the same response
+replay, viewports, throttling, and three independent profiles per scenario. These are separate
+from the initial implementation samples above. All runs displayed eight initial cards and no
+transient empty state.
+
+| Scenario         | Cold shift sums          | Warm shift sums          | Median settled cards, cold / warm (ms) |
+| ---------------- | ------------------------ | ------------------------ | -------------------------------------- |
+| Guest desktop    | 0.0009 / 0.0009 / 0.0009 | 0.0002 / 0.0002 / 0.0002 | 3266 / 2109                            |
+| Guest mobile     | 0.0020 / 0.0020 / 0.0020 | 0 / 0 / 0                | 3330 / 1924                            |
+| Persisted mobile | 0.0020 / 0.0020 / 0.0020 | 0 / 0 / 0                | 3560 / 1960                            |
+| Team mobile      | 0.0020 / 0.0020 / 0.0020 | 0 / 0 / 0                | 3479 / 2120                            |
+
+All layout and settled-card timing budgets still pass against main. The corrected build's
+median complete-card appearance is 10–26% earlier than main across these scenarios. This
+retains the tradeoff above: first incomplete cards previously appeared sooner.
+
+The corrected build's extended mobile Lighthouse runs were score **0.41 / 0.40 / 0.41**,
+TBT **987 / 1034 / 978 ms**, CLS **0.0020 / 0.0020 / 0.0020**, FCP
+**4972 / 5042 / 5046 ms**, and LCP **23357 / 23356 / 23363 ms**. Median TBT is about 8%
+below main's 1077 ms and passes the budget. The LCP candidate/tradeoff remains unchanged.
+
+The review corrections passed 11 focused Vitest files (145 tests), typecheck, and production
+build. Cached-core, edition-revalidation, count-metadata, and edition-deduplication
+regressions failed before their corresponding fixes. Page tests now independently delay
+objectives, rewards, and editions. Local CodeRabbit's second review
+identified the edition loading cleanup race, now covered by a concurrent-request test.
+
+Browser checks repeated successfully on the corrected build: all task controls and shared
+routes listed above, mode switching, and teammate selection/hide/show. Deterministic delayed
+actions in the production browser also verified cached core replacement, empty-core recovery,
+edition revalidation, and count metadata: cards stayed hidden until settlement, then eight
+appeared. Stalled requests released usable cards about 3.2 seconds after core readiness;
+rejections released them promptly. No uncaught browser exceptions were observed.

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -1,6 +1,8 @@
 # Task performance validation (#444)
 
-## Scope
+This records the #808 baseline and the [follow-up validation and closure policy](#follow-up-complete-initial-task-cards).
+
+## #808: warm-cache startup fix
 
 This change fixes two task-page startup races. Nuxt Suspense mounts the
 list in a detached tree. The sentinel's bounding rectangle is then zero, which previously
@@ -41,7 +43,7 @@ Reverting the composable change restores the previous behavior.
 Useful response fingerprints (SHA-256 prefixes): tasks-core `6d8940f89f17`, items-lite
 `625c4c63ec7e`, regular objectives `c925244c5d21`, rewards `84fc091370f6`.
 
-## Acceptance policy
+## #808 acceptance policy
 
 For this fix, a warm-cache page must not spend its auto-load budget on a detached or hidden
 sentinel, or flash an empty result before the first filter refresh settles. At the desktop test viewport with default expanded cards, initial rendering must
@@ -54,12 +56,12 @@ comparison budget, not a new universal performance floor. Keep the existing warn
 0.20 performance floor and single-run collection in PR CI; dedicated investigations use
 repeated runs. The historical 0.55 threshold is not a closure test for this patch.
 
-Issue #444 should remain open for cold-load investigation: expanded desktop cards still shift
-as deferred objectives/rewards arrive. A complete resolution needs those shifts addressed,
-representative persisted/team progress measurements, and a broader performance budget. Passing
-CI or this warm-cache regression check does not prove those remaining goals are complete.
+At the merge of #808, issue #444 remained open: expanded desktop cards still shifted as deferred
+objectives/rewards arrived. The follow-up below addresses those shifts, edition eligibility,
+representative persisted/team rendering, and the broader measurement policy. The #808 checks
+alone were not a closure claim.
 
-## Measured results
+## #808 measured results
 
 Three independent warm-cache desktop profiles per revision:
 
@@ -100,9 +102,9 @@ Median Lighthouse TBT fell from 709 to 582 ms; LCP was effectively unchanged. Th
 comparison budgets above. The real-time 4× CPU traces still show deferred-content movement:
 final cold desktop layout-shift sums were 0.1010, 0.1319, and 0.1010; the final mobile probe
 was 0.2586 cold and 0.1075 warm. None of the final probes flashed the empty state. These are
-why the broader CLS work in #444 remains open despite the low Lighthouse CLS.
+why #808 did not close the broader CLS work in #444 despite its low Lighthouse CLS.
 
-## Functional validation
+## #808 functional validation
 
 - Production build, repository lint, typecheck, and systems drift check passed.
 - Nine focused Vitest files passed (129 tests), covering infinite scroll, tasks/Hideout/Needed
@@ -124,3 +126,140 @@ flashes. These checks produced no uncaught browser exceptions.
 The Cloudflare build/deployment also passed. Its hosted preview requires Cloudflare Access;
 the interaction checks above used the local production build, not an authenticated hosted
 preview session.
+
+## Follow-up: complete initial task cards
+
+The follow-up compares main `8f0c63896ffa8df08d40df241474dcc0e21701c2` (the merged #808
+implementation) with this revision. The same production-build method and public API response
+replay described above are used. The subsequent main release commit changes the version only.
+
+### Cause and behavior
+
+Three asynchronous changes affected the first visible list: objective skeleton replacement,
+reward-summary insertion, and edition eligibility arriving after filtering. A frame-by-frame
+trace of the intermediate follow-up showed Shooting Cans replaced by Shady Contractor once
+edition data arrived. Waiting for objectives/rewards alone therefore did not fix cold CLS.
+
+`useTaskDetailReadiness` requests objectives, rewards, and editions concurrently once core
+metadata is ready. The tasks page filters after those requests settle and presents complete
+cards together. It uses the existing cache, deduplication, and response-context guards; other
+routes retain deferred loading. No card expansion defaults, task eligibility rules, batch sizes,
+progress persistence, or remote data contracts change.
+
+The wait is bounded at **three seconds after core readiness**. Failures release the page;
+stalled requests continue in the background after the bound. This intentionally favors usable
+navigation over stable layout during an outage. A mode/locale change or core reload invalidates
+an earlier wait; unmount clears timers. Filter refresh generations prevent an older async
+completion from releasing a newer loading cycle. Its regression test failed before the guard.
+
+### Measurement policy for closing #444
+
+Keep the existing warning-only 0.20 CI score floor, single collection, and standard simulated
+mobile throttling. Shared-runner scores are a smoke signal, not an application readiness test;
+the historical 0.55 gate is deliberately not restored. For task performance changes:
+
+- Use three independent profiles per comparison scenario, with identical public API responses,
+  viewport, CPU settings, and build configuration. Include guest, persisted progress, and team
+  rendering; include cold and warm caches. Do not run builds/tests alongside measurements.
+- Collect Lighthouse with `pauseAfterFcpMs: 5000` and `pauseAfterLoadMs: 5000` for both revisions.
+  Verify that objectives, rewards, and edition eligibility were included before interpreting
+  the score. Extend collection if the specific environment has not reached that state.
+- Require observed layout-shift sums below **0.1** in successful-load desktop/mobile probes,
+  through 15 seconds after cards appear. Summing all shifts is at least as strict as the CLS
+  session-window maximum. Failure/stall fallbacks are availability tests, not CLS claims.
+- Require median full-window mobile Lighthouse TBT no more than the baseline plus the greater
+  of **100 ms or 10%**. Compare first **settled complete cards** in the real-time traces with
+  the same tolerance. Also report first incomplete cards, FCP, LCP, and its candidate so a
+  loading-state change cannot masquerade as faster useful content.
+- Keep task filtering, paging, progress actions, deep links, game modes, and graph/map routes
+  functional. Exercise delayed/failed detail requests and obsolete refresh completion.
+
+This replaces #808's narrow cold-navigation comparison budget for issue closure. It does not
+claim that the application has reached ideal mobile performance or that arbitrary slow-network
+loads will have no shifts after the availability fallback.
+
+### Why default Lighthouse was misleading
+
+The original default collection on #808 ended before objectives/rewards requests. Its LCP node
+was the header search text. A fresh follow-up default collection includes task content and
+reports a lower score (0.40 versus #808's 0.48 median) and higher LCP. Extending both collection
+windows exposes main's deferred CLS and CPU work:
+
+| Extended mobile Lighthouse | Main runs                | Follow-up runs           |
+| -------------------------- | ------------------------ | ------------------------ |
+| Performance score          | 0.26 / 0.27 / 0.28       | 0.41 / 0.41 / 0.40       |
+| TBT (ms)                   | 1150 / 1077 / 923        | 969 / 945 / 1024         |
+| CLS                        | 0.2565 / 0.2565 / 0.2565 | 0.0020 / 0.0020 / 0.0020 |
+| FCP (ms)                   | 4973 / 5050 / 5048       | 5042 / 5042 / 5045       |
+| LCP (ms)                   | 9277 / 9288 / 9285       | 23359 / 23359 / 23284    |
+
+Median full-window TBT improves about 10%; FCP is effectively unchanged. **LCP is higher**:
+main's candidate remains header search text, while the follow-up candidate is a visible task
+objective. Do not describe this as an LCP improvement. The new readiness boundary delays the
+first incomplete cards in exchange for a stable, complete list; compare the actual settled-card
+timings below. Large game-data downloads and long main-thread tasks remain optimization
+opportunities even after these startup defects are fixed.
+
+### Representative rendering fixtures
+
+The persisted fixture uses a guest-owned localStorage envelope, level 40, and 120 completed
+low-level task IDs selected from the production task dataset. The team fixture adds three
+synthetic teammates at levels 25/30/35 with 50/70/90 completed tasks, using the application's
+teammate progress event and real stores, with the All users filter. Browser assertions verify
+these stores and progress values. Fixtures use no private user data or production credentials.
+This validates team rendering/filtering cost, not authenticated Supabase transport; those
+contracts are unchanged and remain covered by their existing tests.
+
+### Guest traces
+
+Three follow-up profiles per viewport, with eight complete initial cards in every run:
+
+| Real-time trace | Main shift sums          | Follow-up shift sums     | Main median first / settled cards (ms) | Follow-up median first complete cards (ms) |
+| --------------- | ------------------------ | ------------------------ | -------------------------------------- | ------------------------------------------ |
+| Desktop cold    | 0.1010 / 0.1319 / 0.1010 | 0.0009 / 0.0009 / 0.0009 | 2318 / 3740                            | 3324                                       |
+| Desktop warm    | 0.0361 / 0.0361 / 0.0361 | 0.0002 / 0.0002 / 0.0002 | 1170 / 2524                            | 2008                                       |
+| Mobile cold     | 0.2586 / 0.2204 / 0.2204 | 0.0020 / 0.0020 / 0.0020 | 2345 / 3693                            | 3155                                       |
+| Mobile warm     | 0.1075 / 0.1075 / 0.1075 | 0 / 0 / 0                | 1130 / 2507                            | 1969                                       |
+
+The main guest traces retain the #808 final-build samples (identical executable behavior to
+its squash merge), plus a fresh paired mobile profile; all fixture and follow-up samples were
+collected anew. “Settled” is the final card/height frame in the no-input settling window.
+The follow-up has one such frame: no skeleton replacement, reward insertion, or edition-driven
+card replacement after first display. Complete cards appear 11–21% earlier at the median,
+although the first incomplete cards previously appeared sooner.
+
+Warm desktop observed blocking portions were 1065 / 1346 / 1107 ms, compared with
+1061 / 1044 / 1128 ms on main (median about 4% higher). The grouped initial render can produce
+longer individual tasks; this change fixes layout/readiness, not every source of main-thread
+work. Full-window Lighthouse TBT and the complete-card timing pass the stated comparison
+budgets. No transient empty-state frames were observed.
+
+### Persisted/team mobile traces
+
+Three fresh profiles per fixture and revision:
+
+| Fixture        | Main shift sums          | Follow-up shift sums     | Median settled cards (ms) |
+| -------------- | ------------------------ | ------------------------ | ------------------------- |
+| Persisted cold | 0.1818 / 0.1524 / 0.1524 | 0.0020 / 0.0020 / 0.0020 | 4036 → 3414               |
+| Persisted warm | 0.0699 / 0.0699 / 0.0699 | 0.0000 / 0.0000 / 0.0000 | 2640 → 2029               |
+| Team cold      | 0.0540 / 0.0540 / 0.0540 | 0.0020 / 0.0020 / 0.0020 | 4007 → 3327               |
+| Team warm      | 0.0519 / 0.0519 / 0.0519 | 0.0000 / 0.0000 / 0.0000 | 2742 → 2081               |
+
+All fixture values were checked against the live store snapshots. These runs pass the layout
+and settled-card budgets without changing the selected progress or task filters.
+
+### Follow-up functional validation
+
+Production build, lint, typecheck, systems drift check, and eight focused Vitest files
+(123 tests) passed. Coverage includes readiness settlement, failures, the three-second timer,
+mode/locale changes, core reloads, unmount cleanup, and stale filter refreshes, plus existing
+filtering, actions, deep-link, infinite-scroll, and objective visibility regressions.
+
+Real-browser checks passed for paging, collapse/expand, pin/unpin, search/clear, task deep
+links, completion/undo, Hideout/Needed Items scrolling, graph/map routes, and PvP/PvE/Seasonal
+switching. A stalled detail request released the gate after its three-second timer (about
+3.2 seconds including filtering/rendering on the test machine); rejected requests released it
+promptly. Both retained interactive cards. Teammate selection and hide/show were checked with
+a synthetic identity on the offline client; no authenticated network access was involved.
+Desktop/mobile screenshots were inspected. Local CodeRabbit review raised one stale-refresh
+finding, which the generation guard and failing-then-passing regression test address.

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -364,3 +364,33 @@ loader-only cleanup; no readiness timing policy, filters, or card rendering code
 The rebuilt loader also passed cached-core, empty-recovery, edition/count/item delay, and
 deep-link browser probes. Its final mobile cold/warm smoke trace retained eight cards, no
 empty-state frames, and shift sums **0.0020 / 0** (first complete cards **3018 / 1815 ms**).
+
+### Bootstrap phase and deferred-load ownership
+
+Final review reproduced two coordination gaps: cached details could settle before a requested
+locale's bootstrap/core phase, and an edition load queued behind slow prestige could run after
+an eager load had completed. `tasksCoreRefreshing` now covers bootstrap through core settlement;
+a per-store token protects overlapping refreshes, and failures clear the phase. Initialization
+also starts this phase before locale/mode updates and cache reads. It does not
+extend the phase across optional metadata requests. Edition request versions let a later eager
+request consume the queued load, including when the caller joins an existing request.
+
+Nine store ownership tests and a composable regression cover these boundaries. The queued
+load still runs on routes without an eager owner. Both issues also reproduced in the previous
+production build: a delayed-prestige probe counted two overlay downloads, and a delayed
+bootstrap probe exposed eight old cards before core settlement. The updated focused suite
+passes **170 tests across 13 files**, with lint, typecheck, systems drift, and Fallow passing.
+
+The rebuilt production probes now count one overlay download and zero old cards during pending
+bootstrap. Cached-core, empty-recovery, delayed edition/count/item, deep-link, fallback, task
+controls, shared routes, mode switching, and team controls all passed again.
+
+Three fresh mobile profiles recorded cold shift sums **0.0020 / 0.0020 / 0.0020** and warm sums
+**0 / 0 / 0**, with eight cards and no empty-state frames. First complete cards appeared at
+**3094 / 3185 / 3094 ms** cold and **1839 / 1961 / 1871 ms** warm. The team smoke repeat recorded
+shift sums **0.0020 / 0** and first complete cards **3467 / 2202 ms** cold/warm.
+
+Extended Lighthouse repeats recorded scores **0.41 / 0.42 / 0.39**, TBT **942 / 908 / 1077 ms**,
+CLS **0.0020 / 0.0020 / 0.0020**, FCP **5043 / 5040 / 5040 ms**, and LCP
+**23358 / 23353 / 25229 ms**. Median TBT remains about 12% below the baseline's 1077 ms;
+the stated layout and complete-card timing budgets pass. The LCP tradeoff remains explicit.

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -278,7 +278,8 @@ revalidation and count metadata. Edition promise/loading cleanup is identity-gua
 older request cannot clear the current request's tracking. Empty-to-populated core recovery is
 covered as well. The three-second availability timer still bounds all optional waits.
 
-The corrected production build was measured again on September 6 using the same response
+The corrected production build at `98991762f91d0b46e1998f264eeb4ac0a51e0a22` was measured
+again on September 6 using the same response
 replay, viewports, throttling, and three independent profiles per scenario. These are separate
 from the initial implementation samples above. All runs displayed eight initial cards and no
 transient empty state.
@@ -311,3 +312,28 @@ actions in the production browser also verified cached core replacement, empty-c
 edition revalidation, and count metadata: cards stayed hidden until settlement, then eight
 appeared. Stalled requests released usable cards about 3.2 seconds after core readiness;
 rejections released them promptly. No uncaught browser exceptions were observed.
+
+### Final review edge cases
+
+Subsequent review added item-lite hydration to the readiness wait and connected deep-link
+handling to the combined page loading state. Count metadata now explicitly returns `stale`
+when discarded, so the single retry does not repeat handled network failures. Obsolete edition
+cache reads, responses, and errors are ignored before they can change eligibility or cached
+payloads. Request registration precedes execution, including synchronous network failures.
+
+The final corrections passed 12 focused Vitest files (158 tests), lint, typecheck, and Fallow.
+Regression tests reproduced the item wait, premature deep-link handling, failure retry, and
+obsolete edition response/error problems before their fixes. Reverse-order response tests also
+verify that newer edition state and its cache write survive an older request's completion.
+
+The final production browser checks also passed, including a deep link activated during a
+1.5-second cached-detail delay. All task/shared-route controls were repeated. Three fresh
+mobile profiles recorded cold shift sums **0.0020 / 0.0020 / 0.0020** and warm sums **0 / 0 / 0**;
+complete cards appeared at **3250 / 3210 / 3058 ms** cold and **1966 / 1998 / 1902 ms** warm.
+A final team cold/warm smoke repeat also retained eight cards and shift sums of **0.0020 / 0**.
+The broader desktop/persisted/team comparison remains the explicitly identified revision above.
+
+Final extended Lighthouse runs were score **0.40 / 0.42 / 0.41**, TBT **1009 / 910 / 946 ms**,
+CLS **0.0020 / 0.0020 / 0.0020**, FCP **5043 / 5043 / 5045 ms**, and LCP
+**23357 / 23281 / 23360 ms**. Median TBT is about 12% below main; the layout and timing budgets
+still pass. The reported LCP tradeoff remains and is not described as an improvement.

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -337,3 +337,30 @@ Final extended Lighthouse runs were score **0.40 / 0.42 / 0.41**, TBT **1009 / 9
 CLS **0.0020 / 0.0020 / 0.0020**, FCP **5043 / 5043 / 5045 ms**, and LCP
 **23357 / 23281 / 23360 ms**. Median TBT is about 12% below main; the layout and timing budgets
 still pass. The reported LCP tradeoff remains and is not described as an improvement.
+
+### Loader complexity and coverage
+
+The final loader cleanup separates cache reading/application from request control and normalizes
+both network payloads before changing state. A malformed response preserves existing eligibility
+and chapters; malformed cached chapters still fall back to the network while preserving cached
+eligibility. These paths have dedicated regression coverage.
+
+The edition request callback drops from cyclomatic **25 to 14** and cognitive **29 to 11**.
+Fallow classifies the refactored inherited callback as new and estimates zero coverage, producing
+CRAP 210. A focused V8 coverage diagnostic instead measured **30/33 statements** and **17/18
+branches** covered inside this callback across ten edition tests. Using statement coverage in
+Fallow's documented CRAP formula puts it below 15, under the default 30 threshold. The narrowly
+scoped Fallow annotation documents this mismatch; no repository threshold or CI gate is changed.
+Sonar's cognitive-complexity rule remains enabled.
+
+The diagnostic command was `pnpm run test app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
+--coverage --coverage.reporter=json`. Its ten tests passed; the command exits nonzero because a
+single-file run cannot meet the configured whole-application coverage floors. This diagnostic is
+not reported as a passing full coverage run.
+
+After the loader cleanup, all **160 tests across 12 focused files** passed, along with lint,
+typecheck, systems drift, and Fallow. The broader repeated measurements above precede this
+loader-only cleanup; no readiness timing policy, filters, or card rendering code changed in it.
+The rebuilt loader also passed cached-core, empty-recovery, edition/count/item delay, and
+deep-link browser probes. Its final mobile cold/warm smoke trace retained eight cards, no
+empty-state frames, and shift sums **0.0020 / 0** (first complete cards **3018 / 1815 ms**).

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -410,3 +410,27 @@ race, deep-link, fallback, task/shared-route, mode, and team controls passed. A 
 cold/warm smoke retained eight cards and shift sums **0.0020 / 0**, with first complete cards
 **3201 / 2005 ms**. The three-profile Lighthouse comparison above precedes these final fallback
 and overlap corrections; no rendering, throttle, or readiness timeout policy changed.
+
+### Avoid redundant settled requests
+
+Readiness now joins or reuses the universal edition request already started by the current
+session, including one completed while core data was pending. Explicit refreshes still revalidate.
+Queued rewards use request versions to avoid repeating an eager fetch and task merge after cards
+are visible. Regression tests reproduced both duplicate-load paths before these corrections;
+controls cover idle-only loading, in-flight reuse, handled failures, and explicit refreshes.
+
+All **178 tests across 13 focused files**, lint, typecheck, systems drift, Fallow, and production
+build passed. Production probes reproduced one extra reward merge and two overlay downloads
+before the fixes; the rebuilt probes record zero extra reward merges and one overlay download.
+All overlap/readiness, deep-link, fallback, shared-route, mode, and team controls passed again.
+One Puppeteer protocol error interrupted the race harness; its isolated rerun passed unchanged.
+
+Three final mobile profiles record cold shift sums **0.0020 / 0.0020 / 0.0020**, warm sums
+**0 / 0 / 0**, and eight cards without empty-state frames. Complete cards appeared at
+**3111 / 3260 / 3025 ms** cold and **1992 / 1986 / 1942 ms** warm. The team cold/warm smoke
+records shifts **0.0020 / 0** and first complete cards **2896 / 2035 ms**.
+
+Final extended Lighthouse scores are **0.41 / 0.43 / 0.41**, TBT **980 / 834 / 938 ms**,
+CLS **0.0020 / 0.0020 / 0.0020**, FCP **5043 / 4975 / 5044 ms**, and LCP
+**23357 / 23284 / 23280 ms**. Median TBT improves about 13% versus the baseline's 1077 ms.
+The documented complete-card and layout budgets pass; the stated LCP tradeoff remains.

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -394,3 +394,19 @@ Extended Lighthouse repeats recorded scores **0.41 / 0.42 / 0.39**, TBT **942 / 
 CLS **0.0020 / 0.0020 / 0.0020**, FCP **5043 / 5040 / 5040 ms**, and LCP
 **23358 / 23353 / 25229 ms**. Median TBT remains about 12% below the baseline's 1077 ms;
 the stated layout and complete-card timing budgets pass. The LCP tradeoff remains explicit.
+
+### Final fallback and overlapping-refresh regressions
+
+An empty edition cache followed by network failure now preserves loaded eligibility. Core
+readiness tracks all active setup/bootstrap/core phases, so a newer refresh completing before
+an older bootstrap cannot reveal cards early. Initialization hands off its setup phase before
+awaiting optional metadata, preserving the existing bounded detail wait. Both reported failures
+were reproduced by tests before the fixes; an additional test checks the optional-data boundary.
+
+All **173 tests across 13 focused files**, lint, typecheck, systems drift, Fallow, and the production
+build passed. The overlapping-bootstrap browser probe failed with eight prematurely visible
+cards before the correction and now passes with none until both core phases finish. Repeated
+race, deep-link, fallback, task/shared-route, mode, and team controls passed. A final mobile
+cold/warm smoke retained eight cards and shift sums **0.0020 / 0**, with first complete cards
+**3201 / 2005 ms**. The three-profile Lighthouse comparison above precedes these final fallback
+and overlap corrections; no rendering, throttle, or readiness timeout policy changed.


### PR DESCRIPTION
## Summary

Task cards previously changed height as deferred objectives and rewards arrived, and the initial list could be filtered before edition eligibility loaded. This PR waits for card data and eligibility before revealing the filtered list, with a three-second fallback for stalled optional requests.

Closes #444. Follow-up to #808. Closure follows the documented performance policy and successful-load layout target; it does not restore the historical 0.55 Lighthouse gate.

## Changes

- Coordinate objectives, rewards, item hydration, edition eligibility, and objective count metadata using existing cached/deduplicated actions.
- Track all active initialization/bootstrap/core phases, re-arm on core replacement and locale/mode changes, and ignore obsolete detail/filter completions.
- Consume deferred edition/reward work when an eager request starts or joins it; reuse editions already settled during core loading. Preserve current eligibility across obsolete responses, malformed payloads, and empty-cache network failures.
- Wait for combined page readiness before deep-link effects. Keep the bounded optional-request fallback and existing task interactions.
- Update SYSTEMS and [performance methodology, budgets, results, and limitations](https://github.com/tarkovtracker-org/TarkovTracker/blob/515f4a34561f3d6c562f061699a827b29ecf0d90/docs/task-performance-validation.md#follow-up-complete-initial-task-cards).

## Validation

- [x] Production build, lint, typecheck, systems drift, Fallow, and commit hooks
- [x] 178 focused tests across 13 files, including failing-before/passing-after race and fallback regressions
- [x] Production-browser task controls, paging, search, pinning, deep links, completion/undo, shared routes, PvP/PvE/Seasonal, and team controls
- [x] Browser probes for cached/overlapping core refreshes, duplicate deferred requests, delayed details, failures, and the three-second fallback
- [x] Final-commit hosted CI, database checks, security checks, deployment, and 89.36% patch coverage
- [x] Final review disposition complete: Codex found no major issues; Cubic found zero issues; Greptile added no comments; all review threads resolved

Fallow retains a narrowly documented edition-callback annotation: measured coverage is 30/33 statements and 17/18 branches, while callback cyclomatic complexity falls from 25 to 14 and cognitive complexity from 29 to 11. The single-file coverage diagnostic does not satisfy whole-app coverage floors. No global quality gate changed.

## Performance and limitations

Three final mobile profiles retain eight cards, with cold layout-shift sums of 0.0020 and warm sums of zero. Median complete-card times are 3111/1986 ms cold/warm. Three extended Lighthouse runs show median TBT 938 ms versus baseline 1077 ms, and median score 0.41 versus 0.27. Full results and baseline provenance are documented.

First incomplete cards previously appeared sooner. Simulated LCP rises from about 9.3 to 23.4 seconds as its candidate changes from header text to a task objective. This is not an LCP improvement or ideal mobile performance. Final CI retains a warning-only Home score of 0.13; Tasks and Hideout pass their thresholds.

Benchmarks use replayed public API data and the existing offline preview client. Team controls use synthetic progress/identity; authenticated Supabase transport was not exercised. The stalled-request fallback can allow late layout shifts. No dependency, schema, persistence, eligibility-rule, batch-size, or CI-threshold changes.

CodeRabbit's requested refresh was rate-limited and remains incomplete; independent Codex, Cubic, and Greptile review substitute under the repository workflow. Final validated head: `515f4a34561f3d6c562f061699a827b29ecf0d90`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Task cards now remain hidden until objectives, rewards, edition eligibility, objective counts, item details, and visible-task data are ready.
  - Loading resets reliably during language, game-mode, metadata, and filter changes.
  - Stale refreshes and obsolete responses can no longer overwrite current task data or end loading prematurely.
  - Failed or discarded detail requests retry when appropriate.
  - Deep links now wait for required task data and retry when matching cards become available.
  - Empty task lists load immediately, while optional requests release the page after three seconds or when they fail.

- **Documentation**
  - Updated task performance and readiness validation documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
















<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR adds page-scoped task-detail readiness and guards asynchronous metadata/filter refreshes so initial task cards render only after the relevant loading cycle settles or reaches the bounded fallback.
- Coordinates task objectives, rewards, item-lite data, edition eligibility, and objective-count metadata.
- Re-arms readiness when task-core data is replaced, including empty-to-populated recovery.
- Prevents obsolete metadata and filter completions from releasing newer loading cycles.
- Adds focused race, failure, cache, and readiness regression coverage.
- Documents the updated task-loading architecture and performance-validation results.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/composables/useTaskDetailReadiness.ts | Introduces bounded, generation-safe readiness coordination and re-arms it on task-core replacement. |
| app/pages/tasks.vue | Gates filtering, deep-link handling, and initial rendering on combined task-detail readiness. |
| app/stores/useMetadata.ts | Adds core-refresh ownership, replacement revisions, stale-response guards, and request ownership tracking. |
| app/composables/__tests__/useTaskDetailReadiness.test.ts | Covers settlement, timeout, failure, invalidation, cleanup, and empty-to-populated recovery behavior. |
| docs/task-performance-validation.md | Records the validation methodology, measured tradeoffs, and closure policy. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Page as Tasks Page
    participant Ready as Detail Readiness
    participant Store as Metadata Store
    Page->>Ready: Start readiness cycle
    Ready->>Store: Wait for core metadata
    Store-->>Ready: Core revision is ready
    par Detail requests
        Ready->>Store: Fetch objectives
        Ready->>Store: Fetch rewards
        Ready->>Store: Hydrate item-lite data
        Ready->>Store: Ensure edition eligibility
    end
    Ready->>Store: Fetch objective-count differences
    alt Requests settle before timeout
        Store-->>Ready: Current cycle settled
    else Requests stall
        Ready-->>Ready: Three-second fallback
    end
    Ready-->>Page: Release current readiness cycle
    Page->>Page: Refresh visible-task filters
    Page-->>Page: Render initial cards
```
</details>

<sub>Reviews (7): Last reviewed commit: ["fix(tasks): reuse settled editions and c..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/515f4a34561f3d6c562f061699a827b29ecf0d90) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60996884)</sub>

<!-- /greptile_comment -->