### PR TITLE
fix(app): reduce Supabase realtime and transfer waste

### DIFF
--- a/app/composables/__tests__/useAppInitialization.test.ts
+++ b/app/composables/__tests__/useAppInitialization.test.ts
@@ -92,7 +92,7 @@ describe('useAppInitialization locale setup', () => {
   beforeEach(async () => {
     mockSupabase.client.auth.getSession.mockReset().mockResolvedValue({ data: { session: null } });
     mockSupporter.fetchStatus.mockReset().mockResolvedValue(undefined);
-    mockSupporter.subscribe.mockReset().mockResolvedValue(undefined);
+    mockSupporter.subscribe.mockReset().mockResolvedValue(true);
     mockSupporter.reset.mockReset();
     localeRef.value = 'en';
     setLocale.mockClear();
@@ -297,15 +297,20 @@ describe('useAppInitialization locale setup', () => {
       headers: { Authorization: 'Bearer fixture-token' },
     });
   });
-  it('keeps sync usable when optional supporter and activity requests fail', async () => {
-    mockSupporter.subscribe.mockRejectedValue(new Error('supporter offline'));
-    mockSupabase.client.auth.getSession.mockRejectedValue(new Error('session unavailable'));
-    mockSupabaseUser.loggedIn = true;
-    mockSupabaseUser.id = 'user-1';
-    await mountWithComposable();
-    await flushPromises();
-    expect(mockInitializeTarkovSync).toHaveBeenCalledTimes(1);
-    expect(mockMigrateDataIfNeeded).toHaveBeenCalledTimes(1);
-    expect(mockShowLoadFailed).not.toHaveBeenCalled();
-  });
+  it.each(['throw', 'failed read'])(
+    'keeps sync usable when optional supporter status fails: %s',
+    async (outcome) => {
+      if (outcome === 'throw')
+        mockSupporter.subscribe.mockRejectedValue(new Error('supporter offline'));
+      else mockSupporter.subscribe.mockResolvedValue(false);
+      mockSupabase.client.auth.getSession.mockRejectedValue(new Error('session unavailable'));
+      mockSupabaseUser.loggedIn = true;
+      mockSupabaseUser.id = 'user-1';
+      await mountWithComposable();
+      await flushPromises();
+      expect(mockInitializeTarkovSync).toHaveBeenCalledTimes(1);
+      expect(mockMigrateDataIfNeeded).toHaveBeenCalledTimes(1);
+      expect(mockShowLoadFailed).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/app/composables/__tests__/useAppInitialization.test.ts
+++ b/app/composables/__tests__/useAppInitialization.test.ts
@@ -263,11 +263,12 @@ describe('useAppInitialization locale setup', () => {
     pending.resolve(undefined);
     await flushPromises();
     expect(mockMigrateDataIfNeeded).toHaveBeenCalledTimes(1);
-    expect(mockSupporter.fetchStatus).toHaveBeenCalledExactlyOnceWith('user-2');
+    expect(mockSupporter.subscribe).toHaveBeenCalledExactlyOnceWith('user-2');
+    expect(mockSupporter.fetchStatus).not.toHaveBeenCalled();
   });
-  it('does not subscribe to a former account when its supporter lookup finishes late', async () => {
+  it('does not resubscribe to a former account when its subscription finishes late', async () => {
     const pending = Promise.withResolvers<undefined>();
-    mockSupporter.fetchStatus.mockReturnValueOnce(pending.promise);
+    mockSupporter.subscribe.mockReturnValueOnce(pending.promise);
     mockSupabaseUser.loggedIn = true;
     mockSupabaseUser.id = 'user-1';
     await mountWithComposable();
@@ -276,7 +277,10 @@ describe('useAppInitialization locale setup', () => {
     await flushPromises();
     pending.resolve(undefined);
     await flushPromises();
-    expect(mockSupporter.subscribe).toHaveBeenCalledExactlyOnceWith('user-2');
+    expect(mockSupporter.subscribe.mock.calls.map(([userId]) => userId)).toEqual([
+      'user-1',
+      'user-2',
+    ]);
   });
   it('records account activity with the session token after initialization', async () => {
     const fetch = vi.fn().mockResolvedValue({ recorded: true });
@@ -294,7 +298,7 @@ describe('useAppInitialization locale setup', () => {
     });
   });
   it('keeps sync usable when optional supporter and activity requests fail', async () => {
-    mockSupporter.fetchStatus.mockRejectedValue(new Error('supporter offline'));
+    mockSupporter.subscribe.mockRejectedValue(new Error('supporter offline'));
     mockSupabase.client.auth.getSession.mockRejectedValue(new Error('session unavailable'));
     mockSupabaseUser.loggedIn = true;
     mockSupabaseUser.id = 'user-1';

--- a/app/composables/__tests__/useAppInitialization.test.ts
+++ b/app/composables/__tests__/useAppInitialization.test.ts
@@ -267,7 +267,7 @@ describe('useAppInitialization locale setup', () => {
     expect(mockSupporter.fetchStatus).not.toHaveBeenCalled();
   });
   it('does not resubscribe to a former account when its subscription finishes late', async () => {
-    const pending = Promise.withResolvers<undefined>();
+    const pending = Promise.withResolvers<boolean>();
     mockSupporter.subscribe.mockReturnValueOnce(pending.promise);
     mockSupabaseUser.loggedIn = true;
     mockSupabaseUser.id = 'user-1';
@@ -275,12 +275,33 @@ describe('useAppInitialization locale setup', () => {
     await flushPromises();
     mockSupabaseUser.id = 'user-2';
     await flushPromises();
-    pending.resolve(undefined);
+    pending.resolve(false);
     await flushPromises();
     expect(mockSupporter.subscribe.mock.calls.map(([userId]) => userId)).toEqual([
       'user-1',
       'user-2',
     ]);
+    expect(mockSupporter.fetchStatus).not.toHaveBeenCalled();
+  });
+  it('loads supporter status when a same-user relogin cannot recreate its channel', async () => {
+    mockSupporter.subscribe.mockResolvedValueOnce(true).mockResolvedValueOnce(false);
+    mockSupporter.fetchStatus.mockResolvedValue(true);
+    mockSupabaseUser.loggedIn = true;
+    mockSupabaseUser.id = 'user-1';
+    const wrapper = await mountWithComposable();
+    await flushPromises();
+    expect(mockSupporter.fetchStatus).not.toHaveBeenCalled();
+    mockSupabaseUser.loggedIn = false;
+    await flushPromises();
+    mockSupabaseUser.loggedIn = true;
+    await flushPromises();
+    expect(mockSupporter.subscribe.mock.calls.map(([userId]) => userId)).toEqual([
+      'user-1',
+      'user-1',
+    ]);
+    expect(mockSupporter.fetchStatus).toHaveBeenCalledExactlyOnceWith('user-1');
+    expect(mockShowLoadFailed).not.toHaveBeenCalled();
+    wrapper.unmount();
   });
   it('records account activity with the session token after initialization', async () => {
     const fetch = vi.fn().mockResolvedValue({ recorded: true });

--- a/app/composables/__tests__/useSupabaseListener.test.ts
+++ b/app/composables/__tests__/useSupabaseListener.test.ts
@@ -2,6 +2,7 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createPendingStateTracker } from '@/utils/pendingState';
+import { installRealtimeVisibility } from '@/utils/realtimeVisibility';
 import type { WithRemoteSnapshot } from '@/utils/pendingState';
 import type { Store } from 'pinia';
 const { channel, client, loggerMock, removeChannel } = vi.hoisted(() => {
@@ -26,6 +27,7 @@ const { channel, client, loggerMock, removeChannel } = vi.hoisted(() => {
       Promise.resolve(resolve({ data: null, error: null })),
   };
   const supabaseClient = {
+    realtime: undefined as Parameters<typeof installRealtimeVisibility>[0] | undefined,
     channel: vi.fn(() => realtimeChannel),
     from: vi.fn(() => query),
     removeChannel: removeChannelMock,
@@ -66,6 +68,58 @@ describe('useSupabaseListener cleanup', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
+  it.each([
+    { suspendedBeforeCreation: true, disposed: false },
+    { suspendedBeforeCreation: false, disposed: false },
+    { suspendedBeforeCreation: true, disposed: true },
+    { suspendedBeforeCreation: false, disposed: true },
+  ])(
+    'refreshes a suspended first join unless disposed: %j',
+    async ({ suspendedBeforeCreation, disposed }) => {
+      const { useSupabaseListener } = await import('@/composables/supabase/useSupabaseListener');
+      const page = Object.assign(new EventTarget(), {
+        visibilityState: 'hidden' as DocumentVisibilityState,
+      });
+      const transport = {
+        connect: vi.fn(),
+        disconnect: vi.fn(async () => 'ok' as const),
+        getChannels: vi.fn(() => []),
+      };
+      client.realtime = transport;
+      const disposeVisibility = installRealtimeVisibility(transport, page);
+      channel.subscribe.mockImplementationOnce(() => channel);
+      let listener: ReturnType<typeof useSupabaseListener> | undefined;
+      try {
+        if (suspendedBeforeCreation) await vi.advanceTimersByTimeAsync(60_000);
+        listener = useSupabaseListener({
+          filter: 'id=eq.row-1',
+          store: createStore(),
+          table: 'test_table',
+          patchStore: false,
+        });
+        await vi.advanceTimersByTimeAsync(0);
+        expect(client.from).toHaveBeenCalledOnce();
+        const status = channel.subscribe.mock.calls[0]![0];
+        if (!suspendedBeforeCreation) {
+          await vi.advanceTimersByTimeAsync(60_000);
+          status('CHANNEL_ERROR');
+        }
+        expect(transport.disconnect).toHaveBeenCalledOnce();
+        if (disposed) listener.cleanup();
+        page.visibilityState = 'visible';
+        page.dispatchEvent(new Event('visibilitychange'));
+        await vi.advanceTimersByTimeAsync(0);
+        status('SUBSCRIBED');
+        await vi.advanceTimersByTimeAsync(0);
+        expect(client.from).toHaveBeenCalledTimes(disposed ? 1 : 2);
+        expect(listener.isSubscribed.value).toBe(!disposed);
+      } finally {
+        listener?.cleanup();
+        disposeVisibility();
+        client.realtime = undefined;
+      }
+    }
+  );
   it.each([false, true])(
     'waits for the snapshot barrier and respects cleanup while waiting: %s',
     async (disposed) => {

--- a/app/composables/__tests__/useSupabaseListener.test.ts
+++ b/app/composables/__tests__/useSupabaseListener.test.ts
@@ -64,6 +64,27 @@ describe('useSupabaseListener cleanup', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
+  it('does not replace pending local state on reconnect', async () => {
+    const { useSupabaseListener } = await import('@/composables/supabase/useSupabaseListener');
+    const onData = vi.fn();
+    let pending = false;
+    const listener = useSupabaseListener({
+      filter: 'id=eq.row-1',
+      store: createStore(),
+      table: 'test_table',
+      onData,
+      patchStore: false,
+      syncController: { pause: vi.fn(), resume: vi.fn(), hasPendingChanges: () => pending },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    onData.mockClear();
+    pending = true;
+    channel.subscribe.mock.calls[0]?.[0]('SUBSCRIBED');
+    pending = false;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onData).not.toHaveBeenCalled();
+    listener.cleanup();
+  });
   it.each(['UPDATE', 'DELETE'])(
     'completes initialization when %s supersedes the initial fetch',
     async (eventType) => {

--- a/app/composables/__tests__/useSupabaseListener.test.ts
+++ b/app/composables/__tests__/useSupabaseListener.test.ts
@@ -105,7 +105,7 @@ describe('useSupabaseListener cleanup', () => {
     });
     await vi.advanceTimersByTimeAsync(0);
     store.$state = { name: 'old', count: 5 };
-    tracker.acknowledge({ ...store.$state });
+    tracker.captureAcknowledgement({ ...store.$state })();
     store.$state.count = 0;
     onData.mockClear();
     channel.on.mock.calls[0]?.[2]({ eventType: 'UPDATE', new: { name: 'remote', count: 5 } });

--- a/app/composables/__tests__/useSupabaseListener.test.ts
+++ b/app/composables/__tests__/useSupabaseListener.test.ts
@@ -112,23 +112,39 @@ describe('useSupabaseListener cleanup', () => {
     expect(onData).toHaveBeenCalledWith({ name: 'remote', count: 0 });
     listener.cleanup();
   });
-  it('applies reconnect data when unrelated store fields changed during the read', async () => {
+  it('applies a reconnect row while preserving unrelated fields changed during the read', async () => {
     const { useSupabaseListener } = await import('@/composables/supabase/useSupabaseListener');
     const store = createStore();
-    const onData = vi.fn();
+    store.$state = { teamName: 'old', memberProfiles: {} };
+    const tracker = createPendingStateTracker(() => store.$state);
+    let finish!: (value: unknown) => void;
+    const pending = new Promise((resolve) => {
+      finish = resolve;
+    });
+    const queryFor = (result: Promise<unknown>) => {
+      const query = { select: () => query, eq: () => query, single: () => result };
+      return query;
+    };
+    client.from
+      .mockReturnValueOnce(
+        queryFor(Promise.resolve({ data: { teamName: 'old' }, error: null })) as never
+      )
+      .mockReturnValueOnce(queryFor(pending) as never);
+    const onData = vi.fn((data) => Object.assign(store.$state, data));
     const listener = useSupabaseListener({
       filter: 'id=eq.row-1',
       store,
       table: 'test_table',
       patchStore: false,
       onData,
+      syncController: { pause: vi.fn(), resume: vi.fn(), captureRemoteMerge: tracker.capture },
     });
     await vi.advanceTimersByTimeAsync(0);
-    onData.mockClear();
     channel.subscribe.mock.calls[0]?.[0]('SUBSCRIBED');
     store.$state.memberProfiles = { teammate: 'new' };
+    finish({ data: { teamName: 'remote name' }, error: null });
     await vi.advanceTimersByTimeAsync(0);
-    expect(onData).toHaveBeenCalledOnce();
+    expect(store.$state).toEqual({ teamName: 'remote name', memberProfiles: { teammate: 'new' } });
     listener.cleanup();
   });
   it.each(['UPDATE', 'DELETE'])(

--- a/app/composables/__tests__/useSupabaseListener.test.ts
+++ b/app/composables/__tests__/useSupabaseListener.test.ts
@@ -2,6 +2,7 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createPendingStateTracker } from '@/utils/pendingState';
+import type { WithRemoteSnapshot } from '@/utils/pendingState';
 import type { Store } from 'pinia';
 const { channel, client, loggerMock, removeChannel } = vi.hoisted(() => {
   const realtimeChannel = {
@@ -65,6 +66,34 @@ describe('useSupabaseListener cleanup', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
+  it.each([false, true])(
+    'waits for the snapshot barrier and respects cleanup while waiting: %s',
+    async (disposed) => {
+      const { useSupabaseListener } = await import('@/composables/supabase/useSupabaseListener');
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      const withSnapshot: WithRemoteSnapshot = async (read) => {
+        await gate;
+        return read((remote) => remote);
+      };
+      const listener = useSupabaseListener({
+        filter: 'id=eq.row-1',
+        store: createStore(),
+        table: 'test_table',
+        patchStore: false,
+        syncController: { pause: vi.fn(), resume: vi.fn(), withSnapshot },
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      expect(client.from).not.toHaveBeenCalled();
+      if (disposed) listener.cleanup();
+      release();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(client.from).toHaveBeenCalledTimes(disposed ? 0 : 1);
+      listener.cleanup();
+    }
+  );
   it('does not replace pending local state on reconnect', async () => {
     const { useSupabaseListener } = await import('@/composables/supabase/useSupabaseListener');
     const onData = vi.fn();

--- a/app/composables/__tests__/useSupabaseListener.test.ts
+++ b/app/composables/__tests__/useSupabaseListener.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createPendingStateTracker } from '@/utils/pendingState';
 import type { Store } from 'pinia';
 const { channel, client, loggerMock, removeChannel } = vi.hoisted(() => {
   const realtimeChannel = {
@@ -83,6 +84,51 @@ describe('useSupabaseListener cleanup', () => {
     pending = false;
     await vi.advanceTimersByTimeAsync(0);
     expect(onData).not.toHaveBeenCalled();
+    expect(listener.hasInitiallyLoaded.value).toBe(true);
+    listener.cleanup();
+  });
+  it('preserves a pending live edit while applying unrelated remote fields', async () => {
+    const { useSupabaseListener } = await import('@/composables/supabase/useSupabaseListener');
+    const store = createStore();
+    store.$state = { name: 'old', count: 5 };
+    const tracker = createPendingStateTracker(() => store.$state);
+    const onData = vi.fn((data) => {
+      store.$state = data ?? {};
+    });
+    const listener = useSupabaseListener({
+      filter: 'id=eq.row-1',
+      store,
+      table: 'test_table',
+      patchStore: false,
+      onData,
+      syncController: { pause: vi.fn(), resume: vi.fn(), captureRemoteMerge: tracker.capture },
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    store.$state = { name: 'old', count: 5 };
+    tracker.acknowledge({ ...store.$state });
+    store.$state.count = 0;
+    onData.mockClear();
+    channel.on.mock.calls[0]?.[2]({ eventType: 'UPDATE', new: { name: 'remote', count: 5 } });
+    expect(onData).toHaveBeenCalledWith({ name: 'remote', count: 0 });
+    listener.cleanup();
+  });
+  it('applies reconnect data when unrelated store fields changed during the read', async () => {
+    const { useSupabaseListener } = await import('@/composables/supabase/useSupabaseListener');
+    const store = createStore();
+    const onData = vi.fn();
+    const listener = useSupabaseListener({
+      filter: 'id=eq.row-1',
+      store,
+      table: 'test_table',
+      patchStore: false,
+      onData,
+    });
+    await vi.advanceTimersByTimeAsync(0);
+    onData.mockClear();
+    channel.subscribe.mock.calls[0]?.[0]('SUBSCRIBED');
+    store.$state.memberProfiles = { teammate: 'new' };
+    await vi.advanceTimersByTimeAsync(0);
+    expect(onData).toHaveBeenCalledOnce();
     listener.cleanup();
   });
   it.each(['UPDATE', 'DELETE'])(

--- a/app/composables/__tests__/useSupabaseListener.test.ts
+++ b/app/composables/__tests__/useSupabaseListener.test.ts
@@ -64,6 +64,29 @@ describe('useSupabaseListener cleanup', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
+  it.each(['UPDATE', 'DELETE'])(
+    'completes initialization when %s supersedes the initial fetch',
+    async (eventType) => {
+      const { useSupabaseListener } = await import('@/composables/supabase/useSupabaseListener');
+      const onData = vi.fn();
+      const listener = useSupabaseListener({
+        filter: 'id=eq.row-1',
+        onData,
+        patchStore: false,
+        store: createStore(),
+        table: 'test_table',
+      });
+      expect(listener.hasInitiallyLoaded.value).toBe(false);
+      const payloadHandler = channel.on.mock.calls[0]?.[2];
+      payloadHandler?.({ eventType, new: { id: 'row-1' } });
+      expect(listener.hasInitiallyLoaded.value).toBe(true);
+      expect(listener.loadError.value).toBeNull();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(onData).toHaveBeenCalledOnce();
+      expect(onData).toHaveBeenCalledWith(eventType === 'DELETE' ? null : { id: 'row-1' });
+      listener.cleanup();
+    }
+  );
   it('does not resume sync after a delayed realtime update is cleaned up', async () => {
     const { useSupabaseListener } = await import('@/composables/supabase/useSupabaseListener');
     const syncController = {

--- a/app/composables/__tests__/useSupabaseSync.test.ts
+++ b/app/composables/__tests__/useSupabaseSync.test.ts
@@ -65,6 +65,33 @@ describe('useSupabaseSync', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
+  it('queues resumed saves behind an in-flight write', async () => {
+    const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
+    let finishFirst!: (result: { error: null }) => void;
+    upsert.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishFirst = resolve;
+        })
+    );
+    const store = createMockStore({ value: 1 });
+    const sync = useSupabaseSync({ store, table: 'test_table', debounceMs: 10 });
+    const first = sync.syncToSupabase();
+    store.$state.value = 2;
+    store.notifySubscriber();
+    sync.pause();
+    sync.resume();
+    await flushSync(10);
+    expect(upsert).toHaveBeenCalledTimes(1);
+    expect(upsert.mock.calls[0]?.[0]).toMatchObject({ value: 1 });
+    finishFirst({ error: null });
+    await first;
+    await flushSync(0);
+    expect(upsert).toHaveBeenCalledTimes(2);
+    expect(upsert.mock.calls[1]?.[0]).toMatchObject({ value: 2 });
+    expect(sync.hasPendingChanges?.()).toBe(false);
+    sync.cleanup();
+  });
   it('retains pending local edits across a remote reconciliation pause', async () => {
     const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
     const state = { local: 1, remote: 0 };

--- a/app/composables/__tests__/useSupabaseSync.test.ts
+++ b/app/composables/__tests__/useSupabaseSync.test.ts
@@ -171,6 +171,31 @@ describe('useSupabaseSync', () => {
     expect(upsert).toHaveBeenLastCalledWith({ count: 3, name: 'pending local', user_id: 'user-1' });
     sync.cleanup();
   });
+  it('retains a domain-merged pending edit after the deferred save fails', async () => {
+    const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
+    const store = createMockStore({ mode: { count: 5, name: 'old' } });
+    const sync = useSupabaseSync({ store, table: 'test_table', debounceMs: 10 });
+    await sync.withSnapshot!(async (reconcile) => {
+      store.$state.mode.count = 0;
+      store.notifySubscriber();
+      Object.assign(
+        store.$state,
+        reconcile({ mode: { count: 3, name: 'remote' } }, { mode: { count: 0, name: 'remote' } })
+      );
+    });
+    upsert.mockResolvedValueOnce({ error: { code: '42501', message: 'write denied' } });
+    await flushSync(10);
+    expect(upsert).toHaveBeenCalledOnce();
+    expect(sync.hasPendingChanges!()).toBe(true);
+    Object.assign(store.$state, sync.captureRemoteMerge!()({ mode: { count: 4, name: 'newer' } }));
+    expect(store.$state.mode).toEqual({ count: 0, name: 'newer' });
+    await sync.syncToSupabase();
+    expect(sync.hasPendingChanges!()).toBe(false);
+    expect(sync.captureRemoteMerge!()({ mode: { count: 6, name: 'latest' } })).toEqual({
+      mode: { count: 6, name: 'latest' },
+    });
+    sync.cleanup();
+  });
   it('releases the snapshot barrier after a failed read', async () => {
     const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
     const store = createMockStore({ count: 0 });

--- a/app/composables/__tests__/useSupabaseSync.test.ts
+++ b/app/composables/__tests__/useSupabaseSync.test.ts
@@ -108,6 +108,29 @@ describe('useSupabaseSync', () => {
     });
     sync.cleanup();
   });
+  it('does not regress remote fields when a prior save finishes after reconciliation', async () => {
+    const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
+    let finish!: (result: { error: null }) => void;
+    upsert.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        })
+    );
+    const store = createMockStore({ pvp: { count: 5, name: 'old' } });
+    const sync = useSupabaseSync({ store, table: 'test_table' });
+    store.$state.pvp.count = 0;
+    store.notifySubscriber();
+    const saving = sync.syncToSupabase();
+    expect(upsert).toHaveBeenCalledOnce();
+    Object.assign(store.$state, sync.captureRemoteMerge!()({ pvp: { count: 5, name: 'remote' } }));
+    expect(store.$state.pvp).toEqual({ count: 0, name: 'remote' });
+    finish({ error: null });
+    await saving;
+    const newer = sync.captureRemoteMerge!()({ pvp: { count: 3, name: 'newer remote' } });
+    expect(newer).toEqual({ pvp: { count: 3, name: 'newer remote' } });
+    sync.cleanup();
+  });
   it('queues resumed saves behind an in-flight write', async () => {
     const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
     let finishFirst!: (result: { error: null }) => void;

--- a/app/composables/__tests__/useSupabaseSync.test.ts
+++ b/app/composables/__tests__/useSupabaseSync.test.ts
@@ -97,6 +97,11 @@ describe('useSupabaseSync', () => {
     const result = reconcile(remote);
     expect(result).toEqual({ pvp: { name: 'remote', count: 0 }, pve: { name: 'other device' } });
     Object.assign(store.$state, result);
+    // The saved zero remains acknowledged after the stale snapshot: a later
+    // remote change must not be mistaken for a conflict with a pending edit.
+    expect(sync.captureRemoteMerge!()({ pvp: { name: 'remote', count: 3 } })).toEqual({
+      pvp: { name: 'remote', count: 3 },
+    });
     // Applying one remote value must not make it a permanent local override.
     expect(sync.captureRemoteMerge!()({ pve: { name: 'newer remote' } })).toEqual({
       pve: { name: 'newer remote' },

--- a/app/composables/__tests__/useSupabaseSync.test.ts
+++ b/app/composables/__tests__/useSupabaseSync.test.ts
@@ -65,6 +65,44 @@ describe('useSupabaseSync', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
+  it.each(['paused', 'signed-out', 'disposed'])(
+    'does not transform a gated %s save',
+    async (gate) => {
+      const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
+      const transform = vi.fn((state) => state);
+      const sync = useSupabaseSync({
+        store: createMockStore({ value: 1 }),
+        table: 'test_table',
+        transform,
+      });
+      if (gate === 'paused') sync.pause();
+      if (gate === 'signed-out') supabaseContext.user.loggedIn = false;
+      if (gate === 'disposed') sync.cleanup();
+      await sync.syncToSupabase();
+      expect(transform).not.toHaveBeenCalled();
+      expect(upsert).not.toHaveBeenCalled();
+      sync.cleanup();
+    }
+  );
+  it('merges only pending paths and protects edits saved during a snapshot read', async () => {
+    const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
+    const store = createMockStore({ pvp: { name: 'old', count: 5 }, pve: { name: 'old' } });
+    const sync = useSupabaseSync({ store, table: 'test_table' });
+    store.$state.pvp.count = 0;
+    store.notifySubscriber();
+    const reconcile = sync.captureRemoteMerge!();
+    await sync.syncToSupabase();
+    expect(sync.hasPendingChanges!()).toBe(false);
+    const remote = { pvp: { name: 'remote', count: 5 }, pve: { name: 'other device' } };
+    const result = reconcile(remote);
+    expect(result).toEqual({ pvp: { name: 'remote', count: 0 }, pve: { name: 'other device' } });
+    Object.assign(store.$state, result);
+    // Applying one remote value must not make it a permanent local override.
+    expect(sync.captureRemoteMerge!()({ pve: { name: 'newer remote' } })).toEqual({
+      pve: { name: 'newer remote' },
+    });
+    sync.cleanup();
+  });
   it('queues resumed saves behind an in-flight write', async () => {
     const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
     let finishFirst!: (result: { error: null }) => void;

--- a/app/composables/__tests__/useSupabaseSync.test.ts
+++ b/app/composables/__tests__/useSupabaseSync.test.ts
@@ -131,6 +131,61 @@ describe('useSupabaseSync', () => {
     expect(newer).toEqual({ pvp: { count: 3, name: 'newer remote' } });
     sync.cleanup();
   });
+  it('reads snapshots after saves and holds newer edits until reconciliation finishes', async () => {
+    const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
+    let finishSave!: (result: { error: null }) => void;
+    let finishRead!: () => void;
+    upsert.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finishSave = resolve;
+        })
+    );
+    const store = createMockStore({ count: 5, name: 'old' });
+    const sync = useSupabaseSync({ store, table: 'test_table', debounceMs: 10 });
+    store.$state.count = 0;
+    store.notifySubscriber();
+    const saving = sync.syncToSupabase();
+    const read = vi.fn(async (reconcile) => {
+      await new Promise<void>((resolve) => {
+        finishRead = resolve;
+      });
+      Object.assign(store.$state, reconcile({ count: 3, name: 'old' }));
+    });
+    const snapshot = sync.withSnapshot!(read);
+    await flushSync(0);
+    expect(read).not.toHaveBeenCalled();
+    finishSave({ error: null });
+    await saving;
+    await flushSync(0);
+    expect(read).toHaveBeenCalledOnce();
+    store.$state.name = 'pending local';
+    store.notifySubscriber();
+    sync.resume(); // A live-event resume cannot release the snapshot barrier.
+    await flushSync(10);
+    expect(upsert).toHaveBeenCalledOnce();
+    finishRead();
+    await snapshot;
+    expect(store.$state).toEqual({ count: 3, name: 'pending local' });
+    await flushSync(10);
+    expect(upsert).toHaveBeenLastCalledWith({ count: 3, name: 'pending local', user_id: 'user-1' });
+    sync.cleanup();
+  });
+  it('releases the snapshot barrier after a failed read', async () => {
+    const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
+    const store = createMockStore({ count: 0 });
+    const sync = useSupabaseSync({ store, table: 'test_table', debounceMs: 10 });
+    await expect(
+      sync.withSnapshot!(async () => {
+        throw new Error('read failed');
+      })
+    ).rejects.toThrow('read failed');
+    store.$state.count = 1;
+    store.notifySubscriber();
+    await flushSync(10);
+    expect(upsert).toHaveBeenCalledWith({ count: 1, user_id: 'user-1' });
+    sync.cleanup();
+  });
   it('queues resumed saves behind an in-flight write', async () => {
     const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
     let finishFirst!: (result: { error: null }) => void;

--- a/app/composables/__tests__/useSupabaseSync.test.ts
+++ b/app/composables/__tests__/useSupabaseSync.test.ts
@@ -65,6 +65,41 @@ describe('useSupabaseSync', () => {
   afterEach(() => {
     vi.useRealTimers();
   });
+  it('retains pending local edits across a remote reconciliation pause', async () => {
+    const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
+    const state = { local: 1, remote: 0 };
+    const store = createMockStore(state);
+    const sync = useSupabaseSync({ store, table: 'user_progress', debounceMs: 5 });
+    store.notifySubscriber();
+    expect(sync.hasPendingChanges?.()).toBe(true);
+    sync.pause();
+    state.remote = 2;
+    store.notifySubscriber();
+    await flushSync(5);
+    expect(upsert).not.toHaveBeenCalled();
+    sync.resume();
+    await flushSync(5);
+    expect(upsert).toHaveBeenCalledWith({ local: 1, remote: 2, user_id: 'user-1' });
+    expect(sync.hasPendingChanges?.()).toBe(false);
+    sync.cleanup();
+  });
+  it('saves an edit first made during a pause even when its debounce expires while paused', async () => {
+    const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
+    const state = { count: 0 };
+    const store = createMockStore(state);
+    const sync = useSupabaseSync({ store, table: 'user_progress', debounceMs: 5 });
+    sync.pause();
+    state.count = 3;
+    store.notifySubscriber();
+    await flushSync(5);
+    expect(upsert).not.toHaveBeenCalled();
+    expect(sync.hasPendingChanges?.()).toBe(true);
+    sync.resume();
+    await flushSync(5);
+    expect(upsert).toHaveBeenCalledWith({ count: 3, user_id: 'user-1' });
+    expect(sync.hasPendingChanges?.()).toBe(false);
+    sync.cleanup();
+  });
   it('syncs transformed data when store state contains non-cloneable references', async () => {
     const { useSupabaseSync } = await import('@/composables/supabase/useSupabaseSync');
     const storeState = reactive({

--- a/app/composables/__tests__/useSupporter.test.ts
+++ b/app/composables/__tests__/useSupporter.test.ts
@@ -112,6 +112,21 @@ describe('useSupporter', () => {
       supporter.unsubscribe();
     }
   );
+  it('reports a successful initial status read despite an unrelated checkout failure', async () => {
+    const { supporter, subscribing, status } = await startInitialSubscription();
+    const initial = createDeferred<{ data: null; error: null }>();
+    mockMaybeSingle.mockReturnValueOnce(initial.promise);
+    mockSupabase.client.auth.getSession.mockResolvedValue({
+      data: { session: { access_token: 'test-token' } },
+    });
+    mockFetch.mockRejectedValueOnce(new Error('checkout failed'));
+    status('SUBSCRIBED');
+    await expect(supporter.createCheckout({ mode: 'payment' })).resolves.toBeNull();
+    expect(supporter.error.value).toBe('checkout failed');
+    initial.resolve({ data: null, error: null });
+    await expect(subscribing).resolves.toBe(true);
+    supporter.unsubscribe();
+  });
   it('loads once when the initial join fails and ignores disposed channel callbacks', async () => {
     const { supporter, subscribing, nextChannel, status } = await startInitialSubscription();
     status('CHANNEL_ERROR');

--- a/app/composables/__tests__/useSupporter.test.ts
+++ b/app/composables/__tests__/useSupporter.test.ts
@@ -62,6 +62,24 @@ describe('useSupporter', () => {
     const { useSupporter } = await import('@/composables/useSupporter');
     useSupporter().reset();
   });
+  it('refreshes status on rejoin without duplicating the initial fetch', async () => {
+    const nextChannel = { on: vi.fn(), subscribe: vi.fn() };
+    nextChannel.on.mockReturnValue(nextChannel);
+    nextChannel.subscribe.mockReturnValue(nextChannel);
+    mockChannel.mockReturnValue(nextChannel);
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    const { useSupporter } = await import('@/composables/useSupporter');
+    const supporter = useSupporter();
+    await supporter.fetchStatus('user-1');
+    await supporter.subscribe('user-1');
+    mockMaybeSingle.mockClear();
+    const status = nextChannel.subscribe.mock.calls[0]?.[0];
+    status('SUBSCRIBED');
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
+    status('SUBSCRIBED');
+    expect(mockMaybeSingle).toHaveBeenCalledOnce();
+    supporter.unsubscribe();
+  });
   it('does not apply a stale status response after reset', async () => {
     const deferred = createDeferred<{
       data: {

--- a/app/composables/__tests__/useSupporter.test.ts
+++ b/app/composables/__tests__/useSupporter.test.ts
@@ -62,7 +62,7 @@ describe('useSupporter', () => {
     const { useSupporter } = await import('@/composables/useSupporter');
     useSupporter().reset();
   });
-  it('refreshes status after the first join and each rejoin to close the read/join gap', async () => {
+  const startInitialSubscription = async () => {
     const nextChannel = { on: vi.fn(), subscribe: vi.fn() };
     nextChannel.on.mockReturnValue(nextChannel);
     nextChannel.subscribe.mockReturnValue(nextChannel);
@@ -72,9 +72,17 @@ describe('useSupporter', () => {
     const supporter = useSupporter();
     const subscribing = supporter.subscribe('user-1');
     await vi.waitFor(() => expect(nextChannel.subscribe).toHaveBeenCalled());
+    return {
+      supporter,
+      subscribing,
+      nextChannel,
+      status: nextChannel.subscribe.mock.calls[0]?.[0],
+    };
+  };
+  it('refreshes status after the first join and each rejoin to close the read/join gap', async () => {
+    const { supporter, subscribing, status } = await startInitialSubscription();
     expect(mockMaybeSingle).not.toHaveBeenCalled();
     const concurrent = supporter.subscribe('user-1');
-    const status = nextChannel.subscribe.mock.calls[0]?.[0];
     status('SUBSCRIBED');
     await expect(concurrent).resolves.toBe(true);
     await expect(subscribing).resolves.toBe(true);
@@ -84,16 +92,7 @@ describe('useSupporter', () => {
     supporter.unsubscribe();
   });
   it('loads once when the initial join fails and ignores disposed channel callbacks', async () => {
-    const nextChannel = { on: vi.fn(), subscribe: vi.fn() };
-    nextChannel.on.mockReturnValue(nextChannel);
-    nextChannel.subscribe.mockReturnValue(nextChannel);
-    mockChannel.mockReturnValue(nextChannel);
-    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
-    const { useSupporter } = await import('@/composables/useSupporter');
-    const supporter = useSupporter();
-    const subscribing = supporter.subscribe('user-1');
-    await vi.waitFor(() => expect(nextChannel.subscribe).toHaveBeenCalled());
-    const status = nextChannel.subscribe.mock.calls[0]?.[0];
+    const { supporter, subscribing, nextChannel, status } = await startInitialSubscription();
     status('CHANNEL_ERROR');
     await expect(subscribing).resolves.toBe(true);
     status('TIMED_OUT');
@@ -106,14 +105,7 @@ describe('useSupporter', () => {
     expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
   });
   it('settles an initial read waiter when its session is reset before joining', async () => {
-    const nextChannel = { on: vi.fn(), subscribe: vi.fn() };
-    nextChannel.on.mockReturnValue(nextChannel);
-    nextChannel.subscribe.mockReturnValue(nextChannel);
-    mockChannel.mockReturnValue(nextChannel);
-    const { useSupporter } = await import('@/composables/useSupporter');
-    const supporter = useSupporter();
-    const subscribing = supporter.subscribe('user-1');
-    await vi.waitFor(() => expect(nextChannel.subscribe).toHaveBeenCalled());
+    const { supporter, subscribing } = await startInitialSubscription();
     supporter.reset();
     await expect(subscribing).resolves.toBe(false);
     expect(mockMaybeSingle).not.toHaveBeenCalled();

--- a/app/composables/__tests__/useSupporter.test.ts
+++ b/app/composables/__tests__/useSupporter.test.ts
@@ -70,10 +70,14 @@ describe('useSupporter', () => {
     mockMaybeSingle.mockResolvedValue({ data: null, error: null });
     const { useSupporter } = await import('@/composables/useSupporter');
     const supporter = useSupporter();
-    await supporter.subscribe('user-1');
+    const subscribing = supporter.subscribe('user-1');
+    await vi.waitFor(() => expect(nextChannel.subscribe).toHaveBeenCalled());
     expect(mockMaybeSingle).not.toHaveBeenCalled();
+    const concurrent = supporter.subscribe('user-1');
     const status = nextChannel.subscribe.mock.calls[0]?.[0];
     status('SUBSCRIBED');
+    await expect(concurrent).resolves.toBe(true);
+    await expect(subscribing).resolves.toBe(true);
     expect(mockMaybeSingle).toHaveBeenCalledOnce();
     status('SUBSCRIBED');
     expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
@@ -87,9 +91,11 @@ describe('useSupporter', () => {
     mockMaybeSingle.mockResolvedValue({ data: null, error: null });
     const { useSupporter } = await import('@/composables/useSupporter');
     const supporter = useSupporter();
-    await supporter.subscribe('user-1');
+    const subscribing = supporter.subscribe('user-1');
+    await vi.waitFor(() => expect(nextChannel.subscribe).toHaveBeenCalled());
     const status = nextChannel.subscribe.mock.calls[0]?.[0];
     status('CHANNEL_ERROR');
+    await expect(subscribing).resolves.toBe(true);
     status('TIMED_OUT');
     expect(mockMaybeSingle).toHaveBeenCalledOnce();
     status('SUBSCRIBED');
@@ -98,6 +104,39 @@ describe('useSupporter', () => {
     status('SUBSCRIBED');
     nextChannel.on.mock.calls[0]?.[2]();
     expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
+  });
+  it('settles an initial read waiter when its session is reset before joining', async () => {
+    const nextChannel = { on: vi.fn(), subscribe: vi.fn() };
+    nextChannel.on.mockReturnValue(nextChannel);
+    nextChannel.subscribe.mockReturnValue(nextChannel);
+    mockChannel.mockReturnValue(nextChannel);
+    const { useSupporter } = await import('@/composables/useSupporter');
+    const supporter = useSupporter();
+    const subscribing = supporter.subscribe('user-1');
+    await vi.waitFor(() => expect(nextChannel.subscribe).toHaveBeenCalled());
+    supporter.reset();
+    await expect(subscribing).resolves.toBe(false);
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
+  });
+  it('reports a failed initial read and retries on the same channel', async () => {
+    const nextChannel = { on: vi.fn(), subscribe: vi.fn() };
+    nextChannel.on.mockReturnValue(nextChannel);
+    nextChannel.subscribe.mockImplementation((callback) => {
+      callback('SUBSCRIBED');
+      return nextChannel;
+    });
+    mockChannel.mockReturnValue(nextChannel);
+    mockMaybeSingle
+      .mockResolvedValueOnce({ data: null, error: { message: 'offline' } })
+      .mockResolvedValue({ data: null, error: null });
+    const { useSupporter } = await import('@/composables/useSupporter');
+    const supporter = useSupporter();
+    await expect(supporter.subscribe('user-1')).resolves.toBe(false);
+    await expect(supporter.subscribe('user-1')).resolves.toBe(true);
+    await expect(supporter.subscribe('user-1')).resolves.toBe(true);
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
+    expect(mockChannel).toHaveBeenCalledOnce();
+    supporter.unsubscribe();
   });
   it('does not apply a stale status response after reset', async () => {
     const deferred = createDeferred<{
@@ -143,7 +182,10 @@ describe('useSupporter', () => {
         subscribe: vi.fn(),
       };
       nextChannel.on.mockReturnValue(nextChannel);
-      nextChannel.subscribe.mockReturnValue(nextChannel);
+      nextChannel.subscribe.mockImplementation((callback) => {
+        callback?.('SUBSCRIBED');
+        return nextChannel;
+      });
       createdChannels.push(nextChannel);
       return nextChannel;
     });

--- a/app/composables/__tests__/useSupporter.test.ts
+++ b/app/composables/__tests__/useSupporter.test.ts
@@ -70,15 +70,34 @@ describe('useSupporter', () => {
     mockMaybeSingle.mockResolvedValue({ data: null, error: null });
     const { useSupporter } = await import('@/composables/useSupporter');
     const supporter = useSupporter();
-    await supporter.fetchStatus('user-1');
     await supporter.subscribe('user-1');
-    mockMaybeSingle.mockClear();
+    expect(mockMaybeSingle).not.toHaveBeenCalled();
     const status = nextChannel.subscribe.mock.calls[0]?.[0];
     status('SUBSCRIBED');
     expect(mockMaybeSingle).toHaveBeenCalledOnce();
     status('SUBSCRIBED');
     expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
     supporter.unsubscribe();
+  });
+  it('loads once when the initial join fails and ignores disposed channel callbacks', async () => {
+    const nextChannel = { on: vi.fn(), subscribe: vi.fn() };
+    nextChannel.on.mockReturnValue(nextChannel);
+    nextChannel.subscribe.mockReturnValue(nextChannel);
+    mockChannel.mockReturnValue(nextChannel);
+    mockMaybeSingle.mockResolvedValue({ data: null, error: null });
+    const { useSupporter } = await import('@/composables/useSupporter');
+    const supporter = useSupporter();
+    await supporter.subscribe('user-1');
+    const status = nextChannel.subscribe.mock.calls[0]?.[0];
+    status('CHANNEL_ERROR');
+    status('TIMED_OUT');
+    expect(mockMaybeSingle).toHaveBeenCalledOnce();
+    status('SUBSCRIBED');
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
+    supporter.unsubscribe();
+    status('SUBSCRIBED');
+    nextChannel.on.mock.calls[0]?.[2]();
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
   });
   it('does not apply a stale status response after reset', async () => {
     const deferred = createDeferred<{

--- a/app/composables/__tests__/useSupporter.test.ts
+++ b/app/composables/__tests__/useSupporter.test.ts
@@ -62,7 +62,7 @@ describe('useSupporter', () => {
     const { useSupporter } = await import('@/composables/useSupporter');
     useSupporter().reset();
   });
-  it('refreshes status on rejoin without duplicating the initial fetch', async () => {
+  it('refreshes status after the first join and each rejoin to close the read/join gap', async () => {
     const nextChannel = { on: vi.fn(), subscribe: vi.fn() };
     nextChannel.on.mockReturnValue(nextChannel);
     nextChannel.subscribe.mockReturnValue(nextChannel);
@@ -75,9 +75,9 @@ describe('useSupporter', () => {
     mockMaybeSingle.mockClear();
     const status = nextChannel.subscribe.mock.calls[0]?.[0];
     status('SUBSCRIBED');
-    expect(mockMaybeSingle).not.toHaveBeenCalled();
-    status('SUBSCRIBED');
     expect(mockMaybeSingle).toHaveBeenCalledOnce();
+    status('SUBSCRIBED');
+    expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
     supporter.unsubscribe();
   });
   it('does not apply a stale status response after reset', async () => {

--- a/app/composables/__tests__/useSupporter.test.ts
+++ b/app/composables/__tests__/useSupporter.test.ts
@@ -91,6 +91,27 @@ describe('useSupporter', () => {
     expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
     supporter.unsubscribe();
   });
+  it.each([true, false])(
+    'settles initialization from a superseding refresh (success: %s)',
+    async (success) => {
+      const { supporter, subscribing, status, nextChannel } = await startInitialSubscription();
+      const initial = createDeferred<{ data: null; error: null }>();
+      const replacement = createDeferred<{ data: null; error: { message: string } | null }>();
+      mockMaybeSingle.mockReturnValueOnce(initial.promise).mockReturnValueOnce(replacement.promise);
+      const settled = vi.fn();
+      void subscribing.then(settled);
+      status('SUBSCRIBED');
+      nextChannel.on.mock.calls[0]?.[2]();
+      initial.resolve({ data: null, error: null });
+      await initial.promise;
+      await Promise.resolve();
+      expect(settled).not.toHaveBeenCalled();
+      replacement.resolve({ data: null, error: success ? null : { message: 'offline' } });
+      await expect(subscribing).resolves.toBe(success);
+      expect(mockMaybeSingle).toHaveBeenCalledTimes(2);
+      supporter.unsubscribe();
+    }
+  );
   it('loads once when the initial join fails and ignores disposed channel callbacks', async () => {
     const { supporter, subscribing, nextChannel, status } = await startInitialSubscription();
     status('CHANNEL_ERROR');

--- a/app/composables/supabase/useSupabaseListener.ts
+++ b/app/composables/supabase/useSupabaseListener.ts
@@ -179,6 +179,7 @@ export function useSupabaseListener<
     if (channel.value) return;
     if (!currentFilter) return;
     const subscriptionVersion = cleanupVersion;
+    let joined = false;
     const client = $supabase.client;
     const nextChannel = client
       .channel(listenerTopic(currentFilter))
@@ -192,6 +193,8 @@ export function useSupabaseListener<
         },
         (payload: RealtimePostgresChangesPayload<Record<string, unknown>>) => {
           if (subscriptionVersion !== cleanupVersion) return;
+          latestFetchVersion += 1;
+          activeFetchController?.abort();
           syncController?.pause();
           try {
             if (subscriptionVersion !== cleanupVersion) return;
@@ -209,6 +212,8 @@ export function useSupabaseListener<
               }
               if (onData) onData(newData);
             }
+            hasInitiallyLoaded.value = true;
+            loadError.value = null;
           } finally {
             if (subscriptionVersion === cleanupVersion) {
               if (pendingSyncResumeTimeout) clearTimeout(pendingSyncResumeTimeout);
@@ -225,6 +230,10 @@ export function useSupabaseListener<
         // must not flip `isSubscribed` back on or log for a listener that is gone.
         if (subscriptionVersion !== cleanupVersion) return;
         isSubscribed.value = status === 'SUBSCRIBED';
+        if (isSubscribed.value) {
+          if (joined) void fetchData();
+          joined = true;
+        }
         logChannelSubscribeFailure(storeIdForLogging, status, error, { table });
       });
     channel.value = { channel: nextChannel, client, topic: listenerTopic(currentFilter) };

--- a/app/composables/supabase/useSupabaseListener.ts
+++ b/app/composables/supabase/useSupabaseListener.ts
@@ -8,7 +8,7 @@ import {
   type OwnedRealtimeChannel,
 } from '@/utils/realtimeChannel';
 import { clearStaleState, resetStore, safePatchStore } from '@/utils/storeHelpers';
-import type { RemoteStateMerge } from '@/utils/pendingState';
+import type { RemoteStateMerge, WithRemoteSnapshot } from '@/utils/pendingState';
 import type { PostgrestError, RealtimePostgresChangesPayload } from '@supabase/supabase-js';
 import type { StateTree, Store } from 'pinia';
 // Local imports
@@ -29,6 +29,7 @@ export interface SupabaseListenerConfig<
     resume: () => void;
     hasPendingChanges?: () => boolean;
     captureRemoteMerge?: () => RemoteStateMerge;
+    withSnapshot?: WithRemoteSnapshot;
   };
   scope?: ListenerScope;
 }
@@ -141,9 +142,11 @@ export function useSupabaseListener<
   };
   // Initial fetch
   // fallow-ignore-next-line complexity -- tested fetch cancellation and pending-save guards must share one response boundary
-  const fetchData = async (reconnecting = false) => {
+  const fetchData = async (
+    reconnecting = false,
+    reconcile = syncController?.captureRemoteMerge?.()
+  ) => {
     const pendingBeforeRead = syncController?.hasPendingChanges?.() === true;
-    const reconcile = syncController?.captureRemoteMerge?.();
     const fetchVersion = ++latestFetchVersion;
     activeFetchController?.abort();
     const fetchController = new AbortController();
@@ -194,6 +197,12 @@ export function useSupabaseListener<
         activeFetchController = null;
       }
     }
+  };
+  const readData = (reconnecting = false) => {
+    const version = cleanupVersion;
+    const read = (reconcile = syncController?.captureRemoteMerge?.()) =>
+      version === cleanupVersion ? fetchData(reconnecting, reconcile) : Promise.resolve();
+    return syncController?.withSnapshot ? syncController.withSnapshot(read) : read();
   };
   const listenerTopic = (currentFilter: string) => `public:${table}:${currentFilter}`;
   const createSubscription = () => {
@@ -246,7 +255,7 @@ export function useSupabaseListener<
         if (subscriptionVersion !== cleanupVersion) return;
         isSubscribed.value = status === 'SUBSCRIBED';
         if (isSubscribed.value) {
-          if (joined) void fetchData(true);
+          if (joined) void readData(true);
           joined = true;
         }
         logChannelSubscribeFailure(storeIdForLogging, status, error, { table });
@@ -322,7 +331,7 @@ export function useSupabaseListener<
           return;
         }
         hasInitiallyLoaded.value = false;
-        fetchData();
+        readData();
         setupSubscription();
       },
       { immediate: true }
@@ -338,6 +347,6 @@ export function useSupabaseListener<
       stopFilterWatch?.();
       cleanup();
     },
-    fetchData,
+    fetchData: readData,
   };
 }

--- a/app/composables/supabase/useSupabaseListener.ts
+++ b/app/composables/supabase/useSupabaseListener.ts
@@ -104,6 +104,26 @@ export function useSupabaseListener<
   let pendingSyncResumeTimeout: ReturnType<typeof setTimeout> | null = null;
   // Helper to get current filter value (supports both string and ref)
   const getFilterValue = (): string | undefined => unref(filter);
+  const parseFilter = (currentFilter = '') => {
+    const [column, value] = currentFilter.split('=eq.');
+    if (column && value) return { column, value };
+    if (currentFilter) {
+      logger.error(`[${storeIdForLogging}] Invalid filter format. Expected 'col=eq.val'`);
+    }
+    hasInitiallyLoaded.value = true;
+    return null;
+  };
+  const applyFetchedData = (data: TData | null) => {
+    if (patchStore) {
+      if (data) {
+        safePatchStore(store, data as Partial<TStoreState>);
+        clearStaleState(store, data);
+      } else {
+        resetStore(store);
+      }
+    }
+    onData?.(data);
+  };
   // Initial fetch
   // fallow-ignore-next-line complexity -- tested fetch cancellation and pending-save guards must share one response boundary
   const fetchData = async (reconnecting = false) => {
@@ -114,28 +134,13 @@ export function useSupabaseListener<
     const fetchController = new AbortController();
     activeFetchController = fetchController;
     loadError.value = null;
-    const currentFilter = getFilterValue();
-    if (!currentFilter) {
-      if (fetchVersion === latestFetchVersion) {
-        hasInitiallyLoaded.value = true;
-      }
-      return;
-    }
-    // Parse filter to get column and value
-    // Expecting format "column=eq.value"
-    const [column, rest] = currentFilter.split('=eq.');
-    if (!column || !rest) {
-      logger.error(`[${storeIdForLogging}] Invalid filter format. Expected 'col=eq.val'`);
-      if (fetchVersion === latestFetchVersion) {
-        hasInitiallyLoaded.value = true;
-      }
-      return;
-    }
+    const filterQuery = parseFilter(getFilterValue());
+    if (!filterQuery) return;
     try {
       const queryBuilder = $supabase.client
         .from(table)
         .select('*')
-        .eq(column, rest)
+        .eq(filterQuery.column, filterQuery.value)
         .single() as QueryBuilderWithAbortSignal<TData>;
       const result =
         typeof queryBuilder.abortSignal === 'function'
@@ -160,18 +165,7 @@ export function useSupabaseListener<
           stateBeforeRead !== JSON.stringify(store.$state))
       )
         return;
-      if (data) {
-        if (patchStore) {
-          safePatchStore(store, data as Partial<TStoreState>);
-          clearStaleState(store, data);
-        }
-        if (onData) onData(data);
-      } else {
-        if (patchStore) {
-          resetStore(store);
-        }
-        if (onData) onData(null);
-      }
+      applyFetchedData(data);
       hasInitiallyLoaded.value = true;
     } catch (error) {
       if (fetchController.signal.aborted || isAbortError(error)) {

--- a/app/composables/supabase/useSupabaseListener.ts
+++ b/app/composables/supabase/useSupabaseListener.ts
@@ -8,6 +8,7 @@ import {
   type OwnedRealtimeChannel,
 } from '@/utils/realtimeChannel';
 import { clearStaleState, resetStore, safePatchStore } from '@/utils/storeHelpers';
+import type { RemoteStateMerge } from '@/utils/pendingState';
 import type { PostgrestError, RealtimePostgresChangesPayload } from '@supabase/supabase-js';
 import type { StateTree, Store } from 'pinia';
 // Local imports
@@ -23,7 +24,12 @@ export interface SupabaseListenerConfig<
   onData?: (data: TData | null) => void;
   patchStore?: boolean;
   /** Optional sync controller to pause during remote updates */
-  syncController?: { pause: () => void; resume: () => void; hasPendingChanges?: () => boolean };
+  syncController?: {
+    pause: () => void;
+    resume: () => void;
+    hasPendingChanges?: () => boolean;
+    captureRemoteMerge?: () => RemoteStateMerge;
+  };
   scope?: ListenerScope;
 }
 interface SupabaseListenerReturn {
@@ -124,11 +130,20 @@ export function useSupabaseListener<
     }
     onData?.(data);
   };
+  const reconcileData = (data: TData | null, reconcile?: RemoteStateMerge): TData | null => {
+    if (!reconcile) return data;
+    if (data) return reconcile(data) as TData;
+    // A deleted/missing row clears acknowledged fields, but must not erase
+    // local edits that are still waiting for upload.
+    const cleared = Object.fromEntries(Object.keys(store.$state).map((key) => [key, undefined]));
+    const merged = reconcile(cleared);
+    return Object.values(merged).some((value) => value !== undefined) ? (merged as TData) : null;
+  };
   // Initial fetch
   // fallow-ignore-next-line complexity -- tested fetch cancellation and pending-save guards must share one response boundary
   const fetchData = async (reconnecting = false) => {
     const pendingBeforeRead = syncController?.hasPendingChanges?.() === true;
-    const stateBeforeRead = reconnecting ? JSON.stringify(store.$state) : null;
+    const reconcile = syncController?.captureRemoteMerge?.();
     const fetchVersion = ++latestFetchVersion;
     activeFetchController?.abort();
     const fetchController = new AbortController();
@@ -160,12 +175,13 @@ export function useSupabaseListener<
       // save, including edits that were saved while this request was in flight.
       if (
         reconnecting &&
-        (pendingBeforeRead ||
-          syncController?.hasPendingChanges?.() ||
-          stateBeforeRead !== JSON.stringify(store.$state))
-      )
+        !reconcile &&
+        (pendingBeforeRead || syncController?.hasPendingChanges?.())
+      ) {
+        hasInitiallyLoaded.value = true;
         return;
-      applyFetchedData(data);
+      }
+      applyFetchedData(reconcileData(data, reconcile));
       hasInitiallyLoaded.value = true;
     } catch (error) {
       if (fetchController.signal.aborted || isAbortError(error)) {
@@ -204,20 +220,13 @@ export function useSupabaseListener<
           syncController?.pause();
           try {
             if (subscriptionVersion !== cleanupVersion) return;
-            if (payload.eventType === 'DELETE') {
-              if (patchStore) {
-                resetStore(store);
-              }
-              if (onData) onData(null);
-            } else {
-              // INSERT or UPDATE
-              const newData = payload.new as TData;
-              if (patchStore) {
-                safePatchStore(store, newData as Partial<TStoreState>);
-                clearStaleState(store, newData);
-              }
-              if (onData) onData(newData);
+            const reconcile = syncController?.captureRemoteMerge?.();
+            if (!reconcile && syncController?.hasPendingChanges?.()) {
+              hasInitiallyLoaded.value = true;
+              return;
             }
+            const data = payload.eventType === 'DELETE' ? null : (payload.new as TData);
+            applyFetchedData(reconcileData(data, reconcile));
             hasInitiallyLoaded.value = true;
             loadError.value = null;
           } finally {

--- a/app/composables/supabase/useSupabaseListener.ts
+++ b/app/composables/supabase/useSupabaseListener.ts
@@ -7,6 +7,7 @@ import {
   removeOwnedChannel,
   type OwnedRealtimeChannel,
 } from '@/utils/realtimeChannel';
+import { isRealtimeSuspended } from '@/utils/realtimeVisibility';
 import { clearStaleState, resetStore, safePatchStore } from '@/utils/storeHelpers';
 import type { RemoteStateMerge, WithRemoteSnapshot } from '@/utils/pendingState';
 import type { PostgrestError, RealtimePostgresChangesPayload } from '@supabase/supabase-js';
@@ -210,8 +211,9 @@ export function useSupabaseListener<
     if (channel.value) return;
     if (!currentFilter) return;
     const subscriptionVersion = cleanupVersion;
-    let joined = false;
     const client = $supabase.client;
+    const suspended = () => Boolean(client.realtime && isRealtimeSuspended(client.realtime));
+    let needsSnapshot = suspended();
     const nextChannel = client
       .channel(listenerTopic(currentFilter))
       .on(
@@ -253,10 +255,15 @@ export function useSupabaseListener<
         // Cleanup can start while the join is still pending; a disposed channel
         // must not flip `isSubscribed` back on or log for a listener that is gone.
         if (subscriptionVersion !== cleanupVersion) return;
+        if (suspended()) {
+          isSubscribed.value = false;
+          needsSnapshot = true;
+          return;
+        }
         isSubscribed.value = status === 'SUBSCRIBED';
         if (isSubscribed.value) {
-          if (joined) void readData(true);
-          joined = true;
+          if (needsSnapshot) void readData(true);
+          needsSnapshot = true;
         }
         logChannelSubscribeFailure(storeIdForLogging, status, error, { table });
       });

--- a/app/composables/supabase/useSupabaseListener.ts
+++ b/app/composables/supabase/useSupabaseListener.ts
@@ -23,7 +23,7 @@ export interface SupabaseListenerConfig<
   onData?: (data: TData | null) => void;
   patchStore?: boolean;
   /** Optional sync controller to pause during remote updates */
-  syncController?: { pause: () => void; resume: () => void };
+  syncController?: { pause: () => void; resume: () => void; hasPendingChanges?: () => boolean };
   scope?: ListenerScope;
 }
 interface SupabaseListenerReturn {
@@ -105,7 +105,10 @@ export function useSupabaseListener<
   // Helper to get current filter value (supports both string and ref)
   const getFilterValue = (): string | undefined => unref(filter);
   // Initial fetch
-  const fetchData = async () => {
+  // fallow-ignore-next-line complexity -- tested fetch cancellation and pending-save guards must share one response boundary
+  const fetchData = async (reconnecting = false) => {
+    const pendingBeforeRead = syncController?.hasPendingChanges?.() === true;
+    const stateBeforeRead = reconnecting ? JSON.stringify(store.$state) : null;
     const fetchVersion = ++latestFetchVersion;
     activeFetchController?.abort();
     const fetchController = new AbortController();
@@ -148,6 +151,15 @@ export function useSupabaseListener<
         hasInitiallyLoaded.value = true;
         return;
       }
+      // A reconnect must not replace state that still belongs to an outbound
+      // save, including edits that were saved while this request was in flight.
+      if (
+        reconnecting &&
+        (pendingBeforeRead ||
+          syncController?.hasPendingChanges?.() ||
+          stateBeforeRead !== JSON.stringify(store.$state))
+      )
+        return;
       if (data) {
         if (patchStore) {
           safePatchStore(store, data as Partial<TStoreState>);
@@ -231,7 +243,7 @@ export function useSupabaseListener<
         if (subscriptionVersion !== cleanupVersion) return;
         isSubscribed.value = status === 'SUBSCRIBED';
         if (isSubscribed.value) {
-          if (joined) void fetchData();
+          if (joined) void fetchData(true);
           joined = true;
         }
         logChannelSubscribeFailure(storeIdForLogging, status, error, { table });

--- a/app/composables/supabase/useSupabaseSync.ts
+++ b/app/composables/supabase/useSupabaseSync.ts
@@ -127,7 +127,12 @@ export function useSupabaseSync<
   let lastSyncedHash: string | null = null;
   let pendingLocalChanges = false;
   let localVersion = 0;
-  const syncToSupabase = async (state = store.$state as TState): Promise<TPayload | null> => {
+  let disposed = false;
+  let syncQueue: Promise<TPayload | null> | null = null;
+  const syncToSupabase = async (
+    transformedState: TPayload | null,
+    syncVersion: number
+  ): Promise<TPayload | null> => {
     logger.debug('[Sync] syncToSupabase called', {
       loggedIn: $supabase.user.loggedIn,
       isPaused: isPaused.value,
@@ -140,10 +145,9 @@ export function useSupabaseSync<
       logger.debug('[Sync] Skipping - user not logged in');
       return null;
     }
-    const syncVersion = localVersion;
+    const ownerId = $supabase.user.id;
     isSyncing.value = true;
     try {
-      const transformedState = transform ? transform(state) : (state as unknown as TPayload);
       // Skip if transform returned null (e.g., during initial load)
       if (!transformedState) {
         logger.debug('[Sync] Skipping - transform returned null');
@@ -218,7 +222,12 @@ export function useSupabaseSync<
         !isPaused.value
       ) {
         await delay(ABORT_RETRY_DELAY_MS);
-        if (!isPaused.value && $supabase.user.loggedIn && $supabase.user.id) {
+        if (
+          !isPaused.value &&
+          $supabase.user.loggedIn &&
+          $supabase.user.id === ownerId &&
+          !disposed
+        ) {
           syncResult = await upsertWithFallback(dataToSave);
         }
       }
@@ -237,7 +246,7 @@ export function useSupabaseSync<
           logger.error(`[Sync] Error syncing to ${table}:`, formatSupabaseError(syncResult.error));
         }
       }
-      if (syncResult.synced) {
+      if (syncResult.synced && !disposed && $supabase.user.id === ownerId) {
         lastSyncedHash = currentHash;
         if (syncVersion === localVersion) pendingLocalChanges = false;
         logger.debug(`[Sync] ✅ Successfully synced to ${table}`);
@@ -251,7 +260,33 @@ export function useSupabaseSync<
       isSyncing.value = false;
     }
   };
-  const debouncedSync = debounce(syncToSupabase, debounceMs);
+  const capturePayload = (state: TState): TPayload | null => {
+    try {
+      const payload = transform ? transform(state) : (state as unknown as TPayload);
+      return payload ? (JSON.parse(JSON.stringify(payload)) as TPayload) : null;
+    } catch (error) {
+      logger.error('[Sync] Unexpected error:', error);
+      return null;
+    }
+  };
+  const enqueueSync = (state = store.$state as TState): Promise<TPayload | null> => {
+    // Capture each request before queuing: later mutations must not change an
+    // earlier payload, and resumed writes must not overtake an in-flight save.
+    const version = localVersion;
+    const snapshot = capturePayload(state);
+    const ownerId = $supabase.user.id;
+    const run = () => {
+      if (disposed || $supabase.user.id !== ownerId) return Promise.resolve(null);
+      return syncToSupabase(snapshot, version);
+    };
+    const result = syncQueue ? syncQueue.then(run, run) : run();
+    syncQueue = result;
+    void result.finally(() => {
+      if (syncQueue === result) syncQueue = null;
+    });
+    return result;
+  };
+  const debouncedSync = debounce(enqueueSync, debounceMs);
   const unsubscribe = store.$subscribe((_mutation, state) => {
     // Pausing gates transmission, not change tracking: a user can edit while
     // reconciliation is waiting to resume. The RPC suppresses unchanged writes.
@@ -264,6 +299,7 @@ export function useSupabaseSync<
     });
   });
   const cleanup = () => {
+    disposed = true;
     debouncedSync.cancel();
     unsubscribe();
   };
@@ -291,6 +327,6 @@ export function useSupabaseSync<
     cleanup,
     pause,
     resume,
-    syncToSupabase,
+    syncToSupabase: enqueueSync,
   };
 }

--- a/app/composables/supabase/useSupabaseSync.ts
+++ b/app/composables/supabase/useSupabaseSync.ts
@@ -28,6 +28,7 @@ export interface SupabaseSyncReturn<
   TState extends StateTree = StateTree,
   TPayload extends SupabaseSyncPayload = SupabaseSyncPayload,
 > {
+  hasPendingChanges?: () => boolean;
   isSyncing: Ref<boolean>;
   isPaused: Ref<boolean>;
   cleanup: () => void;
@@ -124,6 +125,8 @@ export function useSupabaseSync<
   const isSyncing = ref(false);
   const isPaused = ref(false);
   let lastSyncedHash: string | null = null;
+  let pendingLocalChanges = false;
+  let localVersion = 0;
   const syncToSupabase = async (state = store.$state as TState): Promise<TPayload | null> => {
     logger.debug('[Sync] syncToSupabase called', {
       loggedIn: $supabase.user.loggedIn,
@@ -137,6 +140,7 @@ export function useSupabaseSync<
       logger.debug('[Sync] Skipping - user not logged in');
       return null;
     }
+    const syncVersion = localVersion;
     isSyncing.value = true;
     try {
       const transformedState = transform ? transform(state) : (state as unknown as TPayload);
@@ -154,6 +158,7 @@ export function useSupabaseSync<
       // Skip sync if data hasn't changed (reduces egress significantly)
       const currentHash = hashState(dataToSave);
       if (currentHash === lastSyncedHash) {
+        if (syncVersion === localVersion) pendingLocalChanges = false;
         logger.debug('[Sync] Skipping - data unchanged');
         isSyncing.value = false;
         return null;
@@ -234,6 +239,7 @@ export function useSupabaseSync<
       }
       if (syncResult.synced) {
         lastSyncedHash = currentHash;
+        if (syncVersion === localVersion) pendingLocalChanges = false;
         logger.debug(`[Sync] ✅ Successfully synced to ${table}`);
         onSynced?.();
       }
@@ -247,6 +253,10 @@ export function useSupabaseSync<
   };
   const debouncedSync = debounce(syncToSupabase, debounceMs);
   const unsubscribe = store.$subscribe((_mutation, state) => {
+    // Pausing gates transmission, not change tracking: a user can edit while
+    // reconciliation is waiting to resume. The RPC suppresses unchanged writes.
+    localVersion += 1;
+    pendingLocalChanges = true;
     logger.debug(`[Sync] Store state changed for ${table}, triggering debounced sync`);
     void debouncedSync(state as TState).catch((error) => {
       if (isDebounceRejection(error)) return;
@@ -268,8 +278,14 @@ export function useSupabaseSync<
   const resume = () => {
     logger.debug(`[Sync] Resuming sync for ${table}`);
     isPaused.value = false;
+    if (pendingLocalChanges) {
+      void debouncedSync(store.$state as TState).catch((error) => {
+        if (!isDebounceRejection(error)) logger.error('[Sync] Resumed sync failed', error);
+      });
+    }
   };
   return {
+    hasPendingChanges: () => pendingLocalChanges,
     isSyncing,
     isPaused,
     cleanup,

--- a/app/composables/supabase/useSupabaseSync.ts
+++ b/app/composables/supabase/useSupabaseSync.ts
@@ -129,6 +129,93 @@ export function useSupabaseSync<
   let localVersion = 0;
   let disposed = false;
   let syncQueue: Promise<TPayload | null> | null = null;
+  // fallow-ignore-next-line complexity -- development-only diagnostics exercised through sync tests; inferred coverage misses indirect calls
+  const logPayload = (dataToSave: TPayload) => {
+    // Log detailed info about what we're syncing (dev only)
+    if (import.meta.env.DEV) {
+      if (table === 'user_progress') {
+        const userData = dataToSave as SupabaseUserData;
+        const pvpTasks = Object.keys(userData.pvp_data?.taskCompletions || {}).length;
+        const pveTasks = Object.keys(userData.pve_data?.taskCompletions || {}).length;
+        logger.debug(`[Sync] About to upsert to ${table}:`, {
+          gameMode: userData.current_game_mode,
+          pvpLevel: userData.pvp_data?.level,
+          pvpTasksCompleted: pvpTasks,
+          pveLevel: userData.pve_data?.level,
+          pveTasksCompleted: pveTasks,
+        });
+      } else {
+        logger.debug('[Sync] About to upsert to', table);
+      }
+    }
+  };
+  const upsert = async (payload: Record<string, unknown>) =>
+    sync ? sync(payload as TPayload) : $supabase.client.from(table).upsert(payload);
+  const upsertWithFallback = async (payload: Record<string, unknown>) => {
+    let payloadToSync: Record<string, unknown> | null = payload;
+    let error: SupabaseErrorLike | null = null;
+    let synced = false;
+    const removedMissingColumns = new Set<string>();
+    while (payloadToSync) {
+      const { error: syncError } = await upsert(payloadToSync);
+      if (!syncError) {
+        synced = true;
+        break;
+      }
+      error = syncError;
+      if (!isMissingColumnError(syncError)) {
+        break;
+      }
+      const missingColumn = getMissingColumnName(syncError);
+      if (!missingColumn || removedMissingColumns.has(missingColumn)) {
+        break;
+      }
+      const fallbackPayload = getFallbackPayload(payloadToSync, missingColumn);
+      if (!fallbackPayload) {
+        break;
+      }
+      removedMissingColumns.add(missingColumn);
+      payloadToSync = fallbackPayload;
+    }
+    return { synced, error, removedMissingColumns };
+  };
+  // fallow-ignore-next-line complexity -- retry/fallback outcomes are covered by sync integration tests; keep error reporting with the write result
+  const writePayload = async (dataToSave: TPayload, ownerId: string): Promise<boolean> => {
+    let syncResult = await upsertWithFallback(dataToSave);
+    if (
+      !syncResult.synced &&
+      syncResult.error &&
+      isAbortRequestError(syncResult.error) &&
+      !isPaused.value
+    ) {
+      await delay(ABORT_RETRY_DELAY_MS);
+      if (
+        !isPaused.value &&
+        $supabase.user.loggedIn &&
+        $supabase.user.id === ownerId &&
+        !disposed
+      ) {
+        syncResult = await upsertWithFallback(dataToSave);
+      }
+    }
+    if (syncResult.synced && syncResult.removedMissingColumns.size) {
+      logger.warn(
+        `[Sync] ${table} fallback sync succeeded after removing missing columns: ${Array.from(syncResult.removedMissingColumns).join(', ')}`
+      );
+    }
+    if (!syncResult.synced && syncResult.error) {
+      if (isAbortRequestError(syncResult.error)) {
+        logger.warn(`[Sync] Sync to ${table} was aborted; retry did not succeed yet`, {
+          ...formatSupabaseError(syncResult.error),
+          retryDelayMs: ABORT_RETRY_DELAY_MS,
+        });
+      } else {
+        logger.error(`[Sync] Error syncing to ${table}:`, formatSupabaseError(syncResult.error));
+      }
+    }
+    return syncResult.synced;
+  };
+  // fallow-ignore-next-line complexity -- serialized save/cleanup/version guards are covered in useSupabaseSync.test.ts and sync integration tests
   const syncToSupabase = async (
     transformedState: TPayload | null,
     syncVersion: number
@@ -167,86 +254,9 @@ export function useSupabaseSync<
         isSyncing.value = false;
         return null;
       }
-      // Log detailed info about what we're syncing (dev only)
-      if (import.meta.env.DEV) {
-        if (table === 'user_progress') {
-          const userData = dataToSave as SupabaseUserData;
-          const pvpTasks = Object.keys(userData.pvp_data?.taskCompletions || {}).length;
-          const pveTasks = Object.keys(userData.pve_data?.taskCompletions || {}).length;
-          logger.debug(`[Sync] About to upsert to ${table}:`, {
-            gameMode: userData.current_game_mode,
-            pvpLevel: userData.pvp_data?.level,
-            pvpTasksCompleted: pvpTasks,
-            pveLevel: userData.pve_data?.level,
-            pveTasksCompleted: pveTasks,
-          });
-        } else {
-          logger.debug('[Sync] About to upsert to', table);
-        }
-      }
-      const upsert = async (payload: Record<string, unknown>) =>
-        sync ? sync(payload as TPayload) : $supabase.client.from(table).upsert(payload);
-      const upsertWithFallback = async (payload: Record<string, unknown>) => {
-        let payloadToSync: Record<string, unknown> | null = payload;
-        let error: SupabaseErrorLike | null = null;
-        let synced = false;
-        const removedMissingColumns = new Set<string>();
-        while (payloadToSync) {
-          const { error: syncError } = await upsert(payloadToSync);
-          if (!syncError) {
-            synced = true;
-            break;
-          }
-          error = syncError;
-          if (!isMissingColumnError(syncError)) {
-            break;
-          }
-          const missingColumn = getMissingColumnName(syncError);
-          if (!missingColumn || removedMissingColumns.has(missingColumn)) {
-            break;
-          }
-          const fallbackPayload = getFallbackPayload(payloadToSync, missingColumn);
-          if (!fallbackPayload) {
-            break;
-          }
-          removedMissingColumns.add(missingColumn);
-          payloadToSync = fallbackPayload;
-        }
-        return { synced, error, removedMissingColumns };
-      };
-      let syncResult = await upsertWithFallback(dataToSave);
-      if (
-        !syncResult.synced &&
-        syncResult.error &&
-        isAbortRequestError(syncResult.error) &&
-        !isPaused.value
-      ) {
-        await delay(ABORT_RETRY_DELAY_MS);
-        if (
-          !isPaused.value &&
-          $supabase.user.loggedIn &&
-          $supabase.user.id === ownerId &&
-          !disposed
-        ) {
-          syncResult = await upsertWithFallback(dataToSave);
-        }
-      }
-      if (syncResult.synced && syncResult.removedMissingColumns.size) {
-        logger.warn(
-          `[Sync] ${table} fallback sync succeeded after removing missing columns: ${Array.from(syncResult.removedMissingColumns).join(', ')}`
-        );
-      }
-      if (!syncResult.synced && syncResult.error) {
-        if (isAbortRequestError(syncResult.error)) {
-          logger.warn(`[Sync] Sync to ${table} was aborted; retry did not succeed yet`, {
-            ...formatSupabaseError(syncResult.error),
-            retryDelayMs: ABORT_RETRY_DELAY_MS,
-          });
-        } else {
-          logger.error(`[Sync] Error syncing to ${table}:`, formatSupabaseError(syncResult.error));
-        }
-      }
-      if (syncResult.synced && !disposed && $supabase.user.id === ownerId) {
+      logPayload(dataToSave);
+      const synced = await writePayload(dataToSave, ownerId);
+      if (synced && !disposed && $supabase.user.id === ownerId) {
         lastSyncedHash = currentHash;
         if (syncVersion === localVersion) pendingLocalChanges = false;
         logger.debug(`[Sync] ✅ Successfully synced to ${table}`);
@@ -263,7 +273,10 @@ export function useSupabaseSync<
   const capturePayload = (state: TState): TPayload | null => {
     try {
       const payload = transform ? transform(state) : (state as unknown as TPayload);
-      return payload ? (JSON.parse(JSON.stringify(payload)) as TPayload) : null;
+      if (!payload) return null;
+      // Capture the JSON wire representation, not a clone of reactive references.
+      const serializedPayload = JSON.stringify(payload);
+      return JSON.parse(serializedPayload) as TPayload;
     } catch (error) {
       logger.error('[Sync] Unexpected error:', error);
       return null;

--- a/app/composables/supabase/useSupabaseSync.ts
+++ b/app/composables/supabase/useSupabaseSync.ts
@@ -5,6 +5,7 @@ import {
   createPendingStateTracker,
   snapshotSyncState,
   type RemoteStateMerge,
+  type WithRemoteSnapshot,
 } from '@/utils/pendingState';
 import type { StateTree, Store } from 'pinia';
 import type { UserProgressData } from '~/stores/progressState';
@@ -35,6 +36,7 @@ export interface SupabaseSyncReturn<
 > {
   hasPendingChanges?: () => boolean;
   captureRemoteMerge?: () => RemoteStateMerge;
+  withSnapshot?: WithRemoteSnapshot;
   isSyncing: Ref<boolean>;
   isPaused: Ref<boolean>;
   cleanup: () => void;
@@ -130,6 +132,7 @@ export function useSupabaseSync<
   const { $supabase } = useNuxtApp();
   const isSyncing = ref(false);
   const isPaused = ref(false);
+  let snapshotDepth = 0;
   let lastSyncedHash: string | null = null;
   let pendingLocalChanges = false;
   let localVersion = 0;
@@ -232,7 +235,7 @@ export function useSupabaseSync<
       loggedIn: $supabase.user.loggedIn,
       isPaused: isPaused.value,
     });
-    if (isPaused.value) {
+    if (isPaused.value || snapshotDepth > 0) {
       logger.debug('[Sync] Skipping - sync is paused');
       return null;
     }
@@ -296,7 +299,13 @@ export function useSupabaseSync<
   const enqueueSync = (state = store.$state as TState): Promise<TPayload | null> => {
     // Capture each request before queuing: later mutations must not change an
     // earlier payload, and resumed writes must not overtake an in-flight save.
-    if (disposed || isPaused.value || !$supabase.user.loggedIn || !$supabase.user.id)
+    if (
+      disposed ||
+      isPaused.value ||
+      snapshotDepth > 0 ||
+      !$supabase.user.loggedIn ||
+      !$supabase.user.id
+    )
       return Promise.resolve(null);
     const version = localVersion;
     const acknowledge = pendingState.captureAcknowledgement(snapshotSyncState(state));
@@ -338,18 +347,32 @@ export function useSupabaseSync<
     isPaused.value = true;
     debouncedSync.cancel();
   };
-  const resume = () => {
-    logger.debug(`[Sync] Resuming sync for ${table}`);
-    isPaused.value = false;
-    if (pendingLocalChanges) {
+  const schedulePendingSync = () => {
+    if (!disposed && pendingLocalChanges) {
       void debouncedSync(store.$state as TState).catch((error) => {
         if (!isDebounceRejection(error)) logger.error('[Sync] Resumed sync failed', error);
       });
     }
   };
+  const resume = () => {
+    logger.debug(`[Sync] Resuming sync for ${table}`);
+    isPaused.value = false;
+    schedulePendingSync();
+  };
+  const withSnapshot: WithRemoteSnapshot = async (read) => {
+    snapshotDepth += 1;
+    try {
+      await syncQueue;
+      return await read(pendingState.capture());
+    } finally {
+      snapshotDepth -= 1;
+      schedulePendingSync();
+    }
+  };
   return {
     hasPendingChanges: () => pendingLocalChanges,
     captureRemoteMerge: pendingState.capture,
+    withSnapshot,
     isSyncing,
     isPaused,
     cleanup,

--- a/app/composables/supabase/useSupabaseSync.ts
+++ b/app/composables/supabase/useSupabaseSync.ts
@@ -1,6 +1,11 @@
 import { delay } from '@/utils/async';
 import { debounce, isDebounceRejection } from '@/utils/debounce';
 import { logger } from '@/utils/logger';
+import {
+  createPendingStateTracker,
+  snapshotSyncState,
+  type RemoteStateMerge,
+} from '@/utils/pendingState';
 import type { StateTree, Store } from 'pinia';
 import type { UserProgressData } from '~/stores/progressState';
 type SupabaseErrorLike = {
@@ -29,6 +34,7 @@ export interface SupabaseSyncReturn<
   TPayload extends SupabaseSyncPayload = SupabaseSyncPayload,
 > {
   hasPendingChanges?: () => boolean;
+  captureRemoteMerge?: () => RemoteStateMerge;
   isSyncing: Ref<boolean>;
   isPaused: Ref<boolean>;
   cleanup: () => void;
@@ -127,6 +133,7 @@ export function useSupabaseSync<
   let lastSyncedHash: string | null = null;
   let pendingLocalChanges = false;
   let localVersion = 0;
+  const pendingState = createPendingStateTracker(() => store.$state);
   let disposed = false;
   let syncQueue: Promise<TPayload | null> | null = null;
   // fallow-ignore-next-line complexity -- development-only diagnostics exercised through sync tests; inferred coverage misses indirect calls
@@ -218,7 +225,8 @@ export function useSupabaseSync<
   // fallow-ignore-next-line complexity -- serialized save/cleanup/version guards are covered in useSupabaseSync.test.ts and sync integration tests
   const syncToSupabase = async (
     transformedState: TPayload | null,
-    syncVersion: number
+    syncVersion: number,
+    savedState: Record<string, unknown>
   ): Promise<TPayload | null> => {
     logger.debug('[Sync] syncToSupabase called', {
       loggedIn: $supabase.user.loggedIn,
@@ -249,6 +257,7 @@ export function useSupabaseSync<
       // Skip sync if data hasn't changed (reduces egress significantly)
       const currentHash = hashState(dataToSave);
       if (currentHash === lastSyncedHash) {
+        pendingState.acknowledge(savedState);
         if (syncVersion === localVersion) pendingLocalChanges = false;
         logger.debug('[Sync] Skipping - data unchanged');
         isSyncing.value = false;
@@ -257,6 +266,7 @@ export function useSupabaseSync<
       logPayload(dataToSave);
       const synced = await writePayload(dataToSave, ownerId);
       if (synced && !disposed && $supabase.user.id === ownerId) {
+        pendingState.acknowledge(savedState);
         lastSyncedHash = currentHash;
         if (syncVersion === localVersion) pendingLocalChanges = false;
         logger.debug(`[Sync] ✅ Successfully synced to ${table}`);
@@ -282,15 +292,19 @@ export function useSupabaseSync<
       return null;
     }
   };
+  // fallow-ignore-next-line complexity -- save gates and serialization are exercised through the public method in useSupabaseSync.test.ts
   const enqueueSync = (state = store.$state as TState): Promise<TPayload | null> => {
     // Capture each request before queuing: later mutations must not change an
     // earlier payload, and resumed writes must not overtake an in-flight save.
+    if (disposed || isPaused.value || !$supabase.user.loggedIn || !$supabase.user.id)
+      return Promise.resolve(null);
     const version = localVersion;
+    const savedState = snapshotSyncState(state);
     const snapshot = capturePayload(state);
     const ownerId = $supabase.user.id;
     const run = () => {
       if (disposed || $supabase.user.id !== ownerId) return Promise.resolve(null);
-      return syncToSupabase(snapshot, version);
+      return syncToSupabase(snapshot, version, savedState);
     };
     const result = syncQueue ? syncQueue.then(run, run) : run();
     syncQueue = result;
@@ -335,6 +349,7 @@ export function useSupabaseSync<
   };
   return {
     hasPendingChanges: () => pendingLocalChanges,
+    captureRemoteMerge: pendingState.capture,
     isSyncing,
     isPaused,
     cleanup,

--- a/app/composables/supabase/useSupabaseSync.ts
+++ b/app/composables/supabase/useSupabaseSync.ts
@@ -226,7 +226,7 @@ export function useSupabaseSync<
   const syncToSupabase = async (
     transformedState: TPayload | null,
     syncVersion: number,
-    savedState: Record<string, unknown>
+    acknowledge: () => void
   ): Promise<TPayload | null> => {
     logger.debug('[Sync] syncToSupabase called', {
       loggedIn: $supabase.user.loggedIn,
@@ -257,7 +257,7 @@ export function useSupabaseSync<
       // Skip sync if data hasn't changed (reduces egress significantly)
       const currentHash = hashState(dataToSave);
       if (currentHash === lastSyncedHash) {
-        pendingState.acknowledge(savedState);
+        acknowledge();
         if (syncVersion === localVersion) pendingLocalChanges = false;
         logger.debug('[Sync] Skipping - data unchanged');
         isSyncing.value = false;
@@ -266,7 +266,7 @@ export function useSupabaseSync<
       logPayload(dataToSave);
       const synced = await writePayload(dataToSave, ownerId);
       if (synced && !disposed && $supabase.user.id === ownerId) {
-        pendingState.acknowledge(savedState);
+        acknowledge();
         lastSyncedHash = currentHash;
         if (syncVersion === localVersion) pendingLocalChanges = false;
         logger.debug(`[Sync] ✅ Successfully synced to ${table}`);
@@ -299,12 +299,12 @@ export function useSupabaseSync<
     if (disposed || isPaused.value || !$supabase.user.loggedIn || !$supabase.user.id)
       return Promise.resolve(null);
     const version = localVersion;
-    const savedState = snapshotSyncState(state);
+    const acknowledge = pendingState.captureAcknowledgement(snapshotSyncState(state));
     const snapshot = capturePayload(state);
     const ownerId = $supabase.user.id;
     const run = () => {
       if (disposed || $supabase.user.id !== ownerId) return Promise.resolve(null);
-      return syncToSupabase(snapshot, version, savedState);
+      return syncToSupabase(snapshot, version, acknowledge);
     };
     const result = syncQueue ? syncQueue.then(run, run) : run();
     syncQueue = result;

--- a/app/composables/useAppInitialization.ts
+++ b/app/composables/useAppInitialization.ts
@@ -74,9 +74,6 @@ export function useAppInitialization() {
     if (!authenticatedUserId) return;
     if (supporterLoadedForUserId === authenticatedUserId) return;
     try {
-      await supporter.fetchStatus(authenticatedUserId);
-      if (expectedUserId && getAuthenticatedUserId() !== expectedUserId) return;
-      if (expectedToken !== undefined && expectedToken !== authChangeToken) return;
       await supporter.subscribe(authenticatedUserId);
       if (expectedUserId && getAuthenticatedUserId() !== expectedUserId) return;
       if (expectedToken !== undefined && expectedToken !== authChangeToken) return;

--- a/app/composables/useAppInitialization.ts
+++ b/app/composables/useAppInitialization.ts
@@ -74,10 +74,10 @@ export function useAppInitialization() {
     if (!authenticatedUserId) return;
     if (supporterLoadedForUserId === authenticatedUserId) return;
     try {
-      await supporter.subscribe(authenticatedUserId);
+      const loaded = await supporter.subscribe(authenticatedUserId);
       if (expectedUserId && getAuthenticatedUserId() !== expectedUserId) return;
       if (expectedToken !== undefined && expectedToken !== authChangeToken) return;
-      supporterLoadedForUserId = authenticatedUserId;
+      if (loaded) supporterLoadedForUserId = authenticatedUserId;
     } catch (error) {
       logger.error('[useAppInitialization] Failed to load supporter status:', error);
     }

--- a/app/composables/useAppInitialization.ts
+++ b/app/composables/useAppInitialization.ts
@@ -67,16 +67,21 @@ export function useAppInitialization() {
     resetTarkovStoreForSessionTransition(previousUserId, reason);
     activityLogStore.resetForSession();
   };
+  const isCurrentSupporterRequest = (expectedUserId?: string, expectedToken?: number) =>
+    (!expectedUserId || getAuthenticatedUserId() === expectedUserId) &&
+    (expectedToken === undefined || expectedToken === authChangeToken);
   const loadSupporterStatusIfNeeded = async (expectedUserId?: string, expectedToken?: number) => {
     const authenticatedUserId = getAuthenticatedUserId();
-    if (expectedUserId && authenticatedUserId !== expectedUserId) return;
-    if (expectedToken !== undefined && expectedToken !== authChangeToken) return;
+    if (!isCurrentSupporterRequest(expectedUserId, expectedToken)) return;
     if (!authenticatedUserId) return;
     if (supporterLoadedForUserId === authenticatedUserId) return;
     try {
-      const loaded = await supporter.subscribe(authenticatedUserId);
-      if (expectedUserId && getAuthenticatedUserId() !== expectedUserId) return;
-      if (expectedToken !== undefined && expectedToken !== authChangeToken) return;
+      let loaded = await supporter.subscribe(authenticatedUserId);
+      if (!isCurrentSupporterRequest(expectedUserId, expectedToken)) return;
+      // An unclean channel leave can decline the subscription before any status
+      // request runs. Supporter status remains available over the normal read.
+      if (!loaded) loaded = await supporter.fetchStatus(authenticatedUserId);
+      if (!isCurrentSupporterRequest(expectedUserId, expectedToken)) return;
       if (loaded) supporterLoadedForUserId = authenticatedUserId;
     } catch (error) {
       logger.error('[useAppInitialization] Failed to load supporter status:', error);

--- a/app/composables/useSupporter.ts
+++ b/app/composables/useSupporter.ts
@@ -27,7 +27,11 @@ let channelUserId: string | null = null;
 let statusRequestVersion = 0;
 let subscriptionRequestVersion = 0;
 let statusLoadedForUserId: string | null = null;
-let initialRead: { promise: Promise<boolean>; resolve: (success: boolean) => void } | null = null;
+let initialRead: {
+  userId: string;
+  promise: Promise<boolean>;
+  resolve: (success: boolean) => void;
+} | null = null;
 export function useSupporter() {
   const { $supabase } = useNuxtApp();
   const isCurrentStatusRequest = (userId: string, requestVersion: number) => {
@@ -56,6 +60,13 @@ export function useSupporter() {
     if (tier === 'supporter') return 'Supporter';
     return tier.charAt(0).toUpperCase() + tier.slice(1);
   });
+  const finishStatusRequest = (userId: string, requestVersion: number) => {
+    if (!isCurrentStatusRequest(userId, requestVersion)) return;
+    loading.value = false;
+    if (initialRead?.userId !== userId) return;
+    initialRead.resolve(error.value === null);
+    initialRead = null;
+  };
   async function fetchStatus(userId: string): Promise<boolean> {
     if (!$supabase || !userId) return false;
     const requestVersion = ++statusRequestVersion;
@@ -95,9 +106,7 @@ export function useSupporter() {
       supporterState.value = null;
       return false;
     } finally {
-      if (isCurrentStatusRequest(userId, requestVersion)) {
-        loading.value = false;
-      }
+      finishStatusRequest(userId, requestVersion);
     }
   }
   async function subscribe(userId: string): Promise<boolean> {
@@ -129,7 +138,7 @@ export function useSupporter() {
     const promise = new Promise<boolean>((resolve) => {
       resolveInitial = resolve;
     });
-    const pending = { promise, resolve: resolveInitial };
+    const pending = { userId, promise, resolve: resolveInitial };
     initialRead = pending;
     const nextChannel = client
       .channel(topic)
@@ -154,10 +163,7 @@ export function useSupporter() {
         // Subscribe reports either a join or a failure. Read once even if the initial join fails.
         if (status !== 'SUBSCRIBED' && initialReadStarted) return;
         initialReadStarted = true;
-        void fetchStatus(userId).then((success) => {
-          pending.resolve(success);
-          if (initialRead === pending) initialRead = null;
-        });
+        void fetchStatus(userId);
       });
     channel = { channel: nextChannel, client, topic };
     channelUserId = userId;

--- a/app/composables/useSupporter.ts
+++ b/app/composables/useSupporter.ts
@@ -113,6 +113,7 @@ export function useSupporter() {
     if ($supabase.user?.loggedIn === false || $supabase.user?.id !== userId) return;
     if (channel || channelUserId) return;
     const client = $supabase.client;
+    let joined = false;
     const nextChannel = client
       .channel(topic)
       .on(
@@ -130,8 +131,10 @@ export function useSupporter() {
         }
       )
       .subscribe((status, err) => {
-        if (status === 'SUBSCRIBED' && requestVersion === subscriptionRequestVersion)
-          void fetchStatus(userId);
+        if (status === 'SUBSCRIBED' && requestVersion === subscriptionRequestVersion) {
+          if (joined) void fetchStatus(userId);
+          joined = true;
+        }
         logChannelSubscribeFailure('Supporter', status, err, { userId });
       });
     channel = { channel: nextChannel, client, topic };

--- a/app/composables/useSupporter.ts
+++ b/app/composables/useSupporter.ts
@@ -60,11 +60,11 @@ export function useSupporter() {
     if (tier === 'supporter') return 'Supporter';
     return tier.charAt(0).toUpperCase() + tier.slice(1);
   });
-  const finishStatusRequest = (userId: string, requestVersion: number) => {
+  const finishStatusRequest = (userId: string, requestVersion: number, success: boolean) => {
     if (!isCurrentStatusRequest(userId, requestVersion)) return;
     loading.value = false;
     if (initialRead?.userId !== userId) return;
-    initialRead.resolve(error.value === null);
+    initialRead.resolve(success);
     initialRead = null;
   };
   async function fetchStatus(userId: string): Promise<boolean> {
@@ -72,6 +72,7 @@ export function useSupporter() {
     const requestVersion = ++statusRequestVersion;
     loading.value = true;
     error.value = null;
+    let success = false;
     try {
       const { data, error: err } = await $supabase.client
         .from('supporters')
@@ -98,6 +99,7 @@ export function useSupporter() {
         supporterState.value = null;
       }
       statusLoadedForUserId = userId;
+      success = true;
       return true;
     } catch (e: unknown) {
       logger.error('fetchStatus threw', { userId, err: e });
@@ -106,7 +108,7 @@ export function useSupporter() {
       supporterState.value = null;
       return false;
     } finally {
-      finishStatusRequest(userId, requestVersion);
+      finishStatusRequest(userId, requestVersion, success);
     }
   }
   async function subscribe(userId: string): Promise<boolean> {

--- a/app/composables/useSupporter.ts
+++ b/app/composables/useSupporter.ts
@@ -130,6 +130,8 @@ export function useSupporter() {
         }
       )
       .subscribe((status, err) => {
+        if (status === 'SUBSCRIBED' && requestVersion === subscriptionRequestVersion)
+          void fetchStatus(userId);
         logChannelSubscribeFailure('Supporter', status, err, { userId });
       });
     channel = { channel: nextChannel, client, topic };

--- a/app/composables/useSupporter.ts
+++ b/app/composables/useSupporter.ts
@@ -113,7 +113,6 @@ export function useSupporter() {
     if ($supabase.user?.loggedIn === false || $supabase.user?.id !== userId) return;
     if (channel || channelUserId) return;
     const client = $supabase.client;
-    let joined = false;
     const nextChannel = client
       .channel(topic)
       .on(
@@ -132,8 +131,7 @@ export function useSupporter() {
       )
       .subscribe((status, err) => {
         if (status === 'SUBSCRIBED' && requestVersion === subscriptionRequestVersion) {
-          if (joined) void fetchStatus(userId);
-          joined = true;
+          void fetchStatus(userId);
         }
         logChannelSubscribeFailure('Supporter', status, err, { userId });
       });

--- a/app/composables/useSupporter.ts
+++ b/app/composables/useSupporter.ts
@@ -26,6 +26,8 @@ const channelRelease = createChannelReleaseLatch();
 let channelUserId: string | null = null;
 let statusRequestVersion = 0;
 let subscriptionRequestVersion = 0;
+let statusLoadedForUserId: string | null = null;
+let initialRead: { promise: Promise<boolean>; resolve: (success: boolean) => void } | null = null;
 export function useSupporter() {
   const { $supabase } = useNuxtApp();
   const isCurrentStatusRequest = (userId: string, requestVersion: number) => {
@@ -54,8 +56,8 @@ export function useSupporter() {
     if (tier === 'supporter') return 'Supporter';
     return tier.charAt(0).toUpperCase() + tier.slice(1);
   });
-  async function fetchStatus(userId: string) {
-    if (!$supabase || !userId) return;
+  async function fetchStatus(userId: string): Promise<boolean> {
+    if (!$supabase || !userId) return false;
     const requestVersion = ++statusRequestVersion;
     loading.value = true;
     error.value = null;
@@ -67,11 +69,11 @@ export function useSupporter() {
         .maybeSingle();
       if (err) {
         logger.error('Failed to fetch supporter status', { userId, err });
-        if (!isCurrentStatusRequest(userId, requestVersion)) return;
+        if (!isCurrentStatusRequest(userId, requestVersion)) return false;
         error.value = err.message;
-        return;
+        return false;
       }
-      if (!isCurrentStatusRequest(userId, requestVersion)) return;
+      if (!isCurrentStatusRequest(userId, requestVersion)) return false;
       if (data) {
         supporterState.value = {
           tier: data.tier,
@@ -84,20 +86,29 @@ export function useSupporter() {
       } else {
         supporterState.value = null;
       }
+      statusLoadedForUserId = userId;
+      return true;
     } catch (e: unknown) {
       logger.error('fetchStatus threw', { userId, err: e });
-      if (!isCurrentStatusRequest(userId, requestVersion)) return;
+      if (!isCurrentStatusRequest(userId, requestVersion)) return false;
       error.value = e instanceof Error ? e.message : 'Failed to load supporter status';
       supporterState.value = null;
+      return false;
     } finally {
       if (isCurrentStatusRequest(userId, requestVersion)) {
         loading.value = false;
       }
     }
   }
-  async function subscribe(userId: string) {
-    if (!$supabase || !userId) return;
-    if (channel && channelUserId === userId) return;
+  async function subscribe(userId: string): Promise<boolean> {
+    if (!$supabase || !userId) return false;
+    if (channel && channelUserId === userId) {
+      if (statusLoadedForUserId === userId) return true;
+      return initialRead?.promise ?? fetchStatus(userId);
+    }
+    initialRead?.resolve(false);
+    initialRead = null;
+    statusLoadedForUserId = null;
     const requestVersion = ++subscriptionRequestVersion;
     const previousChannel = channel;
     channel = null;
@@ -108,12 +119,18 @@ export function useSupporter() {
     const topic = `supporters:${userId}`;
     // Resubscribing to the same user reuses the topic, so its leave has to finish
     // first; an unclean leave declines the topic entirely.
-    if (!(await channelRelease.release(topic))) return;
-    if (requestVersion !== subscriptionRequestVersion) return;
-    if ($supabase.user?.loggedIn === false || $supabase.user?.id !== userId) return;
-    if (channel || channelUserId) return;
+    if (!(await channelRelease.release(topic))) return false;
+    if (requestVersion !== subscriptionRequestVersion) return false;
+    if ($supabase.user?.loggedIn === false || $supabase.user?.id !== userId) return false;
+    if (channel || channelUserId) return false;
     const client = $supabase.client;
     let initialReadStarted = false;
+    let resolveInitial!: (success: boolean) => void;
+    const promise = new Promise<boolean>((resolve) => {
+      resolveInitial = resolve;
+    });
+    const pending = { promise, resolve: resolveInitial };
+    initialRead = pending;
     const nextChannel = client
       .channel(topic)
       .on(
@@ -137,13 +154,20 @@ export function useSupporter() {
         // Subscribe reports either a join or a failure. Read once even if the initial join fails.
         if (status !== 'SUBSCRIBED' && initialReadStarted) return;
         initialReadStarted = true;
-        void fetchStatus(userId);
+        void fetchStatus(userId).then((success) => {
+          pending.resolve(success);
+          if (initialRead === pending) initialRead = null;
+        });
       });
     channel = { channel: nextChannel, client, topic };
     channelUserId = userId;
+    return promise;
   }
   function unsubscribe() {
     subscriptionRequestVersion += 1;
+    initialRead?.resolve(false);
+    initialRead = null;
+    statusLoadedForUserId = null;
     const channelToRemove = channel;
     channel = null;
     channelUserId = null;

--- a/app/composables/useSupporter.ts
+++ b/app/composables/useSupporter.ts
@@ -113,6 +113,7 @@ export function useSupporter() {
     if ($supabase.user?.loggedIn === false || $supabase.user?.id !== userId) return;
     if (channel || channelUserId) return;
     const client = $supabase.client;
+    let initialReadStarted = false;
     const nextChannel = client
       .channel(topic)
       .on(
@@ -124,16 +125,19 @@ export function useSupporter() {
           filter: `user_id=eq.${userId}`,
         },
         () => {
+          if (requestVersion !== subscriptionRequestVersion) return;
           fetchStatus(userId).catch((err) => {
             logger.error('Realtime supporter status refresh failed', { userId, err });
           });
         }
       )
       .subscribe((status, err) => {
-        if (status === 'SUBSCRIBED' && requestVersion === subscriptionRequestVersion) {
-          void fetchStatus(userId);
-        }
+        if (requestVersion !== subscriptionRequestVersion) return;
         logChannelSubscribeFailure('Supporter', status, err, { userId });
+        // Subscribe reports either a join or a failure. Read once even if the initial join fails.
+        if (status !== 'SUBSCRIBED' && initialReadStarted) return;
+        initialReadStarted = true;
+        void fetchStatus(userId);
       });
     channel = { channel: nextChannel, client, topic };
     channelUserId = userId;

--- a/app/plugins/__tests__/supabase.client.test.ts
+++ b/app/plugins/__tests__/supabase.client.test.ts
@@ -87,6 +87,11 @@ const createClientMock = (initialUserId: string) => {
   const removeAllChannels = vi.fn().mockResolvedValue([]);
   mockCreateClient.mockReturnValue({
     removeAllChannels,
+    realtime: {
+      connect: vi.fn(),
+      disconnect: vi.fn().mockResolvedValue(undefined),
+      getChannels: vi.fn(() => []),
+    },
     auth: {
       getSession: vi.fn().mockResolvedValue({
         data: {

--- a/app/plugins/supabase.client.ts
+++ b/app/plugins/supabase.client.ts
@@ -2,6 +2,7 @@
 import type { Session, SupabaseClient, User } from '@supabase/supabase-js';
 import { hasSupabaseAuthSessionHint } from '@/utils/clientStorage';
 import { logger } from '@/utils/logger';
+import { installRealtimeVisibility } from '@/utils/realtimeVisibility';
 import { shouldUseOfflineSupabaseFallback } from '@/utils/runtimeConfig';
 import { hydrateUserFromSession } from '@/utils/userHydration';
 type OAuthProvider = 'twitch' | 'discord' | 'google' | 'github';
@@ -326,6 +327,10 @@ export default defineNuxtPlugin({
             flowType: 'pkce',
           },
         });
+        if (client.realtime) {
+          const disposeVisibility = installRealtimeVisibility(client.realtime);
+          if (import.meta.hot) import.meta.hot.dispose(disposeVisibility);
+        }
         supabaseClient = client;
         api.client = client;
         client.auth.onAuthStateChange(handleAuthStateChange);

--- a/app/server/api/profile/[userId]/[mode].get.ts
+++ b/app/server/api/profile/[userId]/[mode].get.ts
@@ -699,13 +699,25 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 403, statusMessage: 'Profile is private for this mode' });
   }
   if (legacyProgressField && !hasMaterializedProgress(modeProgressRow?.progress_data)) {
-    const response = await restFetch(
-      `user_progress?select=${legacyProgressField}&user_id=eq.${userId}&limit=1`
-    );
-    if (!response.ok)
+    try {
+      const response = await restFetch(
+        `user_progress?select=${legacyProgressField}&user_id=eq.${userId}&limit=1`
+      );
+      if (!response.ok)
+        throw createError({ statusCode: 502, statusMessage: 'Failed to load legacy profile data' });
+      const rows = (await response.json()) as ProgressRow[];
+      progressRow[legacyProgressField] = rows[0]?.[legacyProgressField];
+    } catch (error) {
+      resourcesController.abort();
+      if (Object(error).statusCode === 504 || isAbortError(error)) {
+        throw createError({
+          statusCode: 504,
+          statusMessage: 'Timed out while loading shared profile data',
+        });
+      }
+      logger.error('Failed to load legacy profile resources', { error, userId });
       throw createError({ statusCode: 502, statusMessage: 'Failed to load legacy profile data' });
-    const rows = (await response.json()) as ProgressRow[];
-    progressRow[legacyProgressField] = rows[0]?.[legacyProgressField];
+    }
   }
   const profileData = resolveModeProgressData(mode, modeProgressRow?.progress_data, progressRow);
   const hideDisplayName = !isOwner && preferencesRow?.streamer_mode === true;

--- a/app/server/api/profile/[userId]/[mode].get.ts
+++ b/app/server/api/profile/[userId]/[mode].get.ts
@@ -641,7 +641,7 @@ export default defineEventHandler(async (event) => {
   let modeProgressResponse: Response;
   let preferencesResponse: Response;
   const legacyProgressField = getLegacyModeProgressField(mode);
-  const progressSelect = ['user_id', 'game_edition', legacyProgressField].filter(Boolean).join(',');
+  const progressSelect = 'user_id,game_edition';
   try {
     [progressResponse, modeProgressResponse, preferencesResponse] = await Promise.all([
       restFetch(`user_progress?select=${progressSelect}&user_id=eq.${userId}&limit=1`),
@@ -697,6 +697,15 @@ export default defineEventHandler(async (event) => {
   const isModePublic = modeProgressRow ? modeProgressRow.profile_public === true : legacyModePublic;
   if (!isOwner && !isModePublic) {
     throw createError({ statusCode: 403, statusMessage: 'Profile is private for this mode' });
+  }
+  if (legacyProgressField && !hasMaterializedProgress(modeProgressRow?.progress_data)) {
+    const response = await restFetch(
+      `user_progress?select=${legacyProgressField}&user_id=eq.${userId}&limit=1`
+    );
+    if (!response.ok)
+      throw createError({ statusCode: 502, statusMessage: 'Failed to load legacy profile data' });
+    const rows = (await response.json()) as ProgressRow[];
+    progressRow[legacyProgressField] = rows[0]?.[legacyProgressField];
   }
   const profileData = resolveModeProgressData(mode, modeProgressRow?.progress_data, progressRow);
   const hideDisplayName = !isOwner && preferencesRow?.streamer_mode === true;

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -318,6 +318,13 @@ describe('Shared Profile API', () => {
       userId: '11111111-1111-4111-8111-111111111111',
       visibility: 'public',
     });
+    const restCalls = mockFetch.mock.calls
+      .map(([url]) => new URL(String(url)))
+      .filter((url) => url.pathname.includes('/rest/v1/'));
+    expect(restCalls).toHaveLength(3);
+    expect(
+      restCalls.find((url) => url.pathname.endsWith('/user_progress'))?.searchParams.get('select')
+    ).toBe('user_id,game_edition');
   });
   it('falls back to legacy persistent progress and visibility when the normalized row is missing', async () => {
     mockFetch
@@ -325,7 +332,11 @@ describe('Shared Profile API', () => {
         progressResponse(3, { pvp_data: { displayName: 'LegacyPlayer', level: 39 } })
       )
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce(preferencesResponse(false, { pvp: true }));
+      .mockResolvedValueOnce(preferencesResponse(false, { pvp: true }))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ pvp_data: { displayName: 'LegacyPlayer', level: 39 } }],
+      });
     const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
     const result = await handler(mockEvent as H3Event);
     expect(result).toMatchObject({
@@ -341,7 +352,11 @@ describe('Shared Profile API', () => {
         progressResponse(3, { pvp_data: { displayName: 'LegacyPlayer', level: 39 } })
       )
       .mockResolvedValueOnce(modeProgressResponse({ taskCompletions: {} }, true))
-      .mockResolvedValueOnce(preferencesResponse(false, { pvp: true }));
+      .mockResolvedValueOnce(preferencesResponse(false, { pvp: true }))
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ pvp_data: { displayName: 'LegacyPlayer', level: 39 } }],
+      });
     const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
     const result = await handler(mockEvent as H3Event);
     expect(result).toMatchObject({

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -326,6 +326,22 @@ describe('Shared Profile API', () => {
       restCalls.find((url) => url.pathname.endsWith('/user_progress'))?.searchParams.get('select')
     ).toBe('user_id,game_edition');
   });
+  it.each(['network', 'json'])('normalizes deferred legacy %s failures to 502', async (failure) => {
+    mockFetch
+      .mockResolvedValueOnce(progressResponse(3))
+      .mockResolvedValueOnce({ ok: true, json: async () => [] })
+      .mockResolvedValueOnce(preferencesResponse(false, { pvp: true }));
+    if (failure === 'network') mockFetch.mockRejectedValueOnce(new Error('offline'));
+    else
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => {
+          throw new Error('invalid json');
+        },
+      });
+    const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
+    await expect(handler(mockEvent as H3Event)).rejects.toMatchObject({ statusCode: 502 });
+  });
   it('falls back to legacy persistent progress and visibility when the normalized row is missing', async () => {
     mockFetch
       .mockResolvedValueOnce(

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -342,44 +342,43 @@ describe('Shared Profile API', () => {
     const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
     await expect(handler(mockEvent as H3Event)).rejects.toMatchObject({ statusCode: 502 });
   });
-  it('falls back to legacy persistent progress and visibility when the normalized row is missing', async () => {
+  it.each(['missing', 'placeholder'])(
+    'loads deferred legacy data for a %s normalized row',
+    async (kind) => {
+      mockFetch
+        .mockResolvedValueOnce(progressResponse(3))
+        .mockResolvedValueOnce(
+          kind === 'missing'
+            ? { ok: true, json: async () => [] }
+            : modeProgressResponse({ taskCompletions: {} }, true)
+        )
+        .mockResolvedValueOnce(preferencesResponse(false, { pvp: true }))
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => [{ pvp_data: { displayName: 'LegacyPlayer', level: 39 } }],
+        });
+      const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
+      expect(await handler(mockEvent as H3Event)).toMatchObject({
+        data: { displayName: 'LegacyPlayer', level: 39 },
+        gameEdition: 3,
+        mode: 'pvp',
+        visibility: 'public',
+      });
+    }
+  );
+  it.each(['http', 'abort', 'timeout'])('normalizes deferred legacy %s errors', async (failure) => {
     mockFetch
-      .mockResolvedValueOnce(
-        progressResponse(3, { pvp_data: { displayName: 'LegacyPlayer', level: 39 } })
-      )
+      .mockResolvedValueOnce(progressResponse(3))
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
-      .mockResolvedValueOnce(preferencesResponse(false, { pvp: true }))
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ pvp_data: { displayName: 'LegacyPlayer', level: 39 } }],
-      });
+      .mockResolvedValueOnce(preferencesResponse(false, { pvp: true }));
+    if (failure === 'http') mockFetch.mockResolvedValueOnce({ ok: false });
+    else
+      mockFetch.mockRejectedValueOnce(
+        failure === 'abort' ? createAbortError() : { statusCode: 504 }
+      );
     const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
-    const result = await handler(mockEvent as H3Event);
-    expect(result).toMatchObject({
-      data: { displayName: 'LegacyPlayer', level: 39 },
-      gameEdition: 3,
-      mode: 'pvp',
-      visibility: 'public',
-    });
-  });
-  it('falls back to legacy progress when the normalized row carries no level', async () => {
-    mockFetch
-      .mockResolvedValueOnce(
-        progressResponse(3, { pvp_data: { displayName: 'LegacyPlayer', level: 39 } })
-      )
-      .mockResolvedValueOnce(modeProgressResponse({ taskCompletions: {} }, true))
-      .mockResolvedValueOnce(preferencesResponse(false, { pvp: true }))
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => [{ pvp_data: { displayName: 'LegacyPlayer', level: 39 } }],
-      });
-    const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
-    const result = await handler(mockEvent as H3Event);
-    expect(result).toMatchObject({
-      data: { displayName: 'LegacyPlayer', level: 39 },
-      gameEdition: 3,
-      mode: 'pvp',
-      visibility: 'public',
+    await expect(handler(mockEvent as H3Event)).rejects.toMatchObject({
+      statusCode: failure === 'http' ? 502 : 504,
     });
   });
   it('loads Seasonal profiles from the active season row', async () => {

--- a/app/stores/__tests__/localStorage.freshness.test.ts
+++ b/app/stores/__tests__/localStorage.freshness.test.ts
@@ -79,6 +79,48 @@ describe('local mode freshness', () => {
       parseUserScopedStorage(serializer.serialize(next, 'user-1', 40))?._modeTimestamps?.pvp
     ).toBe(30);
   });
+  it('keeps mixed pending fields newer than the snapshot that supplied unrelated changes', () => {
+    const local = structuredClone(defaultState);
+    const serializer = createProgressStorageSerializer(() => null);
+    serializer.serialize(local, 'user-1', 10);
+    local.pvp.displayName = 'pending name';
+    local.gameEdition = 4;
+    serializer.serialize(local, 'user-1', 20);
+    const remote = structuredClone(defaultState);
+    remote.pvp.level = 3;
+    remote.currentGameMode = 'pve';
+    const next = structuredClone(remote);
+    next.pvp.displayName = 'pending name';
+    next.gameEdition = 4;
+    serializer.acceptRemote({
+      state: local,
+      userId: 'user-1',
+      remote,
+      next,
+      updatedAtByMode: { pvp: 30, pve: 30, seasonal: 30 },
+      metadataTimestamp: 30,
+    });
+    const persisted = parseUserScopedStorage<typeof local>(
+      serializer.serialize(next, 'user-1', 40)
+    )!;
+    const restored = resolveInitialSyncState(
+      persisted.data,
+      remote,
+      persisted._metadataTimestamp!,
+      30,
+      1,
+      1,
+      {
+        mergeModeSnapshots: true,
+        localModeTimestamps: persisted._modeTimestamps,
+        modeUpdatedAt: { pvp: 30, pve: 30, seasonal: 30 },
+      }
+    );
+    expect(restored.pvp.displayName).toBe('pending name');
+    expect(restored.pvp.level).toBe(3);
+    expect(restored.gameEdition).toBe(4);
+    expect(restored.currentGameMode).toBe('pve');
+  });
   it('does not let a recent PvP edit make stale PvE fields win at startup', () => {
     const local = structuredClone(defaultState);
     local.pve.displayName = 'stale';

--- a/app/stores/__tests__/localStorage.freshness.test.ts
+++ b/app/stores/__tests__/localStorage.freshness.test.ts
@@ -99,6 +99,43 @@ describe('local mode freshness', () => {
     expect(resolved.pvp.displayName).toBe('newer server edit');
     expect(resolved.gameEdition).toBe(3);
   });
+  it('does not let a stale tab acknowledgement replace newer same-user storage', () => {
+    const local = structuredClone(defaultState);
+    let stored = {
+      state: structuredClone(local),
+      storedUserId: 'user-1',
+      timestamp: 10,
+      metadataTimestamp: 10,
+      modeTimestamps: { pvp: 10, pve: 10, seasonal: 10 },
+      hadDeprecatedProgressData: false,
+    };
+    const persist = vi.fn();
+    const serializer = createProgressStorageSerializer(() => structuredClone(stored), persist);
+    serializer.serialize(local, 'user-1', 10);
+    stored.state.pvp.displayName = 'another tab pending edit';
+    stored.modeTimestamps.pvp = 30;
+    serializer.acceptRemote({
+      state: local,
+      userId: 'user-1',
+      remote: { gameEdition: local.gameEdition },
+      next: { gameEdition: local.gameEdition },
+      updatedAtByMode: {},
+      metadataTimestamp: 20,
+    });
+    expect(persist).not.toHaveBeenCalled();
+    expect(stored.state.pvp.displayName).toBe('another tab pending edit');
+    // Even equal data can carry an independently newer edit clock.
+    stored = { ...stored, state: structuredClone(local) };
+    serializer.acceptRemote({
+      state: local,
+      userId: 'user-1',
+      remote: { gameEdition: local.gameEdition },
+      next: { gameEdition: local.gameEdition },
+      updatedAtByMode: {},
+      metadataTimestamp: 25,
+    });
+    expect(persist).not.toHaveBeenCalled();
+  });
   it('preserves local edit freshness when remote hydration keeps pending fields', () => {
     const local = structuredClone(defaultState);
     const serializer = createProgressStorageSerializer(() => null);

--- a/app/stores/__tests__/localStorage.freshness.test.ts
+++ b/app/stores/__tests__/localStorage.freshness.test.ts
@@ -125,7 +125,7 @@ describe('local mode freshness', () => {
     expect(persist).not.toHaveBeenCalled();
     expect(stored.state.pvp.displayName).toBe('another tab pending edit');
     // Even equal data can carry an independently newer edit clock.
-    stored = { ...stored, state: structuredClone(local) };
+    stored = { ...stored, state: structuredClone(local), metadataTimestamp: 20 };
     serializer.acceptRemote({
       state: local,
       userId: 'user-1',

--- a/app/stores/__tests__/localStorage.freshness.test.ts
+++ b/app/stores/__tests__/localStorage.freshness.test.ts
@@ -57,6 +57,48 @@ describe('local mode freshness', () => {
     });
     expect(resolved.pvp.displayName).toBe('newer at 30');
   });
+  it('persists no-op acknowledgements before reload without another state mutation', () => {
+    const local = structuredClone(defaultState);
+    local.pvp.displayName = 'acknowledged';
+    local.gameEdition = 2;
+    let stored: string;
+    const serializer = createProgressStorageSerializer(
+      () => null,
+      (value) => {
+        stored = value;
+      }
+    );
+    stored = serializer.serialize(local, 'user-1', 100);
+    serializer.acceptRemote({
+      state: local,
+      userId: 'user-1',
+      remote: local,
+      next: local,
+      updatedAtByMode: { pvp: 20, pve: 20, seasonal: 20 },
+      metadataTimestamp: 20,
+    });
+    const persisted = parseUserScopedStorage<typeof local>(stored)!;
+    expect(persisted._modeTimestamps?.pvp).toBe(20);
+    expect(persisted._metadataTimestamp).toBe(20);
+    const newer = structuredClone(local);
+    newer.pvp.displayName = 'newer server edit';
+    newer.gameEdition = 3;
+    const resolved = resolveInitialSyncState(
+      persisted.data,
+      newer,
+      persisted._metadataTimestamp!,
+      30,
+      1,
+      1,
+      {
+        mergeModeSnapshots: true,
+        localModeTimestamps: persisted._modeTimestamps,
+        modeUpdatedAt: { pvp: 30, pve: 20, seasonal: 20 },
+      }
+    );
+    expect(resolved.pvp.displayName).toBe('newer server edit');
+    expect(resolved.gameEdition).toBe(3);
+  });
   it('preserves local edit freshness when remote hydration keeps pending fields', () => {
     const local = structuredClone(defaultState);
     const serializer = createProgressStorageSerializer(() => null);

--- a/app/stores/__tests__/localStorage.freshness.test.ts
+++ b/app/stores/__tests__/localStorage.freshness.test.ts
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+import { describe, expect, it, vi } from 'vitest';
+import { defaultState } from '@/stores/progressState';
+import { createProgressStorageSerializer } from '@/stores/tarkov/localStorage';
+import { resolveInitialSyncState } from '@/stores/tarkov/resetEngine';
+import { parseUserScopedStorage } from '@/utils/userScopedStorage';
+describe('local mode freshness', () => {
+  it('timestamps only changed modes and ignores other tabs overwriting storage', () => {
+    const stored = {
+      state: structuredClone(defaultState),
+      timestamp: 10,
+      storedUserId: 'user-1',
+      hadDeprecatedProgressData: false,
+    };
+    const read = vi.fn(() => stored);
+    const serializer = createProgressStorageSerializer(read);
+    const local = structuredClone(defaultState);
+    serializer.serialize(local, 'user-1', 20);
+    stored.state.pve.level = 25;
+    local.pvp.level = 2;
+    const parsed = parseUserScopedStorage(serializer.serialize(local, 'user-1', 30));
+    expect(parsed?._modeTimestamps).toEqual({ pvp: 30, pve: 10, seasonal: 10 });
+    local.gameEdition = 4;
+    expect(
+      parseUserScopedStorage(serializer.serialize(local, 'user-1', 40))?._modeTimestamps
+    ).toEqual({ pvp: 30, pve: 10, seasonal: 10 });
+    expect(read).toHaveBeenCalledOnce();
+  });
+  it('keeps remote hydration clocks so a later remote snapshot wins after reload', () => {
+    const local = structuredClone(defaultState);
+    const serializer = createProgressStorageSerializer(() => ({
+      state: local,
+      timestamp: 10,
+      storedUserId: 'user-1',
+      hadDeprecatedProgressData: false,
+    }));
+    serializer.serialize(local, 'user-1', 10);
+    const remote = structuredClone(local);
+    remote.pvp.displayName = 'snapshot at 20';
+    serializer.acceptRemote({
+      state: local,
+      userId: 'user-1',
+      remote,
+      next: remote,
+      updatedAtByMode: { pvp: 20, pve: 10, seasonal: 10 },
+    });
+    const persisted = parseUserScopedStorage<typeof local>(
+      serializer.serialize(remote, 'user-1', 40)
+    )!;
+    expect(persisted._modeTimestamps).toEqual({ pvp: 20, pve: 10, seasonal: 10 });
+    const newer = structuredClone(remote);
+    newer.pvp.displayName = 'newer at 30';
+    const resolved = resolveInitialSyncState(persisted.data, newer, 40, 10, 1, 1, {
+      mergeModeSnapshots: true,
+      localModeTimestamps: persisted._modeTimestamps,
+      modeUpdatedAt: { pvp: 30, pve: 10, seasonal: 10 },
+    });
+    expect(resolved.pvp.displayName).toBe('newer at 30');
+  });
+  it('preserves local edit freshness when remote hydration keeps pending fields', () => {
+    const local = structuredClone(defaultState);
+    const serializer = createProgressStorageSerializer(() => null);
+    serializer.serialize(local, 'user-1', 10);
+    local.pvp.displayName = 'pending';
+    serializer.serialize(local, 'user-1', 30);
+    const remote = structuredClone(local);
+    remote.pvp.displayName = 'remote';
+    remote.pvp.level = 2;
+    const next = structuredClone(remote);
+    next.pvp.displayName = 'pending';
+    serializer.acceptRemote({
+      state: local,
+      userId: 'user-1',
+      remote,
+      next,
+      updatedAtByMode: { pvp: 20, pve: 10, seasonal: 10 },
+    });
+    expect(
+      parseUserScopedStorage(serializer.serialize(next, 'user-1', 40))?._modeTimestamps?.pvp
+    ).toBe(30);
+  });
+  it('does not let a recent PvP edit make stale PvE fields win at startup', () => {
+    const local = structuredClone(defaultState);
+    local.pve.displayName = 'stale';
+    const storedState = structuredClone(local);
+    const serializer = createProgressStorageSerializer(() => ({
+      state: storedState,
+      timestamp: 10,
+      storedUserId: 'user-1',
+      hadDeprecatedProgressData: false,
+    }));
+    local.pvp.displayName = 'local';
+    const persisted = parseUserScopedStorage<typeof local>(
+      serializer.serialize(local, 'user-1', 40)
+    )!;
+    const remote = structuredClone(defaultState);
+    remote.pve.displayName = 'newer remote';
+    const resolved = resolveInitialSyncState(local, remote, 40, 20, 1, 1, {
+      mergeModeSnapshots: true,
+      localModeTimestamps: persisted._modeTimestamps,
+      modeUpdatedAt: { pvp: 20, pve: 30 },
+    });
+    expect(resolved.pvp.displayName).toBe('local');
+    expect(resolved.pve.displayName).toBe('newer remote');
+  });
+  it('retains account freshness through hydration and unrelated mode edits', () => {
+    const local = structuredClone(defaultState);
+    const serializer = createProgressStorageSerializer(() => null);
+    serializer.serialize(local, 'user-1', 10);
+    const remote = structuredClone(local);
+    remote.gameEdition = 2;
+    serializer.acceptRemote({
+      state: local,
+      userId: 'user-1',
+      remote,
+      next: remote,
+      updatedAtByMode: { pvp: 10, pve: 10, seasonal: 10 },
+      metadataTimestamp: 20,
+    });
+    remote.pvp.level = 3;
+    const persisted = parseUserScopedStorage<typeof local>(
+      serializer.serialize(remote, 'user-1', 40)
+    )!;
+    expect(persisted._metadataTimestamp).toBe(20);
+    expect(persisted._modeTimestamps?.pvp).toBe(40);
+    const newer = structuredClone(remote);
+    newer.gameEdition = 3;
+    expect(
+      resolveInitialSyncState(remote, newer, persisted._metadataTimestamp!, 30, 1, 1, {
+        localModeTimestamps: persisted._modeTimestamps,
+      }).gameEdition
+    ).toBe(3);
+    remote.gameEdition = 4;
+    expect(
+      parseUserScopedStorage(serializer.serialize(remote, 'user-1', 50))?._metadataTimestamp
+    ).toBe(50);
+  });
+  it('restores preserved owner clocks after guest storage replaced the envelope', () => {
+    const serializer = createProgressStorageSerializer(() => null);
+    const owner = structuredClone(defaultState);
+    owner.pvp.displayName = 'local pending';
+    const preserved = {
+      state: owner,
+      storedUserId: 'user-1',
+      timestamp: 30,
+      metadataTimestamp: 10,
+      modeTimestamps: { pvp: 30, pve: 10, seasonal: 10 },
+      hadDeprecatedProgressData: false,
+    };
+    serializer.serialize(defaultState, null, 40);
+    serializer.reset(preserved);
+    const restored = parseUserScopedStorage(serializer.serialize(owner, 'user-1', 50));
+    expect(restored?._modeTimestamps).toEqual(preserved.modeTimestamps);
+    expect(restored?._metadataTimestamp).toBe(10);
+  });
+  it('does not reuse another user clocks and reloads persisted clocks after hydration', () => {
+    const read = vi.fn(() => null);
+    const serializer = createProgressStorageSerializer(read);
+    serializer.serialize(defaultState, 'user-1', 10);
+    expect(
+      parseUserScopedStorage(serializer.serialize(defaultState, 'user-2', 20))?._modeTimestamps
+    ).toEqual({ pvp: 20, pve: 20, seasonal: 20 });
+    serializer.reset();
+    serializer.serialize(defaultState, 'user-2', 30);
+    expect(read).toHaveBeenCalledTimes(3);
+  });
+  it('retains only finite nonnegative clocks from persisted envelopes', () => {
+    const parsed = parseUserScopedStorage(
+      JSON.stringify({
+        _userId: 'user-1',
+        data: {},
+        _modeTimestamps: { pvp: 20, pve: -1, seasonal: 'wrong' },
+      })
+    );
+    expect(parsed?._modeTimestamps).toEqual({ pvp: 20 });
+  });
+});

--- a/app/stores/__tests__/progressPersistence.test.ts
+++ b/app/stores/__tests__/progressPersistence.test.ts
@@ -56,6 +56,68 @@ describe('progress persistence error handling', () => {
     expect(result.data.seasonal).toEqual({ level: 5 });
     expect(result.data.pve).toBeUndefined();
   });
+  it.each(['42703', 'PGRST204'])(
+    'loads progress before the freshness migration (%s)',
+    async (code) => {
+      const select = vi.fn((columns: string) => ({
+        eq: () => ({
+          in: () => ({
+            in: async () =>
+              columns.includes('progress_updated_at')
+                ? {
+                    data: null,
+                    error: {
+                      code,
+                      message: 'column user_game_mode_progress.progress_updated_at does not exist',
+                    },
+                  }
+                : {
+                    data: [{ game_mode: 'pvp', season_number: 0, progress_data: { level: 8 } }],
+                    error: null,
+                  },
+          }),
+        }),
+      }));
+      const result = await loadModeProgress(
+        { from: () => ({ select }) } as unknown as ModeProgressClient,
+        'user-1'
+      );
+      expect(result.error).toBeNull();
+      expect(result.data.pvp).toEqual({ level: 8 });
+      expect(result.updatedAtByMode).toEqual({});
+      expect(result.updatedAt).toBeUndefined();
+      expect(select).toHaveBeenCalledTimes(2);
+      expect(select).toHaveBeenLastCalledWith('game_mode,season_number,progress_data');
+    }
+  );
+  it.each([
+    { code: '42501', message: 'permission denied for progress_updated_at' },
+    { code: '42703', message: 'column progress_data does not exist' },
+    { code: 'PGRST204', message: 'column other_progress_updated_at does not exist' },
+  ])('does not mask unrelated read errors: $message', async (error) => {
+    const select = vi.fn(() => ({
+      eq: () => ({ in: () => ({ in: async () => ({ data: null, error }) }) }),
+    }));
+    const result = await loadModeProgress(
+      { from: () => ({ select }) } as unknown as ModeProgressClient,
+      'user-1'
+    );
+    expect(result.error).toEqual(error);
+    expect(select).toHaveBeenCalledOnce();
+  });
+  it('surfaces a failed compatibility read without retrying indefinitely', async () => {
+    const error = { code: '42703', message: 'column progress_updated_at does not exist' };
+    const select = vi.fn(() => ({
+      eq: () => ({ in: () => ({ in: async () => ({ data: null, error }) }) }),
+    }));
+    const result = await loadModeProgress(
+      { from: () => ({ select }) } as unknown as ModeProgressClient,
+      'user-1'
+    );
+    expect(result.error).toEqual(error);
+    expect(result.data).toEqual({});
+    expect(select).toHaveBeenCalledTimes(2);
+  });
   it('normalizes rejected sync RPCs into the error result', async () => {
     const client: ProgressRpcClient = {
       rpc: vi.fn().mockRejectedValue(new Error('network unavailable')),

--- a/app/stores/__tests__/progressPersistence.test.ts
+++ b/app/stores/__tests__/progressPersistence.test.ts
@@ -24,20 +24,26 @@ describe('progress persistence error handling', () => {
           game_mode: 'seasonal',
           season_number: ACTIVE_SEASON_NUMBER,
           progress_data: { level: 5 },
-          updated_at: '2026-09-06T12:00:00Z',
+          progress_updated_at: '2026-09-06T12:00:00Z',
+          updated_at: '2026-09-09T12:00:00Z',
         },
         {
           game_mode: 'seasonal',
           season_number: ACTIVE_SEASON_NUMBER + 1,
           progress_data: { level: 1 },
-          updated_at: '2026-09-07T12:00:00Z',
+          progress_updated_at: '2026-09-07T12:00:00Z',
         },
-        { game_mode: 'pvp', season_number: 0, progress_data: { level: 8 }, updated_at: 'invalid' },
+        {
+          game_mode: 'pvp',
+          season_number: 0,
+          progress_data: { level: 8 },
+          progress_updated_at: 'invalid',
+        },
         {
           game_mode: 'pve',
           season_number: 0,
           progress_data: {},
-          updated_at: '2026-09-08T12:00:00Z',
+          progress_updated_at: '2026-09-08T12:00:00Z',
         },
       ],
     });
@@ -46,6 +52,7 @@ describe('progress persistence error handling', () => {
     } as unknown as ModeProgressClient;
     const result = await loadModeProgress(client, 'user-1');
     expect(result.updatedAt).toBe(Date.parse('2026-09-06T12:00:00Z'));
+    expect(result.updatedAtByMode).toEqual({ seasonal: Date.parse('2026-09-06T12:00:00Z') });
     expect(result.data.seasonal).toEqual({ level: 5 });
     expect(result.data.pve).toBeUndefined();
   });

--- a/app/stores/__tests__/progressPersistence.test.ts
+++ b/app/stores/__tests__/progressPersistence.test.ts
@@ -16,6 +16,32 @@ describe('progress persistence error handling', () => {
       expect.objectContaining({ p_seasonal_season_number: ACTIVE_SEASON_NUMBER })
     );
   });
+  it('uses only active mode timestamps when establishing startup freshness', async () => {
+    const query = Promise.resolve({
+      error: null,
+      data: [
+        {
+          game_mode: 'seasonal',
+          season_number: ACTIVE_SEASON_NUMBER,
+          progress_data: { level: 5 },
+          updated_at: '2026-09-06T12:00:00Z',
+        },
+        {
+          game_mode: 'seasonal',
+          season_number: ACTIVE_SEASON_NUMBER + 1,
+          progress_data: { level: 1 },
+          updated_at: '2026-09-07T12:00:00Z',
+        },
+        { game_mode: 'pvp', season_number: 0, progress_data: { level: 8 }, updated_at: 'invalid' },
+      ],
+    });
+    const client = {
+      from: () => ({ select: () => ({ eq: () => ({ in: () => ({ in: () => query }) }) }) }),
+    } as unknown as ModeProgressClient;
+    const result = await loadModeProgress(client, 'user-1');
+    expect(result.updatedAt).toBe(Date.parse('2026-09-06T12:00:00Z'));
+    expect(result.data.seasonal).toEqual({ level: 5 });
+  });
   it('normalizes rejected sync RPCs into the error result', async () => {
     const client: ProgressRpcClient = {
       rpc: vi.fn().mockRejectedValue(new Error('network unavailable')),

--- a/app/stores/__tests__/progressPersistence.test.ts
+++ b/app/stores/__tests__/progressPersistence.test.ts
@@ -33,6 +33,12 @@ describe('progress persistence error handling', () => {
           updated_at: '2026-09-07T12:00:00Z',
         },
         { game_mode: 'pvp', season_number: 0, progress_data: { level: 8 }, updated_at: 'invalid' },
+        {
+          game_mode: 'pve',
+          season_number: 0,
+          progress_data: {},
+          updated_at: '2026-09-08T12:00:00Z',
+        },
       ],
     });
     const client = {
@@ -41,6 +47,7 @@ describe('progress persistence error handling', () => {
     const result = await loadModeProgress(client, 'user-1');
     expect(result.updatedAt).toBe(Date.parse('2026-09-06T12:00:00Z'));
     expect(result.data.seasonal).toEqual({ level: 5 });
+    expect(result.data.pve).toBeUndefined();
   });
   it('normalizes rejected sync RPCs into the error result', async () => {
     const client: ProgressRpcClient = {

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -290,6 +290,26 @@ describe('seasonal progress realtime synchronization', () => {
     expect(state.pvp.taskObjectives.staleOnly).toBeUndefined();
     expect(createdChannels).toHaveLength(1);
   });
+  it('retains an acknowledged newer count clear in a full realtime snapshot', async () => {
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    state.pvp.taskObjectives.objective = { count: 0, timestamp: 20 };
+    state.pvp.hideoutParts.part = { count: 0, timestamp: 20 };
+    await setupRealtimeListener(store);
+    handlers.get('user_game_mode_progress')?.({
+      new: {
+        game_mode: 'pvp',
+        season_number: 0,
+        updated_at: new Date().toISOString(),
+        progress_data: {
+          ...structuredClone(defaultState.pvp),
+          taskObjectives: { objective: { count: 5, timestamp: 10 } },
+          hideoutParts: { part: { count: 3, timestamp: 10 } },
+        },
+      },
+    });
+    expect(state.pvp.taskObjectives.objective?.count).toBe(0);
+    expect(state.pvp.hideoutParts.part?.count).toBe(0);
+  });
   it('does not turn a skipped remote clear into a pending local name edit', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
     state.pvp.displayName = 'existing';

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -238,6 +238,24 @@ describe('seasonal progress realtime synchronization', () => {
       await teardown;
     }
   });
+  it('retains local progress when a reconnect snapshot fails', async () => {
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    const failure = { message: 'snapshot unavailable' };
+    supabaseContext.client.from.mockImplementation((table: string) => ({
+      select: () => ({
+        eq: () =>
+          table === 'user_progress'
+            ? { single: async () => ({ data: null, error: null }) }
+            : Promise.resolve({ data: null, error: failure }),
+      }),
+    }));
+    state.pvp.level = 25;
+    await setupRealtimeListener(store);
+    createdChannels[0]?.subscribeCallback?.('SUBSCRIBED');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(state.pvp.level).toBe(25);
+    expect(createdChannels).toHaveLength(1);
+  });
   it('merges a reconnect snapshot without overwriting a newer live mode event', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
     let resolveModes!: (value: unknown) => void;
@@ -290,7 +308,7 @@ describe('seasonal progress realtime synchronization', () => {
     expect(state.pvp.taskObjectives.staleOnly).toBeUndefined();
     expect(createdChannels).toHaveLength(1);
   });
-  it('retains an acknowledged newer count clear in a full realtime snapshot', async () => {
+  it('uses entry timestamps for counts already clean when the listener starts', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
     state.pvp.taskObjectives.objective = { count: 0, timestamp: 20 };
     state.pvp.hideoutParts.part = { count: 0, timestamp: 20 };

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -127,6 +127,7 @@ describe('seasonal progress realtime synchronization', () => {
     $patch: (mutator: (target: UserState) => void) => mutator(state),
   };
   beforeEach(() => {
+    supabaseContext.client.from.mockReset();
     handlers.clear();
     createdChannels.length = 0;
     openTopics.clear();

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -283,6 +283,80 @@ describe('seasonal progress realtime synchronization', () => {
     expect(state.pvp.level).toBe(35);
     expect(createdChannels).toHaveLength(1);
   });
+  it.each([
+    'pending',
+    'edited-during-read',
+    'saved-during-read',
+    'remote-reset',
+    'missing-metadata',
+  ])('preserves reconnect edits while respecting reset epochs: %s', async (scenario) => {
+    const { setupRealtimeListener, registerSyncControllerGetter } =
+      await import('@/stores/tarkov/realtimeListener');
+    let pending = scenario !== 'edited-during-read';
+    const controller = { pause: vi.fn(), resume: vi.fn(), hasPendingChanges: () => pending };
+    registerSyncControllerGetter(() => controller);
+    let resolveModes!: (result: unknown) => void;
+    const modeResult = new Promise((resolve) => {
+      resolveModes = resolve;
+    });
+    supabaseContext.client.from.mockImplementation((table: string) => ({
+      select: () => ({
+        eq: () =>
+          table === 'user_progress'
+            ? {
+                single: async () => ({
+                  data: null,
+                  error: scenario === 'missing-metadata' ? { code: 'PGRST116' } : null,
+                }),
+              }
+            : modeResult,
+      }),
+    }));
+    try {
+      state.pvp.displayName = 'before';
+      await setupRealtimeListener(store);
+      createdChannels[0]!.subscribeCallback?.('SUBSCRIBED');
+      Object.assign(state.pvp, {
+        displayName: null,
+        pmcFaction: 'BEAR',
+        xpOffset: 123,
+        skillOffsets: { Endurance: 4 },
+      });
+      pending = scenario !== 'saved-during-read';
+      if (!pending) recordLocalSyncTime();
+      resolveModes({
+        data: [
+          {
+            game_mode: 'pvp',
+            season_number: 0,
+            updated_at: '2026-09-06T12:00:00Z',
+            progress_data: {
+              ...structuredClone(defaultState.pvp),
+              displayName: 'remote',
+              progressEpoch: scenario === 'remote-reset' ? 1 : 0,
+              taskCompletions: { remoteTask: { complete: true, timestamp: 10 } },
+            },
+          },
+        ],
+        error: null,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(state.pvp.taskCompletions.remoteTask?.complete).toBe(true);
+      if (scenario === 'remote-reset') {
+        expect(state.pvp.displayName).toBe('remote');
+        expect(state.pvp.progressEpoch).toBe(1);
+      } else {
+        expect(state.pvp).toMatchObject({
+          displayName: null,
+          pmcFaction: 'BEAR',
+          xpOffset: 123,
+          skillOffsets: { Endurance: 4 },
+        });
+      }
+    } finally {
+      registerSyncControllerGetter(() => null);
+    }
+  });
   it('applies only the active Seasonal row without changing persistent modes', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
     await setupRealtimeListener(store);

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -3,6 +3,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultState, type UserState } from '@/stores/progressState';
 import { recordLocalSyncTime, resetSyncTimeline } from '@/stores/tarkov/syncTimeline';
+import { installRealtimeVisibility } from '@/utils/realtimeVisibility';
 const showProgressMerged = vi.fn();
 type FakeChannel = {
   topic: string;
@@ -65,6 +66,11 @@ const {
   });
   const supabaseContext = {
     client: {
+      realtime: {
+        connect: vi.fn(),
+        disconnect: vi.fn().mockResolvedValue(undefined),
+        getChannels: vi.fn(() => []),
+      },
       from: vi.fn(),
       // Mirrors `RealtimeClient.channel()`: an open topic returns the live channel.
       channel: vi.fn((topic: string) => {
@@ -143,6 +149,29 @@ describe('seasonal progress realtime synchronization', () => {
     await cleanupRealtimeListener();
     resetSyncTimeline();
     vi.clearAllMocks();
+  });
+  it('ignores late progress events while the shared transport is suspended', async () => {
+    vi.useFakeTimers();
+    const page = Object.assign(new EventTarget(), { visibilityState: 'hidden' as const });
+    const disposeVisibility = installRealtimeVisibility(supabaseContext.client.realtime, page);
+    try {
+      const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+      await setupRealtimeListener(store);
+      await vi.advanceTimersByTimeAsync(60_000);
+      expect(supabaseContext.client.realtime.disconnect).toHaveBeenCalled();
+      handlers.get('user_game_mode_progress')?.({
+        new: {
+          game_mode: 'pvp',
+          season_number: 0,
+          progress_data: { ...state.pvp, level: 55 },
+          updated_at: new Date().toISOString(),
+        },
+      });
+      expect(state.pvp.level).toBe(defaultState.pvp.level);
+    } finally {
+      disposeVisibility();
+      vi.useRealTimers();
+    }
   });
   it('rebuilds the channel when setup runs again with one already active', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -290,6 +290,25 @@ describe('seasonal progress realtime synchronization', () => {
     expect(state.pvp.taskObjectives.staleOnly).toBeUndefined();
     expect(createdChannels).toHaveLength(1);
   });
+  it('does not turn a skipped remote clear into a pending local name edit', async () => {
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    state.pvp.displayName = 'existing';
+    await setupRealtimeListener(store);
+    const handler = handlers.get('user_game_mode_progress');
+    const send = (displayName: string | null, seconds: number) =>
+      handler?.({
+        new: {
+          game_mode: 'pvp',
+          season_number: 0,
+          updated_at: new Date(Date.UTC(2026, 8, 6, 12, 0, seconds)).toISOString(),
+          progress_data: { ...structuredClone(defaultState.pvp), displayName },
+        },
+      });
+    send(null, 0);
+    expect(state.pvp.displayName).toBe('existing');
+    send('new remote name', 1);
+    expect(state.pvp.displayName).toBe('new remote name');
+  });
   it('preserves local clears while accepting unrelated mode and field updates', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
     state.pvp.taskObjectives.objective = { count: 5 };

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -430,6 +430,56 @@ describe('seasonal progress realtime synchronization', () => {
       await teardown;
     }
   });
+  it('reconciles before the freshness migration without inventing a mode clock', async () => {
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    const { progressStorageSerializer } = await import('@/stores/tarkov/localStorage');
+    const { parseUserScopedStorage } = await import('@/utils/userScopedStorage');
+    progressStorageSerializer.reset();
+    const selects: string[] = [];
+    supabaseContext.client.from.mockImplementation((table: string) => ({
+      select: (columns: string) => ({
+        eq: () => {
+          if (table === 'user_progress')
+            return { single: async () => ({ data: null, error: null }) };
+          selects.push(columns);
+          return Promise.resolve(
+            columns.includes('progress_updated_at')
+              ? {
+                  data: null,
+                  error: {
+                    code: '42703',
+                    message: 'column user_game_mode_progress.progress_updated_at does not exist',
+                  },
+                }
+              : {
+                  data: [
+                    {
+                      game_mode: 'pvp',
+                      season_number: 0,
+                      progress_data: { ...structuredClone(defaultState.pvp), level: 25 },
+                      updated_at: '2026-09-06T12:00:00Z',
+                    },
+                  ],
+                  error: null,
+                }
+          );
+        },
+      }),
+    }));
+    await setupRealtimeListener(store);
+    createdChannels[0]?.subscribeCallback?.('SUBSCRIBED');
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(state.pvp.level).toBe(25);
+    expect(selects).toEqual([
+      'game_mode,season_number,progress_data,updated_at,progress_updated_at',
+      'game_mode,season_number,progress_data,updated_at',
+    ]);
+    const persisted = parseUserScopedStorage(
+      progressStorageSerializer.serialize(state, supabaseContext.user.id, Date.now())
+    );
+    expect(persisted?._modeTimestamps?.pvp).toBe(0);
+    progressStorageSerializer.reset();
+  });
   it('retains local progress when a reconnect snapshot fails', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
     const failure = { message: 'snapshot unavailable' };

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -3,6 +3,7 @@ import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultState, type UserState } from '@/stores/progressState';
 import { recordLocalSyncTime, resetSyncTimeline } from '@/stores/tarkov/syncTimeline';
+import { logger } from '@/utils/logger';
 import { installRealtimeVisibility } from '@/utils/realtimeVisibility';
 const showProgressMerged = vi.fn();
 type FakeChannel = {
@@ -282,6 +283,8 @@ describe('seasonal progress realtime synchronization', () => {
     await setupRealtimeListener(store);
     createdChannels[0]?.subscribeCallback?.('SUBSCRIBED');
     await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(supabaseContext.client.from).toHaveBeenCalledWith('user_game_mode_progress');
+    expect(logger.warn).toHaveBeenCalledWith('[TarkovStore] Reconnect snapshot failed', failure);
     expect(state.pvp.level).toBe(25);
     expect(createdChannels).toHaveLength(1);
   });

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -5,6 +5,7 @@ import { defaultState, type UserState } from '@/stores/progressState';
 import { recordLocalSyncTime, resetSyncTimeline } from '@/stores/tarkov/syncTimeline';
 import { logger } from '@/utils/logger';
 import { installRealtimeVisibility } from '@/utils/realtimeVisibility';
+import type { WithRemoteSnapshot } from '@/utils/pendingState';
 const showProgressMerged = vi.fn();
 type FakeChannel = {
   topic: string;
@@ -150,6 +151,42 @@ describe('seasonal progress realtime synchronization', () => {
     await cleanupRealtimeListener();
     resetSyncTimeline();
     vi.clearAllMocks();
+  });
+  it('waits for the sync controller before starting a reconnect read', async () => {
+    const { setupRealtimeListener, registerSyncControllerGetter } =
+      await import('@/stores/tarkov/realtimeListener');
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const withSnapshot: WithRemoteSnapshot = async (read) => {
+      await gate;
+      return read((remote) => remote);
+    };
+    registerSyncControllerGetter(() => ({ pause: vi.fn(), resume: vi.fn(), withSnapshot }));
+    supabaseContext.client.from.mockImplementation((table: string) => ({
+      select: () => ({
+        eq: () =>
+          table === 'user_progress'
+            ? { single: async () => ({ data: null, error: null }) }
+            : Promise.resolve({
+                data: [{ game_mode: 'pvp', season_number: 0, progress_data: { level: 8 } }],
+                error: null,
+              }),
+      }),
+    }));
+    try {
+      await setupRealtimeListener(store);
+      createdChannels[0]?.subscribeCallback?.('SUBSCRIBED');
+      await Promise.resolve();
+      expect(supabaseContext.client.from).not.toHaveBeenCalled();
+      release();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(supabaseContext.client.from).toHaveBeenCalledWith('user_game_mode_progress');
+      expect(state.pvp.level).toBe(8);
+    } finally {
+      registerSyncControllerGetter(() => null);
+    }
   });
   it('ignores late progress events while the shared transport is suspended', async () => {
     vi.useFakeTimers();

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -152,6 +152,36 @@ describe('seasonal progress realtime synchronization', () => {
     resetSyncTimeline();
     vi.clearAllMocks();
   });
+  it('keeps historical progress freshness unknown after a newer account event', async () => {
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    const { progressStorageSerializer } = await import('@/stores/tarkov/localStorage');
+    const { parseUserScopedStorage } = await import('@/utils/userScopedStorage');
+    progressStorageSerializer.reset();
+    await setupRealtimeListener(store);
+    handlers.get('user_progress')?.({
+      new: {
+        current_game_mode: 'pvp',
+        game_edition: 4,
+        tarkov_uid: null,
+        updated_at: '2026-09-06T12:00:00Z',
+      },
+    });
+    handlers.get('user_game_mode_progress')?.({
+      new: {
+        game_mode: 'pvp',
+        season_number: 0,
+        progress_data: structuredClone(defaultState.pvp),
+        progress_updated_at: null,
+        updated_at: '2026-09-06T12:01:00Z',
+      },
+    });
+    const persisted = parseUserScopedStorage(
+      progressStorageSerializer.serialize(state, supabaseContext.user.id, Date.now())
+    );
+    expect(persisted?._metadataTimestamp).toBe(Date.parse('2026-09-06T12:00:00Z'));
+    expect(persisted?._modeTimestamps?.pvp).toBe(0);
+    progressStorageSerializer.reset();
+  });
   it('waits for the sync controller before starting a reconnect read', async () => {
     const { setupRealtimeListener, registerSyncControllerGetter } =
       await import('@/stores/tarkov/realtimeListener');

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -65,6 +65,7 @@ const {
   });
   const supabaseContext = {
     client: {
+      from: vi.fn(),
       // Mirrors `RealtimeClient.channel()`: an open topic returns the live channel.
       channel: vi.fn((topic: string) => {
         const existing = openTopics.get(topic);
@@ -235,6 +236,52 @@ describe('seasonal progress realtime synchronization', () => {
       releaseDeferredRemovals();
       await teardown;
     }
+  });
+  it('merges a reconnect snapshot without overwriting a newer live mode event', async () => {
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    let resolveModes!: (value: unknown) => void;
+    const modeResult = new Promise((resolve) => {
+      resolveModes = resolve;
+    });
+    supabaseContext.client.from.mockImplementation((table: string) => ({
+      select: () => ({
+        eq: () =>
+          table === 'user_progress'
+            ? {
+                single: async () => ({
+                  data: { current_game_mode: 'pvp', updated_at: '2026-09-06T12:00:00Z' },
+                  error: null,
+                }),
+              }
+            : modeResult,
+      }),
+    }));
+    await setupRealtimeListener(store);
+    const channel = createdChannels[0]!;
+    channel.subscribeCallback?.('SUBSCRIBED');
+    const handler = handlers.get('user_game_mode_progress');
+    handler?.({
+      new: {
+        game_mode: 'pvp',
+        season_number: 0,
+        progress_data: { level: 35 },
+        updated_at: '2026-09-06T12:01:00Z',
+      },
+    });
+    resolveModes({
+      data: [
+        {
+          game_mode: 'pvp',
+          season_number: 0,
+          progress_data: { level: 12 },
+          updated_at: '2026-09-06T12:00:00Z',
+        },
+      ],
+      error: null,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(state.pvp.level).toBe(35);
+    expect(createdChannels).toHaveLength(1);
   });
   it('applies only the active Seasonal row without changing persistent modes', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -288,58 +288,61 @@ describe('seasonal progress realtime synchronization', () => {
     expect(state.pvp.level).toBe(25);
     expect(createdChannels).toHaveLength(1);
   });
-  it('merges a reconnect snapshot without overwriting a newer live mode event', async () => {
-    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
-    let resolveModes!: (value: unknown) => void;
-    const modeResult = new Promise((resolve) => {
-      resolveModes = resolve;
-    });
-    supabaseContext.client.from.mockImplementation((table: string) => ({
-      select: () => ({
-        eq: () =>
-          table === 'user_progress'
-            ? {
-                single: async () => ({
-                  data: { current_game_mode: 'pvp', updated_at: '2026-09-06T12:00:00Z' },
-                  error: null,
-                }),
-              }
-            : modeResult,
-      }),
-    }));
-    await setupRealtimeListener(store);
-    const channel = createdChannels[0]!;
-    channel.subscribeCallback?.('SUBSCRIBED');
-    const handler = handlers.get('user_game_mode_progress');
-    handler?.({
-      new: {
-        game_mode: 'pvp',
-        season_number: 0,
-        progress_data: { level: 35, displayName: 'live' },
-        updated_at: '2026-09-06T12:01:00Z',
-      },
-    });
-    resolveModes({
-      data: [
-        {
+  it.each([false, true])(
+    'uses the newer mode row when a live event arrives during a snapshot (snapshot wins: %s)',
+    async (snapshotWins) => {
+      const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+      let resolveModes!: (value: unknown) => void;
+      const modeResult = new Promise((resolve) => {
+        resolveModes = resolve;
+      });
+      supabaseContext.client.from.mockImplementation((table: string) => ({
+        select: () => ({
+          eq: () =>
+            table === 'user_progress'
+              ? {
+                  single: async () => ({
+                    data: { current_game_mode: 'pvp', updated_at: '2026-09-06T12:00:00Z' },
+                    error: null,
+                  }),
+                }
+              : modeResult,
+        }),
+      }));
+      await setupRealtimeListener(store);
+      const channel = createdChannels[0]!;
+      channel.subscribeCallback?.('SUBSCRIBED');
+      const handler = handlers.get('user_game_mode_progress');
+      handler?.({
+        new: {
           game_mode: 'pvp',
           season_number: 0,
-          progress_data: {
-            level: 12,
-            displayName: 'older',
-            taskObjectives: { staleOnly: { count: 9 } },
-          },
-          updated_at: '2026-09-06T12:00:00Z',
+          progress_data: { level: 35, displayName: 'live' },
+          updated_at: '2026-09-06T12:01:00Z',
         },
-      ],
-      error: null,
-    });
-    await new Promise((resolve) => setTimeout(resolve, 0));
-    expect(state.pvp.level).toBe(35);
-    expect(state.pvp.displayName).toBe('live');
-    expect(state.pvp.taskObjectives.staleOnly).toBeUndefined();
-    expect(createdChannels).toHaveLength(1);
-  });
+      });
+      resolveModes({
+        data: [
+          {
+            game_mode: 'pvp',
+            season_number: 0,
+            progress_data: {
+              level: 45,
+              displayName: 'snapshot',
+              taskObjectives: { staleOnly: { count: 9 } },
+            },
+            updated_at: snapshotWins ? '2026-09-06T12:02:00Z' : '2026-09-06T12:00:00Z',
+          },
+        ],
+        error: null,
+      });
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(state.pvp.level).toBe(snapshotWins ? 45 : 35);
+      expect(state.pvp.displayName).toBe(snapshotWins ? 'snapshot' : 'live');
+      expect(state.pvp.taskObjectives.staleOnly?.count).toBe(snapshotWins ? 9 : undefined);
+      expect(createdChannels).toHaveLength(1);
+    }
+  );
   it('uses entry timestamps for counts already clean when the listener starts', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
     state.pvp.taskObjectives.objective = { count: 0, timestamp: 20 };

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -289,6 +289,7 @@ describe('seasonal progress realtime synchronization', () => {
     'saved-during-read',
     'remote-reset',
     'missing-metadata',
+    'live-event',
   ])('preserves reconnect edits while respecting reset epochs: %s', async (scenario) => {
     const { setupRealtimeListener, registerSyncControllerGetter } =
       await import('@/stores/tarkov/realtimeListener');
@@ -324,6 +325,20 @@ describe('seasonal progress realtime synchronization', () => {
       });
       pending = scenario !== 'saved-during-read';
       if (!pending) recordLocalSyncTime();
+      if (scenario === 'live-event') {
+        handlers.get('user_game_mode_progress')?.({
+          new: {
+            game_mode: 'pvp',
+            season_number: 0,
+            updated_at: '2026-09-06T12:01:00Z',
+            progress_data: {
+              ...structuredClone(defaultState.pvp),
+              displayName: 'live',
+              taskCompletions: { remoteTask: { complete: true, timestamp: 10 } },
+            },
+          },
+        });
+      }
       resolveModes({
         data: [
           {

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -152,7 +152,7 @@ describe('seasonal progress realtime synchronization', () => {
     resetSyncTimeline();
     vi.clearAllMocks();
   });
-  it('keeps historical progress freshness unknown after a newer account event', async () => {
+  it('keeps historical progress freshness unknown after a newer mode event with a null clock', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
     const { progressStorageSerializer } = await import('@/stores/tarkov/localStorage');
     const { parseUserScopedStorage } = await import('@/utils/userScopedStorage');
@@ -182,6 +182,48 @@ describe('seasonal progress realtime synchronization', () => {
     expect(persisted?._modeTimestamps?.pvp).toBe(0);
     progressStorageSerializer.reset();
   });
+  it.each(['live', 'reconnect'])(
+    'ignores visibility-created placeholders during %s updates',
+    async (source) => {
+      const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+      state.pvp.pmcFaction = 'BEAR';
+      state.pvp.xpOffset = 450;
+      state.pvp.skillOffsets = { Endurance: 3 };
+      const before = structuredClone(state.pvp);
+      const placeholder = {
+        game_mode: 'pvp',
+        season_number: 0,
+        progress_data: {},
+        profile_public: true,
+        updated_at: '2026-09-06T12:00:00Z',
+      };
+      supabaseContext.client.from.mockImplementation((table: string) => ({
+        select: () => ({
+          eq: () =>
+            table === 'user_progress'
+              ? { single: async () => ({ data: null, error: null }) }
+              : Promise.resolve({ data: [placeholder], error: null }),
+        }),
+      }));
+      await setupRealtimeListener(store);
+      if (source === 'live') handlers.get('user_game_mode_progress')?.({ new: placeholder });
+      else {
+        createdChannels[0]!.subscribeCallback?.('SUBSCRIBED');
+        await vi.waitFor(() => expect(supabaseContext.client.from).toHaveBeenCalledTimes(2));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      }
+      expect(state.pvp).toEqual(before);
+      // Ignoring the placeholder must not advance ordering past real progress.
+      handlers.get('user_game_mode_progress')?.({
+        new: {
+          ...placeholder,
+          updated_at: '2026-09-06T11:00:00Z',
+          progress_data: { ...before, level: 8 },
+        },
+      });
+      expect(state.pvp.level).toBe(8);
+    }
+  );
   it('waits for the sync controller before starting a reconnect read', async () => {
     const { setupRealtimeListener, registerSyncControllerGetter } =
       await import('@/stores/tarkov/realtimeListener');

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -188,6 +188,26 @@ describe('seasonal progress realtime synchronization', () => {
       registerSyncControllerGetter(() => null);
     }
   });
+  it('reports a rejected snapshot barrier without an unhandled rejection', async () => {
+    const { registerSyncControllerGetter, setupRealtimeListener } =
+      await import('@/stores/tarkov/realtimeListener');
+    const failure = new Error('barrier failed');
+    const withSnapshot: WithRemoteSnapshot = async () => {
+      throw failure;
+    };
+    registerSyncControllerGetter(() => ({ pause: vi.fn(), resume: vi.fn(), withSnapshot }));
+    try {
+      await setupRealtimeListener(store);
+      createdChannels[0]?.subscribeCallback?.('SUBSCRIBED');
+      await Promise.resolve();
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[TarkovStore] Reconnect snapshot barrier failed',
+        failure
+      );
+    } finally {
+      registerSyncControllerGetter(() => null);
+    }
+  });
   it('ignores late progress events while the shared transport is suspended', async () => {
     vi.useFakeTimers();
     const page = Object.assign(new EventTarget(), { visibilityState: 'hidden' as const });

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -265,7 +265,7 @@ describe('seasonal progress realtime synchronization', () => {
       new: {
         game_mode: 'pvp',
         season_number: 0,
-        progress_data: { level: 35 },
+        progress_data: { level: 35, displayName: 'live' },
         updated_at: '2026-09-06T12:01:00Z',
       },
     });
@@ -274,7 +274,11 @@ describe('seasonal progress realtime synchronization', () => {
         {
           game_mode: 'pvp',
           season_number: 0,
-          progress_data: { level: 12 },
+          progress_data: {
+            level: 12,
+            displayName: 'older',
+            taskObjectives: { staleOnly: { count: 9 } },
+          },
           updated_at: '2026-09-06T12:00:00Z',
         },
       ],
@@ -282,7 +286,51 @@ describe('seasonal progress realtime synchronization', () => {
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
     expect(state.pvp.level).toBe(35);
+    expect(state.pvp.displayName).toBe('live');
+    expect(state.pvp.taskObjectives.staleOnly).toBeUndefined();
     expect(createdChannels).toHaveLength(1);
+  });
+  it('preserves local clears while accepting unrelated mode and field updates', async () => {
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    state.pvp.taskObjectives.objective = { count: 5 };
+    state.pvp.hideoutParts.part = { count: 3 };
+    state.pvp.storyChapters.chapter = { complete: true };
+    await setupRealtimeListener(store);
+    state.pvp.taskObjectives.objective = { count: 0 };
+    delete state.pvp.hideoutParts.part;
+    state.pvp.storyChapters.chapter = { complete: false };
+    const handler = handlers.get('user_game_mode_progress');
+    handler?.({
+      new: {
+        game_mode: 'pvp',
+        season_number: 0,
+        updated_at: new Date().toISOString(),
+        progress_data: {
+          ...structuredClone(defaultState.pvp),
+          displayName: 'remote name',
+          taskObjectives: { objective: { count: 5 }, other: { count: 2 } },
+          hideoutParts: { part: { count: 3 } },
+          storyChapters: { chapter: { complete: true } },
+        },
+      },
+    });
+    handler?.({
+      new: {
+        game_mode: 'pve',
+        season_number: 0,
+        updated_at: new Date().toISOString(),
+        progress_data: {
+          ...structuredClone(defaultState.pve),
+          displayName: 'other mode',
+        },
+      },
+    });
+    expect(state.pvp.displayName).toBe('remote name');
+    expect(state.pve.displayName).toBe('other mode');
+    expect(state.pvp.taskObjectives.objective?.count).toBe(0);
+    expect(state.pvp.taskObjectives.other?.count).toBe(2);
+    expect(state.pvp.hideoutParts.part).toBeUndefined();
+    expect(state.pvp.storyChapters.chapter?.complete).toBe(false);
   });
   it.each([
     'pending',

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -208,6 +208,39 @@ describe('seasonal progress realtime synchronization', () => {
       registerSyncControllerGetter(() => null);
     }
   });
+  it('keeps a newer local reset pending when older remote progress arrives', async () => {
+    const { setupRealtimeListener, registerSyncControllerGetter } =
+      await import('@/stores/tarkov/realtimeListener');
+    const { createPendingStateTracker, snapshotSyncState } = await import('@/utils/pendingState');
+    const tracker = createPendingStateTracker(() => state);
+    registerSyncControllerGetter(() => ({
+      pause: vi.fn(),
+      resume: vi.fn(),
+      captureRemoteMerge: tracker.capture,
+    }));
+    try {
+      await setupRealtimeListener(store);
+      state.pvp.progressEpoch = 1;
+      state.pvp.displayName = 'pending reset name';
+      const emit = (progressEpoch: number, displayName: string, updatedAt: string) =>
+        handlers.get('user_game_mode_progress')?.({
+          new: {
+            game_mode: 'pvp',
+            season_number: 0,
+            progress_data: { ...structuredClone(defaultState.pvp), progressEpoch, displayName },
+            updated_at: updatedAt,
+          },
+        });
+      emit(0, 'old remote', '2026-09-06T12:00:00Z');
+      emit(1, 'remote same epoch', '2026-09-06T12:01:00Z');
+      expect(state.pvp.displayName).toBe('pending reset name');
+      tracker.captureAcknowledgement(snapshotSyncState(state))();
+      emit(1, 'after save', '2026-09-06T12:02:00Z');
+      expect(state.pvp.displayName).toBe('after save');
+    } finally {
+      registerSyncControllerGetter(() => null);
+    }
+  });
   it('ignores late progress events while the shared transport is suspended', async () => {
     vi.useFakeTimers();
     const page = Object.assign(new EventTarget(), { visibilityState: 'hidden' as const });

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -152,6 +152,25 @@ describe('seasonal progress realtime synchronization', () => {
     resetSyncTimeline();
     vi.clearAllMocks();
   });
+  it('accepts the SDK message reference without treating it as a snapshot reconciler', async () => {
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    await setupRealtimeListener(store);
+    const channel = createdChannels[0]!;
+    for (const [, config, callback] of channel.on.mock.calls) {
+      const row =
+        config.table === 'user_game_mode_progress'
+          ? {
+              game_mode: 'pvp',
+              season_number: 0,
+              progress_data: { level: 12 },
+              updated_at: new Date().toISOString(),
+            }
+          : { game_edition: 2, current_game_mode: 'pvp', updated_at: new Date().toISOString() };
+      expect(() => callback({ new: row, old: {} }, 'sdk-message-ref')).not.toThrow();
+    }
+    expect(state.pvp.level).toBe(12);
+    expect(state.gameEdition).toBe(2);
+  });
   it('keeps historical progress freshness unknown after a newer mode event with a null clock', async () => {
     const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
     const { progressStorageSerializer } = await import('@/stores/tarkov/localStorage');

--- a/app/stores/__tests__/resetEngine.seasonalReset.test.ts
+++ b/app/stores/__tests__/resetEngine.seasonalReset.test.ts
@@ -2,7 +2,7 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultState, type UserState } from '@/stores/progressState';
-import { performReset } from '@/stores/tarkov/resetEngine';
+import { performReset, resolveInitialSyncState } from '@/stores/tarkov/resetEngine';
 import { ACTIVE_SEASON_NUMBER } from '@/utils/constants';
 const { clearProgressStorageMock, supabaseContext, syncProgressStateMock } = vi.hoisted(() => ({
   clearProgressStorageMock: vi.fn(),
@@ -43,6 +43,21 @@ describe('performReset seasonal', () => {
     supabaseContext.user.loggedIn = true;
     supabaseContext.user.id = 'user-1';
     syncProgressStateMock.mockResolvedValue({ error: null });
+  });
+  it('merges timestamped progress when a visibility-only mode timestamp is newer', () => {
+    const local = structuredClone(defaultState);
+    const remote = structuredClone(defaultState);
+    local.pvp.taskCompletions.localTask = { complete: true, timestamp: 20 };
+    local.pvp.hideoutModules.module = { complete: true, timestamp: 20 };
+    remote.pvp.taskCompletions.remoteTask = { complete: true, timestamp: 10 };
+    const result = resolveInitialSyncState(local, remote, 20, 30, 2, 1, true);
+    expect(result.pvp.taskCompletions.localTask?.complete).toBe(true);
+    expect(result.pvp.taskCompletions.remoteTask?.complete).toBe(true);
+    expect(result.pvp.hideoutModules.module?.complete).toBe(true);
+    remote.pvp.progressEpoch = 1;
+    expect(
+      resolveInitialSyncState(local, remote, 20, 30, 2, 1, true).pvp.taskCompletions.localTask
+    ).toBeUndefined();
   });
   it('resets only the seasonal mode and leaves persistent progress untouched', async () => {
     const store = createStore();

--- a/app/stores/__tests__/resetEngine.seasonalReset.test.ts
+++ b/app/stores/__tests__/resetEngine.seasonalReset.test.ts
@@ -2,6 +2,7 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { defaultState, type UserState } from '@/stores/progressState';
+import { mergeProgressData } from '@/stores/tarkov/progressMerge';
 import { performReset, resolveInitialSyncState } from '@/stores/tarkov/resetEngine';
 import { ACTIVE_SEASON_NUMBER } from '@/utils/constants';
 const { clearProgressStorageMock, supabaseContext, syncProgressStateMock } = vi.hoisted(() => ({
@@ -75,6 +76,40 @@ describe('performReset seasonal', () => {
       expect(result.pvp.taskObjectives.objective?.count).toBe(0);
       expect(result.pvp.taskObjectives.objective?.complete).toBe(false);
       expect(result.pvp.hideoutParts.part?.count).toBe(2);
+    }
+  );
+  it.each([false, true])(
+    'handles count entries without numeric counts (timestamp preference: %s)',
+    (preferNewerCount) => {
+      const local = structuredClone(defaultState.pvp);
+      const remote = structuredClone(defaultState.pvp);
+      local.taskObjectives.noCounts = { complete: false, timestamp: 1 };
+      remote.taskObjectives.noCounts = { complete: true, timestamp: 2 };
+      local.hideoutParts.olderCount = { count: 4, timestamp: 1 };
+      remote.hideoutParts.olderCount = { complete: true, timestamp: 2 };
+      const result = mergeProgressData(local, remote, preferNewerCount);
+      expect(result.taskObjectives.noCounts?.count).toBe(0);
+      expect(result.hideoutParts.olderCount?.count).toBe(4);
+    }
+  );
+  it.each([true, false])(
+    'preserves preferred profile clears at startup (local: %s)',
+    (localWins) => {
+      const local = structuredClone(defaultState);
+      const remote = structuredClone(defaultState);
+      const preferred = localWins ? local : remote;
+      const older = localWins ? remote : local;
+      preferred.pvp.displayName = null;
+      preferred.pvp.skillOffsets = {};
+      preferred.pvp.xpOffset = 0;
+      older.pvp.displayName = 'old name';
+      older.pvp.skillOffsets = { Endurance: 4 };
+      older.pvp.xpOffset = 100;
+      older.pvp.taskCompletions.remoteTask = { complete: true, timestamp: 10 };
+      const result = resolveInitialSyncState(local, remote, localWins ? 30 : 10, 20, 1, 1, true);
+      expect(result.pvp).toMatchObject({ displayName: null, skillOffsets: {}, xpOffset: 0 });
+      expect(result.pvp.skillOffsets).toEqual({});
+      expect(result.pvp.taskCompletions.remoteTask?.complete).toBe(true);
     }
   );
   it('resets only the seasonal mode and leaves persistent progress untouched', async () => {

--- a/app/stores/__tests__/resetEngine.seasonalReset.test.ts
+++ b/app/stores/__tests__/resetEngine.seasonalReset.test.ts
@@ -66,7 +66,6 @@ describe('performReset seasonal', () => {
   it('does not use unrelated mode scores when both mode clocks are unknown', () => {
     const local = structuredClone(defaultState);
     const remote = structuredClone(defaultState);
-    local.pvp.level = 60;
     local.pve.displayName = 'stale local name';
     local.pve.taskObjectives.objective = { count: 4, timestamp: 20 };
     remote.pve.displayName = 'remote name';

--- a/app/stores/__tests__/resetEngine.seasonalReset.test.ts
+++ b/app/stores/__tests__/resetEngine.seasonalReset.test.ts
@@ -51,13 +51,16 @@ describe('performReset seasonal', () => {
     local.pvp.taskCompletions.localTask = { complete: true, timestamp: 20 };
     local.pvp.hideoutModules.module = { complete: true, timestamp: 20 };
     remote.pvp.taskCompletions.remoteTask = { complete: true, timestamp: 10 };
-    const result = resolveInitialSyncState(local, remote, 20, 30, 2, 1, true);
+    const result = resolveInitialSyncState(local, remote, 20, 30, 2, 1, {
+      mergeModeSnapshots: true,
+    });
     expect(result.pvp.taskCompletions.localTask?.complete).toBe(true);
     expect(result.pvp.taskCompletions.remoteTask?.complete).toBe(true);
     expect(result.pvp.hideoutModules.module?.complete).toBe(true);
     remote.pvp.progressEpoch = 1;
     expect(
-      resolveInitialSyncState(local, remote, 20, 30, 2, 1, true).pvp.taskCompletions.localTask
+      resolveInitialSyncState(local, remote, 20, 30, 2, 1, { mergeModeSnapshots: true }).pvp
+        .taskCompletions.localTask
     ).toBeUndefined();
   });
   it.each([true, false])(
@@ -72,7 +75,9 @@ describe('performReset seasonal', () => {
       // Per-entry timestamps override the overall snapshot preference.
       preferred.pvp.hideoutParts.part = { count: 8, timestamp: 10 };
       older.pvp.hideoutParts.part = { count: 2, timestamp: 20 };
-      const result = resolveInitialSyncState(local, remote, preferLocal ? 30 : 10, 20, 1, 1, true);
+      const result = resolveInitialSyncState(local, remote, preferLocal ? 30 : 10, 20, 1, 1, {
+        mergeModeSnapshots: true,
+      });
       expect(result.pvp.taskObjectives.objective?.count).toBe(0);
       expect(result.pvp.taskObjectives.objective?.complete).toBe(false);
       expect(result.pvp.hideoutParts.part?.count).toBe(2);
@@ -109,7 +114,9 @@ describe('performReset seasonal', () => {
       older.pvp.skillOffsets = { Endurance: 4 };
       older.pvp.xpOffset = 100;
       older.pvp.taskCompletions.remoteTask = { complete: true, timestamp: 10 };
-      const result = resolveInitialSyncState(local, remote, localWins ? 30 : 10, 20, 1, 1, true);
+      const result = resolveInitialSyncState(local, remote, localWins ? 30 : 10, 20, 1, 1, {
+        mergeModeSnapshots: true,
+      });
       expect(result.pvp).toMatchObject({ displayName: null, skillOffsets: {}, xpOffset: 0 });
       expect(result.pvp.skillOffsets).toEqual({});
       expect(result.pvp.taskCompletions.remoteTask?.complete).toBe(true);

--- a/app/stores/__tests__/resetEngine.seasonalReset.test.ts
+++ b/app/stores/__tests__/resetEngine.seasonalReset.test.ts
@@ -59,6 +59,24 @@ describe('performReset seasonal', () => {
       resolveInitialSyncState(local, remote, 20, 30, 2, 1, true).pvp.taskCompletions.localTask
     ).toBeUndefined();
   });
+  it.each([true, false])(
+    'preserves newer count decrements and explicit clears (local preferred: %s)',
+    (preferLocal) => {
+      const local = structuredClone(defaultState);
+      const remote = structuredClone(defaultState);
+      const preferred = preferLocal ? local : remote;
+      const older = preferLocal ? remote : local;
+      preferred.pvp.taskObjectives.objective = { count: 0, complete: false };
+      older.pvp.taskObjectives.objective = { count: 5, complete: true };
+      // Per-entry timestamps override the overall snapshot preference.
+      preferred.pvp.hideoutParts.part = { count: 8, timestamp: 10 };
+      older.pvp.hideoutParts.part = { count: 2, timestamp: 20 };
+      const result = resolveInitialSyncState(local, remote, preferLocal ? 30 : 10, 20, 1, 1, true);
+      expect(result.pvp.taskObjectives.objective?.count).toBe(0);
+      expect(result.pvp.taskObjectives.objective?.complete).toBe(false);
+      expect(result.pvp.hideoutParts.part?.count).toBe(2);
+    }
+  );
   it('resets only the seasonal mode and leaves persistent progress untouched', async () => {
     const store = createStore();
     await performReset('seasonal', store);

--- a/app/stores/__tests__/resetEngine.seasonalReset.test.ts
+++ b/app/stores/__tests__/resetEngine.seasonalReset.test.ts
@@ -63,6 +63,39 @@ describe('performReset seasonal', () => {
         .taskCompletions.localTask
     ).toBeUndefined();
   });
+  it.each(['pvp', 'pve', 'seasonal'] as const)(
+    'does not lend account metadata freshness to unknown %s progress',
+    (mode) => {
+      const local = structuredClone(defaultState);
+      const remote = structuredClone(defaultState);
+      local[mode].displayName = null;
+      local[mode].xpOffset = 0;
+      local[mode].skillOffsets = {};
+      local[mode].taskObjectives.objective = { count: 0, timestamp: 20 };
+      remote[mode].displayName = 'older name';
+      remote[mode].xpOffset = 100;
+      remote[mode].skillOffsets = { Endurance: 4 };
+      remote[mode].taskObjectives.objective = { count: 5, timestamp: 10 };
+      remote[mode].taskCompletions.remoteTask = { complete: true, timestamp: 10 };
+      remote.gameEdition = 4;
+      const result = resolveInitialSyncState(local, remote, 10, 30, 1, 99, {
+        localModeTimestamps: { [mode]: 20 },
+        modeUpdatedAt: {},
+      });
+      expect(result.gameEdition).toBe(4);
+      expect(result[mode]).toMatchObject({ displayName: null, xpOffset: 0, skillOffsets: {} });
+      expect(result[mode].skillOffsets).toEqual({});
+      expect(result[mode].taskObjectives.objective?.count).toBe(0);
+      expect(result[mode].taskCompletions.remoteTask?.complete).toBe(true);
+      remote[mode].progressEpoch = 1;
+      const reset = resolveInitialSyncState(local, remote, 10, 30, 1, 99, {
+        localModeTimestamps: { [mode]: 20 },
+        modeUpdatedAt: {},
+      });
+      expect(reset[mode].progressEpoch).toBe(1);
+      expect(reset[mode].displayName).toBe('older name');
+    }
+  );
   it.each([true, false])(
     'preserves newer count decrements and explicit clears (local preferred: %s)',
     (preferLocal) => {

--- a/app/stores/__tests__/resetEngine.seasonalReset.test.ts
+++ b/app/stores/__tests__/resetEngine.seasonalReset.test.ts
@@ -87,7 +87,10 @@ describe('performReset seasonal', () => {
       remote.taskObjectives.noCounts = { complete: true, timestamp: 2 };
       local.hideoutParts.olderCount = { count: 4, timestamp: 1 };
       remote.hideoutParts.olderCount = { complete: true, timestamp: 2 };
+      local.taskObjectives.decreased = { count: 4, timestamp: 1 };
+      remote.taskObjectives.decreased = { count: 2, timestamp: 2 };
       const result = mergeProgressData(local, remote, preferNewerCount);
+      expect(result.taskObjectives.decreased?.count).toBe(preferNewerCount ? 2 : 4);
       expect(result.taskObjectives.noCounts?.count).toBe(0);
       expect(result.hideoutParts.olderCount?.count).toBe(4);
     }

--- a/app/stores/__tests__/resetEngine.seasonalReset.test.ts
+++ b/app/stores/__tests__/resetEngine.seasonalReset.test.ts
@@ -63,6 +63,21 @@ describe('performReset seasonal', () => {
         .taskCompletions.localTask
     ).toBeUndefined();
   });
+  it('does not use unrelated mode scores when both mode clocks are unknown', () => {
+    const local = structuredClone(defaultState);
+    const remote = structuredClone(defaultState);
+    local.pvp.level = 60;
+    local.pve.displayName = 'stale local name';
+    local.pve.taskObjectives.objective = { count: 4, timestamp: 20 };
+    remote.pve.displayName = 'remote name';
+    remote.pve.taskObjectives.objective = { count: 1, timestamp: 10 };
+    const result = resolveInitialSyncState(local, remote, 0, 30, 99, 1, {
+      localModeTimestamps: { pve: 0 },
+      modeUpdatedAt: {},
+    });
+    expect(result.pve.displayName).toBe('remote name');
+    expect(result.pve.taskObjectives.objective?.count).toBe(4);
+  });
   it.each(['pvp', 'pve', 'seasonal'] as const)(
     'does not lend account metadata freshness to unknown %s progress',
     (mode) => {

--- a/app/stores/__tests__/teamChannelController.test.ts
+++ b/app/stores/__tests__/teamChannelController.test.ts
@@ -228,6 +228,42 @@ describe('createTeamChannelController', () => {
       await controller.dispose();
     }
   });
+  it.each([true, false])(
+    'transfers reconnect hydration to a replacement team (old refresh finishes first: %s)',
+    async (oldFinishesFirst) => {
+      const harness = createHarness();
+      const controller = createTeamChannelController(harness.deps);
+      const hydrated = vi.fn();
+      window.addEventListener('teammate-progress-reconnected', hydrated);
+      try {
+        await controller.refresh();
+        harness.channels[0]?.status?.('SUBSCRIBED');
+        let finishOld!: (success: boolean) => void;
+        harness.refreshMembers.mockImplementationOnce(
+          () =>
+            new Promise<boolean>((resolve) => {
+              finishOld = resolve;
+            })
+        );
+        harness.channels[0]?.status?.('SUBSCRIBED');
+        await vi.advanceTimersByTimeAsync(0);
+        // The same teammate store survives the team change and needs a snapshot.
+        harness.state.teamId = 'team-2';
+        const replacement = controller.refresh();
+        if (oldFinishesFirst) finishOld(true);
+        await replacement;
+        expect(hydrated).not.toHaveBeenCalled();
+        harness.channels[1]?.status?.('SUBSCRIBED');
+        expect(hydrated).toHaveBeenCalledOnce();
+        if (!oldFinishesFirst) finishOld(true);
+        await vi.advanceTimersByTimeAsync(0);
+        expect(hydrated).toHaveBeenCalledOnce();
+      } finally {
+        window.removeEventListener('teammate-progress-reconnected', hydrated);
+        await controller.dispose();
+      }
+    }
+  );
   it('does not rebuild while the topic and member filter are unchanged', async () => {
     const harness = createHarness();
     const controller = createTeamChannelController(harness.deps);

--- a/app/stores/__tests__/teamChannelController.test.ts
+++ b/app/stores/__tests__/teamChannelController.test.ts
@@ -65,7 +65,7 @@ const createHarness = (options: { removeStatus?: string | Promise<string> } = {}
     teamId: 'team-1' as string | null,
   };
   const applyProgress = vi.fn();
-  const refreshMembers = vi.fn(async () => undefined);
+  const refreshMembers = vi.fn(async () => true);
   const deps: TeamChannelDeps = {
     applyProgress,
     getClient: () => client,
@@ -138,14 +138,14 @@ describe('createTeamChannelController', () => {
       harness.refreshMembers
         .mockImplementationOnce(
           () =>
-            new Promise<undefined>((resolve) => {
-              finishOld = () => resolve(undefined);
+            new Promise<boolean>((resolve) => {
+              finishOld = () => resolve(true);
             })
         )
         .mockImplementationOnce(
           () =>
-            new Promise<undefined>((resolve) => {
-              finishNew = () => resolve(undefined);
+            new Promise<boolean>((resolve) => {
+              finishNew = () => resolve(true);
             })
         );
       harness.channels[0]?.status?.('SUBSCRIBED');

--- a/app/stores/__tests__/teamChannelController.test.ts
+++ b/app/stores/__tests__/teamChannelController.test.ts
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { createTeamChannelController, type TeamChannelDeps } from '@/stores/useTeamStore';
+import { installRealtimeVisibility } from '@/utils/realtimeVisibility';
 import type { SupabaseClient } from '@supabase/supabase-js';
 const loggerMock = vi.hoisted(() => ({
   debug: vi.fn(),
@@ -125,6 +126,48 @@ describe('createTeamChannelController', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(harness.refreshMembers).toHaveBeenCalledTimes(1);
   });
+  it.each([true, false])(
+    'reconciles a suspended first join (suspended at creation: %s)',
+    async (suspendedAtCreation) => {
+      const harness = createHarness();
+      const transport = { connect: vi.fn(), disconnect: vi.fn(), getChannels: () => [] };
+      Object.assign(harness.client, { realtime: transport });
+      const page = Object.assign(new EventTarget(), {
+        visibilityState: 'hidden' as DocumentVisibilityState,
+      });
+      const releaseVisibility = installRealtimeVisibility(transport, page);
+      const controller = createTeamChannelController(harness.deps);
+      const hydrated = vi.fn();
+      window.addEventListener('teammate-progress-reconnected', hydrated);
+      try {
+        if (suspendedAtCreation) await vi.advanceTimersByTimeAsync(60_000);
+        await controller.refresh();
+        if (!suspendedAtCreation) {
+          await vi.advanceTimersByTimeAsync(60_000);
+          harness.channels[0]?.status?.('CLOSED');
+        }
+        harness.refreshMembers.mockClear();
+        harness.state.members = [MEMBER_A, MEMBER_C];
+        page.visibilityState = 'visible';
+        page.dispatchEvent(new Event('visibilitychange'));
+        await vi.advanceTimersByTimeAsync(0);
+        harness.channels[0]?.status?.('SUBSCRIBED');
+        await vi.advanceTimersByTimeAsync(0);
+        expect(harness.refreshMembers).toHaveBeenCalledOnce();
+        expect(harness.channels).toHaveLength(2);
+        expect(harness.channels[1]?.bindings[1]?.filter).toBe(
+          `user_id=in.(${MEMBER_A},${MEMBER_C})`
+        );
+        expect(hydrated).not.toHaveBeenCalled();
+        harness.channels[1]?.status?.('SUBSCRIBED');
+        expect(hydrated).toHaveBeenCalledOnce();
+      } finally {
+        window.removeEventListener('teammate-progress-reconnected', hydrated);
+        releaseVisibility();
+        await controller.dispose();
+      }
+    }
+  );
   it('reports a rejected reconnect refresh without dispatching hydration', async () => {
     const harness = createHarness();
     const controller = createTeamChannelController(harness.deps);

--- a/app/stores/__tests__/teamChannelController.test.ts
+++ b/app/stores/__tests__/teamChannelController.test.ts
@@ -125,6 +125,24 @@ describe('createTeamChannelController', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(harness.refreshMembers).toHaveBeenCalledTimes(1);
   });
+  it('reports a rejected reconnect refresh without dispatching hydration', async () => {
+    const harness = createHarness();
+    const controller = createTeamChannelController(harness.deps);
+    const hydrated = vi.fn();
+    window.addEventListener('teammate-progress-reconnected', hydrated);
+    try {
+      await controller.refresh();
+      harness.channels[0]?.status?.('SUBSCRIBED');
+      harness.refreshMembers.mockRejectedValueOnce(new Error('network unavailable'));
+      harness.channels[0]?.status?.('SUBSCRIBED');
+      await vi.advanceTimersByTimeAsync(0);
+      expect(hydrated).not.toHaveBeenCalled();
+      expect(harness.channels).toHaveLength(1);
+    } finally {
+      window.removeEventListener('teammate-progress-reconnected', hydrated);
+      await controller.dispose();
+    }
+  });
   it('lets a newer membership refresh finish before reconnect hydration', async () => {
     const harness = createHarness();
     const controller = createTeamChannelController(harness.deps);

--- a/app/stores/__tests__/teamChannelController.test.ts
+++ b/app/stores/__tests__/teamChannelController.test.ts
@@ -225,6 +225,36 @@ describe('createTeamChannelController', () => {
     await controller.refresh();
     expect(harness.channels).toHaveLength(2);
   });
+  it.each(['CLOSED', 'CHANNEL_ERROR'])(
+    'hydrates missed teammate progress after replacing a joined channel on %s',
+    async (status) => {
+      const harness = createHarness();
+      const controller = createTeamChannelController(harness.deps);
+      const hydrated = vi.fn();
+      window.addEventListener('teammate-progress-reconnected', hydrated);
+      try {
+        await controller.refresh();
+        harness.channels[0]?.status?.('SUBSCRIBED');
+        expect(hydrated).not.toHaveBeenCalled();
+        if (status === 'CHANNEL_ERROR') {
+          for (let attempt = 0; attempt < 5; attempt += 1) {
+            harness.channels[0]?.status?.(status, new Error('connection lost'));
+          }
+          await vi.advanceTimersByTimeAsync(60_000);
+        } else {
+          harness.channels[0]?.status?.(status);
+          await controller.refresh();
+        }
+        expect(harness.channels).toHaveLength(2);
+        expect(hydrated).not.toHaveBeenCalled();
+        harness.channels[1]?.status?.('SUBSCRIBED');
+        expect(hydrated).toHaveBeenCalledOnce();
+      } finally {
+        window.removeEventListener('teammate-progress-reconnected', hydrated);
+        await controller.dispose();
+      }
+    }
+  );
   it('tears the channel down when the team disappears', async () => {
     const harness = createHarness();
     const controller = createTeamChannelController(harness.deps);

--- a/app/stores/__tests__/teamChannelController.test.ts
+++ b/app/stores/__tests__/teamChannelController.test.ts
@@ -125,6 +125,48 @@ describe('createTeamChannelController', () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(harness.refreshMembers).toHaveBeenCalledTimes(1);
   });
+  it('lets a newer membership refresh finish before reconnect hydration', async () => {
+    const harness = createHarness();
+    const controller = createTeamChannelController(harness.deps);
+    const hydrated = vi.fn();
+    window.addEventListener('teammate-progress-reconnected', hydrated);
+    try {
+      await controller.refresh();
+      harness.channels[0]?.status?.('SUBSCRIBED');
+      let finishOld!: () => void;
+      let finishNew!: () => void;
+      harness.refreshMembers
+        .mockImplementationOnce(
+          () =>
+            new Promise<undefined>((resolve) => {
+              finishOld = () => resolve(undefined);
+            })
+        )
+        .mockImplementationOnce(
+          () =>
+            new Promise<undefined>((resolve) => {
+              finishNew = () => resolve(undefined);
+            })
+        );
+      harness.channels[0]?.status?.('SUBSCRIBED');
+      await vi.advanceTimersByTimeAsync(0);
+      const newer = controller.refresh();
+      await vi.advanceTimersByTimeAsync(0);
+      finishOld();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(hydrated).not.toHaveBeenCalled();
+      harness.state.members = [MEMBER_A, MEMBER_B, MEMBER_C];
+      finishNew();
+      await newer;
+      expect(hydrated).not.toHaveBeenCalled();
+      expect(harness.channels).toHaveLength(2);
+      harness.channels[1]?.status?.('SUBSCRIBED');
+      expect(hydrated).toHaveBeenCalledOnce();
+    } finally {
+      window.removeEventListener('teammate-progress-reconnected', hydrated);
+      await controller.dispose();
+    }
+  });
   it('does not rebuild while the topic and member filter are unchanged', async () => {
     const harness = createHarness();
     const controller = createTeamChannelController(harness.deps);

--- a/app/stores/__tests__/teamChannelController.test.ts
+++ b/app/stores/__tests__/teamChannelController.test.ts
@@ -114,12 +114,15 @@ describe('createTeamChannelController', () => {
     await controller.refresh();
     expect(harness.channels[0]?.bindings.map(({ table }) => table)).toEqual(['team_memberships']);
   });
-  it('refreshes members once the join is acknowledged', async () => {
+  it('refreshes members on rejoin without duplicating the initial refresh', async () => {
     const harness = createHarness();
     const controller = createTeamChannelController(harness.deps);
     await controller.refresh();
     harness.refreshMembers.mockClear();
     harness.channels[0]?.status?.('SUBSCRIBED');
+    expect(harness.refreshMembers).not.toHaveBeenCalled();
+    harness.channels[0]?.status?.('SUBSCRIBED');
+    await vi.advanceTimersByTimeAsync(0);
     expect(harness.refreshMembers).toHaveBeenCalledTimes(1);
   });
   it('does not rebuild while the topic and member filter are unchanged', async () => {

--- a/app/stores/__tests__/teammate_flow.test.ts
+++ b/app/stores/__tests__/teammate_flow.test.ts
@@ -107,6 +107,41 @@ describe('teammate store hydration and lifetime', () => {
     await addMember();
     expect(flow.teammateStores.value.other?.$state.pvp.level).toBe(25);
   });
+  it('retains hydrated progress when a reconnect placeholder has a failed legacy fallback', async () => {
+    mocks.eq.mockResolvedValue({
+      data: [{ ...row(25), progress_data: { level: 25, pmcFaction: 'BEAR', xpOffset: 450 } }],
+      error: null,
+    });
+    await addMember();
+    const teammate = flow.teammateStores.value.other!;
+    const previous = JSON.parse(JSON.stringify(teammate.$state.pvp));
+    const placeholder = { ...row(1), progress_data: {} };
+    mocks.eq.mockResolvedValue({ data: [placeholder], error: null });
+    mocks.rpc.mockResolvedValue({ data: null, error: { message: 'temporarily unavailable' } });
+    window.dispatchEvent(new Event('teammate-progress-reconnected'));
+    await flushPromises();
+    expect(mocks.rpc).toHaveBeenCalledWith('get_teammate_legacy_progress', {
+      p_user_id: 'other',
+      p_game_mode: 'pvp',
+    });
+    expect(teammate.$state.pvp).toEqual(previous);
+    emitProgress(placeholder);
+    expect(teammate.$state.pvp).toEqual(previous);
+    mocks.rpc.mockResolvedValue({ data: { level: 31, pmcFaction: 'BEAR' }, error: null });
+    window.dispatchEvent(new Event('teammate-progress-reconnected'));
+    await flushPromises();
+    expect(teammate.$state.pvp.level).toBe(31);
+  });
+  it('does not let a live placeholder suppress an outstanding usable legacy read', async () => {
+    const legacy = Promise.withResolvers<{ data: { level: number }; error: null }>();
+    mocks.eq.mockResolvedValue({ data: [{ ...row(1), progress_data: {} }], error: null });
+    mocks.rpc.mockReturnValue(legacy.promise);
+    await addMember();
+    emitProgress({ ...row(1), progress_data: {} });
+    legacy.resolve({ data: { level: 37 }, error: null });
+    await flushPromises();
+    expect(flow.teammateStores.value.other?.$state.pvp.level).toBe(37);
+  });
   it('never uses persistent legacy fallback for a Seasonal teammate', async () => {
     mocks.eq.mockResolvedValue({
       data: [row(20, 'seasonal', ACTIVE_SEASON_NUMBER - 1)],

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -253,7 +253,7 @@ mockNuxtImport('useNuxtApp', () => () => ({
   $supabase: supabaseContext,
 }));
 vi.mock('@/composables/supabase/useSupabaseSync', () => ({
-  useSupabaseSync: () => useSupabaseSyncMock(),
+  useSupabaseSync: (options: unknown) => useSupabaseSyncMock(options),
 }));
 vi.mock('@/composables/useToastI18n', () => ({
   useToastI18n: () => ({
@@ -412,6 +412,73 @@ describe('useTarkov sync integration', () => {
     resetTarkovSync('test teardown');
     localStorage.clear();
   });
+  it.each(['', 'invalid-date'])(
+    'restores owned progress when server timestamps are unusable: %s',
+    async (updatedAt) => {
+      localStorage.setItem(
+        STORAGE_KEYS.progress,
+        JSON.stringify({
+          _timestamp: Date.now(),
+          _userId: 'user-1',
+          data: { ...structuredClone(defaultState), pvp: progressWithLevel(7) },
+        })
+      );
+      single.mockResolvedValue({ data: createRemoteRow({ updated_at: updatedAt }), error: null });
+      modeProgressResult.data = [
+        { game_mode: 'pvp', season_number: 0, progress_data: progressWithLevel(5) },
+        { game_mode: 'pve', season_number: 0, progress_data: progressWithLevel(1) },
+      ];
+      await initializeTarkovSync();
+      expect(useTarkovStore().pvp.level).toBe(7);
+    }
+  );
+  it('stops initialization after deferred legacy reads exhaust their retries', async () => {
+    single
+      .mockResolvedValueOnce({ data: createRemoteRow(), error: null })
+      .mockResolvedValue({ data: null, error: { message: 'legacy unavailable' } });
+    await expect(initializeTarkovSync()).rejects.toThrow('Supabase initial load failed');
+    expect(useSupabaseSyncMock).not.toHaveBeenCalled();
+  });
+  it('records the local sync timestamp only when the save callback succeeds', async () => {
+    await initializeTarkovSync();
+    const { getLastLocalSyncTime } = await import('@/stores/tarkov/syncTimeline');
+    const options = useSupabaseSyncMock.mock.calls.at(-1)?.[0] as { onSynced: () => void };
+    vi.spyOn(Date, 'now').mockReturnValue(123456789);
+    options.onSynced();
+    expect(getLastLocalSyncTime()).toBe(123456789);
+    vi.restoreAllMocks();
+  });
+  it.each(['success', 'error', 'throw', 'session-reset'])(
+    'tracks an in-flight RPC and removes failed or stale markers: %s',
+    async (outcome) => {
+      await initializeTarkovSync();
+      const timeline = await import('@/stores/tarkov/syncTimeline');
+      const options = useSupabaseSyncMock.mock.calls.at(-1)?.[0] as {
+        sync: (payload: Record<string, unknown>) => Promise<unknown>;
+      };
+      let resolve!: (value: { error: null | { message: string } }) => void;
+      let reject!: (error: Error) => void;
+      rpc.mockReturnValueOnce(
+        new Promise((res, rej) => {
+          resolve = res;
+          reject = rej;
+        })
+      );
+      const startedAt = Date.now();
+      const saving = options.sync({});
+      expect(timeline.isLikelySelfOriginUpdate(startedAt)).toBe(true);
+      expect(timeline.getLastLocalSyncTime()).toBe(0);
+      if (outcome === 'session-reset') timeline.resetSyncTimeline();
+      if (outcome === 'throw') {
+        reject(new Error('offline'));
+        await expect(saving).rejects.toThrow('offline');
+      } else {
+        resolve({ error: outcome === 'error' ? { message: 'denied' } : null });
+        await saving;
+      }
+      expect(timeline.isLikelySelfOriginUpdate(startedAt)).toBe(outcome === 'success');
+    }
+  );
   it('skips reinitialization when sync already exists for same user', async () => {
     await initializeTarkovSync();
     expect(useSupabaseSyncMock).toHaveBeenCalledTimes(1);

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -690,7 +690,7 @@ describe('useTarkov sync integration', () => {
     expect(cleanupSync).toHaveBeenCalledTimes(1);
     expect(useSupabaseSyncMock).toHaveBeenCalledTimes(1);
   });
-  it('shows other_account toast and clears mismatched local data', async () => {
+  it('shows other_account toast and replaces mismatched data with current-user progress', async () => {
     localStorage.setItem(
       STORAGE_KEYS.progress,
       JSON.stringify({

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -1,7 +1,9 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { createPinia, setActivePinia } from 'pinia';
+import piniaPluginPersistedstate from 'pinia-plugin-persistedstate';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createApp, nextTick } from 'vue';
 import { defaultState } from '@/stores/progressState';
 import {
   initializeTarkovSync,
@@ -419,6 +421,65 @@ describe('useTarkov sync integration', () => {
     resetTarkovSync('test teardown');
     localStorage.clear();
   });
+  it('persists remote freshness through the real Pinia persistence plugin', async () => {
+    const base = Date.parse('2026-09-06T12:00:00Z');
+    vi.spyOn(Date, 'now').mockReturnValue(base + 40_000);
+    const local = { ...structuredClone(defaultState), pvp: progressWithLevel(1) };
+    localStorage.setItem(
+      STORAGE_KEYS.progress,
+      JSON.stringify({
+        _userId: 'user-1',
+        _timestamp: base + 10_000,
+        data: local,
+      })
+    );
+    const pinia = createPinia().use(piniaPluginPersistedstate);
+    createApp({}).use(pinia);
+    setActivePinia(pinia);
+    single.mockResolvedValue({
+      data: createRemoteRow({ game_edition: 2, updated_at: new Date(base + 20_000).toISOString() }),
+      error: null,
+    });
+    modeProgressResult.data = [
+      {
+        game_mode: 'pvp',
+        season_number: 0,
+        progress_data: progressWithLevel(2),
+        progress_updated_at: new Date(base + 20_000).toISOString(),
+      },
+      {
+        game_mode: 'pve',
+        season_number: 0,
+        progress_data: progressWithLevel(1),
+        progress_updated_at: new Date(base + 10_000).toISOString(),
+      },
+    ];
+    await initializeTarkovSync();
+    await nextTick();
+    const read = () => JSON.parse(localStorage.getItem(STORAGE_KEYS.progress)!);
+    expect(read()._metadataTimestamp).toBe(base + 20_000);
+    expect(read()._modeTimestamps.pvp).toBe(base + 20_000);
+    getModeProgressCallback()?.({
+      old: null,
+      new: {
+        game_mode: 'pvp',
+        season_number: 0,
+        progress_data: progressWithLevel(3),
+        updated_at: new Date(base + 35_000).toISOString(),
+        progress_updated_at: new Date(base + 30_000).toISOString(),
+      },
+    });
+    await nextTick();
+    expect(read().data.pvp.level).toBe(3);
+    expect(read()._modeTimestamps.pvp).toBe(base + 30_000);
+    useTarkovStore().$patch((state) => {
+      state.pve.level = 4;
+    });
+    await nextTick();
+    expect(read()._modeTimestamps.pve).toBe(base + 40_000);
+    expect(read()._modeTimestamps.pvp).toBe(base + 30_000);
+    expect(read()._metadataTimestamp).toBe(base + 20_000);
+  });
   it.each(['', 'invalid-date'])(
     'restores owned progress when server timestamps are unusable: %s',
     async (updatedAt) => {
@@ -449,6 +510,7 @@ describe('useTarkov sync integration', () => {
       STORAGE_KEYS.progress,
       JSON.stringify({
         _timestamp: now - 1000,
+        _modeTimestamps: { pvp: now - 1000, pve: now - 5000, seasonal: now - 5000 },
         _userId: 'user-1',
         data: local,
       })
@@ -473,7 +535,7 @@ describe('useTarkov sync integration', () => {
         season_number: 0,
         updated_at: new Date(now + 2000).toISOString(),
         progress_updated_at: new Date(now - 2000).toISOString(),
-        progress_data: local.pve,
+        progress_data: { ...local.pve, level: 25 },
       },
       {
         game_mode: 'seasonal',
@@ -485,6 +547,7 @@ describe('useTarkov sync integration', () => {
     await initializeTarkovSync();
     expect(useTarkovStore().pvp.taskObjectives.objective?.count).toBe(0);
     expect(useTarkovStore().pvp.hideoutParts.part?.count).toBe(0);
+    expect(useTarkovStore().pve.level).toBe(25);
     expect(useTarkovStore().seasonal.level).toBe(55);
   });
   it('stops initialization after deferred legacy reads exhaust their retries', async () => {

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -1357,7 +1357,8 @@ describe('useTarkov sync integration', () => {
     await expect(initializeTarkovSync()).rejects.toThrow('Supabase initial load failed');
     expect(showLocalIgnored).toHaveBeenCalledTimes(1);
   });
-  it('retries a transient deferred legacy progress read', async () => {
+  it('retries a transient deferred legacy read for an empty normalized placeholder', async () => {
+    modeProgressResult.data = [{ game_mode: 'pvp', season_number: 0, progress_data: {} }];
     const row = createRemoteRow({ pvp_data: progressWithTaskState('legacy-task', true) });
     single
       .mockResolvedValueOnce({ data: row, error: null })

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -116,7 +116,13 @@ const {
     error: null,
   }));
   const modeProgressResult: {
-    data: Array<{ game_mode: string; progress_data: unknown; season_number: number }>;
+    data: Array<{
+      game_mode: string;
+      progress_data: unknown;
+      season_number: number;
+      updated_at?: string;
+      progress_updated_at?: string;
+    }>;
     error: SupabaseErrorLike;
     errorSequence?: SupabaseErrorLike[];
   } = { data: [], error: null };
@@ -409,6 +415,7 @@ describe('useTarkov sync integration', () => {
     });
   });
   afterEach(() => {
+    vi.restoreAllMocks();
     resetTarkovSync('test teardown');
     localStorage.clear();
   });
@@ -432,6 +439,54 @@ describe('useTarkov sync integration', () => {
       expect(useTarkovStore().pvp.level).toBe(7);
     }
   );
+  it('keeps mode freshness independent of other modes and visibility-only timestamps', async () => {
+    const now = Date.now();
+    const local = structuredClone(defaultState);
+    local.pvp.level = 7;
+    local.pvp.taskObjectives.objective = { count: 0 };
+    local.pvp.hideoutParts.part = { count: 0 };
+    localStorage.setItem(
+      STORAGE_KEYS.progress,
+      JSON.stringify({
+        _timestamp: now - 1000,
+        _userId: 'user-1',
+        data: local,
+      })
+    );
+    single.mockResolvedValue({
+      data: createRemoteRow({ updated_at: new Date(now - 5000).toISOString() }),
+      error: null,
+    });
+    modeProgressResult.data = [
+      {
+        game_mode: 'pvp',
+        season_number: 0,
+        progress_updated_at: new Date(now - 2000).toISOString(),
+        progress_data: {
+          ...local.pvp,
+          taskObjectives: { objective: { count: 5 } },
+          hideoutParts: { part: { count: 5 } },
+        },
+      },
+      {
+        game_mode: 'pve',
+        season_number: 0,
+        updated_at: new Date(now + 2000).toISOString(),
+        progress_updated_at: new Date(now - 2000).toISOString(),
+        progress_data: local.pve,
+      },
+      {
+        game_mode: 'seasonal',
+        season_number: ACTIVE_SEASON_NUMBER,
+        progress_updated_at: new Date(now).toISOString(),
+        progress_data: { ...local.seasonal, level: 55 },
+      },
+    ];
+    await initializeTarkovSync();
+    expect(useTarkovStore().pvp.taskObjectives.objective?.count).toBe(0);
+    expect(useTarkovStore().pvp.hideoutParts.part?.count).toBe(0);
+    expect(useTarkovStore().seasonal.level).toBe(55);
+  });
   it('stops initialization after deferred legacy reads exhaust their retries', async () => {
     single
       .mockResolvedValueOnce({ data: createRemoteRow(), error: null })
@@ -446,7 +501,6 @@ describe('useTarkov sync integration', () => {
     vi.spyOn(Date, 'now').mockReturnValue(123456789);
     options.onSynced();
     expect(getLastLocalSyncTime()).toBe(123456789);
-    vi.restoreAllMocks();
   });
   it.each(['success', 'error', 'throw', 'session-reset'])(
     'tracks an in-flight RPC and removes failed or stale markers: %s',

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -1361,7 +1361,7 @@ describe('useTarkov sync integration', () => {
     modeProgressResult.data = [{ game_mode: 'pvp', season_number: 0, progress_data: {} }];
     const row = createRemoteRow({ pvp_data: progressWithTaskState('legacy-task', true) });
     single
-      .mockResolvedValueOnce({ data: row, error: null })
+      .mockResolvedValueOnce({ data: { ...row, pvp_data: null, pve_data: null }, error: null })
       .mockResolvedValueOnce({ data: null, error: { message: 'temporary' } })
       .mockResolvedValue({ data: row, error: null });
     await initializeTarkovSync();

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -123,7 +123,7 @@ const {
       progress_data: unknown;
       season_number: number;
       updated_at?: string;
-      progress_updated_at?: string;
+      progress_updated_at?: string | null;
     }>;
     error: SupabaseErrorLike;
     errorSequence?: SupabaseErrorLike[];
@@ -421,6 +421,60 @@ describe('useTarkov sync integration', () => {
     resetTarkovSync('test teardown');
     localStorage.clear();
   });
+  it('keeps offline Seasonal edits when historical mode freshness is unknown and metadata is newer', async () => {
+    const base = Date.parse('2026-09-06T12:00:00Z');
+    const local = structuredClone(defaultState);
+    local.currentGameMode = 'seasonal';
+    local.seasonal.displayName = 'offline edit';
+    local.seasonal.level = 12;
+    local.seasonal.taskObjectives['objective-1'] = {
+      complete: false,
+      count: 4,
+      timestamp: base + 20_000,
+    };
+    localStorage.setItem(
+      STORAGE_KEYS.progress,
+      JSON.stringify({
+        _userId: 'user-1',
+        _timestamp: base + 20_000,
+        _metadataTimestamp: base + 10_000,
+        _modeTimestamps: { pvp: base + 10_000, pve: base + 10_000, seasonal: base + 20_000 },
+        data: local,
+      })
+    );
+    single.mockResolvedValue({
+      data: createRemoteRow({
+        current_game_mode: 'pve',
+        game_edition: 3,
+        updated_at: new Date(base + 30_000).toISOString(),
+      }),
+      error: null,
+    });
+    modeProgressResult.data = [
+      {
+        game_mode: 'seasonal',
+        season_number: ACTIVE_SEASON_NUMBER,
+        progress_data: {
+          ...progressWithLevel(2),
+          displayName: 'historical',
+          taskObjectives: { 'objective-1': { complete: false, count: 1 } },
+        },
+        progress_updated_at: null,
+      },
+    ];
+    await initializeTarkovSync();
+    const store = useTarkovStore();
+    expect(store.currentGameMode).toBe('pve');
+    expect(store.gameEdition).toBe(3);
+    expect(store.seasonal.displayName).toBe('offline edit');
+    expect(store.seasonal.level).toBe(12);
+    expect(store.seasonal.taskObjectives['objective-1']?.count).toBe(4);
+    expect(getLastSyncPayload()?.p_modes).toEqual(
+      expect.objectContaining({
+        seasonal: expect.objectContaining({ displayName: 'offline edit', level: 12 }),
+      })
+    );
+  });
   it('persists remote freshness through the real Pinia persistence plugin', async () => {
     const base = Date.parse('2026-09-06T12:00:00Z');
     vi.spyOn(Date, 'now').mockReturnValue(base + 40_000);
@@ -479,6 +533,28 @@ describe('useTarkov sync integration', () => {
     expect(read()._modeTimestamps.pve).toBe(base + 40_000);
     expect(read()._modeTimestamps.pvp).toBe(base + 30_000);
     expect(read()._metadataTimestamp).toBe(base + 20_000);
+    // A matching echo needs no Pinia patch, but must persist its server clock.
+    getModeProgressCallback()?.({
+      old: null,
+      new: {
+        game_mode: 'pve',
+        season_number: 0,
+        progress_data: progressWithLevel(4),
+        updated_at: new Date(base + 35_000).toISOString(),
+        progress_updated_at: new Date(base + 35_000).toISOString(),
+      },
+    });
+    await nextTick();
+    expect(read()._modeTimestamps.pve).toBe(base + 35_000);
+    useTarkovStore().$patch({ gameEdition: 3 });
+    await nextTick();
+    expect(read()._metadataTimestamp).toBe(base + 40_000);
+    getRealtimeCallback()?.({
+      old: null,
+      new: createRemoteRow({ game_edition: 3, updated_at: new Date(base + 36_000).toISOString() }),
+    });
+    await nextTick();
+    expect(read()._metadataTimestamp).toBe(base + 36_000);
   });
   it.each(['', 'invalid-date'])(
     'restores owned progress when server timestamps are unusable: %s',
@@ -620,12 +696,15 @@ describe('useTarkov sync integration', () => {
       JSON.stringify({
         _timestamp: Date.now(),
         _userId: 'other-user',
-        data: useTarkovStore().$state,
+        data: { ...structuredClone(defaultState), pvp: progressWithLevel(47) },
       })
     );
     await initializeTarkovSync();
     expect(showLocalIgnored).toHaveBeenCalledWith('other_account');
-    expect(localStorage.getItem(STORAGE_KEYS.progress)).toBeNull();
+    expect(JSON.parse(localStorage.getItem(STORAGE_KEYS.progress)!)).toMatchObject({
+      _userId: 'user-1',
+      data: { pvp: { level: 1 } },
+    });
   });
   it('keeps scoped local progress hidden until the matching user session is hydrated', async () => {
     supabaseContext.user.loggedIn = false;
@@ -1630,6 +1709,7 @@ describe('useTarkov sync integration', () => {
     callback?.({
       new: {
         ...payload,
+        progress_data: { ...payload.progress_data, level: 2 },
         updated_at: new Date(now + 2000).toISOString(),
       },
       old: {},

--- a/app/stores/__tests__/useTarkov.sync.integration.test.ts
+++ b/app/stores/__tests__/useTarkov.sync.integration.test.ts
@@ -1357,6 +1357,16 @@ describe('useTarkov sync integration', () => {
     await expect(initializeTarkovSync()).rejects.toThrow('Supabase initial load failed');
     expect(showLocalIgnored).toHaveBeenCalledTimes(1);
   });
+  it('retries a transient deferred legacy progress read', async () => {
+    const row = createRemoteRow({ pvp_data: progressWithTaskState('legacy-task', true) });
+    single
+      .mockResolvedValueOnce({ data: row, error: null })
+      .mockResolvedValueOnce({ data: null, error: { message: 'temporary' } })
+      .mockResolvedValue({ data: row, error: null });
+    await initializeTarkovSync();
+    expect(single.mock.calls.length).toBeGreaterThanOrEqual(3);
+    expect(useTarkovStore().pvp.taskCompletions['legacy-task']?.complete).toBe(true);
+  });
   it('deduplicates repeated API update toast payloads by update id', async () => {
     const now = Date.now();
     single.mockResolvedValue({

--- a/app/stores/__tests__/useTeamStore.test.ts
+++ b/app/stores/__tests__/useTeamStore.test.ts
@@ -1,5 +1,6 @@
 import { createPinia, setActivePinia } from 'pinia';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useSystemStore, useSystemStoreWithSupabase } from '@/stores/useSystemStore';
 import {
   applyLegacyPersistentProgressResult,
   applyTeammateProgressEvent,
@@ -691,6 +692,23 @@ describe('Team realtime resources', () => {
   const buildRealtimeHarness = () => {
     const currentUserId = '11111111-1111-4111-8111-111111111111';
     const teammateId = '22222222-2222-4222-8222-222222222222';
+    useSystemStore().$reset();
+    useSystemStore().$patch((state) => {
+      state.pvp_team_id = 'team-1';
+    });
+    useTeamStore().$reset();
+    useTeamStore().$patch((state) => {
+      state.members = [currentUserId, teammateId];
+      state.memberProfiles = {
+        [teammateId]: {
+          displayName: 'Teammate',
+          gameEdition: 4,
+          gameMode: GAME_MODES.PVP,
+          level: 10,
+          tasksCompleted: 2,
+        },
+      };
+    });
     const records: ChannelRecord[] = [];
     const createRecord = (topic: string, config?: unknown): ChannelRecord => {
       const record: ChannelRecord = {
@@ -758,6 +776,7 @@ describe('Team realtime resources', () => {
     nuxtApp.$supabase.client = client;
     nuxtApp.$supabase.ready = vi.fn().mockResolvedValue(null);
     nuxtApp.$supabase.user = { id: currentUserId, loggedIn: true };
+    mockGetTeamMembers.mockReset();
     mockGetTeamMembers.mockResolvedValue({
       members: [currentUserId, teammateId],
       profiles: {
@@ -777,6 +796,7 @@ describe('Team realtime resources', () => {
       isSubscribed: { value: false },
       loadError: { value: null },
     }));
+    useSystemStoreWithSupabase().cleanup();
     const teamRecords = () => records.filter((record) => record.topic.startsWith('team:'));
     return { client, currentUserId, teamRecords, teammateId };
   };
@@ -785,6 +805,108 @@ describe('Team realtime resources', () => {
     if (!record) throw new Error('team channel was never created');
     return record;
   };
+  const deliverTeamSnapshot = () => {
+    const options = mockUseSupabaseListener.mock.calls.find(
+      ([config]) => config.table === 'teams'
+    )?.[0];
+    if (!options) throw new Error('Missing team listener');
+    options.onData({ id: 'team-1' });
+  };
+  it('ignores snapshot refreshes when logged out, throttled, or no longer in a team', async () => {
+    const { teamRecords } = buildRealtimeHarness();
+    const instance = useTeamStoreWithSupabase();
+    try {
+      await vi.waitFor(() => expect(teamRecords()).toHaveLength(1));
+      const calls = mockGetTeamMembers.mock.calls.length;
+      deliverTeamSnapshot();
+      await Promise.resolve();
+      expect(mockGetTeamMembers).toHaveBeenCalledTimes(calls);
+      const app = useNuxtApp();
+      app.$supabase.user.loggedIn = false;
+      deliverTeamSnapshot();
+      expect(instance.teamStore.members).toEqual([]);
+      app.$supabase.user.loggedIn = true;
+      useSystemStore().$patch((state) => {
+        state.pvp_team_id = null;
+      });
+      // Make the explicit refresh eligible despite the recent successful read.
+      vi.spyOn(Date, 'now').mockReturnValue(Date.now() + 3000);
+      deliverTeamSnapshot();
+      await Promise.resolve();
+      expect(instance.teamStore.memberProfiles).toEqual({});
+      expect(mockGetTeamMembers).toHaveBeenCalledTimes(calls);
+    } finally {
+      vi.restoreAllMocks();
+      instance.cleanup();
+    }
+  });
+  it.each(['success', 'forbidden', 'unavailable'])(
+    'coalesces member reads and handles %s for every waiter',
+    async (outcome) => {
+      const { teamRecords, currentUserId } = buildRealtimeHarness();
+      const instance = useTeamStoreWithSupabase();
+      let resolve!: (value: unknown) => void;
+      let reject!: (error: unknown) => void;
+      try {
+        await vi.waitFor(() => expect(teamRecords()).toHaveLength(1));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        mockGetTeamMembers.mockReturnValueOnce(
+          new Promise((yes, no) => {
+            resolve = yes;
+            reject = no;
+          })
+        );
+        const calls = mockGetTeamMembers.mock.calls.length;
+        firstTeamRecord(teamRecords).statusCallbacks[0]?.('SUBSCRIBED');
+        await vi.waitFor(() => expect(mockGetTeamMembers).toHaveBeenCalledTimes(calls + 1));
+        deliverTeamSnapshot();
+        if (outcome === 'success') resolve({ members: [currentUserId], profiles: {} });
+        else reject({ statusCode: outcome === 'forbidden' ? 403 : 500 });
+        await new Promise((finish) => setTimeout(finish, 0));
+        expect(mockGetTeamMembers).toHaveBeenCalledTimes(calls + 1);
+        if (outcome === 'success') expect(instance.teamStore.members).toEqual([currentUserId]);
+        else expect(instance.teamStore.members).toHaveLength(2);
+      } finally {
+        instance.cleanup();
+      }
+    }
+  );
+  it.each(['switch', 'leave'])(
+    'does not apply a completed member read after a team %s',
+    async (change) => {
+      const { teamRecords, currentUserId } = buildRealtimeHarness();
+      const instance = useTeamStoreWithSupabase();
+      let finish!: (value: unknown) => void;
+      try {
+        await vi.waitFor(() => expect(teamRecords()).toHaveLength(1));
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        mockGetTeamMembers.mockReturnValueOnce(
+          new Promise((resolve) => {
+            finish = resolve;
+          })
+        );
+        const calls = mockGetTeamMembers.mock.calls.length;
+        firstTeamRecord(teamRecords).statusCallbacks[0]?.('SUBSCRIBED');
+        await vi.waitFor(() => expect(mockGetTeamMembers).toHaveBeenCalledTimes(calls + 1));
+        mockGetTeamMembers.mockResolvedValue({ members: [currentUserId], profiles: {} });
+        useSystemStore().$patch((state) => {
+          state.pvp_team_id = change === 'switch' ? 'team-2' : null;
+          state.team = null;
+          state.team_id = null;
+        });
+        if (change === 'switch') {
+          await vi.waitFor(() =>
+            expect(mockGetTeamMembers).toHaveBeenLastCalledWith('team-2', true)
+          );
+        }
+        finish({ members: ['stale-member'], profiles: {} });
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        expect(instance.teamStore.members).not.toContain('stale-member');
+      } finally {
+        instance.cleanup();
+      }
+    }
+  );
   it('filters teammate progress and cleans up scoped subscriptions', async () => {
     const { client, currentUserId, teamRecords, teammateId } = buildRealtimeHarness();
     const instance = useTeamStoreWithSupabase();

--- a/app/stores/__tests__/useTeamStore.test.ts
+++ b/app/stores/__tests__/useTeamStore.test.ts
@@ -827,6 +827,33 @@ describe('Team realtime resources', () => {
     // assertion does not depend on `$supabase.client` still being this mock.
     expect(client.removeChannel).toHaveBeenCalledWith(firstTeamRecord(teamRecords).channel);
   });
+  it('hydrates only on rejoin and rebuilds changed member filters before hydration', async () => {
+    const { teamRecords, currentUserId, teammateId } = buildRealtimeHarness();
+    const hydrated = vi.fn();
+    window.addEventListener('teammate-progress-reconnected', hydrated);
+    const instance = useTeamStoreWithSupabase();
+    try {
+      await vi.waitFor(() => expect(teamRecords()).toHaveLength(1));
+      expect(hydrated).not.toHaveBeenCalled();
+      mockGetTeamMembers.mockResolvedValue({
+        members: [currentUserId, teammateId, '44444444-4444-4444-8444-444444444444'],
+        profiles: {},
+      });
+      firstTeamRecord(teamRecords).statusCallbacks[0]?.('SUBSCRIBED');
+      await vi.waitFor(() => expect(teamRecords()).toHaveLength(2));
+      expect(hydrated).toHaveBeenCalledOnce();
+      expect(
+        teamRecords()[1]?.handlers.some(
+          ({ config }) =>
+            config.table === 'user_game_mode_progress' &&
+            JSON.stringify(config).includes('44444444')
+        )
+      ).toBe(true);
+    } finally {
+      window.removeEventListener('teammate-progress-reconnected', hydrated);
+      instance.cleanup();
+    }
+  });
   it('does not rejoin the team channel when the member set is unchanged', async () => {
     const { client, teamRecords } = buildRealtimeHarness();
     const instance = useTeamStoreWithSupabase();

--- a/app/stores/__tests__/useTeamStore.test.ts
+++ b/app/stores/__tests__/useTeamStore.test.ts
@@ -827,6 +827,23 @@ describe('Team realtime resources', () => {
     // assertion does not depend on `$supabase.client` still being this mock.
     expect(client.removeChannel).toHaveBeenCalledWith(firstTeamRecord(teamRecords).channel);
   });
+  it('does not hydrate or rebuild after a rejected member refresh', async () => {
+    const { teamRecords } = buildRealtimeHarness();
+    const hydrated = vi.fn();
+    window.addEventListener('teammate-progress-reconnected', hydrated);
+    const instance = useTeamStoreWithSupabase();
+    try {
+      await vi.waitFor(() => expect(teamRecords()).toHaveLength(1));
+      mockGetTeamMembers.mockRejectedValueOnce(new Error('members unavailable'));
+      firstTeamRecord(teamRecords).statusCallbacks[0]?.('SUBSCRIBED');
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(hydrated).not.toHaveBeenCalled();
+      expect(teamRecords()).toHaveLength(1);
+    } finally {
+      window.removeEventListener('teammate-progress-reconnected', hydrated);
+      instance.cleanup();
+    }
+  });
   it('hydrates only on rejoin and rebuilds changed member filters before hydration', async () => {
     const { teamRecords, currentUserId, teammateId } = buildRealtimeHarness();
     const hydrated = vi.fn();

--- a/app/stores/tarkov/localStorage.ts
+++ b/app/stores/tarkov/localStorage.ts
@@ -1,5 +1,7 @@
 import { migrateToGameModeStructure, type UserState } from '@/stores/progressState';
+import { deepEqual } from '@/stores/tarkov/deepEqual';
 import { clearProgressStorage } from '@/utils/clientStorage';
+import { GAME_MODE_VALUES, type GameMode } from '@/utils/constants';
 import { logger } from '@/utils/logger';
 import {
   hasDeprecatedTarkovDevProfileData,
@@ -12,6 +14,118 @@ export type PersistedProgressSnapshot = {
   state: UserState;
   storedUserId: string | null;
   timestamp: number | null;
+  metadataTimestamp?: number;
+  modeTimestamps?: Partial<Record<GameMode, number>>;
+};
+const metadataKeys = ['currentGameMode', 'gameEdition', 'tarkovUid'] as const;
+const sameMetadata = (left: Partial<UserState>, right: Partial<UserState>) =>
+  metadataKeys.every((key) => deepEqual(left[key], right[key]));
+type RemoteProgressSnapshot = {
+  state: UserState;
+  userId: string;
+  remote: Partial<UserState>;
+  next: Partial<UserState>;
+  updatedAtByMode: Partial<Record<GameMode, number>>;
+  metadataTimestamp?: number;
+};
+const retainedModeTimestamp = (previous: PersistedProgressSnapshot, mode: GameMode): number =>
+  previous.modeTimestamps?.[mode] ?? previous.timestamp ?? 0;
+const nextModeTimestamp = (
+  previous: PersistedProgressSnapshot | null,
+  state: UserState,
+  mode: GameMode,
+  timestamp: number
+): number => {
+  if (!previous || !deepEqual(previous.state[mode], state[mode])) return timestamp;
+  return retainedModeTimestamp(previous, mode);
+};
+const retainedMetadataTimestamp = (previous: PersistedProgressSnapshot): number =>
+  previous.metadataTimestamp ?? previous.timestamp ?? 0;
+const nextMetadataTimestamp = (
+  previous: PersistedProgressSnapshot | null,
+  state: UserState,
+  timestamp: number
+): number => {
+  if (!previous || !sameMetadata(previous.state, state)) return timestamp;
+  return retainedMetadataTimestamp(previous);
+};
+const acceptedRemoteTimestamp = (
+  matchesRemote: boolean,
+  localTimestamp = 0,
+  remoteTimestamp = 0
+): number => Math.max(matchesRemote ? 0 : localTimestamp, remoteTimestamp);
+const acceptRemoteMetadata = (
+  accepted: PersistedProgressSnapshot,
+  snapshot: RemoteProgressSnapshot
+): void => {
+  if (snapshot.metadataTimestamp === undefined) return;
+  accepted.metadataTimestamp = acceptedRemoteTimestamp(
+    sameMetadata(snapshot.next, snapshot.remote),
+    accepted.metadataTimestamp,
+    snapshot.metadataTimestamp
+  );
+  const presentKeys = metadataKeys.filter((key) => Object.hasOwn(snapshot.next, key));
+  Object.assign(
+    accepted.state,
+    Object.fromEntries(presentKeys.map((key) => [key, snapshot.next[key]]))
+  );
+};
+const acceptRemoteMode = (
+  accepted: PersistedProgressSnapshot,
+  snapshot: RemoteProgressSnapshot,
+  mode: GameMode
+): void => {
+  const next = snapshot.next[mode];
+  const remote = snapshot.remote[mode];
+  if (!next || !remote) return;
+  accepted.modeTimestamps![mode] = acceptedRemoteTimestamp(
+    deepEqual(next, remote),
+    accepted.modeTimestamps![mode],
+    snapshot.updatedAtByMode[mode]
+  );
+  accepted.state[mode] = cloneStateSnapshot(next);
+};
+export const createProgressStorageSerializer = (
+  readPrevious: (userId: string | null) => PersistedProgressSnapshot | null
+) => {
+  let previous: PersistedProgressSnapshot | null = null;
+  const serialize = (state: UserState, userId: string | null, timestamp: number): string => {
+    if (!previous || previous.storedUserId !== userId) previous = readPrevious(userId);
+    const modeTimestamps = Object.fromEntries(
+      GAME_MODE_VALUES.map((mode) => [mode, nextModeTimestamp(previous, state, mode, timestamp)])
+    );
+    const metadataTimestamp = nextMetadataTimestamp(previous, state, timestamp);
+    previous = {
+      metadataTimestamp,
+      state: cloneStateSnapshot(state),
+      storedUserId: userId,
+      timestamp,
+      modeTimestamps,
+      hadDeprecatedProgressData: false,
+    };
+    return JSON.stringify({
+      _timestamp: timestamp,
+      _metadataTimestamp: metadataTimestamp,
+      _modeTimestamps: modeTimestamps,
+      _userId: userId,
+      data: state,
+    });
+  };
+  return {
+    reset: (snapshot: PersistedProgressSnapshot | null = null) => {
+      previous = snapshot ? cloneStateSnapshot(snapshot) : null;
+    },
+    serialize,
+    acceptRemote: (snapshot: RemoteProgressSnapshot) => {
+      // Capture any local edits before replacing the baseline. Pinia persistence
+      // can run after a synchronous remote patch, so comparing only in serialize
+      // would incorrectly timestamp downloaded progress as a new local edit.
+      serialize(snapshot.state, snapshot.userId, Date.now());
+      const accepted = previous!;
+      acceptRemoteMetadata(accepted, snapshot);
+      GAME_MODE_VALUES.forEach((mode) => acceptRemoteMode(accepted, snapshot, mode));
+    },
+  };
 };
 export const cloneStateSnapshot = <T>(value: T): T => {
   const rawValue = value !== null && typeof value === 'object' ? toRaw(value) : value;
@@ -88,6 +202,8 @@ const parsePersistedProgressState = (
       state: sanitizeOwnedUserState(migrateToGameModeStructure(wrapped.data)),
       storedUserId: wrapped._userId,
       timestamp: wrapped._timestamp ?? null,
+      metadataTimestamp: wrapped._metadataTimestamp,
+      modeTimestamps: wrapped._modeTimestamps,
     };
   }
   try {
@@ -131,3 +247,6 @@ export const patchStoreState = (
     state.seasonal = sanitizedSnapshot.seasonal;
   });
 };
+export const progressStorageSerializer = createProgressStorageSerializer(
+  readPersistedProgressState
+);

--- a/app/stores/tarkov/localStorage.ts
+++ b/app/stores/tarkov/localStorage.ts
@@ -41,6 +41,16 @@ const nextModeTimestamp = (
 };
 const retainedMetadataTimestamp = (previous: PersistedProgressSnapshot): number =>
   previous.metadataTimestamp ?? previous.timestamp ?? 0;
+const matchesPersistedSnapshot = (
+  current: PersistedProgressSnapshot | null,
+  expected: PersistedProgressSnapshot
+): boolean =>
+  !current ||
+  (deepEqual(current.state, expected.state) &&
+    retainedMetadataTimestamp(current) === retainedMetadataTimestamp(expected) &&
+    GAME_MODE_VALUES.every(
+      (mode) => retainedModeTimestamp(current, mode) === retainedModeTimestamp(expected, mode)
+    ));
 const nextMetadataTimestamp = (
   previous: PersistedProgressSnapshot | null,
   state: UserState,
@@ -123,11 +133,16 @@ export const createProgressStorageSerializer = (
       // would incorrectly timestamp downloaded progress as a new local edit.
       serialize(snapshot.state, snapshot.userId, Date.now());
       const accepted = previous!;
+      const canPersist = matchesPersistedSnapshot(readPrevious(snapshot.userId), accepted);
       acceptRemoteMetadata(accepted, snapshot);
       GAME_MODE_VALUES.forEach((mode) => acceptRemoteMode(accepted, snapshot, mode));
       // Matching echoes may require no Pinia patch. Persist the accepted clocks
       // now so a reload cannot restore an obsolete client-side edit timestamp.
-      persistAccepted?.(serialize(accepted.state, snapshot.userId, accepted.timestamp ?? 0));
+      // Another tab may have persisted an unsaved edit since our last write.
+      // A clock-only acknowledgement must not overwrite that shared envelope.
+      if (canPersist) {
+        persistAccepted?.(serialize(accepted.state, snapshot.userId, accepted.timestamp ?? 0));
+      }
     },
   };
 };

--- a/app/stores/tarkov/localStorage.ts
+++ b/app/stores/tarkov/localStorage.ts
@@ -86,7 +86,8 @@ const acceptRemoteMode = (
   accepted.state[mode] = cloneStateSnapshot(next);
 };
 export const createProgressStorageSerializer = (
-  readPrevious: (userId: string | null) => PersistedProgressSnapshot | null
+  readPrevious: (userId: string | null) => PersistedProgressSnapshot | null,
+  persistAccepted?: (value: string) => void
 ) => {
   let previous: PersistedProgressSnapshot | null = null;
   const serialize = (state: UserState, userId: string | null, timestamp: number): string => {
@@ -124,6 +125,9 @@ export const createProgressStorageSerializer = (
       const accepted = previous!;
       acceptRemoteMetadata(accepted, snapshot);
       GAME_MODE_VALUES.forEach((mode) => acceptRemoteMode(accepted, snapshot, mode));
+      // Matching echoes may require no Pinia patch. Persist the accepted clocks
+      // now so a reload cannot restore an obsolete client-side edit timestamp.
+      persistAccepted?.(serialize(accepted.state, snapshot.userId, accepted.timestamp ?? 0));
     },
   };
 };
@@ -248,5 +252,8 @@ export const patchStoreState = (
   });
 };
 export const progressStorageSerializer = createProgressStorageSerializer(
-  readPersistedProgressState
+  readPersistedProgressState,
+  (value) => {
+    safeSetItem(STORAGE_KEYS.progress, value);
+  }
 );

--- a/app/stores/tarkov/localStorage.ts
+++ b/app/stores/tarkov/localStorage.ts
@@ -53,7 +53,7 @@ const acceptedRemoteTimestamp = (
   matchesRemote: boolean,
   localTimestamp = 0,
   remoteTimestamp = 0
-): number => Math.max(matchesRemote ? 0 : localTimestamp, remoteTimestamp);
+): number => (matchesRemote ? remoteTimestamp : Math.max(localTimestamp, remoteTimestamp + 1));
 const acceptRemoteMetadata = (
   accepted: PersistedProgressSnapshot,
   snapshot: RemoteProgressSnapshot

--- a/app/stores/tarkov/localStorage.ts
+++ b/app/stores/tarkov/localStorage.ts
@@ -90,7 +90,7 @@ export const createProgressStorageSerializer = (
 ) => {
   let previous: PersistedProgressSnapshot | null = null;
   const serialize = (state: UserState, userId: string | null, timestamp: number): string => {
-    if (!previous || previous.storedUserId !== userId) previous = readPrevious(userId);
+    if (previous?.storedUserId !== userId) previous = readPrevious(userId);
     const modeTimestamps = Object.fromEntries(
       GAME_MODE_VALUES.map((mode) => [mode, nextModeTimestamp(previous, state, mode, timestamp)])
     );

--- a/app/stores/tarkov/progressMerge.ts
+++ b/app/stores/tarkov/progressMerge.ts
@@ -166,7 +166,8 @@ const mergeHideoutModules = (
 };
 const mergeCountableObjects = <T extends Record<string, CountableEntry>>(
   local: T | undefined,
-  remote: T | undefined
+  remote: T | undefined,
+  preferNewerCount = false
 ): T => {
   const merged = { ...local, ...remote } as T;
   for (const id of Object.keys(merged)) {
@@ -181,7 +182,9 @@ const mergeCountableObjects = <T extends Record<string, CountableEntry>>(
       const olderHasComplete = typeof older.complete === 'boolean';
       merged[id as keyof T] = {
         complete: newerHasComplete ? newer.complete : olderHasComplete ? older.complete : false,
-        count: Math.max(l.count || 0, r.count || 0),
+        count: preferNewerCount
+          ? (newer.count ?? older.count ?? 0)
+          : Math.max(l.count || 0, r.count || 0),
         timestamp: Math.max(localTs, remoteTs) || undefined,
       } as T[keyof T];
     }
@@ -288,7 +291,8 @@ const mergeApiUpdateHistory = (
 };
 export function mergeProgressData(
   local: UserProgressData | undefined,
-  remote: UserProgressData | undefined
+  remote: UserProgressData | undefined,
+  preferNewerCount = false
 ): UserProgressData {
   if (!local && !remote) return {} as UserProgressData;
   if (!local) return structuredClone(remote!);
@@ -374,9 +378,13 @@ export function mergeProgressData(
       }
       return merged;
     })(),
-    taskObjectives: mergeCountableObjects(local.taskObjectives, remote.taskObjectives),
+    taskObjectives: mergeCountableObjects(
+      local.taskObjectives,
+      remote.taskObjectives,
+      preferNewerCount
+    ),
     hideoutModules: mergeHideoutModules(local.hideoutModules, remote.hideoutModules),
-    hideoutParts: mergeCountableObjects(local.hideoutParts, remote.hideoutParts),
+    hideoutParts: mergeCountableObjects(local.hideoutParts, remote.hideoutParts, preferNewerCount),
     storyChapters: mergeStoryChapterProgress(local.storyChapters, remote.storyChapters),
     traders: {
       ...local.traders,

--- a/app/stores/tarkov/progressPersistence.ts
+++ b/app/stores/tarkov/progressPersistence.ts
@@ -20,6 +20,7 @@ type ModeProgressRow = {
   game_mode: string;
   progress_data: unknown;
   season_number: number;
+  updated_at?: string;
 };
 type ModeProgressQuery = PromiseLike<{
   data: ModeProgressRow[] | null;
@@ -92,12 +93,13 @@ export const loadModeProgress = async (
   userId: string
 ): Promise<{
   data: Partial<Record<GameMode, UserProgressData>>;
+  updatedAt?: number;
   error: SupabaseError | null;
 }> => {
   try {
     const { data: rows, error } = await client
       .from('user_game_mode_progress')
-      .select('game_mode,season_number,progress_data')
+      .select('game_mode,season_number,progress_data,updated_at')
       .eq('user_id', userId)
       .in('game_mode', GAME_MODE_VALUES)
       .in('season_number', [0, ACTIVE_SEASON_NUMBER]);
@@ -107,7 +109,15 @@ export const loadModeProgress = async (
       return activeProgress ? [[activeProgress.mode, activeProgress.progress] as const] : [];
     });
     const data = Object.fromEntries(entries) as Partial<Record<GameMode, UserProgressData>>;
-    return { data, error: null };
+    const timestamps = (rows ?? [])
+      .filter((row) => getActiveModeProgress(row) !== null)
+      .map((row) => Date.parse(row.updated_at ?? ''))
+      .filter(Number.isFinite);
+    return {
+      data,
+      error: null,
+      updatedAt: timestamps.length > 0 ? Math.max(...timestamps) : undefined,
+    };
   } catch (error) {
     const normalizedError = normalizePersistenceError(error);
     logger.error(

--- a/app/stores/tarkov/progressPersistence.ts
+++ b/app/stores/tarkov/progressPersistence.ts
@@ -8,6 +8,7 @@ import {
   type GameMode,
 } from '@/utils/constants';
 import { logger } from '@/utils/logger';
+import { hasMaterializedProgress } from '@/utils/modeProgressFallback';
 import type { UserProgressData, UserState } from '@/stores/progressState';
 type SupabaseError = { code?: string; message: string };
 export type ProgressRpcClient = {
@@ -54,6 +55,7 @@ const getActiveModeProgress = (
 ): { mode: GameMode; progress: UserProgressData } | null => {
   if (!isGameMode(row.game_mode)) return null;
   if (row.season_number !== getGameModeSeasonNumber(row.game_mode)) return null;
+  if (!hasMaterializedProgress(row.progress_data)) return null;
   return { mode: row.game_mode, progress: row.progress_data as UserProgressData };
 };
 const normalizePersistenceError = (error: unknown): SupabaseError => ({

--- a/app/stores/tarkov/progressPersistence.ts
+++ b/app/stores/tarkov/progressPersistence.ts
@@ -40,6 +40,20 @@ export type ModeProgressClient = {
     };
   };
 };
+const isMissingProgressFreshness = (error: SupabaseError | null): boolean =>
+  error !== null &&
+  ['42703', 'PGRST204'].includes(error.code ?? '') &&
+  /\bprogress_updated_at\b/.test(error.message);
+/** Retry only the additive freshness column; all other read failures stay visible. */
+export const readWithProgressFreshness = async <T extends { error: SupabaseError | null }>(
+  read: (includeFreshness: boolean) => PromiseLike<T>
+): Promise<T> => {
+  const result = await read(true);
+  if (isMissingProgressFreshness(result.error)) {
+    return await read(false);
+  }
+  return result;
+};
 const getPersistenceErrorCode = (error: unknown): string | undefined => {
   try {
     const code = (error as { code?: unknown }).code;
@@ -101,12 +115,18 @@ export const loadModeProgress = async (
   error: SupabaseError | null;
 }> => {
   try {
-    const { data: rows, error } = await client
-      .from('user_game_mode_progress')
-      .select('game_mode,season_number,progress_data,progress_updated_at')
-      .eq('user_id', userId)
-      .in('game_mode', GAME_MODE_VALUES)
-      .in('season_number', [0, ACTIVE_SEASON_NUMBER]);
+    const { data: rows, error } = await readWithProgressFreshness((includeFreshness) =>
+      client
+        .from('user_game_mode_progress')
+        .select(
+          includeFreshness
+            ? 'game_mode,season_number,progress_data,progress_updated_at'
+            : 'game_mode,season_number,progress_data'
+        )
+        .eq('user_id', userId)
+        .in('game_mode', GAME_MODE_VALUES)
+        .in('season_number', [0, ACTIVE_SEASON_NUMBER])
+    );
     if (error) return { data: {}, error };
     const entries = (rows ?? []).flatMap((row) => {
       const activeProgress = getActiveModeProgress(row);

--- a/app/stores/tarkov/progressPersistence.ts
+++ b/app/stores/tarkov/progressPersistence.ts
@@ -88,6 +88,7 @@ export const syncProgressState = async (
     return { error: normalizedError };
   }
 };
+// fallow-ignore-next-line complexity -- active-mode timestamp and legacy fallback branches are covered in progressPersistence.test.ts
 export const loadModeProgress = async (
   client: ModeProgressClient,
   userId: string

--- a/app/stores/tarkov/progressPersistence.ts
+++ b/app/stores/tarkov/progressPersistence.ts
@@ -21,7 +21,7 @@ type ModeProgressRow = {
   game_mode: string;
   progress_data: unknown;
   season_number: number;
-  updated_at?: string;
+  progress_updated_at?: string | null;
 };
 type ModeProgressQuery = PromiseLike<{
   data: ModeProgressRow[] | null;
@@ -97,12 +97,13 @@ export const loadModeProgress = async (
 ): Promise<{
   data: Partial<Record<GameMode, UserProgressData>>;
   updatedAt?: number;
+  updatedAtByMode?: Partial<Record<GameMode, number>>;
   error: SupabaseError | null;
 }> => {
   try {
     const { data: rows, error } = await client
       .from('user_game_mode_progress')
-      .select('game_mode,season_number,progress_data,updated_at')
+      .select('game_mode,season_number,progress_data,progress_updated_at')
       .eq('user_id', userId)
       .in('game_mode', GAME_MODE_VALUES)
       .in('season_number', [0, ACTIVE_SEASON_NUMBER]);
@@ -112,13 +113,18 @@ export const loadModeProgress = async (
       return activeProgress ? [[activeProgress.mode, activeProgress.progress] as const] : [];
     });
     const data = Object.fromEntries(entries) as Partial<Record<GameMode, UserProgressData>>;
-    const timestamps = (rows ?? [])
-      .filter((row) => getActiveModeProgress(row) !== null)
-      .map((row) => Date.parse(row.updated_at ?? ''))
-      .filter(Number.isFinite);
+    const updatedAtByMode = Object.fromEntries(
+      (rows ?? []).flatMap((row) => {
+        const active = getActiveModeProgress(row);
+        const timestamp = Date.parse(row.progress_updated_at ?? '');
+        return active && Number.isFinite(timestamp) ? [[active.mode, timestamp]] : [];
+      })
+    ) as Partial<Record<GameMode, number>>;
+    const timestamps = Object.values(updatedAtByMode);
     return {
       data,
       error: null,
+      updatedAtByMode,
       updatedAt: timestamps.length > 0 ? Math.max(...timestamps) : undefined,
     };
   } catch (error) {

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -2,6 +2,7 @@ import { useToastI18n } from '@/composables/useToastI18n';
 import { maybeNotifyApiUpdate } from '@/stores/tarkov/apiUpdateNotifier';
 import { detectDataConflicts } from '@/stores/tarkov/conflictDetection';
 import { deepEqual } from '@/stores/tarkov/deepEqual';
+import { progressStorageSerializer } from '@/stores/tarkov/localStorage';
 import { coerceGameMode, mergeProgressData, toProgressEpoch } from '@/stores/tarkov/progressMerge';
 import {
   getLastLocalSyncTime,
@@ -11,7 +12,11 @@ import {
 import { useMetadataStore } from '@/stores/useMetadata';
 import { getGameModeSeasonNumber, isGameMode, type GameMode } from '@/utils/constants';
 import { logger } from '@/utils/logger';
-import { createPendingStateTracker, type RemoteStateMerge } from '@/utils/pendingState';
+import {
+  createPendingStateTracker,
+  type RemoteStateMerge,
+  type WithRemoteSnapshot,
+} from '@/utils/pendingState';
 import {
   sanitizeGameEdition,
   sanitizeOwnedProgressData,
@@ -31,6 +36,7 @@ const SYNC_RESUME_DELAY_MS = 1000;
 export type SyncControllerHandle = {
   hasPendingChanges?: () => boolean;
   captureRemoteMerge?: () => RemoteStateMerge;
+  withSnapshot?: WithRemoteSnapshot;
   pause: () => void;
   resume: () => void;
 };
@@ -43,6 +49,7 @@ type RealtimeModeProgress = {
   mode: GameMode;
   progress: UserProgressData;
   updateTime: number;
+  progressTime: number | null;
 };
 type LegacyProgressMetadata = {
   current_game_mode?: string;
@@ -74,6 +81,12 @@ const isActiveRealtimeModeRow = (
   row: Record<string, unknown>
 ): row is Record<string, unknown> & { game_mode: GameMode } =>
   isGameMode(row.game_mode) && row.season_number === getGameModeSeasonNumber(row.game_mode);
+const parseProgressTime = (value: unknown): number | null => {
+  const parsed = typeof value === 'string' ? Date.parse(value) : Number.NaN;
+  return Number.isFinite(parsed) ? parsed : null;
+};
+const resolveProgressClock = (progressTime: number | null, metadataTime: number | undefined) =>
+  progressTime ?? metadataTime ?? 0;
 const parseRealtimeModeProgress = (value: unknown): RealtimeModeProgress | null => {
   if (!value || typeof value !== 'object') return null;
   const row = value as Record<string, unknown>;
@@ -82,6 +95,7 @@ const parseRealtimeModeProgress = (value: unknown): RealtimeModeProgress | null 
     mode: row.game_mode,
     progress: sanitizeOwnedProgressData(row.progress_data),
     updateTime: parseRealtimeUpdateTime(row.updated_at),
+    progressTime: parseProgressTime(row.progress_updated_at),
   };
 };
 const buildLegacyMetadataState = (
@@ -274,12 +288,21 @@ async function runSetupRealtimeListener(
     if (!acceptLegacyMetadataUpdate(updateTime)) return;
     const localState = sanitizeOwnedUserState(tarkovStore.$state);
     const remoteState = buildLegacyMetadataState(remoteData, localState);
-    const metadata = reconcile({
+    const remoteMetadata = {
       currentGameMode: remoteState.currentGameMode,
       gameEdition: remoteState.gameEdition,
       tarkovUid: remoteState.tarkovUid,
-    });
+    };
+    const metadata = reconcile(remoteMetadata);
     const nextState = { ...localState, ...metadata } as UserState;
+    progressStorageSerializer.acceptRemote({
+      state: localState,
+      userId: currentUserId,
+      remote: remoteMetadata,
+      next: nextState,
+      updatedAtByMode: {},
+      metadataTimestamp: updateTime,
+    });
     if (shouldIgnoreLegacyMetadataUpdate(updateTime, nextState, localState)) return;
     const isLikelySelfOrigin = isLikelySelfOriginUpdate(updateTime);
     logger.debug('[TarkovStore] Remote metadata update detected, applying changes', {
@@ -311,6 +334,15 @@ async function runSetupRealtimeListener(
       { [mode]: merged },
       toProgressEpoch(localState[mode]) === toProgressEpoch(remoteProgress)
     )[mode] as UserProgressData;
+    progressStorageSerializer.acceptRemote({
+      state: localState,
+      userId: currentUserId,
+      remote: { [mode]: remoteProgress },
+      next: { [mode]: nextProgress },
+      updatedAtByMode: {
+        [mode]: resolveProgressClock(remote.progressTime, latestLegacyMetadataUpdateTime),
+      },
+    });
     if (shouldIgnoreModeProgressUpdate(mode, updateTime, nextProgress, localState[mode])) return;
     const conflicts = detectDataConflicts(localState[mode], remoteProgress);
     const apiUpdateHandled = maybeNotifyApiUpdate(
@@ -363,9 +395,8 @@ async function runSetupRealtimeListener(
     );
   let refreshGeneration = 0;
   // fallow-ignore-next-line complexity -- snapshot/event/edit races are covered in realtimeListener.seasonal.test.ts; keep generation checks together
-  const refreshSnapshot = async () => {
-    const request = ++refreshGeneration;
-    const reconcile = captureRemoteMerge();
+  const refreshSnapshot = async (reconcile: RemoteStateMerge, request: number) => {
+    if (!isCurrentRealtimeUser() || request !== refreshGeneration) return;
     try {
       const [metadata, modes] = await Promise.all([
         client
@@ -375,7 +406,7 @@ async function runSetupRealtimeListener(
           .single(),
         client
           .from('user_game_mode_progress')
-          .select('game_mode,season_number,progress_data,updated_at')
+          .select('game_mode,season_number,progress_data,updated_at,progress_updated_at')
           .eq('user_id', currentUserId),
       ]);
       if (!isCurrentRealtimeUser() || request !== refreshGeneration) return;
@@ -409,7 +440,12 @@ async function runSetupRealtimeListener(
       },
       REALTIME_SUBSCRIPTION_TIMEOUT_MS,
       () => {
-        void refreshSnapshot();
+        const request = ++refreshGeneration;
+        const read = (reconcile: RemoteStateMerge) => refreshSnapshot(reconcile, request);
+        const controller = getRegisteredSyncController();
+        void (controller?.withSnapshot
+          ? controller.withSnapshot(read)
+          : read(captureRemoteMerge()));
       }
     );
   } catch (error) {

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -305,7 +305,7 @@ async function runSetupRealtimeListener(
     if (!remote) return;
     const { mode, progress: remoteProgress, updateTime } = remote;
     const localState = sanitizeOwnedUserState(tarkovStore.$state);
-    const merged = mergeProgressData(localState[mode], remoteProgress);
+    const merged = mergeProgressData(localState[mode], remoteProgress, true);
     const nextProgress = reconcile(
       { [mode]: remoteProgress },
       { [mode]: merged },

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -12,6 +12,7 @@ import {
 import { useMetadataStore } from '@/stores/useMetadata';
 import { getGameModeSeasonNumber, isGameMode, type GameMode } from '@/utils/constants';
 import { logger } from '@/utils/logger';
+import { hasMaterializedProgress } from '@/utils/modeProgressFallback';
 import {
   createPendingStateTracker,
   type RemoteStateMerge,
@@ -77,10 +78,12 @@ const parseRealtimeUpdateTime = (value: unknown): number => {
   const parsed = typeof value === 'string' ? Date.parse(value) : Number.NaN;
   return Number.isNaN(parsed) ? Date.now() : parsed;
 };
-const isActiveRealtimeModeRow = (
+const isMaterializedActiveModeRow = (
   row: Record<string, unknown>
 ): row is Record<string, unknown> & { game_mode: GameMode } =>
-  isGameMode(row.game_mode) && row.season_number === getGameModeSeasonNumber(row.game_mode);
+  isGameMode(row.game_mode) &&
+  row.season_number === getGameModeSeasonNumber(row.game_mode) &&
+  hasMaterializedProgress(row.progress_data);
 const parseProgressTime = (value: unknown): number => {
   const parsed = typeof value === 'string' ? Date.parse(value) : Number.NaN;
   return Number.isFinite(parsed) ? parsed : 0;
@@ -88,7 +91,7 @@ const parseProgressTime = (value: unknown): number => {
 const parseRealtimeModeProgress = (value: unknown): RealtimeModeProgress | null => {
   if (!value || typeof value !== 'object') return null;
   const row = value as Record<string, unknown>;
-  if (!isActiveRealtimeModeRow(row)) return null;
+  if (!isMaterializedActiveModeRow(row)) return null;
   return {
     mode: row.game_mode,
     progress: sanitizeOwnedProgressData(row.progress_data),

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -4,6 +4,7 @@ import { detectDataConflicts } from '@/stores/tarkov/conflictDetection';
 import { deepEqual } from '@/stores/tarkov/deepEqual';
 import { progressStorageSerializer } from '@/stores/tarkov/localStorage';
 import { coerceGameMode, mergeProgressData, toProgressEpoch } from '@/stores/tarkov/progressMerge';
+import { readWithProgressFreshness } from '@/stores/tarkov/progressPersistence';
 import {
   getLastLocalSyncTime,
   isLikelySelfOriginUpdate,
@@ -405,10 +406,16 @@ async function runSetupRealtimeListener(
           .select('current_game_mode,game_edition,tarkov_uid,updated_at')
           .eq('user_id', currentUserId)
           .single(),
-        client
-          .from('user_game_mode_progress')
-          .select('game_mode,season_number,progress_data,updated_at,progress_updated_at')
-          .eq('user_id', currentUserId),
+        readWithProgressFreshness((includeFreshness) => {
+          const query = client.from('user_game_mode_progress');
+          return includeFreshness
+            ? query
+                .select('game_mode,season_number,progress_data,updated_at,progress_updated_at')
+                .eq('user_id', currentUserId)
+            : query
+                .select('game_mode,season_number,progress_data,updated_at')
+                .eq('user_id', currentUserId);
+        }),
       ]);
       if (!isCurrentRealtimeUser() || request !== refreshGeneration) return;
       if (modes.error) throw modes.error;

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -11,6 +11,7 @@ import {
 import { useMetadataStore } from '@/stores/useMetadata';
 import { getGameModeSeasonNumber, isGameMode, type GameMode } from '@/utils/constants';
 import { logger } from '@/utils/logger';
+import { createPendingStateTracker, type RemoteStateMerge } from '@/utils/pendingState';
 import {
   sanitizeGameEdition,
   sanitizeOwnedProgressData,
@@ -27,25 +28,9 @@ import {
 import { isRealtimeSuspended } from '@/utils/realtimeVisibility';
 import type { UserProgressData, UserState } from '@/stores/progressState';
 const SYNC_RESUME_DELAY_MS = 1000;
-const mergeSnapshotProgress = (
-  local: UserProgressData,
-  remote: UserProgressData,
-  preserveLocal: boolean
-): UserProgressData => {
-  const merged = mergeProgressData(local, remote);
-  if (!preserveLocal || toProgressEpoch(local) !== toProgressEpoch(remote)) return merged;
-  // These fields have no per-field timestamps. A reconnect read cannot replace
-  // unsaved edits, including explicit clears; reset epochs still take precedence.
-  return {
-    ...merged,
-    displayName: local.displayName,
-    pmcFaction: local.pmcFaction,
-    xpOffset: local.xpOffset,
-    skillOffsets: local.skillOffsets,
-  };
-};
 export type SyncControllerHandle = {
   hasPendingChanges?: () => boolean;
+  captureRemoteMerge?: () => RemoteStateMerge;
   pause: () => void;
   resume: () => void;
 };
@@ -81,8 +66,6 @@ export const registerSyncControllerGetter = (getter: SyncControllerGetter): void
 };
 export const getRegisteredSyncController = (): SyncControllerHandle | null =>
   syncControllerGetter();
-const hasPendingLocalChanges = (): boolean =>
-  getRegisteredSyncController()?.hasPendingChanges?.() === true;
 const parseRealtimeUpdateTime = (value: unknown): number => {
   const parsed = typeof value === 'string' ? Date.parse(value) : Number.NaN;
   return Number.isNaN(parsed) ? Date.now() : parsed;
@@ -248,6 +231,9 @@ async function runSetupRealtimeListener(
   const currentUserId = $supabase.user.id;
   if (!$supabase.user.loggedIn || !currentUserId) return;
   if (!(await prepareProgressTopic(currentUserId, generation))) return;
+  const fallbackTracker = createPendingStateTracker(() => tarkovStore.$state);
+  const captureRemoteMerge = () =>
+    getRegisteredSyncController()?.captureRemoteMerge?.() ?? fallbackTracker.capture();
   const latestModeUpdateTimes = new Map<GameMode, number>();
   const acceptModeUpdate = (mode: GameMode, updateTime: number): boolean => {
     const latestUpdateTime = latestModeUpdateTimes.get(mode);
@@ -278,13 +264,22 @@ async function runSetupRealtimeListener(
     stillOwnsSetup(currentUserId, generation) &&
     !($supabase.client.realtime && isRealtimeSuspended($supabase.client.realtime));
   logger.debug('[TarkovStore] Setting up realtime listener for multi-device sync');
-  const handleProgressChange = (payload: { new: unknown; old: unknown }) => {
+  const handleProgressChange = (
+    payload: { new: unknown; old: unknown },
+    reconcile = captureRemoteMerge()
+  ) => {
     if (!isCurrentRealtimeUser()) return;
     const remoteData = payload.new as LegacyProgressMetadata;
     const updateTime = parseRealtimeUpdateTime(remoteData.updated_at);
     if (!acceptLegacyMetadataUpdate(updateTime)) return;
     const localState = sanitizeOwnedUserState(tarkovStore.$state);
-    const nextState = buildLegacyMetadataState(remoteData, localState);
+    const remoteState = buildLegacyMetadataState(remoteData, localState);
+    const metadata = reconcile({
+      currentGameMode: remoteState.currentGameMode,
+      gameEdition: remoteState.gameEdition,
+      tarkovUid: remoteState.tarkovUid,
+    });
+    const nextState = { ...localState, ...metadata } as UserState;
     if (shouldIgnoreLegacyMetadataUpdate(updateTime, nextState, localState)) return;
     const isLikelySelfOrigin = isLikelySelfOriginUpdate(updateTime);
     logger.debug('[TarkovStore] Remote metadata update detected, applying changes', {
@@ -303,14 +298,19 @@ async function runSetupRealtimeListener(
   };
   const handleModeProgressChange = (
     payload: { new: unknown },
-    preserveLocal = hasPendingLocalChanges()
+    reconcile = captureRemoteMerge()
   ) => {
     if (!isCurrentRealtimeUser()) return;
     const remote = acceptRealtimeModeProgress(payload.new);
     if (!remote) return;
     const { mode, progress: remoteProgress, updateTime } = remote;
     const localState = sanitizeOwnedUserState(tarkovStore.$state);
-    const nextProgress = mergeSnapshotProgress(localState[mode], remoteProgress, preserveLocal);
+    const merged = mergeProgressData(localState[mode], remoteProgress);
+    const nextProgress = reconcile(
+      { [mode]: remoteProgress },
+      { [mode]: merged },
+      toProgressEpoch(localState[mode]) === toProgressEpoch(remoteProgress)
+    )[mode] as UserProgressData;
     if (shouldIgnoreModeProgressUpdate(mode, updateTime, nextProgress, localState[mode])) return;
     const conflicts = detectDataConflicts(localState[mode], remoteProgress);
     const apiUpdateHandled = maybeNotifyApiUpdate(
@@ -365,12 +365,7 @@ async function runSetupRealtimeListener(
   // fallow-ignore-next-line complexity -- snapshot/event/edit races are covered in realtimeListener.seasonal.test.ts; keep generation checks together
   const refreshSnapshot = async () => {
     const request = ++refreshGeneration;
-    const stateBeforeRead = sanitizeOwnedUserState(tarkovStore.$state);
-    const pendingBeforeRead = hasPendingLocalChanges();
-    const metadataBeforeRead = buildLegacyMetadataState(
-      {},
-      sanitizeOwnedUserState(tarkovStore.$state)
-    );
+    const reconcile = captureRemoteMerge();
     try {
       const [metadata, modes] = await Promise.all([
         client
@@ -386,27 +381,12 @@ async function runSetupRealtimeListener(
       if (!isCurrentRealtimeUser() || request !== refreshGeneration) return;
       if (modes.error) throw modes.error;
       if (metadata.error && metadata.error.code !== 'PGRST116') throw metadata.error;
-      const currentState = sanitizeOwnedUserState(tarkovStore.$state);
-      const metadataUnchanged =
-        currentState.currentGameMode === metadataBeforeRead.currentGameMode &&
-        currentState.gameEdition === metadataBeforeRead.gameEdition &&
-        currentState.tarkovUid === metadataBeforeRead.tarkovUid;
-      if (
-        metadata.data &&
-        metadataUnchanged &&
-        !hasPendingLocalChanges() &&
-        parseRealtimeUpdateTime(metadata.data.updated_at) >= getLastLocalSyncTime()
-      ) {
-        handleProgressChange({ new: metadata.data, old: null });
+      if (metadata.data) {
+        handleProgressChange({ new: metadata.data, old: null }, reconcile);
       }
       for (const row of modes.data ?? []) {
         if (!isGameMode(row.game_mode)) continue;
-        const preserveLocal =
-          pendingBeforeRead ||
-          hasPendingLocalChanges() ||
-          !deepEqual(stateBeforeRead[row.game_mode], tarkovStore.$state[row.game_mode]) ||
-          parseRealtimeUpdateTime(row.updated_at) < getLastLocalSyncTime();
-        handleModeProgressChange({ new: row }, preserveLocal);
+        handleModeProgressChange({ new: row }, reconcile);
       }
     } catch (error) {
       logger.warn('[TarkovStore] Reconnect snapshot failed', error);

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -49,7 +49,7 @@ type RealtimeModeProgress = {
   mode: GameMode;
   progress: UserProgressData;
   updateTime: number;
-  progressTime: number | null;
+  progressTime: number;
 };
 type LegacyProgressMetadata = {
   current_game_mode?: string;
@@ -81,12 +81,10 @@ const isActiveRealtimeModeRow = (
   row: Record<string, unknown>
 ): row is Record<string, unknown> & { game_mode: GameMode } =>
   isGameMode(row.game_mode) && row.season_number === getGameModeSeasonNumber(row.game_mode);
-const parseProgressTime = (value: unknown): number | null => {
+const parseProgressTime = (value: unknown): number => {
   const parsed = typeof value === 'string' ? Date.parse(value) : Number.NaN;
-  return Number.isFinite(parsed) ? parsed : null;
+  return Number.isFinite(parsed) ? parsed : 0;
 };
-const resolveProgressClock = (progressTime: number | null, metadataTime: number | undefined) =>
-  progressTime ?? metadataTime ?? 0;
 const parseRealtimeModeProgress = (value: unknown): RealtimeModeProgress | null => {
   if (!value || typeof value !== 'object') return null;
   const row = value as Record<string, unknown>;
@@ -340,7 +338,7 @@ async function runSetupRealtimeListener(
       remote: { [mode]: remoteProgress },
       next: { [mode]: nextProgress },
       updatedAtByMode: {
-        [mode]: resolveProgressClock(remote.progressTime, latestLegacyMetadataUpdateTime),
+        [mode]: remote.progressTime,
       },
     });
     if (shouldIgnoreModeProgressUpdate(mode, updateTime, nextProgress, localState[mode])) return;

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -443,9 +443,12 @@ async function runSetupRealtimeListener(
         const request = ++refreshGeneration;
         const read = (reconcile: RemoteStateMerge) => refreshSnapshot(reconcile, request);
         const controller = getRegisteredSyncController();
-        void (controller?.withSnapshot
+        const refreshing = controller?.withSnapshot
           ? controller.withSnapshot(read)
-          : read(captureRemoteMerge()));
+          : read(captureRemoteMerge());
+        refreshing.catch((error: unknown) => {
+          logger.warn('[TarkovStore] Reconnect snapshot barrier failed', error);
+        });
       }
     );
   } catch (error) {

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -332,7 +332,7 @@ async function runSetupRealtimeListener(
     const nextProgress = reconcile(
       { [mode]: remoteProgress },
       { [mode]: merged },
-      toProgressEpoch(localState[mode]) === toProgressEpoch(remoteProgress)
+      toProgressEpoch(localState[mode]) >= toProgressEpoch(remoteProgress)
     )[mode] as UserProgressData;
     progressStorageSerializer.acceptRemote({
       state: localState,

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -2,7 +2,7 @@ import { useToastI18n } from '@/composables/useToastI18n';
 import { maybeNotifyApiUpdate } from '@/stores/tarkov/apiUpdateNotifier';
 import { detectDataConflicts } from '@/stores/tarkov/conflictDetection';
 import { deepEqual } from '@/stores/tarkov/deepEqual';
-import { coerceGameMode, mergeProgressData } from '@/stores/tarkov/progressMerge';
+import { coerceGameMode, mergeProgressData, toProgressEpoch } from '@/stores/tarkov/progressMerge';
 import {
   getLastLocalSyncTime,
   isLikelySelfOriginUpdate,
@@ -27,6 +27,23 @@ import {
 import { isRealtimeSuspended } from '@/utils/realtimeVisibility';
 import type { UserProgressData, UserState } from '@/stores/progressState';
 const SYNC_RESUME_DELAY_MS = 1000;
+const mergeSnapshotProgress = (
+  local: UserProgressData,
+  remote: UserProgressData,
+  preserveLocal: boolean
+): UserProgressData => {
+  const merged = mergeProgressData(local, remote);
+  if (!preserveLocal || toProgressEpoch(local) !== toProgressEpoch(remote)) return merged;
+  // These fields have no per-field timestamps. A reconnect read cannot replace
+  // unsaved edits, including explicit clears; reset epochs still take precedence.
+  return {
+    ...merged,
+    displayName: local.displayName,
+    pmcFaction: local.pmcFaction,
+    xpOffset: local.xpOffset,
+    skillOffsets: local.skillOffsets,
+  };
+};
 export type SyncControllerHandle = {
   hasPendingChanges?: () => boolean;
   pause: () => void;
@@ -282,13 +299,13 @@ async function runSetupRealtimeListener(
     });
     scheduleSyncResume();
   };
-  const handleModeProgressChange = (payload: { new: unknown }) => {
+  const handleModeProgressChange = (payload: { new: unknown }, preserveLocal = false) => {
     if (!isCurrentRealtimeUser()) return;
     const remote = acceptRealtimeModeProgress(payload.new);
     if (!remote) return;
     const { mode, progress: remoteProgress, updateTime } = remote;
     const localState = sanitizeOwnedUserState(tarkovStore.$state);
-    const nextProgress = mergeProgressData(localState[mode], remoteProgress);
+    const nextProgress = mergeSnapshotProgress(localState[mode], remoteProgress, preserveLocal);
     if (shouldIgnoreModeProgressUpdate(mode, updateTime, nextProgress, localState[mode])) return;
     const conflicts = detectDataConflicts(localState[mode], remoteProgress);
     const apiUpdateHandled = maybeNotifyApiUpdate(
@@ -340,8 +357,11 @@ async function runSetupRealtimeListener(
       handleProgressChange
     );
   let refreshGeneration = 0;
+  // fallow-ignore-next-line complexity -- snapshot/event/edit races are covered in realtimeListener.seasonal.test.ts; keep generation checks together
   const refreshSnapshot = async () => {
     const request = ++refreshGeneration;
+    const stateBeforeRead = sanitizeOwnedUserState(tarkovStore.$state);
+    const pendingBeforeRead = getRegisteredSyncController()?.hasPendingChanges?.() ?? false;
     const metadataBeforeRead = buildLegacyMetadataState(
       {},
       sanitizeOwnedUserState(tarkovStore.$state)
@@ -359,8 +379,9 @@ async function runSetupRealtimeListener(
           .eq('user_id', currentUserId),
       ]);
       if (!isCurrentRealtimeUser() || request !== refreshGeneration) return;
-      if (metadata.error || modes.error) throw metadata.error ?? modes.error;
-      const currentState = tarkovStore.$state;
+      if (modes.error) throw modes.error;
+      if (metadata.error && metadata.error.code !== 'PGRST116') throw metadata.error;
+      const currentState = sanitizeOwnedUserState(tarkovStore.$state);
       const metadataUnchanged =
         currentState.currentGameMode === metadataBeforeRead.currentGameMode &&
         currentState.gameEdition === metadataBeforeRead.gameEdition &&
@@ -373,7 +394,15 @@ async function runSetupRealtimeListener(
       ) {
         handleProgressChange({ new: metadata.data, old: null });
       }
-      for (const row of modes.data ?? []) handleModeProgressChange({ new: row });
+      for (const row of modes.data ?? []) {
+        if (!isGameMode(row.game_mode)) continue;
+        const preserveLocal =
+          pendingBeforeRead ||
+          getRegisteredSyncController()?.hasPendingChanges?.() === true ||
+          !deepEqual(stateBeforeRead[row.game_mode], tarkovStore.$state[row.game_mode]) ||
+          parseRealtimeUpdateTime(row.updated_at) < getLastLocalSyncTime();
+        handleModeProgressChange({ new: row }, preserveLocal);
+      }
     } catch (error) {
       logger.warn('[TarkovStore] Reconnect snapshot failed', error);
     }

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -81,6 +81,8 @@ export const registerSyncControllerGetter = (getter: SyncControllerGetter): void
 };
 export const getRegisteredSyncController = (): SyncControllerHandle | null =>
   syncControllerGetter();
+const hasPendingLocalChanges = (): boolean =>
+  getRegisteredSyncController()?.hasPendingChanges?.() === true;
 const parseRealtimeUpdateTime = (value: unknown): number => {
   const parsed = typeof value === 'string' ? Date.parse(value) : Number.NaN;
   return Number.isNaN(parsed) ? Date.now() : parsed;
@@ -299,7 +301,10 @@ async function runSetupRealtimeListener(
     });
     scheduleSyncResume();
   };
-  const handleModeProgressChange = (payload: { new: unknown }, preserveLocal = false) => {
+  const handleModeProgressChange = (
+    payload: { new: unknown },
+    preserveLocal = hasPendingLocalChanges()
+  ) => {
     if (!isCurrentRealtimeUser()) return;
     const remote = acceptRealtimeModeProgress(payload.new);
     if (!remote) return;
@@ -361,7 +366,7 @@ async function runSetupRealtimeListener(
   const refreshSnapshot = async () => {
     const request = ++refreshGeneration;
     const stateBeforeRead = sanitizeOwnedUserState(tarkovStore.$state);
-    const pendingBeforeRead = getRegisteredSyncController()?.hasPendingChanges?.() ?? false;
+    const pendingBeforeRead = hasPendingLocalChanges();
     const metadataBeforeRead = buildLegacyMetadataState(
       {},
       sanitizeOwnedUserState(tarkovStore.$state)
@@ -389,7 +394,7 @@ async function runSetupRealtimeListener(
       if (
         metadata.data &&
         metadataUnchanged &&
-        !getRegisteredSyncController()?.hasPendingChanges?.() &&
+        !hasPendingLocalChanges() &&
         parseRealtimeUpdateTime(metadata.data.updated_at) >= getLastLocalSyncTime()
       ) {
         handleProgressChange({ new: metadata.data, old: null });
@@ -398,7 +403,7 @@ async function runSetupRealtimeListener(
         if (!isGameMode(row.game_mode)) continue;
         const preserveLocal =
           pendingBeforeRead ||
-          getRegisteredSyncController()?.hasPendingChanges?.() === true ||
+          hasPendingLocalChanges() ||
           !deepEqual(stateBeforeRead[row.game_mode], tarkovStore.$state[row.game_mode]) ||
           parseRealtimeUpdateTime(row.updated_at) < getLastLocalSyncTime();
         handleModeProgressChange({ new: row }, preserveLocal);

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -22,10 +22,13 @@ import {
   removeOwnedChannel,
   subscribeAndWaitForRealtimeChannel,
   type OwnedRealtimeChannel,
+  REALTIME_SUBSCRIPTION_TIMEOUT_MS,
 } from '@/utils/realtimeChannel';
+import { isRealtimeSuspended } from '@/utils/realtimeVisibility';
 import type { UserProgressData, UserState } from '@/stores/progressState';
 const SYNC_RESUME_DELAY_MS = 1000;
 export type SyncControllerHandle = {
+  hasPendingChanges?: () => boolean;
   pause: () => void;
   resume: () => void;
 };
@@ -252,7 +255,9 @@ async function runSetupRealtimeListener(
     latestLegacyMetadataUpdateTime = updateTime;
     return true;
   };
-  const isCurrentRealtimeUser = () => stillOwnsSetup(currentUserId, generation);
+  const isCurrentRealtimeUser = () =>
+    stillOwnsSetup(currentUserId, generation) &&
+    !($supabase.client.realtime && isRealtimeSuspended($supabase.client.realtime));
   logger.debug('[TarkovStore] Setting up realtime listener for multi-device sync');
   const handleProgressChange = (payload: { new: unknown; old: unknown }) => {
     if (!isCurrentRealtimeUser()) return;
@@ -334,6 +339,45 @@ async function runSetupRealtimeListener(
       },
       handleProgressChange
     );
+  let refreshGeneration = 0;
+  const refreshSnapshot = async () => {
+    const request = ++refreshGeneration;
+    const metadataBeforeRead = buildLegacyMetadataState(
+      {},
+      sanitizeOwnedUserState(tarkovStore.$state)
+    );
+    try {
+      const [metadata, modes] = await Promise.all([
+        client
+          .from('user_progress')
+          .select('current_game_mode,game_edition,tarkov_uid,updated_at')
+          .eq('user_id', currentUserId)
+          .single(),
+        client
+          .from('user_game_mode_progress')
+          .select('game_mode,season_number,progress_data,updated_at')
+          .eq('user_id', currentUserId),
+      ]);
+      if (!isCurrentRealtimeUser() || request !== refreshGeneration) return;
+      if (metadata.error || modes.error) throw metadata.error ?? modes.error;
+      const currentState = tarkovStore.$state;
+      const metadataUnchanged =
+        currentState.currentGameMode === metadataBeforeRead.currentGameMode &&
+        currentState.gameEdition === metadataBeforeRead.gameEdition &&
+        currentState.tarkovUid === metadataBeforeRead.tarkovUid;
+      if (
+        metadata.data &&
+        metadataUnchanged &&
+        !getRegisteredSyncController()?.hasPendingChanges?.() &&
+        parseRealtimeUpdateTime(metadata.data.updated_at) >= getLastLocalSyncTime()
+      ) {
+        handleProgressChange({ new: metadata.data, old: null });
+      }
+      for (const row of modes.data ?? []) handleModeProgressChange({ new: row });
+    } catch (error) {
+      logger.warn('[TarkovStore] Reconnect snapshot failed', error);
+    }
+  };
   const owned = { channel, client, topic } satisfies OwnedRealtimeChannel;
   if (!stillOwnsSetup(currentUserId, generation)) {
     await releaseProgressChannel(owned);
@@ -343,9 +387,17 @@ async function runSetupRealtimeListener(
   // this channel instead of creating a duplicate subscription for the topic.
   realtimeChannel = owned;
   try {
-    await subscribeAndWaitForRealtimeChannel(channel, 'TarkovStore', {
-      table: 'user_progress',
-    });
+    await subscribeAndWaitForRealtimeChannel(
+      channel,
+      'TarkovStore',
+      {
+        table: 'user_progress',
+      },
+      REALTIME_SUBSCRIPTION_TIMEOUT_MS,
+      () => {
+        void refreshSnapshot();
+      }
+    );
   } catch (error) {
     if (realtimeChannel === owned) await releaseProgressChannel(owned);
     // A newer setup or teardown intentionally superseded this request. Its

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -373,7 +373,7 @@ async function runSetupRealtimeListener(
         table: 'user_progress',
         filter: `user_id=eq.${currentUserId}`,
       },
-      handleProgressChange
+      (payload) => handleProgressChange(payload)
     )
     .on(
       'postgres_changes' as const,
@@ -383,7 +383,7 @@ async function runSetupRealtimeListener(
         table: 'user_game_mode_progress',
         filter: `user_id=eq.${currentUserId}`,
       },
-      handleModeProgressChange
+      (payload) => handleModeProgressChange(payload)
     )
     .on(
       'postgres_changes' as const,
@@ -393,7 +393,7 @@ async function runSetupRealtimeListener(
         table: 'user_progress',
         filter: `user_id=eq.${currentUserId}`,
       },
-      handleProgressChange
+      (payload) => handleProgressChange(payload)
     );
   let refreshGeneration = 0;
   // fallow-ignore-next-line complexity -- snapshot/event/edit races are covered in realtimeListener.seasonal.test.ts; keep generation checks together

--- a/app/stores/tarkov/resetEngine.ts
+++ b/app/stores/tarkov/resetEngine.ts
@@ -82,14 +82,14 @@ export const resolveInitialSyncState = (
     // callers using the legacy account-clock contract. Account-only changes
     // cannot establish whether an unknown mode is newer than an offline edit.
     const unknownModeClock = modeUpdatedAt !== undefined && modeUpdatedAt[mode] === undefined;
-    const preferLocalMode =
-      (unknownModeClock && Boolean(localModeTimestamp)) ||
-      shouldPreferLocalStartupMetadata(
-        localModeTimestamp,
-        unknownModeClock ? null : (modeUpdatedAt?.[mode] ?? remoteUpdatedAt),
-        localScore,
-        remoteScore
-      );
+    const preferLocalMode = unknownModeClock
+      ? (localModeTimestamp ?? 0) > 0
+      : shouldPreferLocalStartupMetadata(
+          localModeTimestamp,
+          modeUpdatedAt?.[mode] ?? remoteUpdatedAt,
+          localScore,
+          remoteScore
+        );
     const preferredModeData = preferLocalMode ? localModeData : remoteModeData;
     // Seasonal writes can advance independently of account metadata. Keep entry
     // timestamps and reset epochs while using this mode's own progress freshness.

--- a/app/stores/tarkov/resetEngine.ts
+++ b/app/stores/tarkov/resetEngine.ts
@@ -75,9 +75,16 @@ export const resolveInitialSyncState = (
     // Mode updated_at also changes for visibility. It cannot establish that an
     // entire progress snapshot supersedes local timestamped edits.
     if (mergeModeSnapshots) {
-      return preferLocalMetadata
+      const merged = preferLocalMetadata
         ? mergeProgressData(remoteModeData, localModeData, true)
         : mergeProgressData(localModeData, remoteModeData, true);
+      return {
+        ...merged,
+        displayName: preferredModeData.displayName,
+        pmcFaction: preferredModeData.pmcFaction,
+        xpOffset: preferredModeData.xpOffset,
+        skillOffsets: preferredModeData.skillOffsets,
+      };
     }
     return {
       ...preferredModeData,

--- a/app/stores/tarkov/resetEngine.ts
+++ b/app/stores/tarkov/resetEngine.ts
@@ -56,6 +56,7 @@ export const resolveInitialSyncState = (
   options: {
     mergeModeSnapshots?: boolean;
     modeUpdatedAt?: Partial<Record<GameMode, number>>;
+    localModeTimestamps?: Partial<Record<GameMode, number>>;
   } = {}
 ): UserState => {
   const { mergeModeSnapshots = false, modeUpdatedAt } = options;
@@ -77,7 +78,7 @@ export const resolveInitialSyncState = (
       return mergeProgressData(localModeData, remoteModeData);
     }
     const preferLocalMode = shouldPreferLocalStartupMetadata(
-      localTimestamp,
+      options.localModeTimestamps?.[mode] ?? localTimestamp,
       modeUpdatedAt?.[mode] ?? remoteUpdatedAt,
       localScore,
       remoteScore

--- a/app/stores/tarkov/resetEngine.ts
+++ b/app/stores/tarkov/resetEngine.ts
@@ -53,9 +53,12 @@ export const resolveInitialSyncState = (
   remoteUpdatedAt: number | null,
   localScore: number,
   remoteScore: number,
-  mergeModeSnapshots = false,
-  modeUpdatedAt?: Partial<Record<GameMode, number>>
+  options: {
+    mergeModeSnapshots?: boolean;
+    modeUpdatedAt?: Partial<Record<GameMode, number>>;
+  } = {}
 ): UserState => {
+  const { mergeModeSnapshots = false, modeUpdatedAt } = options;
   const preferLocalMetadata = shouldPreferLocalStartupMetadata(
     localTimestamp,
     remoteUpdatedAt,

--- a/app/stores/tarkov/resetEngine.ts
+++ b/app/stores/tarkov/resetEngine.ts
@@ -52,7 +52,8 @@ export const resolveInitialSyncState = (
   localTimestamp: number | null,
   remoteUpdatedAt: number | null,
   localScore: number,
-  remoteScore: number
+  remoteScore: number,
+  mergeModeSnapshots = false
 ): UserState => {
   const preferLocalMetadata = shouldPreferLocalStartupMetadata(
     localTimestamp,
@@ -60,6 +61,7 @@ export const resolveInitialSyncState = (
     localScore,
     remoteScore
   );
+  // fallow-ignore-next-line complexity -- startup merge/reset precedence is covered in resetEngine.seasonalReset.test.ts
   const resolveModeData = (
     localModeData: UserProgressData,
     remoteModeData: UserProgressData
@@ -70,6 +72,13 @@ export const resolveInitialSyncState = (
       return mergeProgressData(localModeData, remoteModeData);
     }
     const preferredModeData = preferLocalMetadata ? localModeData : remoteModeData;
+    // Mode updated_at also changes for visibility. It cannot establish that an
+    // entire progress snapshot supersedes local timestamped edits.
+    if (mergeModeSnapshots) {
+      return preferLocalMetadata
+        ? mergeProgressData(remoteModeData, localModeData)
+        : mergeProgressData(localModeData, remoteModeData);
+    }
     return {
       ...preferredModeData,
       storyChapters: mergeStoryChapterProgress(

--- a/app/stores/tarkov/resetEngine.ts
+++ b/app/stores/tarkov/resetEngine.ts
@@ -53,7 +53,8 @@ export const resolveInitialSyncState = (
   remoteUpdatedAt: number | null,
   localScore: number,
   remoteScore: number,
-  mergeModeSnapshots = false
+  mergeModeSnapshots = false,
+  modeUpdatedAt?: Partial<Record<GameMode, number>>
 ): UserState => {
   const preferLocalMetadata = shouldPreferLocalStartupMetadata(
     localTimestamp,
@@ -64,18 +65,25 @@ export const resolveInitialSyncState = (
   // fallow-ignore-next-line complexity -- startup merge/reset precedence is covered in resetEngine.seasonalReset.test.ts
   const resolveModeData = (
     localModeData: UserProgressData,
-    remoteModeData: UserProgressData
+    remoteModeData: UserProgressData,
+    mode: GameMode
   ): UserProgressData => {
     const localEpoch = toProgressEpoch(localModeData);
     const remoteEpoch = toProgressEpoch(remoteModeData);
     if (localEpoch !== remoteEpoch) {
       return mergeProgressData(localModeData, remoteModeData);
     }
-    const preferredModeData = preferLocalMetadata ? localModeData : remoteModeData;
-    // Mode updated_at also changes for visibility. It cannot establish that an
-    // entire progress snapshot supersedes local timestamped edits.
+    const preferLocalMode = shouldPreferLocalStartupMetadata(
+      localTimestamp,
+      modeUpdatedAt?.[mode] ?? remoteUpdatedAt,
+      localScore,
+      remoteScore
+    );
+    const preferredModeData = preferLocalMode ? localModeData : remoteModeData;
+    // Seasonal writes can advance independently of account metadata. Keep entry
+    // timestamps and reset epochs while using this mode's own progress freshness.
     if (mergeModeSnapshots) {
-      const merged = preferLocalMetadata
+      const merged = preferLocalMode
         ? mergeProgressData(remoteModeData, localModeData, true)
         : mergeProgressData(localModeData, remoteModeData, true);
       return {
@@ -102,9 +110,9 @@ export const resolveInitialSyncState = (
     tarkovUid: preferLocalMetadata
       ? (localState.tarkovUid ?? null)
       : (remoteState.tarkovUid ?? null),
-    pvp: resolveModeData(localState.pvp, remoteState.pvp),
-    pve: resolveModeData(localState.pve, remoteState.pve),
-    seasonal: resolveModeData(localState.seasonal, remoteState.seasonal),
+    pvp: resolveModeData(localState.pvp, remoteState.pvp, GAME_MODES.PVP),
+    pve: resolveModeData(localState.pve, remoteState.pve, GAME_MODES.PVE),
+    seasonal: resolveModeData(localState.seasonal, remoteState.seasonal, GAME_MODES.SEASONAL),
     seasonalSeasonNumber: ACTIVE_SEASON_NUMBER,
   };
 };

--- a/app/stores/tarkov/resetEngine.ts
+++ b/app/stores/tarkov/resetEngine.ts
@@ -76,8 +76,8 @@ export const resolveInitialSyncState = (
     // entire progress snapshot supersedes local timestamped edits.
     if (mergeModeSnapshots) {
       return preferLocalMetadata
-        ? mergeProgressData(remoteModeData, localModeData)
-        : mergeProgressData(localModeData, remoteModeData);
+        ? mergeProgressData(remoteModeData, localModeData, true)
+        : mergeProgressData(localModeData, remoteModeData, true);
     }
     return {
       ...preferredModeData,

--- a/app/stores/tarkov/resetEngine.ts
+++ b/app/stores/tarkov/resetEngine.ts
@@ -77,16 +77,23 @@ export const resolveInitialSyncState = (
     if (localEpoch !== remoteEpoch) {
       return mergeProgressData(localModeData, remoteModeData);
     }
-    const preferLocalMode = shouldPreferLocalStartupMetadata(
-      options.localModeTimestamps?.[mode] ?? localTimestamp,
-      modeUpdatedAt?.[mode] ?? remoteUpdatedAt,
-      localScore,
-      remoteScore
-    );
+    const localModeTimestamp = options.localModeTimestamps?.[mode] ?? localTimestamp;
+    // An explicit clock map distinguishes historical unknown progress from
+    // callers using the legacy account-clock contract. Account-only changes
+    // cannot establish whether an unknown mode is newer than an offline edit.
+    const unknownModeClock = modeUpdatedAt !== undefined && modeUpdatedAt[mode] === undefined;
+    const preferLocalMode =
+      (unknownModeClock && Boolean(localModeTimestamp)) ||
+      shouldPreferLocalStartupMetadata(
+        localModeTimestamp,
+        unknownModeClock ? null : (modeUpdatedAt?.[mode] ?? remoteUpdatedAt),
+        localScore,
+        remoteScore
+      );
     const preferredModeData = preferLocalMode ? localModeData : remoteModeData;
     // Seasonal writes can advance independently of account metadata. Keep entry
     // timestamps and reset epochs while using this mode's own progress freshness.
-    if (mergeModeSnapshots) {
+    if (mergeModeSnapshots || unknownModeClock) {
       const merged = preferLocalMode
         ? mergeProgressData(remoteModeData, localModeData, true)
         : mergeProgressData(localModeData, remoteModeData, true);

--- a/app/stores/tarkov/syncTimeline.ts
+++ b/app/stores/tarkov/syncTimeline.ts
@@ -2,17 +2,28 @@ const SELF_ORIGIN_THRESHOLD_MS = 3000;
 const RECENT_LOCAL_SYNC_HISTORY_SIZE = 20;
 const recentLocalSyncTimes: number[] = [];
 let lastLocalSyncTime = 0;
-export const recordLocalSyncTime = (): void => {
-  const now = Date.now();
-  lastLocalSyncTime = now;
+const pendingWrites = new Map<symbol, number>();
+const recordSyncTime = (now: number): void => {
+  lastLocalSyncTime = Math.max(lastLocalSyncTime, now);
   recentLocalSyncTimes.push(now);
   if (recentLocalSyncTimes.length > RECENT_LOCAL_SYNC_HISTORY_SIZE) {
     recentLocalSyncTimes.shift();
   }
 };
+export const recordLocalSyncTime = (): void => recordSyncTime(Date.now());
+/** Mark only an actual write; failed requests leave no permanent timeline entry. */
+export const beginLocalSync = (): ((succeeded: boolean) => void) => {
+  const token = Symbol();
+  const startedAt = Date.now();
+  pendingWrites.set(token, startedAt);
+  return (succeeded) => {
+    if (!pendingWrites.delete(token)) return;
+    if (succeeded) recordSyncTime(startedAt);
+  };
+};
 export const isLikelySelfOriginUpdate = (updateTime: number): boolean => {
   if (!Number.isFinite(updateTime)) return false;
-  return recentLocalSyncTimes.some((syncTime) => {
+  return [...recentLocalSyncTimes, ...pendingWrites.values()].some((syncTime) => {
     return Math.abs(updateTime - syncTime) < SELF_ORIGIN_THRESHOLD_MS;
   });
 };
@@ -20,5 +31,6 @@ export const getLastLocalSyncTime = (): number => lastLocalSyncTime;
 export const resetSyncTimeline = (): void => {
   lastLocalSyncTime = 0;
   recentLocalSyncTimes.length = 0;
+  pendingWrites.clear();
 };
 export const SYNC_TIMELINE_SELF_ORIGIN_THRESHOLD_MS = SELF_ORIGIN_THRESHOLD_MS;

--- a/app/stores/useSystemStore.ts
+++ b/app/stores/useSystemStore.ts
@@ -266,6 +266,9 @@ export function useSystemStoreWithSupabase(): SystemStoreInstance {
         () => void refreshTeamMemberships(userId, sessionId)
       )
       .subscribe((status, error) => {
+        if (status === 'SUBSCRIBED' && isCurrentMembershipSession(sessionId, userId)) {
+          void refreshTeamMemberships(userId, sessionId);
+        }
         logChannelSubscribeFailure('SystemStore', status, error, {
           table: 'team_memberships',
         });

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -1437,12 +1437,9 @@ export async function initializeTarkovSync() {
       const localScore = progressScore(localState);
       if (normalizedRemote) {
         const accountUpdatedAt = data?.updated_at ? Date.parse(data.updated_at) : 0;
-        // Seasonal-only saves no longer touch the legacy account row.
-        const remoteUpdatedAt =
-          Math.max(
-            Number.isFinite(accountUpdatedAt) ? accountUpdatedAt : 0,
-            modeProgressResult.updatedAt ?? 0
-          ) || null;
+        // Account metadata and each mode have independent freshness. Visibility
+        // changes must never lend their timestamps to progress in another mode.
+        const remoteUpdatedAt = Number.isFinite(accountUpdatedAt) ? accountUpdatedAt || null : null;
         const localOwnedByUser = storedUserId === currentUserId;
         const remoteHadDeprecatedProgressData = hasDeprecatedTarkovDevProfileData({
           pvp: modeProgressResult.data.pvp ?? data?.pvp_data,
@@ -1460,7 +1457,8 @@ export async function initializeTarkovSync() {
             remoteUpdatedAt,
             localScore,
             remoteScore,
-            (modeProgressResult.updatedAt ?? 0) > (accountUpdatedAt || 0)
+            (modeProgressResult.updatedAt ?? 0) > (accountUpdatedAt || 0),
+            modeProgressResult.updatedAtByMode
           );
           const remoteMatchesResolved = deepEqual(resolvedState, normalizedRemote);
           if (!remoteMatchesResolved) {

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -1353,7 +1353,7 @@ export async function initializeTarkovSync() {
         }
         const result = await $supabase.client
           .from('user_progress')
-          .select('*')
+          .select('user_id,current_game_mode,game_edition,tarkov_uid,updated_at')
           .eq('user_id', $supabase.user.id)
           .single();
         data = result.data as UserProgressRow | null;
@@ -1395,6 +1395,21 @@ export async function initializeTarkovSync() {
         );
         return { hadRemoteData, needsRemoteCleanup, ok: false };
       }
+      const missingLegacyFields = (['pvp', 'pve'] as const)
+        .filter((mode) => modeProgressResult.data[mode] == null)
+        .map((mode) => `${mode}_data`);
+      if (data && missingLegacyFields.length > 0) {
+        const legacy = await $supabase.client
+          .from('user_progress')
+          .select(missingLegacyFields.join(','))
+          .eq('user_id', currentUserId)
+          .single();
+        if (legacy.error) return { hadRemoteData, needsRemoteCleanup, ok: false };
+        data = {
+          ...data,
+          ...(legacy.data as unknown as Partial<UserProgressRow>),
+        } as UserProgressRow;
+      }
       // Normalize Supabase data with defaults for safety
       const hasNormalizedProgress = Object.keys(modeProgressResult.data).length > 0;
       const normalizedRemote =
@@ -1411,7 +1426,13 @@ export async function initializeTarkovSync() {
       const remoteScore = normalizedRemote ? progressScore(normalizedRemote) : 0;
       const localScore = progressScore(localState);
       if (normalizedRemote) {
-        const remoteUpdatedAt = data?.updated_at ? Date.parse(data.updated_at) : null;
+        const accountUpdatedAt = data?.updated_at ? Date.parse(data.updated_at) : 0;
+        // Seasonal-only saves no longer touch the legacy account row.
+        const remoteUpdatedAt =
+          Math.max(
+            Number.isFinite(accountUpdatedAt) ? accountUpdatedAt : 0,
+            modeProgressResult.updatedAt ?? 0
+          ) || null;
         const localOwnedByUser = storedUserId === currentUserId;
         const remoteHadDeprecatedProgressData = hasDeprecatedTarkovDevProfileData({
           pvp: modeProgressResult.data.pvp ?? data?.pvp_data,

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -65,7 +65,11 @@ import {
   performReset,
   resolveInitialSyncState,
 } from '@/stores/tarkov/resetEngine';
-import { recordLocalSyncTime, resetSyncTimeline } from '@/stores/tarkov/syncTimeline';
+import {
+  beginLocalSync,
+  recordLocalSyncTime,
+  resetSyncTimeline,
+} from '@/stores/tarkov/syncTimeline';
 import { useMetadataStore } from '@/stores/useMetadata';
 import { delay } from '@/utils/async';
 import {
@@ -1669,18 +1673,27 @@ export async function initializeTarkovSync() {
             seasonal_data: sanitizedUserState.seasonal,
           };
         },
-        sync: async (payload: UserProgressSyncPayload) =>
-          await $supabase.client.rpc('sync_user_game_mode_progress', {
-            p_current_game_mode: payload.current_game_mode,
-            p_game_edition: payload.game_edition,
-            p_seasonal_season_number: ACTIVE_SEASON_NUMBER,
-            p_tarkov_uid: payload.tarkov_uid,
-            p_modes: {
-              [GAME_MODES.PVP]: payload.pvp_data,
-              [GAME_MODES.PVE]: payload.pve_data,
-              [GAME_MODES.SEASONAL]: payload.seasonal_data,
-            },
-          }),
+        sync: async (payload: UserProgressSyncPayload) => {
+          const finish = beginLocalSync();
+          try {
+            const result = await $supabase.client.rpc('sync_user_game_mode_progress', {
+              p_current_game_mode: payload.current_game_mode,
+              p_game_edition: payload.game_edition,
+              p_seasonal_season_number: ACTIVE_SEASON_NUMBER,
+              p_tarkov_uid: payload.tarkov_uid,
+              p_modes: {
+                [GAME_MODES.PVP]: payload.pvp_data,
+                [GAME_MODES.PVE]: payload.pve_data,
+                [GAME_MODES.SEASONAL]: payload.seasonal_data,
+              },
+            });
+            finish(!result.error);
+            return result;
+          } catch (error) {
+            finish(false);
+            throw error;
+          }
+        },
       });
     };
     const shouldStartSyncNow = loadResult.hadRemoteData || hasProgress(tarkovStore.$state);

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -1635,6 +1635,7 @@ export async function initializeTarkovSync() {
         table: 'user_progress',
         debounceMs: SYNC_DEBOUNCE_MS,
         onSynced: () => {
+          recordLocalSyncTime();
           if (typeof BroadcastChannel !== 'undefined') {
             const bc = new BroadcastChannel(`tarkov-progress:${$supabase.user.id}`);
             bc.postMessage('updated');
@@ -1655,8 +1656,6 @@ export async function initializeTarkovSync() {
             );
             return null; // Returning null prevents the sync
           }
-          // Track sync time for self-origin filtering in realtime listener
-          recordLocalSyncTime();
           const sanitizedUserState = sanitizeOwnedUserState(userState);
           return {
             current_game_mode: sanitizedUserState.currentGameMode || GAME_MODES.PVP,

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -21,6 +21,7 @@ import {
   clearActiveProgressStorage,
   clearProgressStorageSafely,
   cloneStateSnapshot,
+  progressStorageSerializer,
   getPreservedProgressStorageValue,
   patchStoreState,
   readPersistedProgressState,
@@ -75,6 +76,7 @@ import { delay } from '@/utils/async';
 import {
   ACTIVE_SEASON_NUMBER,
   GAME_MODES,
+  GAME_MODE_VALUES,
   MANUAL_FAIL_TASK_IDS,
   type GameMode,
 } from '@/utils/constants';
@@ -86,11 +88,7 @@ import {
   sanitizeTarkovUid,
 } from '@/utils/progressSanitizers';
 import { STORAGE_KEYS } from '@/utils/storageKeys';
-import {
-  getCurrentSupabaseUserId,
-  parseUserScopedStorage,
-  serializeUserScopedStorage,
-} from '@/utils/userScopedStorage';
+import { getCurrentSupabaseUserId, parseUserScopedStorage } from '@/utils/userScopedStorage';
 import type { Task } from '@/types/tarkov';
 export type { PrestigeRunRecord } from '@/stores/tarkov/prestige';
 // ============================================================================
@@ -958,7 +956,7 @@ export const useTarkovStore = defineStore('swapTarkov', {
         const now = Date.now();
         const currentUserId = getCurrentSupabaseUserId();
         const sanitizedState = sanitizeOwnedUserState(state as UserState);
-        const serialized = serializeUserScopedStorage(
+        const serialized = progressStorageSerializer.serialize(
           cloneStateSnapshot(sanitizedState),
           currentUserId,
           now
@@ -1028,6 +1026,7 @@ export const useTarkovStore = defineStore('swapTarkov', {
         return serialized;
       },
       deserialize: (value: string) => {
+        progressStorageSerializer.reset();
         try {
           const wrapped = parseUserScopedStorage<UserState>(value);
           const currentUserId = getCurrentSupabaseUserId();
@@ -1162,6 +1161,7 @@ export function resetTarkovSync(
   syncUserId = null;
   shownLocalIgnoreReasons.clear();
   resetSyncTimeline();
+  progressStorageSerializer.reset();
   resetApiUpdateState();
 }
 export function resetTarkovStoreForSessionTransition(
@@ -1214,22 +1214,21 @@ export async function initializeTarkovSync() {
         return {
           storedUserId: preservedLocalSnapshot.storedUserId,
           timestamp: preservedLocalSnapshot.timestamp,
+          metadataTimestamp: preservedLocalSnapshot.metadataTimestamp,
+          modeTimestamps: preservedLocalSnapshot.modeTimestamps,
         };
       }
       if (typeof window === 'undefined') return null;
       const raw = safeGetItem(STORAGE_KEYS.progress);
       if (!raw) return null;
       try {
-        const parsed = JSON.parse(raw) as
-          | { _userId?: string | null; _timestamp?: number; data?: unknown }
-          | Record<string, unknown>;
-        if (parsed && typeof parsed === 'object' && 'data' in parsed) {
+        const parsed = parseUserScopedStorage<UserState>(raw);
+        if (parsed) {
           return {
-            storedUserId: (parsed as { _userId?: string | null })._userId ?? null,
-            timestamp:
-              typeof (parsed as { _timestamp?: number })._timestamp === 'number'
-                ? (parsed as { _timestamp?: number })._timestamp
-                : null,
+            storedUserId: parsed._userId,
+            timestamp: parsed._timestamp ?? null,
+            metadataTimestamp: parsed._metadataTimestamp,
+            modeTimestamps: parsed._modeTimestamps,
           };
         }
         return { storedUserId: null, timestamp: null };
@@ -1256,7 +1255,7 @@ export async function initializeTarkovSync() {
       if (
         !safeSetItem(
           STORAGE_KEYS.progress,
-          serializeUserScopedStorage(
+          progressStorageSerializer.serialize(
             cloneStateSnapshot(sanitizedState),
             userId,
             timestamp ?? Date.now()
@@ -1302,6 +1301,7 @@ export async function initializeTarkovSync() {
         patchStoreState(tarkovStore, localState);
       }
       if (preservedLocalSnapshot) {
+        progressStorageSerializer.reset(preservedLocalSnapshot);
         shouldPersistSanitizedLocalState ||= preservedLocalSnapshot.hadDeprecatedProgressData;
         localState = sanitizeOwnedUserState(preservedLocalSnapshot.state);
         hasLocalProgress = hasProgress(localState);
@@ -1313,6 +1313,7 @@ export async function initializeTarkovSync() {
           readPersistedProgressState(currentUserId) ??
           (storedUserId !== currentUserId ? readPersistedProgressState(storedUserId) : null);
         if (persistedLocalState) {
+          progressStorageSerializer.reset(persistedLocalState);
           shouldPersistSanitizedLocalState ||= persistedLocalState.hadDeprecatedProgressData;
           localState = persistedLocalState.state;
           hasLocalProgress = hasProgress(localState);
@@ -1453,13 +1454,19 @@ export async function initializeTarkovSync() {
           const resolvedState = resolveInitialSyncState(
             localState,
             normalizedRemote!,
-            localTimestamp,
+            localMeta?.metadataTimestamp ?? localTimestamp,
             remoteUpdatedAt,
             localScore,
             remoteScore,
             {
               mergeModeSnapshots: (modeProgressResult.updatedAt ?? 0) > (accountUpdatedAt || 0),
               modeUpdatedAt: modeProgressResult.updatedAtByMode,
+              localModeTimestamps: Object.fromEntries(
+                GAME_MODE_VALUES.map((mode) => [
+                  mode,
+                  localMeta?.modeTimestamps?.[mode] ?? localTimestamp ?? 0,
+                ])
+              ),
             }
           );
           const remoteMatchesResolved = deepEqual(resolvedState, normalizedRemote);
@@ -1489,6 +1496,19 @@ export async function initializeTarkovSync() {
             logger.debug('[TarkovStore] Startup sync resolved to existing remote state');
             needsRemoteCleanup = remoteHadDeprecatedProgressData;
           }
+          progressStorageSerializer.acceptRemote({
+            state: localState,
+            userId: currentUserId,
+            remote: normalizedRemote,
+            metadataTimestamp: remoteUpdatedAt ?? 0,
+            next: resolvedState,
+            updatedAtByMode: Object.fromEntries(
+              GAME_MODE_VALUES.map((mode) => [
+                mode,
+                modeProgressResult.updatedAtByMode?.[mode] ?? remoteUpdatedAt ?? 0,
+              ])
+            ),
+          });
           if (!deepEqual(resolvedState, localState)) {
             tarkovStore.$patch((state) => {
               state.currentGameMode = resolvedState.currentGameMode;
@@ -1503,6 +1523,19 @@ export async function initializeTarkovSync() {
         } else {
           needsRemoteCleanup = remoteHadDeprecatedProgressData;
           logger.debug('[TarkovStore] Loading data from Supabase (user exists in DB)');
+          progressStorageSerializer.acceptRemote({
+            state: tarkovStore.$state,
+            userId: currentUserId,
+            remote: normalizedRemote,
+            metadataTimestamp: remoteUpdatedAt ?? 0,
+            next: normalizedRemote,
+            updatedAtByMode: Object.fromEntries(
+              GAME_MODE_VALUES.map((mode) => [
+                mode,
+                modeProgressResult.updatedAtByMode?.[mode] ?? remoteUpdatedAt ?? 0,
+              ])
+            ),
+          });
           tarkovStore.$patch((state) => {
             state.currentGameMode = normalizedRemote?.currentGameMode ?? state.currentGameMode;
             state.gameEdition = normalizedRemote?.gameEdition ?? state.gameEdition;

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -1399,11 +1399,17 @@ export async function initializeTarkovSync() {
         .filter((mode) => modeProgressResult.data[mode] == null)
         .map((mode) => `${mode}_data`);
       if (data && missingLegacyFields.length > 0) {
-        const legacy = await $supabase.client
-          .from('user_progress')
-          .select(missingLegacyFields.join(','))
-          .eq('user_id', currentUserId)
-          .single();
+        const readLegacy = () =>
+          $supabase.client
+            .from('user_progress')
+            .select(missingLegacyFields.join(','))
+            .eq('user_id', currentUserId)
+            .single();
+        let legacy = await readLegacy();
+        for (let attempt = 1; attempt < LOAD_RETRY_COUNT && legacy.error; attempt++) {
+          await delay(LOAD_RETRY_DELAY_MS);
+          legacy = await readLegacy();
+        }
         if (legacy.error) return { hadRemoteData, needsRemoteCleanup, ok: false };
         data = {
           ...data,
@@ -1449,7 +1455,8 @@ export async function initializeTarkovSync() {
             localTimestamp,
             remoteUpdatedAt,
             localScore,
-            remoteScore
+            remoteScore,
+            (modeProgressResult.updatedAt ?? 0) > (accountUpdatedAt || 0)
           );
           const remoteMatchesResolved = deepEqual(resolvedState, normalizedRemote);
           if (!remoteMatchesResolved) {

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -1457,8 +1457,10 @@ export async function initializeTarkovSync() {
             remoteUpdatedAt,
             localScore,
             remoteScore,
-            (modeProgressResult.updatedAt ?? 0) > (accountUpdatedAt || 0),
-            modeProgressResult.updatedAtByMode
+            {
+              mergeModeSnapshots: (modeProgressResult.updatedAt ?? 0) > (accountUpdatedAt || 0),
+              modeUpdatedAt: modeProgressResult.updatedAtByMode,
+            }
           );
           const remoteMatchesResolved = deepEqual(resolvedState, normalizedRemote);
           if (!remoteMatchesResolved) {

--- a/app/stores/useTarkov.ts
+++ b/app/stores/useTarkov.ts
@@ -81,6 +81,7 @@ import {
   type GameMode,
 } from '@/utils/constants';
 import { logger } from '@/utils/logger';
+import { hasMaterializedProgress } from '@/utils/modeProgressFallback';
 import {
   hasDeprecatedTarkovDevProfileData,
   sanitizeGameEdition,
@@ -1441,6 +1442,20 @@ export async function initializeTarkovSync() {
         // Account metadata and each mode have independent freshness. Visibility
         // changes must never lend their timestamps to progress in another mode.
         const remoteUpdatedAt = Number.isFinite(accountUpdatedAt) ? accountUpdatedAt || null : null;
+        const remoteModeUpdatedAt = { ...modeProgressResult.updatedAtByMode };
+        // Only a payload actually read from the legacy account row inherits
+        // that row's clock. A historical normalized row still has unknown
+        // progress freshness, even when account metadata changed recently.
+        if (remoteUpdatedAt !== null) {
+          for (const mode of ['pvp', 'pve'] as const) {
+            if (
+              modeProgressResult.data[mode] == null &&
+              hasMaterializedProgress(data?.[`${mode}_data`])
+            ) {
+              remoteModeUpdatedAt[mode] = remoteUpdatedAt;
+            }
+          }
+        }
         const localOwnedByUser = storedUserId === currentUserId;
         const remoteHadDeprecatedProgressData = hasDeprecatedTarkovDevProfileData({
           pvp: modeProgressResult.data.pvp ?? data?.pvp_data,
@@ -1460,7 +1475,7 @@ export async function initializeTarkovSync() {
             remoteScore,
             {
               mergeModeSnapshots: (modeProgressResult.updatedAt ?? 0) > (accountUpdatedAt || 0),
-              modeUpdatedAt: modeProgressResult.updatedAtByMode,
+              modeUpdatedAt: remoteModeUpdatedAt,
               localModeTimestamps: Object.fromEntries(
                 GAME_MODE_VALUES.map((mode) => [
                   mode,
@@ -1503,10 +1518,7 @@ export async function initializeTarkovSync() {
             metadataTimestamp: remoteUpdatedAt ?? 0,
             next: resolvedState,
             updatedAtByMode: Object.fromEntries(
-              GAME_MODE_VALUES.map((mode) => [
-                mode,
-                modeProgressResult.updatedAtByMode?.[mode] ?? remoteUpdatedAt ?? 0,
-              ])
+              GAME_MODE_VALUES.map((mode) => [mode, remoteModeUpdatedAt[mode] ?? 0])
             ),
           });
           if (!deepEqual(resolvedState, localState)) {
@@ -1530,10 +1542,7 @@ export async function initializeTarkovSync() {
             metadataTimestamp: remoteUpdatedAt ?? 0,
             next: normalizedRemote,
             updatedAtByMode: Object.fromEntries(
-              GAME_MODE_VALUES.map((mode) => [
-                mode,
-                modeProgressResult.updatedAtByMode?.[mode] ?? remoteUpdatedAt ?? 0,
-              ])
+              GAME_MODE_VALUES.map((mode) => [mode, remoteModeUpdatedAt[mode] ?? 0])
             ),
           });
           tarkovStore.$patch((state) => {

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -803,6 +803,11 @@ export function useTeammateStores() {
             .from('user_game_mode_progress')
             .select('game_mode,season_number,progress_data')
             .eq('user_id', teammateId);
+          if (!isHydrationActive() || request !== hydrationRequest) return;
+          if (modeRows.error) {
+            logTeammateModeProgressHydrationFailure(modeRows.error, teammateId);
+            return;
+          }
           const needsLegacy = !(modeRows.data ?? []).some(
             (row) =>
               row.game_mode === legacyMode &&
@@ -813,10 +818,6 @@ export function useTeammateStores() {
             ? await fetchLegacyTeammateProgress($supabase.client, teammateId, legacyMode)
             : { data: null, error: null };
           if (!isHydrationActive() || request !== hydrationRequest) return;
-          if (modeRows.error) {
-            logTeammateModeProgressHydrationFailure(modeRows.error, teammateId);
-            return;
-          }
           applyModeProgressRows(modeRows.data);
           applyLegacyModeProgress(legacyRow);
           replayHydratedProgressMetadata();

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -260,17 +260,16 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
   let disposed = false;
   const previouslyJoined = new WeakSet<OwnedRealtimeChannel>();
   let hydrationTeam: string | null = null;
-  const dispatchHydration = (teamId: string) => {
-    if (hydrationTeam !== teamId) return;
+  const dispatchHydration = (teamId: string | null) => {
+    if (!teamId || hydrationTeam !== teamId) return;
     hydrationTeam = null;
     if (typeof window !== 'undefined')
       window.dispatchEvent(new Event('teammate-progress-reconnected'));
   };
-  const reconcileRejoin = async (owned: OwnedRealtimeChannel, teamId: string) => {
+  const reconcileRejoin = async (teamId: string) => {
     hydrationTeam = teamId;
     try {
       await refresh();
-      if (channel.value === owned) dispatchHydration(teamId);
     } catch (error) {
       logger.warn('[TeamStore] Reconnect member refresh failed', error);
     }
@@ -334,7 +333,7 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
       joinedTeamId = teamId;
       joinedFilter = filter;
       errorCount = 0;
-      if (previouslyJoined.has(owned)) void reconcileRejoin(owned, teamId);
+      if (previouslyJoined.has(owned)) void reconcileRejoin(teamId);
       else {
         previouslyJoined.add(owned);
         dispatchHydration(teamId);
@@ -413,7 +412,12 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     if (!(await shouldContinue(requestVersion))) return;
     await deps.refreshMembers(true);
     if (!(await shouldContinue(requestVersion))) return;
-    if (!needsRebuild(deps.getTeamId())) return;
+    if (!needsRebuild(deps.getTeamId())) {
+      // Only the winning refresh can hydrate an unchanged binding. An older
+      // reconnect request may have been superseded by a membership event.
+      dispatchHydration(joinedTeamId);
+      return;
+    }
     await setup(requestVersion);
   };
   return {

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -229,7 +229,7 @@ export type TeamChannelDeps = {
   getTeamId: () => string | null;
   getMembers: () => string[] | undefined;
   applyProgress: (data: Record<string, unknown>) => void;
-  refreshMembers: (force?: boolean) => Promise<void>;
+  refreshMembers: (force?: boolean) => Promise<boolean>;
 };
 export type TeamChannelController = {
   /** Leaves the channel and waits for the leave to settle. */
@@ -407,10 +407,11 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
   const isStale = (requestVersion: number): boolean => disposed || requestVersion !== version;
   const shouldContinue = async (requestVersion: number): Promise<boolean> =>
     !isStale(requestVersion) && (await resolveTargetTeam()) !== null;
+  // fallow-ignore-next-line complexity -- refresh success and generation fences are covered in teamChannelController.test.ts and useTeamStore.test.ts
   const refresh = async (): Promise<void> => {
     const requestVersion = ++version;
     if (!(await shouldContinue(requestVersion))) return;
-    await deps.refreshMembers(true);
+    if (!(await deps.refreshMembers(true))) return;
     if (!(await shouldContinue(requestVersion))) return;
     if (!needsRebuild(deps.getTeamId())) {
       // Only the winning refresh can hydrate an unchanged binding. An older
@@ -444,7 +445,7 @@ export function useTeamStoreWithSupabase(): TeamStoreInstance {
   const { $supabase } = useNuxtApp();
   const listenerScope = effectScope(true);
   let lastMembersRefreshAt = 0;
-  let refreshInFlight: Promise<void> | null = null;
+  let refreshInFlight: Promise<boolean> | null = null;
   let refreshInFlightTeamId: string | null = null;
   let latestMembersRequestVersion = 0;
   // Computed reference to the team document based on system store
@@ -493,7 +494,7 @@ export function useTeamStoreWithSupabase(): TeamStoreInstance {
         state.members = [];
         state.memberProfiles = {};
       });
-      return;
+      return false;
     }
     if (refreshInFlight) {
       const currentTeamId = getTeamIdFromSystemStore(systemStore);
@@ -502,23 +503,23 @@ export function useTeamStoreWithSupabase(): TeamStoreInstance {
         refreshInFlightTeamId = null;
       } else {
         try {
-          await refreshInFlight;
+          return await refreshInFlight;
         } catch (error) {
           const status = getErrorStatus(error);
           if (status === 401 || status === 403) {
             logger.debug('[TeamStore] Skipping team member refresh due auth/membership status:', {
               status,
             });
-            return;
+            return false;
           }
           logger.warn('[TeamStore] Failed to load team members:', error);
         }
-        return;
+        return false;
       }
     }
     const now = Date.now();
     if (!force && now - lastMembersRefreshAt < 2000) {
-      return;
+      return false;
     }
     const currentTeamId = getTeamIdFromSystemStore(systemStore);
     if (!currentTeamId) {
@@ -527,36 +528,38 @@ export function useTeamStoreWithSupabase(): TeamStoreInstance {
         state.memberProfiles = {};
       });
       await teamChannel.cleanup();
-      return;
+      return false;
     }
     const requestVersion = ++latestMembersRequestVersion;
     const inFlightRequest = (async () => {
       const { getTeamMembers } = useEdgeFunctions();
       const result = await getTeamMembers(currentTeamId, force);
       if (requestVersion !== latestMembersRequestVersion) {
-        return;
+        return false;
       }
       if (getTeamIdFromSystemStore(systemStore) !== currentTeamId) {
-        return;
+        return false;
       }
       teamStore.$patch((state) => {
         state.members = result?.members || [];
         state.memberProfiles = result?.profiles || {};
       });
+      return true;
     })();
     refreshInFlight = inFlightRequest;
     refreshInFlightTeamId = currentTeamId;
     try {
-      await inFlightRequest;
+      return await inFlightRequest;
     } catch (error) {
       const status = getErrorStatus(error);
       if (status === 401 || status === 403) {
         logger.debug('[TeamStore] Skipping team member refresh due auth/membership status:', {
           status,
         });
-        return;
+        return false;
       }
       logger.warn('[TeamStore] Failed to load team members:', error);
+      return false;
     } finally {
       if (refreshInFlight === inFlightRequest) {
         lastMembersRefreshAt = Date.now();

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -266,6 +266,11 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     if (typeof window !== 'undefined')
       window.dispatchEvent(new Event('teammate-progress-reconnected'));
   };
+  const transferHydration = (teamId: string) => {
+    // Retained teammate stores need the missed snapshot even if the winning
+    // membership refresh moved us to another team while reconnect was pending.
+    if (hydrationTeam !== null) hydrationTeam = teamId;
+  };
   const reconcileRejoin = async (teamId: string) => {
     hydrationTeam = teamId;
     try {
@@ -391,6 +396,7 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     // The latch is shared, so an overlapping setup waits on the same leave.
     if (!(await release.release(teamTopic(teamId)))) return;
     if (!canBuild(setupVersion)) return;
+    transferHydration(teamId);
     buildChannel(teamId, buildMemberProgressFilter(deps.getMembers()));
   };
   const isCurrentBinding = (teamId: string): boolean =>
@@ -401,6 +407,7 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
   const resolveTargetTeam = async (): Promise<string | null> => {
     const teamId = deps.getTeamId();
     if (teamId) return teamId;
+    hydrationTeam = null;
     await cleanup();
     return null;
   };
@@ -432,6 +439,7 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     cleanup,
     dispose: () => {
       disposed = true;
+      hydrationTeam = null;
       version += 1;
       clearRetry();
       return cleanup();

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -19,6 +19,7 @@ import {
   type OwnedRealtimeChannel,
   type SupabaseRealtimeChannel,
 } from '@/utils/realtimeChannel';
+import { isRealtimeSuspended } from '@/utils/realtimeVisibility';
 import type { MemberProfile, TeamGetters, TeamState } from '@/types/tarkov';
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { Store } from 'pinia';
@@ -310,11 +311,14 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     error?: Error
   ) => {
     if (channel.value !== owned) return;
+    if (deps.getClient().realtime && isRealtimeSuspended(deps.getClient().realtime)) return;
     if (status === 'SUBSCRIBED') {
       joinedTeamId = teamId;
       joinedFilter = filter;
       errorCount = 0;
-      void deps.refreshMembers();
+      void deps.refreshMembers(true);
+      if (typeof window !== 'undefined')
+        window.dispatchEvent(new Event('teammate-progress-reconnected'));
       return;
     }
     // A closed channel is no longer joined, so drop the binding to let the next
@@ -765,16 +769,25 @@ export function useTeammateStores() {
         if (!isHydrationActive()) return;
         replayProgressMetadataMigration();
       };
+      let hydrationRequest = 0;
       const hydrateModeProgress = async () => {
+        const request = ++hydrationRequest;
+        appliedModes.clear();
         try {
-          const [modeRows, legacyRow] = await Promise.all([
-            $supabase.client
-              .from('user_game_mode_progress')
-              .select('game_mode,season_number,progress_data')
-              .eq('user_id', teammateId),
-            fetchLegacyTeammateProgress($supabase.client, teammateId, legacyMode),
-          ]);
-          if (!isHydrationActive()) return;
+          const modeRows = await $supabase.client
+            .from('user_game_mode_progress')
+            .select('game_mode,season_number,progress_data')
+            .eq('user_id', teammateId);
+          const needsLegacy = !(modeRows.data ?? []).some(
+            (row) =>
+              row.game_mode === legacyMode &&
+              row.season_number === 0 &&
+              hasMaterializedProgress(row.progress_data)
+          );
+          const legacyRow = needsLegacy
+            ? await fetchLegacyTeammateProgress($supabase.client, teammateId, legacyMode)
+            : { data: null, error: null };
+          if (!isHydrationActive() || request !== hydrationRequest) return;
           if (modeRows.error) {
             logTeammateModeProgressHydrationFailure(modeRows.error, teammateId);
             return;
@@ -793,11 +806,13 @@ export function useTeammateStores() {
       };
       if (typeof window !== 'undefined') {
         window.addEventListener('teammate-mode-progress', handleModeProgress);
+        window.addEventListener('teammate-progress-reconnected', hydrateModeProgress);
       }
       teammateUnsubscribes.value[teammateId] = () => {
         hydrationActive = false;
         if (typeof window !== 'undefined') {
           window.removeEventListener('teammate-mode-progress', handleModeProgress);
+          window.removeEventListener('teammate-progress-reconnected', hydrateModeProgress);
         }
       };
       void hydrateModeProgress();

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -7,7 +7,7 @@ import { replayProgressMetadataMigration } from '@/stores/tarkov/metadataStoreBr
 import { getTeamIdFromState, useSystemStoreWithSupabase } from '@/stores/useSystemStore';
 import { useTarkovStore } from '@/stores/useTarkov';
 import { getCurrentGameMode } from '@/stores/utils/gameMode';
-import { ACTIVE_SEASON_NUMBER, GAME_MODES, isGameMode, type GameMode } from '@/utils/constants';
+import { GAME_MODES, getGameModeSeasonNumber, isGameMode, type GameMode } from '@/utils/constants';
 import { getErrorStatus } from '@/utils/errors';
 import { logger } from '@/utils/logger';
 import { hasMaterializedProgress, summarizeModeProgressData } from '@/utils/modeProgressFallback';
@@ -162,7 +162,7 @@ const isTrackedTeammate = (
 const isActiveSeasonProgressEvent = (data: Record<string, unknown>): boolean => {
   const mode = data.game_mode;
   if (!isGameMode(mode)) return false;
-  const expectedSeason = mode === GAME_MODES.SEASONAL ? ACTIVE_SEASON_NUMBER : 0;
+  const expectedSeason = getGameModeSeasonNumber(mode);
   return data.season_number === expectedSeason;
 };
 /**
@@ -776,8 +776,11 @@ export function useTeammateStores() {
       ): GameMode | null => {
         const mode = row.game_mode;
         if (!isGameMode(mode)) return null;
-        const expectedSeason = mode === GAME_MODES.SEASONAL ? ACTIVE_SEASON_NUMBER : 0;
+        const expectedSeason = getGameModeSeasonNumber(mode);
         if (row.season_number !== expectedSeason) return null;
+        // Visibility can create a row without progress. Keep the last usable
+        // snapshot and let legacy hydration recover, even after a live event.
+        if (!hasMaterializedProgress(row.progress_data)) return null;
         applyProgressData(mode, row.progress_data, authoritative);
         return mode;
       };

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -258,6 +258,23 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
   let retryTimeout: ReturnType<typeof setTimeout> | null = null;
   const release = createChannelReleaseLatch();
   let disposed = false;
+  const previouslyJoined = new WeakSet<OwnedRealtimeChannel>();
+  let hydrationTeam: string | null = null;
+  const dispatchHydration = (teamId: string) => {
+    if (hydrationTeam !== teamId) return;
+    hydrationTeam = null;
+    if (typeof window !== 'undefined')
+      window.dispatchEvent(new Event('teammate-progress-reconnected'));
+  };
+  const reconcileRejoin = async (owned: OwnedRealtimeChannel, teamId: string) => {
+    hydrationTeam = teamId;
+    try {
+      await refresh();
+      if (channel.value === owned) dispatchHydration(teamId);
+    } catch (error) {
+      logger.warn('[TeamStore] Reconnect member refresh failed', error);
+    }
+  };
   const clearRetry = () => {
     if (retryTimeout === null) return;
     clearTimeout(retryTimeout);
@@ -303,6 +320,7 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
    * invisible while Realtime rejoins forever. The binding is recorded as joined
    * only here, so a join that silently no-ops is never mistaken for a live one.
    */
+  // fallow-ignore-next-line complexity -- tested subscription ownership and recovery state machine; inferred coverage misses callback calls
   const handleStatus = (
     owned: OwnedRealtimeChannel,
     teamId: string,
@@ -316,9 +334,11 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
       joinedTeamId = teamId;
       joinedFilter = filter;
       errorCount = 0;
-      void deps.refreshMembers(true);
-      if (typeof window !== 'undefined')
-        window.dispatchEvent(new Event('teammate-progress-reconnected'));
+      if (previouslyJoined.has(owned)) void reconcileRejoin(owned, teamId);
+      else {
+        previouslyJoined.add(owned);
+        dispatchHydration(teamId);
+      }
       return;
     }
     // A closed channel is no longer joined, so drop the binding to let the next
@@ -770,6 +790,7 @@ export function useTeammateStores() {
         replayProgressMetadataMigration();
       };
       let hydrationRequest = 0;
+      // fallow-ignore-next-line complexity -- hydration ordering and stale-event guards are covered in useTeamStore.test.ts
       const hydrateModeProgress = async () => {
         const request = ++hydrationRequest;
         appliedModes.clear();

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -328,7 +328,10 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     error?: Error
   ) => {
     if (channel.value !== owned) return;
-    if (deps.getClient().realtime && isRealtimeSuspended(deps.getClient().realtime)) return;
+    if (deps.getClient().realtime && isRealtimeSuspended(deps.getClient().realtime)) {
+      previouslyJoined.add(owned);
+      return;
+    }
     if (status === 'SUBSCRIBED') {
       joinedTeamId = teamId;
       joinedFilter = filter;
@@ -342,6 +345,9 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     }
     // A closed channel is no longer joined, so drop the binding to let the next
     // membership event rebuild it.
+    // Recovery can replace the owned channel before it rejoins. Carry the
+    // missed-progress refresh across that replacement, too.
+    if (previouslyJoined.has(owned)) hydrationTeam = teamId;
     joinedTeamId = null;
     joinedFilter = undefined;
     recordStatusFailure(status, error);
@@ -372,6 +378,7 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     if (progressFilter) next = bindProgress(next, progressFilter);
     const owned: OwnedRealtimeChannel = { channel: next, client, topic };
     channel.value = owned;
+    if (client.realtime && isRealtimeSuspended(client.realtime)) previouslyJoined.add(owned);
     next.subscribe((status, error) => handleStatus(owned, teamId, progressFilter, status, error));
   };
   const canBuild = (setupVersion: number): boolean => !disposed && setupVersion === version;

--- a/app/utils/__tests__/pendingState.test.ts
+++ b/app/utils/__tests__/pendingState.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { preservePendingPaths, snapshotSyncState } from '@/utils/pendingState';
+describe('pending state reconciliation', () => {
+  it('snapshots persisted fields without retaining references or transient cycles', () => {
+    const transient: Record<string, unknown> = {};
+    transient.self = transient;
+    const state = { progress: { count: 2 }, empty: undefined, transient };
+    const snapshot = snapshotSyncState(state);
+    state.progress.count = 9;
+    expect(snapshot).toEqual({ progress: { count: 2 }, empty: undefined });
+    expect(snapshotSyncState(null)).toEqual({});
+  });
+  it('preserves local deletion and array replacement while accepting other remote keys', () => {
+    const base = { removed: { count: 5 }, list: ['a'], unchanged: 'old' };
+    const local = { list: [], unchanged: 'old' };
+    const remote = { removed: { count: 5 }, list: ['a', 'b'], unchanged: 'new', added: 3 };
+    expect(preservePendingPaths(base, local, remote)).toEqual({
+      list: [],
+      unchanged: 'new',
+      added: 3,
+    });
+    expect(remote.removed).toEqual({ count: 5 });
+  });
+});

--- a/app/utils/__tests__/pendingState.test.ts
+++ b/app/utils/__tests__/pendingState.test.ts
@@ -1,6 +1,29 @@
 import { describe, expect, it } from 'vitest';
-import { preservePendingPaths, snapshotSyncState } from '@/utils/pendingState';
+import {
+  createPendingStateTracker,
+  preservePendingPaths,
+  snapshotSyncState,
+} from '@/utils/pendingState';
 describe('pending state reconciliation', () => {
+  it('does not classify accepted remote events as local edits during another read', () => {
+    const state = { mode: { count: 1, pending: 'old' } };
+    const tracker = createPendingStateTracker(() => state);
+    state.mode.pending = 'local';
+    const snapshot = tracker.capture();
+    Object.assign(state, tracker.capture()({ mode: { count: 2, pending: 'old' } }));
+    expect(snapshot({ mode: { count: 3, pending: 'old' } })).toEqual({
+      mode: { count: 3, pending: 'local' },
+    });
+  });
+  it('handles remote values returning to an earlier value after a save', () => {
+    const state = { count: 0 };
+    const tracker = createPendingStateTracker(() => state);
+    state.count = 1;
+    tracker.captureAcknowledgement({ ...state })();
+    const snapshot = tracker.capture();
+    Object.assign(state, tracker.capture()({ count: 0 }));
+    expect(snapshot({ count: 2 })).toEqual({ count: 2 });
+  });
   it('snapshots persisted fields without retaining references or transient cycles', () => {
     const transient: Record<string, unknown> = {};
     transient.self = transient;

--- a/app/utils/__tests__/pendingState.test.ts
+++ b/app/utils/__tests__/pendingState.test.ts
@@ -15,6 +15,50 @@ describe('pending state reconciliation', () => {
       mode: { count: 3, pending: 'local' },
     });
   });
+  it('does not acknowledge pending fields retained by a domain merge', () => {
+    const state = { mode: { count: 5, name: 'old' } };
+    const tracker = createPendingStateTracker(() => state);
+    const read = tracker.capture();
+    state.mode.count = 0;
+    Object.assign(
+      state,
+      read({ mode: { count: 3, name: 'remote' } }, { mode: { count: 0, name: 'remote' } })
+    );
+    Object.assign(state, tracker.capture()({ mode: { count: 4, name: 'newer' } }));
+    expect(state.mode).toEqual({ count: 0, name: 'newer' });
+    tracker.captureAcknowledgement(snapshotSyncState(state))();
+    expect(tracker.capture()({ mode: { count: 6, name: 'latest' } })).toEqual({
+      mode: { count: 6, name: 'latest' },
+    });
+  });
+  it('accepts domain fallbacks that are not pending local edits', () => {
+    const state = { mode: { count: 5, name: 'old' } };
+    const tracker = createPendingStateTracker(() => state);
+    Object.assign(
+      state,
+      tracker.capture()(
+        { mode: { count: 3, name: 'remote' } },
+        { mode: { count: 5, name: 'remote' } }
+      )
+    );
+    expect(tracker.capture()({ mode: { count: 6, name: 'newer' } })).toEqual({
+      mode: { count: 6, name: 'newer' },
+    });
+  });
+  it('does not let an old write acknowledge over an authoritative remote reset', () => {
+    const state = { mode: { progressEpoch: 0, count: 5 }, other: 'old' };
+    const tracker = createPendingStateTracker(() => state);
+    state.mode.count = 6;
+    state.other = 'saved';
+    const acknowledge = tracker.captureAcknowledgement(snapshotSyncState(state));
+    const reset = { mode: { progressEpoch: 1, count: 0 } };
+    Object.assign(state, tracker.capture()(reset, reset, false));
+    acknowledge();
+    expect(tracker.capture()({ mode: { progressEpoch: 1, count: 2 }, other: 'newer' })).toEqual({
+      mode: { progressEpoch: 1, count: 2 },
+      other: 'newer',
+    });
+  });
   it('handles remote values returning to an earlier value after a save', () => {
     const state = { count: 0 };
     const tracker = createPendingStateTracker(() => state);

--- a/app/utils/__tests__/realtimeChannel.test.ts
+++ b/app/utils/__tests__/realtimeChannel.test.ts
@@ -9,6 +9,8 @@ import {
 vi.mock('@/utils/logger', () => ({
   logger: { debug: vi.fn(), error: vi.fn(), warn: vi.fn() },
 }));
+const { suspension } = vi.hoisted(() => ({ suspension: { active: false } }));
+vi.mock('@/utils/realtimeVisibility', () => ({ isRealtimeSuspended: () => suspension.active }));
 const owned = (topic: string) => ({ topic }) as OwnedRealtimeChannel;
 const deferred = () => {
   let resolve!: (value: boolean) => void;
@@ -99,6 +101,24 @@ describe('subscribeAndWaitForRealtimeChannel', () => {
     emit('SUBSCRIBED');
     await expect(ready).resolves.toBeUndefined();
     expect(settled).toBe(true);
+  });
+  it('retains a pending join through a suspended CLOSED transition', async () => {
+    vi.useFakeTimers();
+    const { channel, emit } = createChannel();
+    Object.assign(channel, { socket: {} });
+    const refresh = vi.fn();
+    const ready = subscribeAndWaitForRealtimeChannel(channel, 'test', {}, 10, refresh);
+    suspension.active = true;
+    try {
+      emit('CLOSED');
+      await vi.advanceTimersByTimeAsync(20);
+      suspension.active = false;
+      emit('SUBSCRIBED');
+      await expect(ready).resolves.toBeUndefined();
+      expect(refresh).toHaveBeenCalledOnce();
+    } finally {
+      suspension.active = false;
+    }
   });
   it('rejects on an explicit subscription failure', async () => {
     const { channel, emit } = createChannel();

--- a/app/utils/__tests__/realtimeChannel.test.ts
+++ b/app/utils/__tests__/realtimeChannel.test.ts
@@ -102,6 +102,21 @@ describe('subscribeAndWaitForRealtimeChannel', () => {
     await expect(ready).resolves.toBeUndefined();
     expect(settled).toBe(true);
   });
+  it('refreshes on the first join when subscription began while suspended', async () => {
+    const { channel, emit } = createChannel();
+    Object.assign(channel, { socket: {} });
+    const refresh = vi.fn();
+    suspension.active = true;
+    try {
+      const ready = subscribeAndWaitForRealtimeChannel(channel, 'test', {}, 10, refresh);
+      suspension.active = false;
+      emit('SUBSCRIBED');
+      await ready;
+      expect(refresh).toHaveBeenCalledOnce();
+    } finally {
+      suspension.active = false;
+    }
+  });
   it('retains a pending join through a suspended CLOSED transition', async () => {
     vi.useFakeTimers();
     const { channel, emit } = createChannel();

--- a/app/utils/__tests__/realtimeVisibility.test.ts
+++ b/app/utils/__tests__/realtimeVisibility.test.ts
@@ -1,0 +1,149 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { installRealtimeVisibility, isRealtimeSuspended } from '@/utils/realtimeVisibility';
+const setup = () => {
+  const page = new EventTarget() as EventTarget & { visibilityState: DocumentVisibilityState };
+  page.visibilityState = 'visible';
+  const transport = {
+    connect: vi.fn(),
+    disconnect: vi.fn(async () => 'ok' as const),
+    getChannels: vi.fn(() => [{}]),
+  };
+  const connect = transport.connect;
+  const dispose = installRealtimeVisibility(
+    transport as unknown as Parameters<typeof installRealtimeVisibility>[0],
+    page
+  );
+  const visibility = (state: DocumentVisibilityState) => {
+    page.visibilityState = state;
+    page.dispatchEvent(new Event('visibilitychange'));
+  };
+  return { page, transport, connect, dispose, visibility };
+};
+afterEach(() => vi.useRealTimers());
+describe('Realtime background transport', () => {
+  it('disconnects after 60 seconds, blocks joins while hidden and reconnects once', async () => {
+    vi.useFakeTimers();
+    const { transport, connect, dispose, visibility } = setup();
+    visibility('hidden');
+    await vi.advanceTimersByTimeAsync(59_999);
+    expect(transport.disconnect).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(1);
+    expect(transport.disconnect).toHaveBeenCalledTimes(1);
+    transport.connect();
+    expect(connect).not.toHaveBeenCalled();
+    visibility('visible');
+    visibility('visible');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+  it('cancels brief hides and does not open a socket with no channels', async () => {
+    vi.useFakeTimers();
+    const { transport, connect, dispose, visibility } = setup();
+    visibility('hidden');
+    await vi.advanceTimersByTimeAsync(30_000);
+    visibility('visible');
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(transport.disconnect).not.toHaveBeenCalled();
+    visibility('hidden');
+    await vi.advanceTimersByTimeAsync(60_000);
+    transport.getChannels.mockReturnValue([]);
+    visibility('visible');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).not.toHaveBeenCalled();
+    dispose();
+  });
+  it('waits for an outstanding disconnect and honors a second hide', async () => {
+    vi.useFakeTimers();
+    const { transport, connect, dispose, visibility } = setup();
+    let finish!: () => void;
+    transport.disconnect.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finish = () => resolve('ok');
+        })
+    );
+    visibility('hidden');
+    await vi.advanceTimersByTimeAsync(60_000);
+    visibility('visible');
+    transport.connect();
+    expect(connect).not.toHaveBeenCalled();
+    visibility('hidden');
+    finish();
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).not.toHaveBeenCalled();
+    expect(
+      isRealtimeSuspended(transport as unknown as Parameters<typeof isRealtimeSuspended>[0])
+    ).toBe(true);
+    visibility('visible');
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).toHaveBeenCalledTimes(1);
+    dispose();
+  });
+});
+it('retains and rejoins actual SDK channels after the background socket closes', async () => {
+  vi.useFakeTimers();
+  const { createClient } = await import('@supabase/supabase-js');
+  const sockets: FakeSocket[] = [];
+  class FakeSocket {
+    static OPEN = 1;
+    static CLOSED = 3;
+    readyState = 0;
+    bufferedAmount = 0;
+    onopen = (_event: unknown) => {};
+    onclose = (_event: unknown) => {};
+    onerror = (_event: unknown) => {};
+    onmessage = (_event: unknown) => {};
+    constructor(_url: string) {
+      sockets.push(this);
+      setTimeout(() => {
+        this.readyState = 1;
+        this.onopen({});
+      }, 0);
+    }
+    send(data: string) {
+      const parsed = JSON.parse(data);
+      const message = Array.isArray(parsed)
+        ? { join_ref: parsed[0], ref: parsed[1], topic: parsed[2], event: parsed[3] }
+        : parsed;
+      if (message.event === 'phx_join' || message.event === 'heartbeat') {
+        const payload = { status: 'ok', response: { postgres_changes: [] } };
+        const reply = Array.isArray(parsed)
+          ? [message.join_ref, message.ref, message.topic, 'phx_reply', payload]
+          : { ...message, event: 'phx_reply', payload };
+        setTimeout(() => this.onmessage({ data: JSON.stringify(reply) }), 0);
+      }
+    }
+    close() {
+      this.readyState = 3;
+      this.onclose({ code: 1000 });
+    }
+  }
+  const client = createClient('https://example.supabase.co', 'test-key', {
+    auth: { persistSession: false, autoRefreshToken: false },
+    realtime: { transport: FakeSocket as unknown as typeof WebSocket },
+  });
+  const page = new EventTarget() as EventTarget & { visibilityState: DocumentVisibilityState };
+  page.visibilityState = 'visible';
+  const dispose = installRealtimeVisibility(client.realtime, page);
+  const statuses = vi.fn();
+  client.channel('test').subscribe(statuses);
+  await vi.advanceTimersByTimeAsync(20);
+  expect(statuses.mock.calls.some(([status]) => status === 'SUBSCRIBED')).toBe(true);
+  page.visibilityState = 'hidden';
+  page.dispatchEvent(new Event('visibilitychange'));
+  await vi.advanceTimersByTimeAsync(60_020);
+  expect(sockets.every((socket) => socket.readyState === 3)).toBe(true);
+  expect(client.getChannels()).toHaveLength(1);
+  client.channel('created-while-hidden').subscribe();
+  await vi.advanceTimersByTimeAsync(30_000);
+  expect(sockets).toHaveLength(1);
+  page.visibilityState = 'visible';
+  page.dispatchEvent(new Event('visibilitychange'));
+  await vi.advanceTimersByTimeAsync(20);
+  expect(sockets).toHaveLength(2);
+  expect(statuses.mock.calls.filter(([status]) => status === 'SUBSCRIBED')).toHaveLength(2);
+  dispose();
+  await client.realtime.disconnect();
+});

--- a/app/utils/__tests__/realtimeVisibility.test.ts
+++ b/app/utils/__tests__/realtimeVisibility.test.ts
@@ -38,6 +38,27 @@ describe('Realtime background transport', () => {
     expect(connect).toHaveBeenCalledTimes(1);
     dispose();
   });
+  it('recovers visibility after a failed disconnect without leaving an unhandled rejection', async () => {
+    vi.useFakeTimers();
+    const { transport, connect, dispose, visibility } = setup();
+    let rejectLeave!: (reason: Error) => void;
+    transport.disconnect.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectLeave = reject;
+        })
+    );
+    visibility('hidden');
+    await vi.advanceTimersByTimeAsync(60_000);
+    visibility('visible');
+    rejectLeave(new Error('socket close failed'));
+    await vi.advanceTimersByTimeAsync(0);
+    expect(connect).toHaveBeenCalledOnce();
+    expect(
+      isRealtimeSuspended(transport as unknown as Parameters<typeof isRealtimeSuspended>[0])
+    ).toBe(false);
+    dispose();
+  });
   it('cancels brief hides and does not open a socket with no channels', async () => {
     vi.useFakeTimers();
     const { transport, connect, dispose, visibility } = setup();

--- a/app/utils/pendingState.ts
+++ b/app/utils/pendingState.ts
@@ -40,6 +40,12 @@ export const preservePendingPaths = (base: unknown, local: unknown, remote: unkn
   }
   return result;
 };
+const reconcileValue = (
+  base: unknown,
+  local: unknown,
+  remote: unknown,
+  preserveChanges: boolean
+) => (preserveChanges ? preservePendingPaths(base, local, remote) : remote);
 const advanceReadBaseline = (cursor: { next?: RemoteAdvance }, baseline: Snapshot) => {
   while (cursor.next) {
     const advance = cursor.next;
@@ -50,16 +56,24 @@ const advanceReadBaseline = (cursor: { next?: RemoteAdvance }, baseline: Snapsho
 };
 export const createPendingStateTracker = (getState: () => unknown) => {
   let baseline = snapshotSyncState(getState());
+  const replacements = new Map<string, symbol>();
   // Only in-flight captures retain earlier links. The tracker holds the tail,
   // so completed reads do not leave an ever-growing event history.
   let remoteCursor: { next?: RemoteAdvance } = {};
   return {
     captureAcknowledgement: (state: Snapshot): (() => void) => {
       const beforeWrite = baseline;
+      const beforeReplacements = new Map(replacements);
       return () => {
         // A save acknowledges its changed paths, not unrelated remote values
         // accepted while that save was queued or in flight.
-        baseline = snapshotSyncState(preservePendingPaths(beforeWrite, state, baseline));
+        const acknowledged = snapshotSyncState(preservePendingPaths(beforeWrite, state, baseline));
+        // A newer authoritative replacement (such as a remote reset) invalidates
+        // older writes only for its own scope, not unrelated queued save paths.
+        for (const [key, token] of replacements) {
+          if (beforeReplacements.get(key) !== token) acknowledged[key] = baseline[key];
+        }
+        baseline = acknowledged;
       };
     },
     capture: (): RemoteStateMerge => {
@@ -73,15 +87,19 @@ export const createPendingStateTracker = (getState: () => unknown) => {
         const result = { ...merged };
         const acknowledged = { ...baseline };
         for (const key of Object.keys(remote)) {
-          result[key] = preserveChanges
-            ? preservePendingPaths(beforeRead[key], current[key], merged[key])
+          result[key] = reconcileValue(beforeRead[key], current[key], merged[key], preserveChanges);
+          // Retain accepted domain fallbacks, but remove unsaved local paths
+          // from the acknowledgement. A domain merge can contain those edits.
+          const accepted = preserveChanges
+            ? preservePendingPaths(current[key], beforeRead[key], merged[key])
             : merged[key];
-          // A domain merge may intentionally keep a fallback instead of the
-          // raw remote value. Preserve acknowledgements that advanced since
-          // this read started, rather than restoring its pre-save baseline.
-          acknowledged[key] = preserveChanges
-            ? preservePendingPaths(beforeRead[key], baseline[key], merged[key])
-            : merged[key];
+          acknowledged[key] = reconcileValue(
+            beforeRead[key],
+            baseline[key],
+            accepted,
+            preserveChanges
+          );
+          if (!preserveChanges) replacements.set(key, Symbol());
         }
         const advance: RemoteAdvance = { before: baseline, after: snapshotSyncState(acknowledged) };
         remoteCursor.next = advance;

--- a/app/utils/pendingState.ts
+++ b/app/utils/pendingState.ts
@@ -1,5 +1,6 @@
 import { deepEqual } from '@/stores/tarkov/deepEqual';
 type Snapshot = Record<string, unknown>;
+type RemoteAdvance = { before: Snapshot; after: Snapshot; next?: RemoteAdvance };
 export type RemoteStateMerge = (
   remote: Snapshot,
   merged?: Snapshot,
@@ -36,8 +37,19 @@ export const preservePendingPaths = (base: unknown, local: unknown, remote: unkn
   }
   return result;
 };
+const advanceReadBaseline = (cursor: { next?: RemoteAdvance }, baseline: Snapshot) => {
+  while (cursor.next) {
+    const advance = cursor.next;
+    baseline = preservePendingPaths(advance.before, advance.after, baseline) as Snapshot;
+    cursor = advance;
+  }
+  return { cursor, baseline };
+};
 export const createPendingStateTracker = (getState: () => unknown) => {
   let baseline = snapshotSyncState(getState());
+  // Only in-flight captures retain earlier links. The tracker holds the tail,
+  // so completed reads do not leave an ever-growing event history.
+  let remoteCursor: { next?: RemoteAdvance } = {};
   return {
     captureAcknowledgement: (state: Snapshot): (() => void) => {
       const beforeWrite = baseline;
@@ -48,8 +60,12 @@ export const createPendingStateTracker = (getState: () => unknown) => {
       };
     },
     capture: (): RemoteStateMerge => {
-      const beforeRead = baseline;
+      let beforeRead = baseline;
+      let cursor = remoteCursor;
       return (remote, merged = remote, preserveChanges = true) => {
+        const advanced = advanceReadBaseline(cursor, beforeRead);
+        beforeRead = advanced.baseline;
+        cursor = advanced.cursor;
         const current = snapshotSyncState(getState());
         const result = { ...merged };
         const acknowledged = { ...baseline };
@@ -64,7 +80,10 @@ export const createPendingStateTracker = (getState: () => unknown) => {
             ? preservePendingPaths(beforeRead[key], baseline[key], merged[key])
             : merged[key];
         }
-        baseline = snapshotSyncState(acknowledged);
+        const advance: RemoteAdvance = { before: baseline, after: snapshotSyncState(acknowledged) };
+        remoteCursor.next = advance;
+        remoteCursor = advance;
+        baseline = advance.after;
         return result;
       };
     },

--- a/app/utils/pendingState.ts
+++ b/app/utils/pendingState.ts
@@ -47,12 +47,19 @@ export const createPendingStateTracker = (getState: () => unknown) => {
       return (remote, merged = remote, preserveChanges = true) => {
         const current = snapshotSyncState(getState());
         const result = { ...merged };
+        const acknowledged = { ...baseline };
         for (const key of Object.keys(remote)) {
           result[key] = preserveChanges
             ? preservePendingPaths(beforeRead[key], current[key], merged[key])
             : merged[key];
+          // A domain merge may intentionally keep a fallback instead of the
+          // raw remote value. Only advance clean paths to what was accepted;
+          // locally changed paths retain their prior baseline until saved.
+          acknowledged[key] = preserveChanges
+            ? preservePendingPaths(current[key], beforeRead[key], merged[key])
+            : merged[key];
         }
-        baseline = { ...baseline, ...snapshotSyncState(remote) };
+        baseline = snapshotSyncState(acknowledged);
         return result;
       };
     },

--- a/app/utils/pendingState.ts
+++ b/app/utils/pendingState.ts
@@ -39,8 +39,13 @@ export const preservePendingPaths = (base: unknown, local: unknown, remote: unkn
 export const createPendingStateTracker = (getState: () => unknown) => {
   let baseline = snapshotSyncState(getState());
   return {
-    acknowledge: (state: Snapshot) => {
-      baseline = state;
+    captureAcknowledgement: (state: Snapshot): (() => void) => {
+      const beforeWrite = baseline;
+      return () => {
+        // A save acknowledges its changed paths, not unrelated remote values
+        // accepted while that save was queued or in flight.
+        baseline = snapshotSyncState(preservePendingPaths(beforeWrite, state, baseline));
+      };
     },
     capture: (): RemoteStateMerge => {
       const beforeRead = baseline;

--- a/app/utils/pendingState.ts
+++ b/app/utils/pendingState.ts
@@ -1,0 +1,60 @@
+import { deepEqual } from '@/stores/tarkov/deepEqual';
+type Snapshot = Record<string, unknown>;
+export type RemoteStateMerge = (
+  remote: Snapshot,
+  merged?: Snapshot,
+  preserveChanges?: boolean
+) => Snapshot;
+const isRecord = (value: unknown): value is Snapshot =>
+  value !== null && typeof value === 'object' && !Array.isArray(value);
+// Snapshot JSON-backed fields independently so transient UI references cannot
+// prevent reconciliation of the persisted fields next to them.
+// fallow-ignore-next-line complexity -- JSON/undefined/cyclic fields are covered directly in pendingState.test.ts; estimated coverage reports none
+export const snapshotSyncState = (state: unknown): Snapshot => {
+  const result: Snapshot = {};
+  if (!isRecord(state)) return result;
+  for (const [key, value] of Object.entries(state)) {
+    try {
+      const json = JSON.stringify(value);
+      result[key] = json === undefined ? undefined : JSON.parse(json);
+    } catch {
+      // Non-serializable UI state is not part of the persistence contract.
+    }
+  }
+  return result;
+};
+// Three-way merge: retain only paths changed locally since the acknowledged
+// baseline. Remote changes to other paths still apply, including other modes.
+// fallow-ignore-next-line complexity -- deletion/array/remote-field merges are covered in pendingState.test.ts and live/snapshot integration tests
+export const preservePendingPaths = (base: unknown, local: unknown, remote: unknown): unknown => {
+  if (deepEqual(base, local)) return remote;
+  if (!isRecord(base) || !isRecord(local)) return local;
+  const result: Snapshot = isRecord(remote) ? { ...remote } : {};
+  for (const key of new Set([...Object.keys(base), ...Object.keys(local)])) {
+    if (!Object.hasOwn(local, key)) Reflect.deleteProperty(result, key);
+    else result[key] = preservePendingPaths(base[key], local[key], result[key]);
+  }
+  return result;
+};
+export const createPendingStateTracker = (getState: () => unknown) => {
+  let baseline = snapshotSyncState(getState());
+  return {
+    acknowledge: (state: Snapshot) => {
+      baseline = state;
+    },
+    capture: (): RemoteStateMerge => {
+      const beforeRead = baseline;
+      return (remote, merged = remote, preserveChanges = true) => {
+        const current = snapshotSyncState(getState());
+        const result = { ...merged };
+        for (const key of Object.keys(remote)) {
+          result[key] = preserveChanges
+            ? preservePendingPaths(beforeRead[key], current[key], merged[key])
+            : merged[key];
+        }
+        baseline = { ...baseline, ...snapshotSyncState(remote) };
+        return result;
+      };
+    },
+  };
+};

--- a/app/utils/pendingState.ts
+++ b/app/utils/pendingState.ts
@@ -1,5 +1,8 @@
 import { deepEqual } from '@/stores/tarkov/deepEqual';
 type Snapshot = Record<string, unknown>;
+export type WithRemoteSnapshot = <T>(
+  read: (reconcile: RemoteStateMerge) => Promise<T>
+) => Promise<T>;
 type RemoteAdvance = { before: Snapshot; after: Snapshot; next?: RemoteAdvance };
 export type RemoteStateMerge = (
   remote: Snapshot,

--- a/app/utils/pendingState.ts
+++ b/app/utils/pendingState.ts
@@ -53,10 +53,10 @@ export const createPendingStateTracker = (getState: () => unknown) => {
             ? preservePendingPaths(beforeRead[key], current[key], merged[key])
             : merged[key];
           // A domain merge may intentionally keep a fallback instead of the
-          // raw remote value. Only advance clean paths to what was accepted;
-          // locally changed paths retain their prior baseline until saved.
+          // raw remote value. Preserve acknowledgements that advanced since
+          // this read started, rather than restoring its pre-save baseline.
           acknowledged[key] = preserveChanges
-            ? preservePendingPaths(current[key], beforeRead[key], merged[key])
+            ? preservePendingPaths(beforeRead[key], baseline[key], merged[key])
             : merged[key];
         }
         baseline = snapshotSyncState(acknowledged);

--- a/app/utils/realtimeChannel.ts
+++ b/app/utils/realtimeChannel.ts
@@ -150,8 +150,8 @@ export const subscribeAndWaitForRealtimeChannel = (
   new Promise<void>((resolve, reject) => {
     let settled = false;
     let joined = false;
-    let needsRefresh = false;
     const suspended = () => channel.socket && isRealtimeSuspended(channel.socket);
+    let needsRefresh = Boolean(suspended());
     const timeoutJoin = () => {
       if (suspended()) {
         timeout = setTimeout(timeoutJoin, timeoutMs);

--- a/app/utils/realtimeChannel.ts
+++ b/app/utils/realtimeChannel.ts
@@ -184,7 +184,7 @@ export const subscribeAndWaitForRealtimeChannel = (
           return;
         }
         needsRefresh = true;
-        if (suspended() && status !== 'CLOSED') return;
+        if (suspended()) return;
         if (
           logChannelSubscribeFailure(label, status, error, context, {
             treatClosedAsFailure: true,

--- a/app/utils/realtimeChannel.ts
+++ b/app/utils/realtimeChannel.ts
@@ -173,6 +173,7 @@ export const subscribeAndWaitForRealtimeChannel = (
       else resolve();
     };
     try {
+      // fallow-ignore-next-line complexity -- tested join/rejoin state machine; inferred coverage misses the SDK callback
       channel.subscribe((status: string, error?: Error) => {
         logger.debug(`[${label}] Realtime subscription status: ${status}`);
         if (status === 'SUBSCRIBED') {

--- a/app/utils/realtimeChannel.ts
+++ b/app/utils/realtimeChannel.ts
@@ -1,4 +1,5 @@
 import { logger } from '@/utils/logger';
+import { isRealtimeSuspended } from '@/utils/realtimeVisibility';
 import type { RealtimeChannel, SupabaseClient } from '@supabase/supabase-js';
 /**
  * The channel type `SupabaseClient.channel()` actually returns.
@@ -143,18 +144,27 @@ export const subscribeAndWaitForRealtimeChannel = (
   channel: SupabaseRealtimeChannel,
   label: string,
   context: Record<string, unknown>,
-  timeoutMs = REALTIME_SUBSCRIPTION_TIMEOUT_MS
+  timeoutMs = REALTIME_SUBSCRIPTION_TIMEOUT_MS,
+  onRejoined?: () => void
 ): Promise<void> =>
   new Promise<void>((resolve, reject) => {
     let settled = false;
-    const timeout = setTimeout(() => {
+    let joined = false;
+    let needsRefresh = false;
+    const suspended = () => channel.socket && isRealtimeSuspended(channel.socket);
+    const timeoutJoin = () => {
+      if (suspended()) {
+        timeout = setTimeout(timeoutJoin, timeoutMs);
+        return;
+      }
       const error = new Error(`Realtime subscription timed out after ${timeoutMs}ms for ${label}`);
       logger.warn(`[${label}] Realtime subscription timed out:`, {
         ...context,
         timeoutMs,
       });
       settle(error);
-    }, timeoutMs);
+    };
+    let timeout = setTimeout(timeoutJoin, timeoutMs);
     const settle = (error?: Error): void => {
       if (settled) return;
       settled = true;
@@ -166,9 +176,14 @@ export const subscribeAndWaitForRealtimeChannel = (
       channel.subscribe((status: string, error?: Error) => {
         logger.debug(`[${label}] Realtime subscription status: ${status}`);
         if (status === 'SUBSCRIBED') {
+          if (joined || needsRefresh) onRejoined?.();
+          needsRefresh = false;
+          joined = true;
           settle();
           return;
         }
+        needsRefresh = true;
+        if (suspended() && status !== 'CLOSED') return;
         if (
           logChannelSubscribeFailure(label, status, error, context, {
             treatClosedAsFailure: true,

--- a/app/utils/realtimeVisibility.ts
+++ b/app/utils/realtimeVisibility.ts
@@ -44,6 +44,7 @@ export const installRealtimeVisibility = (
     if (!suspendedTransports.has(transport)) return;
     void Promise.resolve(leaving)
       .catch(() => undefined)
+      // fallow-ignore-next-line complexity -- disconnect/visibility races covered with the real SDK in realtimeVisibility.test.ts
       .then(() => {
         if (disposed || version !== generation || page.visibilityState === 'hidden') return;
         leaving = null;

--- a/app/utils/realtimeVisibility.ts
+++ b/app/utils/realtimeVisibility.ts
@@ -1,0 +1,64 @@
+import { logger } from '@/utils/logger';
+import type { SupabaseClient } from '@supabase/supabase-js';
+export const REALTIME_BACKGROUND_GRACE_MS = 60_000;
+type RealtimeTransport = Pick<SupabaseClient['realtime'], 'connect' | 'disconnect' | 'getChannels'>;
+const suspendedTransports = new WeakSet<RealtimeTransport>();
+export const isRealtimeSuspended = (transport: RealtimeTransport): boolean =>
+  suspendedTransports.has(transport);
+/** Keep channel ownership intact while closing the shared socket in background tabs. */
+export const installRealtimeVisibility = (
+  transport: RealtimeTransport,
+  page: Pick<Document, 'visibilityState' | 'addEventListener' | 'removeEventListener'> = document
+): (() => void) => {
+  const originalConnect = transport.connect;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let leaving: Promise<unknown> | null = null;
+  let disposed = false;
+  let generation = 0;
+  const connect = () => {
+    if (disposed || suspendedTransports.has(transport) || leaving) return;
+    originalConnect.call(transport);
+  };
+  transport.connect = connect;
+  const suspend = () => {
+    timer = undefined;
+    if (disposed || page.visibilityState !== 'hidden') return;
+    generation += 1;
+    suspendedTransports.add(transport);
+    const pending = Promise.resolve().then(() => transport.disconnect());
+    leaving = pending;
+    void pending
+      .catch((error: unknown) => logger.warn('[Realtime] Background disconnect failed', error))
+      .finally(() => {
+        if (leaving === pending) leaving = null;
+      });
+  };
+  const visibilityChanged = () => {
+    clearTimeout(timer);
+    if (page.visibilityState === 'hidden') {
+      if (!suspendedTransports.has(transport))
+        timer = setTimeout(suspend, REALTIME_BACKGROUND_GRACE_MS);
+      return;
+    }
+    const version = ++generation;
+    if (!suspendedTransports.has(transport)) return;
+    void Promise.resolve(leaving)
+      .catch(() => undefined)
+      .then(() => {
+        if (disposed || version !== generation || page.visibilityState === 'hidden') return;
+        leaving = null;
+        suspendedTransports.delete(transport);
+        if (transport.getChannels().length > 0) connect();
+      });
+  };
+  page.addEventListener('visibilitychange', visibilityChanged);
+  visibilityChanged();
+  return () => {
+    disposed = true;
+    generation += 1;
+    clearTimeout(timer);
+    page.removeEventListener('visibilitychange', visibilityChanged);
+    suspendedTransports.delete(transport);
+    transport.connect = originalConnect;
+  };
+};

--- a/app/utils/userScopedStorage.ts
+++ b/app/utils/userScopedStorage.ts
@@ -1,5 +1,7 @@
 export type UserScopedStorageEnvelope<T> = {
   _timestamp?: number;
+  _metadataTimestamp?: number;
+  _modeTimestamps?: Record<string, number>;
   _userId: string | null;
   data: T;
 };
@@ -33,7 +35,21 @@ export const parseUserScopedStorage = <T>(raw: string): UserScopedStorageEnvelop
     }
     const userId = typeof parsed._userId === 'string' ? parsed._userId : null;
     const timestamp = typeof parsed._timestamp === 'number' ? parsed._timestamp : undefined;
+    const modeTimestamps = isRecord(parsed._modeTimestamps)
+      ? Object.fromEntries(
+          Object.entries(parsed._modeTimestamps).filter(
+            (entry): entry is [string, number] =>
+              typeof entry[1] === 'number' && Number.isFinite(entry[1]) && entry[1] >= 0
+          )
+        )
+      : undefined;
     return {
+      ...(modeTimestamps ? { _modeTimestamps: modeTimestamps } : {}),
+      ...(typeof parsed._metadataTimestamp === 'number' &&
+      Number.isFinite(parsed._metadataTimestamp) &&
+      parsed._metadataTimestamp >= 0
+        ? { _metadataTimestamp: parsed._metadataTimestamp }
+        : {}),
       _timestamp: timestamp,
       _userId: userId,
       data: parsed.data as T,

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -787,7 +787,9 @@ flowchart LR
   with sanitized progress. Visibility-only writes never advance it. Historical rows retain null until
   progress changes; unknown normalized mode freshness stays unknown instead of borrowing metadata
   freshness. Known local mode clocks preserve offline scalar edits while entry timestamps and reset
-  epochs still reconcile progress. Only progress actually read from a legacy row uses that row's clock.
+  epochs still reconcile progress. With both mode clocks unknown, remote scalar fields win;
+  progress scores from unrelated modes cannot choose them. Only progress actually read from a
+  legacy row uses that row's clock.
   When a mode is newer than account metadata, startup merges progress by entry timestamps and reset epochs;
   clearable profile fields use the preferred snapshot verbatim, including null names and empty offsets.
   Startup skill-offset maps are atomic: absent keys represent deletions, and historical snapshots
@@ -797,7 +799,9 @@ flowchart LR
   within a mode advance its local clock; account hydration keeps the server metadata clock, and switching modes or editing another mode does not. Legacy
   envelopes seed unchanged modes from their original timestamp (unknown history stays zero).
   Startup and Realtime hydration retain remote progress freshness, rather than download time.
-  Accepted envelopes are persisted even when a matching acknowledgement needs no Pinia patch;
+  Accepted envelopes are persisted even when a matching acknowledgement needs no Pinia patch,
+  provided shared storage still matches the tab's prior data and clocks. Divergence skips that
+  acknowledgement write so another tab's unsaved edits remain stored;
   merged snapshots that retain local fields use at least one millisecond beyond the incoming
   snapshot clock, so reload cannot discard pending edits on a timestamp tie. Each tab compares
   with its own prior snapshot so another tab's storage write cannot make stale fields look edited.
@@ -816,12 +820,13 @@ flowchart LR
   changes separately from local acknowledgements, so older live events cannot override newer snapshots.
   Domain merges do not acknowledge unsaved local fields. A newer remote reset invalidates older
   save acknowledgements for that mode; a newer local reset stays pending until its save succeeds.
+  Reconnect and live mode hydration ignore unmaterialized placeholder rows, preserving legacy progress.
   Reconnect reads wait for in-flight saves and hold new outbound writes until snapshot application
   completes. Local changes remain tracked and are saved afterward; read failures also release this barrier.
   Supporter status refreshes after the first join as well as subsequent joins to close the
   initial read/join gap. An owner or generic subscription whose first join is delayed by suspension reconciles on its first
   eventual join. Initialization delegates the initial status read to the subscription, with a
-  single fallback read if the initial join fails. Initialization marks status loaded only after a
+  fallback status read if the subscription declines or the initial join fails. Initialization marks status loaded only after a
   successful read; initial callers share the latest request's result even when a refresh supersedes
   the initial query. Session reset releases waiters, and failed reads can retry on the existing channel.
   Skipped saves do not run payload transforms. Actual RPC writes temporarily mark the self-origin

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -770,6 +770,19 @@ flowchart LR
   tear the team channel down and schedule one rebuild a minute later, replacing Realtime's unbounded
   rejoin loop with a bounded retry cycle.
 - `user_system` is included in `supabase_realtime`, and sign-out tears down all client channels.
+- The shared browser Realtime transport disconnects after 60 seconds continuously hidden. Channel
+  ownership is retained, new connect attempts are gated while suspended, and a visible tab waits for
+  an outstanding disconnect before reconnecting once. Auth, local persistence, and outbound saves
+  remain active. Rejoined consumers refresh authoritative snapshots; owner progress uses existing
+  merge/epoch rules, and snapshot responses cannot overwrite newer live events or another session.
+- Progress RPC upserts compare sanitized account/mode values before updating. Identical saves do not
+  change progress timestamps or emit progress-row events. The legacy compatibility trigger remains;
+  its normalized write makes the subsequent identical RPC upsert a no-op. Startup freshness uses
+  the newest account or active-mode timestamp because Seasonal-only saves no longer touch the account.
+- Startup fetches metadata and normalized modes before requesting missing persistent legacy columns.
+  Shared-profile, gateway, and teammate reads request legacy progress only when their existing
+  fallback rules require it. Public visibility and team authorization still precede fallback use.
+  This reduces Supabase transfer; gateway response ETags alone do not avoid upstream reads.
 - New clients read teammate progress from mode rows. When a persistent normalized row is missing or
   carries no `level`, `useTeamStore` calls `get_teammate_legacy_progress` for only the teammate's
   authorized mode column; the raw `user_progress` teammate policy is not used. Account-wide metadata

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -784,7 +784,8 @@ flowchart LR
   When only a mode row is newer, startup merges progress by entry timestamps and reset epochs;
   visibility changes also update mode timestamps and cannot justify replacing whole mode snapshots.
   Team rejoin refreshes membership and rebuilds changed filters before hydrating teammates; initial
-  joins do not trigger an additional hydration. Optional missing account metadata never blocks
+  joins do not trigger an additional hydration. Only the winning membership refresh may trigger
+  hydration; a superseded reconnect request cannot race ahead of a newer filter rebuild. Optional missing account metadata never blocks
   normalized reconnect progress. Deferred legacy reads retain startup retries and API error mapping.
   Unmaterialized normalized rows are absent for startup fallback and freshness. Outbound writes are
   serialized with captured payloads and versions; resumed saves cannot overtake an in-flight save.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -782,10 +782,14 @@ flowchart LR
   and edits made during those reads; a higher reset epoch still wins over an older epoch's edits.
 - Progress RPC upserts compare sanitized account/mode values before updating. Identical saves do not
   change progress timestamps or emit progress-row events. The legacy compatibility trigger remains;
-  its normalized write makes the subsequent identical RPC upsert a no-op. Startup freshness uses
-  the newest account or active-mode timestamp because Seasonal-only saves no longer touch the account.
-  When only a mode row is newer, startup merges progress by entry timestamps and reset epochs;
+  its normalized write makes the subsequent identical RPC upsert a no-op. Startup account metadata
+  uses the account timestamp; each mode independently uses `progress_updated_at`, which changes only
+  with sanitized progress. Visibility-only writes never advance it. Historical rows retain null until
+  progress changes and use the account timestamp as the legacy fallback, never visibility freshness.
+  When a mode is newer than account metadata, startup merges progress by entry timestamps and reset epochs;
   clearable profile fields use the preferred snapshot verbatim, including null names and empty offsets.
+  Startup skill-offset maps are atomic: absent keys represent deletions, and historical snapshots
+  have no per-offset timestamps or deletion markers to safely union concurrent edits.
   Visibility changes also update mode timestamps and cannot justify replacing whole mode snapshots.
   Team rejoin refreshes membership and rebuilds changed filters before hydrating teammates; initial
   joins do not trigger an additional hydration. Only the winning membership refresh may trigger
@@ -797,7 +801,8 @@ flowchart LR
   Save acknowledgements advance only their changed paths, preserving unrelated remote values
   accepted while the save was queued or in flight.
   Supporter status refreshes after the first join as well as subsequent joins to close the
-  initial read/join gap. Initialization delegates the initial status read to the subscription, with a
+  initial read/join gap. A progress subscription begun while suspended also reconciles on its first
+  eventual join. Initialization delegates the initial status read to the subscription, with a
   single fallback read if the initial join fails.
   Skipped saves do not run payload transforms. Actual RPC writes temporarily mark the self-origin
   timeline before awaiting the response; failure removes that marker, success retains it, and

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -785,7 +785,8 @@ flowchart LR
   its normalized write makes the subsequent identical RPC upsert a no-op. Startup freshness uses
   the newest account or active-mode timestamp because Seasonal-only saves no longer touch the account.
   When only a mode row is newer, startup merges progress by entry timestamps and reset epochs;
-  visibility changes also update mode timestamps and cannot justify replacing whole mode snapshots.
+  clearable profile fields use the preferred snapshot verbatim, including null names and empty offsets.
+  Visibility changes also update mode timestamps and cannot justify replacing whole mode snapshots.
   Team rejoin refreshes membership and rebuilds changed filters before hydrating teammates; initial
   joins do not trigger an additional hydration. Only the winning membership refresh may trigger
   hydration after a successful membership read; a failed read neither hydrates nor rebuilds.
@@ -794,8 +795,11 @@ flowchart LR
   Unmaterialized normalized rows are absent for startup fallback and freshness. Outbound writes are
   serialized with captured payloads and versions; resumed saves cannot overtake an in-flight save.
   Supporter status refreshes after the first join as well as subsequent joins to close the
-  initial read/join gap and recover an unsuccessful initial read. Skipped saves do not run
-  payload transforms; the self-origin timestamp advances only after a successful write.
+  initial read/join gap. Initialization delegates the initial status read to the subscription, with a
+  single fallback read if the initial join fails.
+  Skipped saves do not run payload transforms. Actual RPC writes temporarily mark the self-origin
+  timeline before awaiting the response; failure removes that marker, success retains it, and
+  session reset invalidates outstanding markers.
 - Startup fetches metadata and normalized modes before requesting missing persistent legacy columns.
   Shared-profile, gateway, and teammate reads request legacy progress only when their existing
   fallback rules require it. Public visibility and team authorization still precede fallback use.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -790,7 +790,10 @@ flowchart LR
   clearable profile fields use the preferred snapshot verbatim, including null names and empty offsets.
   Startup skill-offset maps are atomic: absent keys represent deletions, and historical snapshots
   have no per-offset timestamps or deletion markers to safely union concurrent edits.
-  Visibility changes also update mode timestamps and cannot justify replacing whole mode snapshots.
+  Local envelopes still carry one whole-state timestamp, as before this optimization; unrelated local
+  mode edits can affect startup preference for untimestamped fields. Per-mode local edit provenance
+  requires a separate persisted-format change, including remote hydration and legacy-envelope handling.
+  Visibility changes update `updated_at`, never `progress_updated_at`, and cannot justify replacing whole mode snapshots.
   Team rejoin refreshes membership and rebuilds changed filters before hydrating teammates; initial
   joins do not trigger an additional hydration. Only the winning membership refresh may trigger
   hydration after a successful membership read; a failed read neither hydrates nor rebuilds.
@@ -799,11 +802,14 @@ flowchart LR
   Unmaterialized normalized rows are absent for startup fallback and freshness. Outbound writes are
   serialized with captured payloads and versions; resumed saves cannot overtake an in-flight save.
   Save acknowledgements advance only their changed paths, preserving unrelated remote values
-  accepted while the save was queued or in flight.
+  accepted while the save was queued or in flight. Pending captures track intervening accepted remote
+  changes separately from local acknowledgements, so older live events cannot override newer snapshots.
   Supporter status refreshes after the first join as well as subsequent joins to close the
   initial read/join gap. A progress subscription begun while suspended also reconciles on its first
   eventual join. Initialization delegates the initial status read to the subscription, with a
-  single fallback read if the initial join fails.
+  single fallback read if the initial join fails. Initialization marks status loaded only after a
+  successful read; initial callers share its result, session reset releases waiters, and failed reads
+  can retry on the existing channel.
   Skipped saves do not run payload transforms. Actual RPC writes temporarily mark the self-origin
   timeline before awaiting the response; failure removes that marker, success retains it, and
   session reset invalidates outstanding markers.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -790,6 +790,11 @@ flowchart LR
   epochs still reconcile progress. With both mode clocks unknown, remote scalar fields win;
   progress scores from unrelated modes cannot choose them. Only progress actually read from a
   legacy row uses that row's clock.
+  During the additive freshness-column rollout, startup and reconnect reads retry once without
+  `progress_updated_at` only when PostgreSQL/PostgREST reports that column missing. Those rows
+  retain unknown mode freshness; account timestamps never substitute for it. Other errors and
+  failed fallback reads remain failures. Each read probes the column again so completed migrations
+  take effect without a reload.
   When a mode is newer than account metadata, startup merges progress by entry timestamps and reset epochs;
   clearable profile fields use the preferred snapshot verbatim, including null names and empty offsets.
   Startup skill-offset maps are atomic: absent keys represent deletions, and historical snapshots
@@ -811,6 +816,9 @@ flowchart LR
   connection failure also hydrates after successful membership refresh and the replacement join.
   Only the winning membership refresh may trigger
   hydration after a successful membership read; a failed read neither hydrates nor rebuilds.
+  Pending hydration follows the winning replacement team when a team switch retains teammate
+  stores during reconnect; it fires only after the replacement joins. Leaving all teams or disposing
+  the controller clears that intent.
   A superseded reconnect request cannot race ahead of a newer filter rebuild. Optional missing account metadata never blocks
   normalized reconnect progress. Deferred legacy reads retain startup retries and API error mapping.
   Unmaterialized normalized rows are absent for startup fallback and freshness. Outbound writes are

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -790,12 +790,18 @@ flowchart LR
   clearable profile fields use the preferred snapshot verbatim, including null names and empty offsets.
   Startup skill-offset maps are atomic: absent keys represent deletions, and historical snapshots
   have no per-offset timestamps or deletion markers to safely union concurrent edits.
-  Local envelopes still carry one whole-state timestamp, as before this optimization; unrelated local
-  mode edits can affect startup preference for untimestamped fields. Per-mode local edit provenance
-  requires a separate persisted-format change, including remote hydration and legacy-envelope handling.
+  Local envelopes retain `_timestamp` for envelope compatibility and add `_metadataTimestamp` for
+  account settings plus independent `_modeTimestamps` for progress. Only changes
+  within a mode advance its local clock; account hydration keeps the server metadata clock, and switching modes or editing another mode does not. Legacy
+  envelopes seed unchanged modes from their original timestamp (unknown history stays zero).
+  Startup and Realtime hydration retain remote progress freshness, rather than download time;
+  merged snapshots that retain local fields also retain their local edit clock. Each tab compares
+  with its own prior snapshot so another tab's storage write cannot make stale fields look edited.
   Visibility changes update `updated_at`, never `progress_updated_at`, and cannot justify replacing whole mode snapshots.
   Team rejoin refreshes membership and rebuilds changed filters before hydrating teammates; initial
-  joins do not trigger an additional hydration. Only the winning membership refresh may trigger
+  joins do not trigger an additional hydration. Replacement of a previously joined channel after
+  connection failure also hydrates after successful membership refresh and the replacement join.
+  Only the winning membership refresh may trigger
   hydration after a successful membership read; a failed read neither hydrates nor rebuilds.
   A superseded reconnect request cannot race ahead of a newer filter rebuild. Optional missing account metadata never blocks
   normalized reconnect progress. Deferred legacy reads retain startup retries and API error mapping.
@@ -804,12 +810,14 @@ flowchart LR
   Save acknowledgements advance only their changed paths, preserving unrelated remote values
   accepted while the save was queued or in flight. Pending captures track intervening accepted remote
   changes separately from local acknowledgements, so older live events cannot override newer snapshots.
+  Reconnect reads wait for in-flight saves and hold new outbound writes until snapshot application
+  completes. Local changes remain tracked and are saved afterward; read failures also release this barrier.
   Supporter status refreshes after the first join as well as subsequent joins to close the
   initial read/join gap. A progress subscription begun while suspended also reconciles on its first
   eventual join. Initialization delegates the initial status read to the subscription, with a
   single fallback read if the initial join fails. Initialization marks status loaded only after a
-  successful read; initial callers share its result, session reset releases waiters, and failed reads
-  can retry on the existing channel.
+  successful read; initial callers share the latest request's result even when a refresh supersedes
+  the initial query. Session reset releases waiters, and failed reads can retry on the existing channel.
   Skipped saves do not run payload transforms. Actual RPC writes temporarily mark the self-origin
   timeline before awaiting the response; failure removes that marker, success retains it, and
   session reset invalidates outstanding markers.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -777,7 +777,8 @@ flowchart LR
   merge/epoch rules, and snapshot responses cannot overwrite newer live events or another session.
   A three-way merge compares each field with its acknowledged baseline, retaining only locally
   changed paths while accepting unrelated remote changes, including changes in other modes.
-  Pending fields (including explicit clears) survive reconnect reads, incoming live events,
+  Live mode rows and startup snapshots resolve counts by entry timestamp rather than maximum,
+  so an acknowledged count clear is not resurrected. Pending fields (including explicit clears) survive reconnect reads, incoming live events,
   and edits made during those reads; a higher reset epoch still wins over an older epoch's edits.
 - Progress RPC upserts compare sanitized account/mode values before updating. Identical saves do not
   change progress timestamps or emit progress-row events. The legacy compatibility trigger remains;
@@ -787,7 +788,8 @@ flowchart LR
   visibility changes also update mode timestamps and cannot justify replacing whole mode snapshots.
   Team rejoin refreshes membership and rebuilds changed filters before hydrating teammates; initial
   joins do not trigger an additional hydration. Only the winning membership refresh may trigger
-  hydration; a superseded reconnect request cannot race ahead of a newer filter rebuild. Optional missing account metadata never blocks
+  hydration after a successful membership read; a failed read neither hydrates nor rebuilds.
+  A superseded reconnect request cannot race ahead of a newer filter rebuild. Optional missing account metadata never blocks
   normalized reconnect progress. Deferred legacy reads retain startup retries and API error mapping.
   Unmaterialized normalized rows are absent for startup fallback and freshness. Outbound writes are
   serialized with captured payloads and versions; resumed saves cannot overtake an in-flight save.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -775,7 +775,9 @@ flowchart LR
   an outstanding disconnect before reconnecting once. Auth, local persistence, and outbound saves
   remain active. Rejoined consumers refresh authoritative snapshots; owner progress uses existing
   merge/epoch rules, and snapshot responses cannot overwrite newer live events or another session.
-  Pending profile fields (including explicit clears) survive reconnect reads, incoming live events,
+  A three-way merge compares each field with its acknowledged baseline, retaining only locally
+  changed paths while accepting unrelated remote changes, including changes in other modes.
+  Pending fields (including explicit clears) survive reconnect reads, incoming live events,
   and edits made during those reads; a higher reset epoch still wins over an older epoch's edits.
 - Progress RPC upserts compare sanitized account/mode values before updating. Identical saves do not
   change progress timestamps or emit progress-row events. The legacy compatibility trigger remains;
@@ -789,7 +791,9 @@ flowchart LR
   normalized reconnect progress. Deferred legacy reads retain startup retries and API error mapping.
   Unmaterialized normalized rows are absent for startup fallback and freshness. Outbound writes are
   serialized with captured payloads and versions; resumed saves cannot overtake an in-flight save.
-  Supporter status refreshes on subsequent joins without duplicating the initial status load.
+  Supporter status refreshes after the first join as well as subsequent joins to close the
+  initial read/join gap and recover an unsuccessful initial read. Skipped saves do not run
+  payload transforms; the self-origin timestamp advances only after a successful write.
 - Startup fetches metadata and normalized modes before requesting missing persistent legacy columns.
   Shared-profile, gateway, and teammate reads request legacy progress only when their existing
   fallback rules require it. Public visibility and team authorization still precede fallback use.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -775,10 +775,17 @@ flowchart LR
   an outstanding disconnect before reconnecting once. Auth, local persistence, and outbound saves
   remain active. Rejoined consumers refresh authoritative snapshots; owner progress uses existing
   merge/epoch rules, and snapshot responses cannot overwrite newer live events or another session.
+  Pending profile fields (including explicit clears) survive reconnect reads and edits made during
+  those reads; a higher reset epoch still wins over pending fields from an older epoch.
 - Progress RPC upserts compare sanitized account/mode values before updating. Identical saves do not
   change progress timestamps or emit progress-row events. The legacy compatibility trigger remains;
   its normalized write makes the subsequent identical RPC upsert a no-op. Startup freshness uses
   the newest account or active-mode timestamp because Seasonal-only saves no longer touch the account.
+  When only a mode row is newer, startup merges progress by entry timestamps and reset epochs;
+  visibility changes also update mode timestamps and cannot justify replacing whole mode snapshots.
+  Team rejoin refreshes membership and rebuilds changed filters before hydrating teammates; initial
+  joins do not trigger an additional hydration. Optional missing account metadata never blocks
+  normalized reconnect progress. Deferred legacy reads retain startup retries and API error mapping.
 - Startup fetches metadata and normalized modes before requesting missing persistent legacy columns.
   Shared-profile, gateway, and teammate reads request legacy progress only when their existing
   fallback rules require it. Public visibility and team authorization still precede fallback use.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -795,7 +795,8 @@ flowchart LR
   within a mode advance its local clock; account hydration keeps the server metadata clock, and switching modes or editing another mode does not. Legacy
   envelopes seed unchanged modes from their original timestamp (unknown history stays zero).
   Startup and Realtime hydration retain remote progress freshness, rather than download time;
-  merged snapshots that retain local fields also retain their local edit clock. Each tab compares
+  merged snapshots that retain local fields use at least one millisecond beyond the incoming
+  snapshot clock, so reload cannot discard pending edits on a timestamp tie. Each tab compares
   with its own prior snapshot so another tab's storage write cannot make stale fields look edited.
   Visibility changes update `updated_at`, never `progress_updated_at`, and cannot justify replacing whole mode snapshots.
   Team rejoin refreshes membership and rebuilds changed filters before hydrating teammates; initial
@@ -810,10 +811,12 @@ flowchart LR
   Save acknowledgements advance only their changed paths, preserving unrelated remote values
   accepted while the save was queued or in flight. Pending captures track intervening accepted remote
   changes separately from local acknowledgements, so older live events cannot override newer snapshots.
+  Domain merges do not acknowledge unsaved local fields. A newer remote reset invalidates older
+  save acknowledgements for that mode; a newer local reset stays pending until its save succeeds.
   Reconnect reads wait for in-flight saves and hold new outbound writes until snapshot application
   completes. Local changes remain tracked and are saved afterward; read failures also release this barrier.
   Supporter status refreshes after the first join as well as subsequent joins to close the
-  initial read/join gap. A progress subscription begun while suspended also reconciles on its first
+  initial read/join gap. An owner or generic subscription whose first join is delayed by suspension reconciles on its first
   eventual join. Initialization delegates the initial status read to the subscription, with a
   single fallback read if the initial join fails. Initialization marks status loaded only after a
   successful read; initial callers share the latest request's result even when a refresh supersedes

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -794,6 +794,8 @@ flowchart LR
   normalized reconnect progress. Deferred legacy reads retain startup retries and API error mapping.
   Unmaterialized normalized rows are absent for startup fallback and freshness. Outbound writes are
   serialized with captured payloads and versions; resumed saves cannot overtake an in-flight save.
+  Save acknowledgements advance only their changed paths, preserving unrelated remote values
+  accepted while the save was queued or in flight.
   Supporter status refreshes after the first join as well as subsequent joins to close the
   initial read/join gap. Initialization delegates the initial status read to the subscription, with a
   single fallback read if the initial join fails.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -785,7 +785,9 @@ flowchart LR
   its normalized write makes the subsequent identical RPC upsert a no-op. Startup account metadata
   uses the account timestamp; each mode independently uses `progress_updated_at`, which changes only
   with sanitized progress. Visibility-only writes never advance it. Historical rows retain null until
-  progress changes and use the account timestamp as the legacy fallback, never visibility freshness.
+  progress changes; unknown normalized mode freshness stays unknown instead of borrowing metadata
+  freshness. Known local mode clocks preserve offline scalar edits while entry timestamps and reset
+  epochs still reconcile progress. Only progress actually read from a legacy row uses that row's clock.
   When a mode is newer than account metadata, startup merges progress by entry timestamps and reset epochs;
   clearable profile fields use the preferred snapshot verbatim, including null names and empty offsets.
   Startup skill-offset maps are atomic: absent keys represent deletions, and historical snapshots
@@ -794,7 +796,8 @@ flowchart LR
   account settings plus independent `_modeTimestamps` for progress. Only changes
   within a mode advance its local clock; account hydration keeps the server metadata clock, and switching modes or editing another mode does not. Legacy
   envelopes seed unchanged modes from their original timestamp (unknown history stays zero).
-  Startup and Realtime hydration retain remote progress freshness, rather than download time;
+  Startup and Realtime hydration retain remote progress freshness, rather than download time.
+  Accepted envelopes are persisted even when a matching acknowledgement needs no Pinia patch;
   merged snapshots that retain local fields use at least one millisecond beyond the incoming
   snapshot clock, so reload cannot discard pending edits on a timestamp tie. Each tab compares
   with its own prior snapshot so another tab's storage write cannot make stale fields look edited.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -820,7 +820,8 @@ flowchart LR
   changes separately from local acknowledgements, so older live events cannot override newer snapshots.
   Domain merges do not acknowledge unsaved local fields. A newer remote reset invalidates older
   save acknowledgements for that mode; a newer local reset stays pending until its save succeeds.
-  Reconnect and live mode hydration ignore unmaterialized placeholder rows, preserving legacy progress.
+  Owner and teammate reconnect/live mode hydration ignore unmaterialized placeholder rows.
+  Teammates retain previously hydrated progress if the legacy fallback read fails.
   Reconnect reads wait for in-flight saves and hold new outbound writes until snapshot application
   completes. Local changes remain tracked and are saved afterward; read failures also release this barrier.
   Supporter status refreshes after the first join as well as subsequent joins to close the

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -786,6 +786,9 @@ flowchart LR
   Team rejoin refreshes membership and rebuilds changed filters before hydrating teammates; initial
   joins do not trigger an additional hydration. Optional missing account metadata never blocks
   normalized reconnect progress. Deferred legacy reads retain startup retries and API error mapping.
+  Unmaterialized normalized rows are absent for startup fallback and freshness. Outbound writes are
+  serialized with captured payloads and versions; resumed saves cannot overtake an in-flight save.
+  Supporter status refreshes on subsequent joins without duplicating the initial status load.
 - Startup fetches metadata and normalized modes before requesting missing persistent legacy columns.
   Shared-profile, gateway, and teammate reads request legacy progress only when their existing
   fallback rules require it. Public visibility and team authorization still precede fallback use.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -775,8 +775,8 @@ flowchart LR
   an outstanding disconnect before reconnecting once. Auth, local persistence, and outbound saves
   remain active. Rejoined consumers refresh authoritative snapshots; owner progress uses existing
   merge/epoch rules, and snapshot responses cannot overwrite newer live events or another session.
-  Pending profile fields (including explicit clears) survive reconnect reads and edits made during
-  those reads; a higher reset epoch still wins over pending fields from an older epoch.
+  Pending profile fields (including explicit clears) survive reconnect reads, incoming live events,
+  and edits made during those reads; a higher reset epoch still wins over an older epoch's edits.
 - Progress RPC upserts compare sanitized account/mode values before updating. Identical saves do not
   change progress timestamps or emit progress-row events. The legacy compatibility trigger remains;
   its normalized write makes the subsequent identical RPC upsert a no-op. Startup freshness uses

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -830,6 +830,8 @@ flowchart LR
   save acknowledgements for that mode; a newer local reset stays pending until its save succeeds.
   Owner and teammate reconnect/live mode hydration ignore unmaterialized placeholder rows.
   Teammates retain previously hydrated progress if the legacy fallback read fails.
+  Realtime SDK callbacks forward only their payload to reconciliation handlers; transport message
+  references must never be interpreted as snapshot reconciliation functions.
   Reconnect reads wait for in-flight saves and hold new outbound writes until snapshot application
   completes. Local changes remain tracked and are saved afterward; read failures also release this barrier.
   Supporter status refreshes after the first join as well as subsequent joins to close the

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -407,6 +407,27 @@ References: [migration history](https://supabase.com/docs/reference/cli/supabase
 - Platform-managed extensions (`pg_graphql`, `pg_net`) differ between the local stack and prod;
   migrations do not control these and the difference is expected.
 
+### Progress transfer and freshness rollout
+
+For `20260906174817_suppress_unchanged_progress_writes.sql` and
+`20260906234500_track_mode_progress_freshness.sql`, verify linked history, exact pending SQL,
+and production observer preflight before approving the migration rollout. Apply schema before
+frontend when possible; Cloudflare and Supabase integrations run independently.
+
+The frontend tolerates the freshness column being absent during deployment: startup and reconnect
+retry only a missing `progress_updated_at` column without that field and retain unknown mode
+freshness. This prevents an ordering race from aborting progress initialization; it does not prove
+the migrations succeeded. Confirm both history entries and deployed column/function definitions
+using the database migration procedure above. Without the migrations, write suppression and
+independent server mode clocks are not fully enabled. Do not backfill historical clocks from
+account or visibility timestamps.
+
+Before release sign-off, use two authenticated browser sessions to check progress edits and clears,
+a tab hidden longer than 60 seconds, edits while disconnected, reconnect, team changes during
+reconnect, and reload. Verify no saved progress is lost or resurrected, retained teammates refresh,
+and resumed saves succeed. Frontend rollback remains compatible with these additive migrations;
+preserve applied migrations.
+
 ### Reconcile migration `20260630075121_reconcile_prod_schema_drift`
 
 - Captures schema changes that were previously made directly in the dashboard (teams

--- a/supabase/functions/_shared/database.types.ts
+++ b/supabase/functions/_shared/database.types.ts
@@ -470,6 +470,7 @@ export type Database = {
           game_mode: string
           profile_public: boolean
           progress_data: Json
+          progress_updated_at: string | null
           season_number: number
           updated_at: string
           user_id: string
@@ -479,6 +480,7 @@ export type Database = {
           game_mode: string
           profile_public?: boolean
           progress_data?: Json
+          progress_updated_at?: string | null
           season_number?: number
           updated_at?: string
           user_id: string
@@ -488,6 +490,7 @@ export type Database = {
           game_mode?: string
           profile_public?: boolean
           progress_data?: Json
+          progress_updated_at?: string | null
           season_number?: number
           updated_at?: string
           user_id?: string

--- a/supabase/migrations/20260906174817_suppress_unchanged_progress_writes.sql
+++ b/supabase/migrations/20260906174817_suppress_unchanged_progress_writes.sql
@@ -1,0 +1,151 @@
+-- Preserve legacy mirroring while avoiding duplicate WAL events and timestamp churn.
+CREATE OR REPLACE FUNCTION public.sync_user_game_mode_progress(
+  p_current_game_mode TEXT,
+  p_game_edition INTEGER,
+  p_tarkov_uid BIGINT,
+  p_modes JSONB,
+  p_seasonal_season_number SMALLINT DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id UUID := (SELECT auth.uid());
+  v_mode TEXT;
+  v_pvp_mode CONSTANT TEXT := 'pvp';
+  v_pve_mode CONSTANT TEXT := 'pve';
+  v_seasonal_mode CONSTANT TEXT := 'seasonal';
+  v_empty_object CONSTANT JSONB := '{}'::jsonb;
+  v_progress JSONB;
+  v_season_number SMALLINT;
+  v_active_season SMALLINT := private.active_season_number();
+  v_existing_pvp JSONB := v_empty_object;
+  v_existing_pve JSONB := v_empty_object;
+  v_rate_allowed BOOLEAN;
+BEGIN
+  IF v_user_id IS NULL THEN
+    RAISE EXCEPTION 'Not authenticated';
+  END IF;
+  IF p_current_game_mode IS NULL
+    OR p_current_game_mode NOT IN (v_pvp_mode, v_pve_mode, v_seasonal_mode) THEN
+    RAISE EXCEPTION 'Unsupported game mode';
+  END IF;
+  IF p_modes IS NULL OR jsonb_typeof(p_modes) <> 'object' THEN
+    RAISE EXCEPTION 'p_modes must be a JSON object';
+  END IF;
+  IF pg_column_size(p_modes) > 524288 THEN
+    RAISE EXCEPTION 'p_modes exceeds the maximum payload size';
+  END IF;
+
+  -- Validate every mode before spending rate-limit budget: a later RAISE would
+  -- roll the whole transaction back, refunding the consumed slot and leaving
+  -- malformed requests effectively unthrottled.
+  FOR v_mode, v_progress IN SELECT key, value FROM jsonb_each(p_modes) LOOP
+    IF v_mode NOT IN (v_pvp_mode, v_pve_mode, v_seasonal_mode) THEN
+      RAISE EXCEPTION 'Unsupported game mode: %', v_mode;
+    END IF;
+    IF jsonb_typeof(v_progress) <> 'object' THEN
+      RAISE EXCEPTION 'Progress for % must be a JSON object', v_mode;
+    END IF;
+  END LOOP;
+
+  SELECT allowed
+  INTO v_rate_allowed
+  FROM public.consume_mutation_rate_limit('progress-sync', v_user_id::TEXT, 60, 60);
+  IF NOT COALESCE(v_rate_allowed, false) THEN
+    RAISE EXCEPTION 'Progress sync rate limit exceeded';
+  END IF;
+
+  INSERT INTO public.user_progress (
+    user_id,
+    current_game_mode,
+    game_edition,
+    tarkov_uid,
+    pvp_data,
+    pve_data
+  )
+  VALUES (
+    v_user_id,
+    p_current_game_mode,
+    COALESCE(p_game_edition, 1),
+    p_tarkov_uid,
+    public.sanitize_user_progress_mode_data(COALESCE(p_modes->v_pvp_mode, v_empty_object)),
+    public.sanitize_user_progress_mode_data(COALESCE(p_modes->v_pve_mode, v_empty_object))
+  )
+  ON CONFLICT (user_id) DO NOTHING;
+
+  SELECT
+    COALESCE(pvp_data, v_empty_object),
+    COALESCE(pve_data, v_empty_object)
+  INTO v_existing_pvp, v_existing_pve
+  FROM public.user_progress
+  WHERE user_id = v_user_id
+  FOR UPDATE;
+
+  INSERT INTO public.user_progress (
+    user_id,
+    current_game_mode,
+    game_edition,
+    tarkov_uid,
+    pvp_data,
+    pve_data
+  )
+  VALUES (
+    v_user_id,
+    p_current_game_mode,
+    COALESCE(p_game_edition, 1),
+    p_tarkov_uid,
+    public.sanitize_user_progress_mode_data(COALESCE(p_modes->v_pvp_mode, v_existing_pvp)),
+    public.sanitize_user_progress_mode_data(COALESCE(p_modes->v_pve_mode, v_existing_pve))
+  )
+  ON CONFLICT (user_id) DO UPDATE
+  SET
+    current_game_mode = EXCLUDED.current_game_mode,
+    game_edition = EXCLUDED.game_edition,
+    tarkov_uid = EXCLUDED.tarkov_uid,
+    pvp_data = EXCLUDED.pvp_data,
+    pve_data = EXCLUDED.pve_data
+  WHERE (user_progress.current_game_mode, user_progress.game_edition,
+         user_progress.tarkov_uid, user_progress.pvp_data, user_progress.pve_data)
+    IS DISTINCT FROM
+        (EXCLUDED.current_game_mode, EXCLUDED.game_edition,
+         EXCLUDED.tarkov_uid, EXCLUDED.pvp_data, EXCLUDED.pve_data);
+
+  FOR v_mode, v_progress IN SELECT key, value FROM jsonb_each(p_modes) LOOP
+    IF v_mode = v_seasonal_mode
+      AND (p_seasonal_season_number IS NULL OR p_seasonal_season_number <> v_active_season) THEN
+      -- A client sync always carries every mode in one payload. Skip stale
+      -- Seasonal state instead of raising, which would roll back the valid
+      -- persistent-mode progress from the same request and take cloud sync
+      -- offline for every client whose bundled season number lags the database.
+      CONTINUE;
+    END IF;
+    v_season_number := CASE
+      WHEN v_mode = v_seasonal_mode THEN v_active_season
+      ELSE 0
+    END;
+    INSERT INTO public.user_game_mode_progress (
+      user_id,
+      game_mode,
+      season_number,
+      progress_data
+    )
+    VALUES (
+      v_user_id,
+      v_mode,
+      v_season_number,
+      public.sanitize_user_progress_mode_data(v_progress)
+    )
+    ON CONFLICT (user_id, game_mode, season_number) DO UPDATE
+    SET progress_data = EXCLUDED.progress_data
+    WHERE user_game_mode_progress.progress_data IS DISTINCT FROM EXCLUDED.progress_data;
+  END LOOP;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.sync_user_game_mode_progress(TEXT, INTEGER, BIGINT, JSONB, SMALLINT)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.sync_user_game_mode_progress(TEXT, INTEGER, BIGINT, JSONB, SMALLINT)
+  TO authenticated;

--- a/supabase/migrations/20260906234500_track_mode_progress_freshness.sql
+++ b/supabase/migrations/20260906234500_track_mode_progress_freshness.sql
@@ -1,0 +1,27 @@
+-- Existing rows deliberately remain unknown; visibility timestamps cannot be backfilled
+-- into progress timestamps without inventing freshness or rewriting all progress rows.
+ALTER TABLE public.user_game_mode_progress
+  ADD COLUMN progress_updated_at timestamptz;
+
+CREATE OR REPLACE FUNCTION public.prepare_user_game_mode_progress_row()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = public
+AS $$
+BEGIN
+  NEW.progress_data := public.sanitize_user_progress_mode_data(
+    COALESCE(NEW.progress_data, '{}'::jsonb)
+  );
+  IF TG_OP = 'INSERT' THEN
+    NEW.progress_updated_at := now();
+  ELSIF NEW.progress_data IS DISTINCT FROM OLD.progress_data THEN
+    NEW.progress_updated_at := now();
+  ELSE
+    NEW.progress_updated_at := OLD.progress_updated_at;
+  END IF;
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.prepare_user_game_mode_progress_row() FROM PUBLIC, anon, authenticated;

--- a/supabase/tests/database/mode_progress_freshness.test.sql
+++ b/supabase/tests/database/mode_progress_freshness.test.sql
@@ -1,0 +1,26 @@
+BEGIN;
+SELECT plan(5);
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000892', 'progress-freshness@example.invalid');
+DELETE FROM public.user_game_mode_progress
+WHERE user_id = '00000000-0000-0000-0000-000000000892';
+INSERT INTO public.user_game_mode_progress (user_id, game_mode, season_number, progress_data)
+VALUES ('00000000-0000-0000-0000-000000000892', 'pvp', 0, '{"level":10}');
+SELECT ok((SELECT progress_updated_at IS NOT NULL FROM public.user_game_mode_progress
+  WHERE user_id = '00000000-0000-0000-0000-000000000892'), 'new progress has a progress timestamp');
+UPDATE public.user_game_mode_progress SET progress_updated_at = '2000-01-01' WHERE user_id = '00000000-0000-0000-0000-000000000892';
+UPDATE public.user_game_mode_progress SET profile_public = NOT profile_public WHERE user_id = '00000000-0000-0000-0000-000000000892';
+SELECT is((SELECT progress_updated_at FROM public.user_game_mode_progress WHERE user_id = '00000000-0000-0000-0000-000000000892'),
+  '2000-01-01'::timestamptz, 'visibility does not advance progress freshness');
+UPDATE public.user_game_mode_progress SET progress_data = progress_data WHERE user_id = '00000000-0000-0000-0000-000000000892';
+SELECT is((SELECT progress_updated_at FROM public.user_game_mode_progress WHERE user_id = '00000000-0000-0000-0000-000000000892'),
+  '2000-01-01'::timestamptz, 'an unchanged sanitized payload does not advance progress freshness');
+UPDATE public.user_game_mode_progress SET progress_updated_at = NULL WHERE user_id = '00000000-0000-0000-0000-000000000892';
+UPDATE public.user_game_mode_progress SET profile_public = NOT profile_public WHERE user_id = '00000000-0000-0000-0000-000000000892';
+SELECT ok((SELECT progress_updated_at IS NULL FROM public.user_game_mode_progress
+  WHERE user_id = '00000000-0000-0000-0000-000000000892'), 'unknown historical freshness stays unknown after a visibility change');
+UPDATE public.user_game_mode_progress SET progress_data = '{"level":11}' WHERE user_id = '00000000-0000-0000-0000-000000000892';
+SELECT ok((SELECT progress_updated_at > '2000-01-01'::timestamptz FROM public.user_game_mode_progress
+  WHERE user_id = '00000000-0000-0000-0000-000000000892'), 'changed progress advances its own freshness');
+SELECT * FROM finish();
+ROLLBACK;

--- a/supabase/tests/database/progress_write_deduplication.test.sql
+++ b/supabase/tests/database/progress_write_deduplication.test.sql
@@ -1,0 +1,41 @@
+BEGIN;
+SELECT plan(5);
+INSERT INTO auth.users (id, email) VALUES
+  ('00000000-0000-0000-0000-000000000891', 'progress-dedup@example.invalid');
+SELECT set_config('request.jwt.claim.sub', '00000000-0000-0000-0000-000000000891', true);
+SELECT public.sync_user_game_mode_progress('pvp', 1, NULL,
+  '{"pvp":{"level":10},"pve":{"level":20},"seasonal":{"level":30}}',
+  private.active_season_number());
+CREATE TEMP TABLE progress_write_events (relation_name TEXT, mode TEXT);
+CREATE FUNCTION pg_temp.record_progress_write() RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  INSERT INTO progress_write_events VALUES (TG_TABLE_NAME, to_jsonb(NEW)->>'game_mode');
+  RETURN NEW;
+END;
+$$;
+CREATE TRIGGER test_record_account_write AFTER UPDATE ON public.user_progress
+  FOR EACH ROW EXECUTE FUNCTION pg_temp.record_progress_write();
+CREATE TRIGGER test_record_mode_write AFTER UPDATE ON public.user_game_mode_progress
+  FOR EACH ROW EXECUTE FUNCTION pg_temp.record_progress_write();
+SELECT public.sync_user_game_mode_progress('pvp', 1, NULL,
+  '{"pvp":{"level":10},"pve":{"level":20},"seasonal":{"level":30}}',
+  private.active_season_number());
+SELECT is((SELECT count(*) FROM progress_write_events), 0::bigint,
+  'identical progress does not update rows or invoke timestamp triggers');
+SELECT public.sync_user_game_mode_progress('pvp', 1, NULL,
+  '{"pvp":{"level":11},"pve":{"level":20},"seasonal":{"level":30}}',
+  private.active_season_number());
+SELECT is((SELECT count(*) FROM progress_write_events WHERE relation_name = 'user_progress'), 1::bigint,
+  'one persistent change updates the legacy mirror once');
+SELECT is((SELECT count(*) FROM progress_write_events WHERE mode = 'pvp'), 1::bigint,
+  'the RPC does not repeat the legacy trigger normalized write');
+SELECT is((SELECT count(*) FROM progress_write_events WHERE mode IN ('pve', 'seasonal')), 0::bigint,
+  'unrelated modes do not produce writes');
+TRUNCATE progress_write_events;
+SELECT public.sync_user_game_mode_progress('pvp', 1, NULL,
+  '{"pvp":{"level":11},"pve":{"level":20},"seasonal":{"level":31}}',
+  private.active_season_number());
+SELECT is((SELECT count(*) FROM progress_write_events), 1::bigint,
+  'a seasonal-only change writes only its normalized row');
+SELECT * FROM finish();
+ROLLBACK;

--- a/workers/api-gateway/src/__tests__/gateway.test.ts
+++ b/workers/api-gateway/src/__tests__/gateway.test.ts
@@ -1086,8 +1086,8 @@ describe('api-gateway', () => {
     return requestUrl ? new URL(requestUrl) : undefined;
   };
   it.each([
-    ['pvp', 0, 'user_id,game_edition,pvp_data'],
-    ['pve', 0, 'user_id,game_edition,pve_data'],
+    ['pvp', 0, 'user_id,game_edition'],
+    ['pve', 0, 'user_id,game_edition'],
     ['seasonal', 1, 'user_id,game_edition'],
   ] as const)(
     'loads the normalized %s progress row for its season',
@@ -1253,11 +1253,11 @@ describe('api-gateway', () => {
     const editionRequest = fetchMock.mock.calls
       .map((call) => new URL(String(call[0])))
       .find((url) => url.pathname.endsWith('/rest/v1/user_progress'));
-    expect(editionRequest?.searchParams.get('select')).toBe('user_id,game_edition,pve_data');
+    expect(editionRequest?.searchParams.get('select')).toBe('user_id,game_edition');
   });
   it.each([
-    ['pvp', 'user_id,game_edition,pvp_data'],
-    ['pve', 'user_id,game_edition,pve_data'],
+    ['pvp', 'user_id,game_edition'],
+    ['pve', 'user_id,game_edition'],
     ['seasonal', 'user_id,game_edition'],
   ] as const)(
     'narrows the solo team-progress edition select for %s',

--- a/workers/api-gateway/src/handlers/progress.ts
+++ b/workers/api-gateway/src/handlers/progress.ts
@@ -114,9 +114,7 @@ async function fetchUserProgressMode(
 ): Promise<UserProgressModeRow | null> {
   const seasonNumber = await getGameModeSeasonNumber(env, gameMode);
   const legacyProgressField = getLegacyModeProgressField(gameMode);
-  const metadataSelect = ['user_id', 'game_edition', legacyProgressField]
-    .filter(Boolean)
-    .join(',');
+  const metadataSelect = 'user_id,game_edition';
   const modeUrl = `${env.SUPABASE_URL}/rest/v1/user_game_mode_progress?user_id=eq.${userId}&game_mode=eq.${gameMode}&season_number=eq.${seasonNumber}&select=user_id,progress_data&limit=1`;
   const metadataUrl = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=eq.${userId}&select=${metadataSelect}&limit=1`;
   const [modeResponse, metadataResponse] = await Promise.all([
@@ -138,10 +136,23 @@ async function fetchUserProgressMode(
   }>;
   const modeRow = modeRows[0];
   const metadataRow = metadataRows[0];
+  if (legacyProgressField && !hasMaterializedProgress(modeRow?.progress_data)) {
+    const legacy = await fetchLegacyProgressRow(env, userId, gameMode);
+    if (metadataRow)
+      metadataRow[legacyProgressField] = legacy?.[
+        legacyProgressField
+      ] as typeof metadataRow.pvp_data;
+    else if (legacy)
+      metadataRows.push({
+        ...legacy,
+        user_id: userId,
+        game_edition: null,
+      } as (typeof metadataRows)[number]);
+  }
   return {
     user_id: modeRow?.user_id ?? userId,
     game_edition: metadataRow?.game_edition ?? 1,
-    progress_data: resolveModeProgressData(gameMode, modeRow?.progress_data, metadataRow),
+    progress_data: resolveModeProgressData(gameMode, modeRow?.progress_data, metadataRows[0]),
   };
 }
 const asProgressRecord = (value: unknown): Record<string, unknown> =>

--- a/workers/api-gateway/src/handlers/progress.ts
+++ b/workers/api-gateway/src/handlers/progress.ts
@@ -107,6 +107,7 @@ const getServiceHeaders = (env: Env) => ({
   Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
   apikey: env.SUPABASE_SERVICE_ROLE_KEY,
 });
+// fallow-ignore-next-line complexity -- normalized/legacy fallback branches are exercised by gateway.test.ts; inferred coverage misses indirect route calls
 async function fetchUserProgressMode(
   env: Env,
   userId: string,

--- a/workers/api-gateway/src/handlers/team.ts
+++ b/workers/api-gateway/src/handlers/team.ts
@@ -1,5 +1,6 @@
 import {
   getLegacyModeProgressField,
+  hasMaterializedProgress,
   resolveModeProgressData,
 } from '../../../../app/utils/modeProgressFallback';
 import { getTasks, getHideoutStations } from '../services/tarkov';
@@ -37,6 +38,31 @@ const getServiceHeaders = (env: Env) => ({
   Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
   apikey: env.SUPABASE_SERVICE_ROLE_KEY,
 });
+const loadMissingLegacyProgress = async (
+  env: Env,
+  gameMode: GameMode,
+  userIds: string[],
+  progressRows: ProgressRow[],
+  editionRows: EditionRow[]
+): Promise<void> => {
+  const field = getLegacyModeProgressField(gameMode);
+  if (!field) return;
+  const missing = userIds.filter(
+    (id) => !hasMaterializedProgress(progressRows.find((row) => row.user_id === id)?.progress_data)
+  );
+  if (missing.length === 0) return;
+  const response = await fetch(
+    `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=in.(${missing.join(',')})&select=user_id,${field}`,
+    { headers: getServiceHeaders(env) }
+  );
+  if (!response.ok) throw new Error('Failed to fetch legacy team progress');
+  const rows = (await response.json()) as EditionRow[];
+  for (const row of rows) {
+    const metadata = editionRows.find((entry) => entry.user_id === row.user_id);
+    if (metadata) metadata[field] = row[field];
+    else editionRows.push(row);
+  }
+};
 const buildProgressResponse = (
   self: string,
   data: ProgressResponseData[]
@@ -50,10 +76,7 @@ const fetchUserModeRow = async (
   gameMode: GameMode
 ): Promise<UserProgressModeRow> => {
   const seasonNumber = await getGameModeSeasonNumber(env, gameMode);
-  const legacyProgressField = getLegacyModeProgressField(gameMode);
-  const editionSelect = ['user_id', 'game_edition', legacyProgressField]
-    .filter(Boolean)
-    .join(',');
+  const editionSelect = 'user_id,game_edition';
   const progressUrl = `${env.SUPABASE_URL}/rest/v1/user_game_mode_progress?user_id=eq.${userId}&game_mode=eq.${gameMode}&season_number=eq.${seasonNumber}&select=user_id,progress_data&limit=1`;
   const editionUrl = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=eq.${userId}&select=${editionSelect}&limit=1`;
   const [progressResponse, editionResponse] = await Promise.all([
@@ -63,15 +86,12 @@ const fetchUserModeRow = async (
   if (!progressResponse.ok || !editionResponse.ok) throw new Error('Failed to fetch user progress');
   const progressRows = (await progressResponse.json()) as ProgressRow[];
   const editionRows = (await editionResponse.json()) as EditionRow[];
+  await loadMissingLegacyProgress(env, gameMode, [userId], progressRows, editionRows);
   const editionRow = editionRows[0];
   return {
     user_id: progressRows[0]?.user_id ?? userId,
     game_edition: editionRow?.game_edition ?? 1,
-    progress_data: resolveModeProgressData(
-      gameMode,
-      progressRows[0]?.progress_data,
-      editionRow
-    ),
+    progress_data: resolveModeProgressData(gameMode, progressRows[0]?.progress_data, editionRow),
   };
 };
 const transformUserModeRow = async (
@@ -197,10 +217,7 @@ export async function handleGetTeamProgress(
   }
   const seasonNumber = await getGameModeSeasonNumber(env, gameMode);
   const ids = memberIds.join(',');
-  const legacyProgressField = getLegacyModeProgressField(gameMode);
-  const editionSelect = ['user_id', 'game_edition', legacyProgressField]
-    .filter(Boolean)
-    .join(',');
+  const editionSelect = 'user_id,game_edition';
   const progressUrl = `${env.SUPABASE_URL}/rest/v1/user_game_mode_progress?user_id=in.(${ids})&game_mode=eq.${gameMode}&season_number=eq.${seasonNumber}&select=user_id,progress_data`;
   const editionsUrl = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=in.(${ids})&select=${editionSelect}`;
   const [progressRes, editionsRes] = await Promise.all([
@@ -222,6 +239,7 @@ export async function handleGetTeamProgress(
   }
   const progressRows = (await progressRes.json()) as ProgressRow[];
   const editionRows = (await editionsRes.json()) as EditionRow[];
+  await loadMissingLegacyProgress(env, gameMode, memberIds, progressRows, editionRows);
   // Step 4: Fetch task and hideout data (cached)
   const [tasks, hideoutStations] = await Promise.all([
     getTasks(gameMode),
@@ -235,11 +253,7 @@ export async function handleGetTeamProgress(
       const row: UserProgressModeRow = {
         user_id: memberId,
         game_edition: editionRow?.game_edition ?? 1,
-        progress_data: resolveModeProgressData(
-          gameMode,
-          progressRow?.progress_data,
-          editionRow
-        ),
+        progress_data: resolveModeProgressData(gameMode, progressRow?.progress_data, editionRow),
       };
       return buildProgressData(env, row, memberId, tasks, hideoutStations);
     })

--- a/workers/api-gateway/src/handlers/team.ts
+++ b/workers/api-gateway/src/handlers/team.ts
@@ -22,8 +22,8 @@ type ProgressRow = {
 };
 type EditionRow = {
   game_edition: number | null;
-  pve_data: UserProgressModeRow['progress_data'];
-  pvp_data: UserProgressModeRow['progress_data'];
+  pve_data?: UserProgressModeRow['progress_data'];
+  pvp_data?: UserProgressModeRow['progress_data'];
   user_id: string;
 };
 // Team progress response format (matching RatScanner expectations)
@@ -56,11 +56,12 @@ const loadMissingLegacyProgress = async (
     { headers: getServiceHeaders(env) }
   );
   if (!response.ok) throw new Error('Failed to fetch legacy team progress');
-  const rows = (await response.json()) as EditionRow[];
+  const rows = (await response.json()) as Omit<EditionRow, 'game_edition'>[];
   for (const row of rows) {
     const metadata = editionRows.find((entry) => entry.user_id === row.user_id);
     if (metadata) metadata[field] = row[field];
-    else editionRows.push(row);
+    // An account can appear between the metadata and fallback requests.
+    else editionRows.push({ ...row, game_edition: null });
   }
 };
 const buildProgressResponse = (


### PR DESCRIPTION
## Summary

Reduces redundant Supabase progress writes and legacy downloads, suspends hidden-tab Realtime transport after 60 seconds, and reconciles authoritative snapshots on reconnect.

Reconnect reads wait for active saves and hold new outbound writes until reconciliation completes. Local mode and account freshness persist independently; remote hydration and auth restoration retain source timestamps instead of inventing local edits. Supporter initialization follows the winning refresh request, and replacement team channels rehydrate missed progress after membership verification and joining.

The latest correction transfers pending hydration to the winning replacement team when a team switch retains teammate stores during reconnect. Startup and reconnect reads retry once without `progress_updated_at` only when PostgreSQL/PostgREST specifically reports that column missing. Those rows retain unknown mode freshness; permission, network, unrelated schema errors, and failed fallback reads remain failures.

## Changes

- Suspend hidden-tab Realtime transport and reconcile authoritative snapshots on reconnect.
- Preserve pending edits, independent mode freshness, and retained teammate hydration.
- Suppress unchanged progress writes and defer legacy downloads until needed.
- Add regression coverage, additive migrations, generated types, and rollout documentation.

## Type of Change

Bug fix and performance enhancement.

## Area(s) Affected

Frontend, Backend, Team Features, API, Supabase.

## Related Issues

No linked issue; this PR directly addresses redundant progress transfer and reconnect correctness.

## Testing

- [x] Tested locally
- [x] Tested in production-like local environment
- [x] Added/updated unit tests
- [x] Authenticated browser automation performed

### Test Plan

1. Run focused synchronization, storage, visibility, supporter, shared-profile, and team regressions.
2. Replay migrations and run database assertions, gateway tests, type/lint/generated binding checks, and Worker dry-run.
3. Complete the authenticated two-session smoke test described under rollout prerequisites before release sign-off.

## Screenshots/Videos

Not applicable: no rendered UI changes. Authenticated behavioral smoke-test evidence is summarized below.

## Validation

Current head: `bb5e452696e0ff28dc390ab88a61a42fd25f7b99`. PR worktree clean after commit and push.

The authenticated browser smoke found and reproduced a live SDK integration defect missed by mocks: Realtime supplies a message-reference argument, which the reconciliation handlers interpreted as a function. Payload-only callback adapters fix all three registrations. A regression failed before the fix and passes afterward. SYSTEMS documents the boundary.

- `pnpm run test app/stores/__tests__/realtimeListener.seasonal.test.ts app/stores/__tests__/useTarkov.sync.integration.test.ts app/composables/__tests__/useSupabaseSync.test.ts`: 102 tests passed.
- `pnpm run lint`, `pnpm run typecheck`, `pnpm run systems:check`, `pnpm run lint:fallow --base origin/main --format json`, `git diff --check`, and commit formatting hooks passed. Typecheck was rerun successfully with the dev server stopped after a concurrent generated-Nuxt-config race; no code suppression was added.
- Complete-branch `coderabbit review --agent --base origin/main` completed with zero findings after the fix.
- Earlier unchanged database and gateway inputs passed local database replay (71 assertions and schema lint), gateway tests (184), binding generation check, gateway typecheck and Worker dry-run. All posted current-head CI checks completed successfully (scope skips remain). Codex reviewed `bb5e452696` without major findings; Greptile and Cubic checks passed. The complete-branch local CodeRabbit review covered this fix; its older hosted summary is not claimed as a new-head review. All 76 inline threads remain resolved.

### Authenticated browser smoke

Passed against the final code using real Chrome, isolated authenticated sessions, and a disposable local Supabase stack with both migrations, Auth, Realtime and Edge Functions. App store actions drove edits; real network/database events drove synchronization.

1. Level changes propagated between owner sessions after the callback fix.
2. Objective count 3 propagated and was cleared to 0.
3. Offline name edits survived reconnect while another session changed level; both sessions converged without resurrecting the cleared objective.
4. Controlled document visibility remained hidden for over 74 seconds and the actual Realtime socket disconnected. Missed teammate progress recovered from level 21 to 22 after reconnect.
5. Reload retained level 14, the offline name edit, and objective count 0.
6. Held an actual membership HTTP response during reconnect, moved disposable memberships to a replacement team via a local fixture, then released the stale response. The replacement channel joined and retained teammate progress recovered to level 23.

Harness limitations: native OS tab visibility was simulated at the document visibility input; the production timer and real socket were exercised. Fresh local setup required restoring missing authenticated table grants for user_system, supporters and user_preferences; RLS and repository migrations were unchanged. An unrelated local account-audit endpoint returned 500, so audit logging is not covered by this smoke.

User explicitly approved the PR in the closeout session. No formal review was authored on their behalf. Production preflight is complete through the Supabase MCP read-only route requested by the user. Both pending migrations were freshly confirmed absent using the Supabase migration-history connector for `knptqelvsodccnoehmbj`. A separate observer login was not provisioned; this session used the user-requested MCP alternative with an explicitly READ ONLY transaction and a 10-second statement timeout.

## Rollout prerequisites

Two forward migrations remain: `20260906174817_suppress_unchanged_progress_writes.sql` and `20260906234500_track_mode_progress_freshness.sql`. Applied migration files are unchanged. Fresh Supabase migration history for `knptqelvsodccnoehmbj` ends at `20260906103256`; both PR versions remain pending. History timestamps alone do not establish deployed SQL/catalog equivalence.

An operator must verify linked history, exact pending SQL, and production observer preflight using the runbook. Prefer applying both migrations before the frontend; separate Cloudflare and Supabase integrations do not guarantee deployment order. The missing-column fallback prevents a rollout race from aborting progress initialization, but write suppression and independent server mode clocks are not fully enabled until both migrations are applied and verified. Pre-deployment verification used live MCP migration history and catalog inspection instead of a linked CLI dry-run. No production migration was applied during preflight.

The local authenticated smoke covered the runbook scenarios: edits and clears, a tab hidden over 60 seconds, disconnected edits, reconnect, a team switch during reconnect, and reload. Verify retained teammate recovery and no lost or resurrected progress.

Historical normalized rows keep unknown mode freshness until progress changes; unrelated account metadata never supplies their progress clock. Only actual legacy PvP/PvE payloads use their source-row timestamp. Legacy local envelopes retain their original whole-state clock until independent clocks are established. Exact historical mode provenance cannot be reconstructed without existing metadata. Frontend rollback remains compatible with the additive migrations; preserve applied migrations.

## Documentation impact

`docs/SYSTEMS.md` documents reconnect ordering, freshness provenance, compatibility reads, legacy fallback, supporter initialization, and team recovery. `docs/runbook.md` records migration verification, rollout-window behavior, smoke testing, and rollback requirements.

## Checklist

- [x] Code follows project conventions; lint and typecheck pass.
- [x] Final diff self-reviewed for scope, debug code, temporary workarounds, and credentials.
- [x] Non-obvious synchronization invariants documented in SYSTEMS.
- [x] Required local automated validation passed; current-head hosted checks successful.
- [x] Rolling compatibility and additive frontend rollback reviewed.
- [x] User approval obtained in closeout session.
- [x] Production migration history and schema preflight verified through the user-requested read-only MCP route.
- [x] Authenticated two-session smoke test completed with the harness limitations above.

## Additional Notes

Current-head CI/review and production preflight are complete. User approval and conditional merge authorization were provided in the closeout session. Verify the deployed migrations and catalog after the merge integrations finish. No production migration or merge was performed during closeout.



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR reduces redundant Supabase traffic while strengthening reconnect reconciliation and freshness tracking.
- Suspends hidden-tab Realtime transport and refreshes authoritative snapshots after reconnect.
- Serializes saves with snapshot reads and reconciles local changes per path.
- Adds independent mode-freshness metadata, compatibility fallbacks, write deduplication, team rehydration, and regression coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The code changes appear safe to merge, with no blocking failure remaining from the previously reported reconciliation issues.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/utils/pendingState.ts | Implements per-path acknowledgement and reconciliation while preserving unsaved edits and newer accepted remote state. |
| app/composables/supabase/useSupabaseSync.ts | Serializes writes, gates them behind snapshot reconciliation, retries aborts, and suppresses unchanged payloads. |
| app/composables/supabase/useSupabaseListener.ts | Reconciles initial and reconnect snapshots with pending state while handling suspension, cancellation, and cleanup. |
| app/stores/tarkov/realtimeListener.ts | Applies freshness-aware snapshots and events through the shared pending-state reconciliation flow. |
| app/stores/useTeamStore.ts | Transfers pending teammate hydration to the winning replacement team after membership verification. |
| supabase/migrations/20260906174817_suppress_unchanged_progress_writes.sql | Adds database-side suppression for unchanged progress writes. |
| supabase/migrations/20260906234500_track_mode_progress_freshness.sql | Adds independent server-side freshness tracking for PvP and PvE progress. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
  participant UI as Local Store
  participant Sync as Sync Controller
  participant DB as Supabase
  participant RT as Realtime Listener
  UI->>Sync: Local mutation
  Sync->>DB: Serialize pending save
  Note over RT: Hidden transport reconnects
  RT->>Sync: Begin snapshot barrier
  Sync->>Sync: Wait for active save
  Sync->>DB: Read authoritative snapshot
  DB-->>Sync: Remote state and freshness
  Sync->>UI: Three-way per-path reconciliation
  Sync->>Sync: Release snapshot barrier
  Sync->>DB: Persist remaining local edits
```
</details>

<sub>Reviews (22): Last reviewed commit: ["fix(sync): isolate SDK callback referenc..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/bb5e452696e0ff28dc390ab88a61a42fd25f7b99) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61029193)</sub>

<!-- /greptile_comment -->


### Production preflight evidence — 2026-09-07

Project `knptqelvsodccnoehmbj`, PostgreSQL 17.6; catalog captured at `2026-09-07T08:34:08.933726Z` via an explicitly read-only transaction with a 10-second timeout.

- Exact expected pending versions: `20260906174817`, `20260906234500`; zero remote-only versions.
- Live `sync_user_game_mode_progress` and `prepare_user_game_mode_progress_row` bodies match the expected pre-PR migration definitions exactly.
- `progress_updated_at` is absent as expected before the additive migration. Required unique indexes and mirroring/preparation triggers exist; both affected tables have RLS enabled.
- `user_game_mode_progress`: approximately 28,886 rows / 239,468,544 total bytes; `user_progress`: approximately 19,680 rows / 492,027,904 total bytes. These are statistics estimates, not application-row reads.
- Zero waiting locks on the affected tables and zero other transactions older than one minute at capture time. These are point-in-time observations, not guarantees against later deployment contention.
- The change adds a nullable column without a default or backfill and replaces existing function bodies. It preserves old-client compatibility, while the frontend handles a not-yet-deployed column. Post-deployment verification must confirm both history entries and the new trigger/function behavior.

Migration SHA-256: `28c7698b0c4f2283fc2c8e872ee1989566dd8a9bca4b75e20f6807380348a92c` (write suppression), `fec6213b16f9c61c50cd481cd8c9078dd112c97e1d10bd078fd4ffc90bbec795` (freshness).
