### PR TITLE
test(db): cover seasonal progress and transaction regressions

### DIFF
--- a/supabase/tests/database/prestige_progress.test.sql
+++ b/supabase/tests/database/prestige_progress.test.sql
@@ -1,0 +1,313 @@
+BEGIN;
+
+SELECT plan(17);
+
+CREATE TEMP TABLE prestige_progress_fixture AS
+SELECT
+  '00000000-0000-0000-0000-000000000771'::UUID AS user_id,
+  private.active_season_number() AS active_season,
+  TIMESTAMPTZ '2026-08-03 12:00:00+00' AS archived_at,
+  jsonb_build_object(
+    'pvp', jsonb_build_object(
+      'displayName', 'Prestige PvP',
+      'level', 79,
+      'prestigeLevel', 2,
+      'progressEpoch', 2
+    ),
+    'pve', jsonb_build_object(
+      'displayName', 'Preserved PvE',
+      'level', 52,
+      'prestigeLevel', 0,
+      'progressEpoch', 0
+    ),
+    'seasonal', jsonb_build_object(
+      'displayName', 'Preserved Seasonal',
+      'level', 31,
+      'prestigeLevel', 0,
+      'progressEpoch', 0
+    )
+  ) AS initial_modes,
+  jsonb_build_object(
+    'displayName', 'Reset PvP',
+    'level', 1,
+    'prestigeLevel', 3,
+    'progressEpoch', 3
+  ) AS reset_pvp,
+  jsonb_build_object(
+    'displayName', 'Rolled back PvE',
+    'level', 60,
+    'prestigeLevel', 0,
+    'progressEpoch', 0
+  ) AS changed_pve;
+
+INSERT INTO auth.users (id, email)
+VALUES ((SELECT user_id FROM prestige_progress_fixture), 'prestige-progress@example.invalid');
+
+GRANT SELECT ON prestige_progress_fixture TO authenticated;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  (SELECT user_id::TEXT FROM prestige_progress_fixture),
+  TRUE
+);
+SELECT lives_ok(
+  $$SELECT public.sync_user_game_mode_progress(
+    'pvp'::TEXT,
+    3::INTEGER,
+    771771::BIGINT,
+    (SELECT initial_modes FROM prestige_progress_fixture),
+    (SELECT active_season FROM prestige_progress_fixture)
+  )$$,
+  'the prestige fixture starts with all three modes materialized'
+);
+RESET ROLE;
+
+CREATE TEMP TABLE prestige_preserved_snapshot AS
+SELECT
+  (
+    SELECT pve_data
+    FROM public.user_progress
+    WHERE user_id = fixture.user_id
+  ) AS legacy_pve,
+  (
+    SELECT progress_data
+    FROM public.user_game_mode_progress
+    WHERE user_id = fixture.user_id
+      AND game_mode = 'pve'
+      AND season_number = 0
+  ) AS mode_pve,
+  (
+    SELECT progress_data
+    FROM public.user_game_mode_progress
+    WHERE user_id = fixture.user_id
+      AND game_mode = 'seasonal'
+      AND season_number = fixture.active_season
+  ) AS mode_seasonal
+FROM prestige_progress_fixture AS fixture;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  (SELECT user_id::TEXT FROM prestige_progress_fixture),
+  TRUE
+);
+SELECT lives_ok(
+  $$SELECT public.archive_prestige_run_and_reset_progress(
+    'pvp'::TEXT,
+    2::INTEGER,
+    3::INTEGER,
+    (SELECT initial_modes->'pvp' FROM prestige_progress_fixture),
+    '{"reason":"prestige"}'::JSONB,
+    (SELECT archived_at FROM prestige_progress_fixture),
+    'pvp'::TEXT,
+    4::INTEGER,
+    773773::BIGINT,
+    (SELECT reset_pvp FROM prestige_progress_fixture),
+    (SELECT initial_modes->'pve' FROM prestige_progress_fixture)
+  )$$,
+  'the current 11-argument PvP prestige RPC succeeds'
+);
+RESET ROLE;
+
+SELECT results_eq(
+  $$SELECT mode, prestige_from, prestige_to, archived_progress, summary, created_at
+    FROM public.user_prestige_runs
+    WHERE user_id = (SELECT user_id FROM prestige_progress_fixture)$$,
+  $$SELECT
+      'pvp'::TEXT,
+      2::INTEGER,
+      3::INTEGER,
+      public.sanitize_user_progress_mode_data(initial_modes->'pvp'),
+      '{"reason":"prestige"}'::JSONB,
+      archived_at
+    FROM prestige_progress_fixture$$,
+  'PvP prestige archives the completed run'
+);
+SELECT is(
+  (SELECT pvp_data FROM public.user_progress
+   WHERE user_id = (SELECT user_id FROM prestige_progress_fixture)),
+  (SELECT public.sanitize_user_progress_mode_data(reset_pvp) FROM prestige_progress_fixture),
+  'PvP prestige resets the legacy PvP mirror'
+);
+SELECT is(
+  (
+    SELECT progress_data
+    FROM public.user_game_mode_progress
+    WHERE user_id = (SELECT user_id FROM prestige_progress_fixture)
+      AND game_mode = 'pvp'
+      AND season_number = 0
+  ),
+  (SELECT public.sanitize_user_progress_mode_data(reset_pvp) FROM prestige_progress_fixture),
+  'PvP prestige resets normalized PvP progress'
+);
+SELECT is(
+  (SELECT pve_data FROM public.user_progress
+   WHERE user_id = (SELECT user_id FROM prestige_progress_fixture)),
+  (SELECT legacy_pve FROM prestige_preserved_snapshot),
+  'PvP prestige preserves the legacy PvE mirror'
+);
+SELECT is(
+  (
+    SELECT progress_data
+    FROM public.user_game_mode_progress
+    WHERE user_id = (SELECT user_id FROM prestige_progress_fixture)
+      AND game_mode = 'pve'
+      AND season_number = 0
+  ),
+  (SELECT mode_pve FROM prestige_preserved_snapshot),
+  'PvP prestige preserves normalized PvE progress'
+);
+SELECT is(
+  (
+    SELECT progress_data
+    FROM public.user_game_mode_progress
+    WHERE user_id = (SELECT user_id FROM prestige_progress_fixture)
+      AND game_mode = 'seasonal'
+      AND season_number = (SELECT active_season FROM prestige_progress_fixture)
+  ),
+  (SELECT mode_seasonal FROM prestige_preserved_snapshot),
+  'PvP prestige preserves active Seasonal progress'
+);
+SELECT is(
+  (
+    SELECT jsonb_build_object(
+      'currentGameMode', current_game_mode,
+      'gameEdition', game_edition,
+      'tarkovUid', tarkov_uid
+    )
+    FROM public.user_progress
+    WHERE user_id = (SELECT user_id FROM prestige_progress_fixture)
+  ),
+  '{"currentGameMode":"pvp","gameEdition":4,"tarkovUid":773773}'::JSONB,
+  'PvP prestige applies the replacement account metadata'
+);
+
+CREATE TEMP TABLE prestige_progress_snapshot AS
+SELECT
+  (
+    SELECT to_jsonb(progress)
+    FROM public.user_progress AS progress
+    WHERE progress.user_id = fixture.user_id
+  ) AS legacy_row,
+  (
+    SELECT jsonb_agg(to_jsonb(progress) ORDER BY progress.game_mode, progress.season_number)
+    FROM public.user_game_mode_progress AS progress
+    WHERE progress.user_id = fixture.user_id
+  ) AS mode_rows,
+  (
+    SELECT jsonb_agg(to_jsonb(run) ORDER BY run.created_at, run.id)
+    FROM public.user_prestige_runs AS run
+    WHERE run.user_id = fixture.user_id
+  ) AS prestige_rows
+FROM prestige_progress_fixture AS fixture;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  (SELECT user_id::TEXT FROM prestige_progress_fixture),
+  TRUE
+);
+SELECT throws_ok(
+  $$SELECT public.archive_prestige_run_and_reset_progress(
+    'pvp'::TEXT,
+    3::INTEGER,
+    4::INTEGER,
+    (SELECT reset_pvp FROM prestige_progress_fixture),
+    '{"reason":"must roll back"}'::JSONB,
+    TIMESTAMPTZ '2026-08-04 12:00:00+00',
+    'pve'::TEXT,
+    9::INTEGER,
+    999999::BIGINT,
+    '"not-an-object"'::JSONB,
+    (SELECT changed_pve FROM prestige_progress_fixture)
+  )$$,
+  'Progress for pvp must be a JSON object',
+  'invalid nested sync progress aborts the prestige RPC'
+);
+RESET ROLE;
+
+SELECT is(
+  (
+    SELECT jsonb_agg(to_jsonb(run) ORDER BY run.created_at, run.id)
+    FROM public.user_prestige_runs AS run
+    WHERE run.user_id = (SELECT user_id FROM prestige_progress_fixture)
+  ),
+  (SELECT prestige_rows FROM prestige_progress_snapshot),
+  'a nested sync failure rolls back the new prestige archive'
+);
+SELECT is(
+  (
+    SELECT to_jsonb(progress)
+    FROM public.user_progress AS progress
+    WHERE progress.user_id = (SELECT user_id FROM prestige_progress_fixture)
+  ),
+  (SELECT legacy_row FROM prestige_progress_snapshot),
+  'a nested sync failure rolls back legacy progress and metadata'
+);
+SELECT is(
+  (
+    SELECT jsonb_agg(to_jsonb(progress) ORDER BY progress.game_mode, progress.season_number)
+    FROM public.user_game_mode_progress AS progress
+    WHERE progress.user_id = (SELECT user_id FROM prestige_progress_fixture)
+  ),
+  (SELECT mode_rows FROM prestige_progress_snapshot),
+  'a nested sync failure rolls back every normalized progress change'
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  (SELECT user_id::TEXT FROM prestige_progress_fixture),
+  TRUE
+);
+SELECT throws_ok(
+  $$SELECT public.archive_prestige_run_and_reset_progress(
+    'seasonal'::TEXT,
+    0::INTEGER,
+    1::INTEGER,
+    (SELECT initial_modes->'seasonal' FROM prestige_progress_fixture),
+    '{"reason":"unsupported"}'::JSONB,
+    TIMESTAMPTZ '2026-08-05 12:00:00+00',
+    'seasonal'::TEXT,
+    4::INTEGER,
+    773773::BIGINT,
+    (SELECT reset_pvp FROM prestige_progress_fixture),
+    (SELECT initial_modes->'pve' FROM prestige_progress_fixture)
+  )$$,
+  'Prestige is not supported for seasonal',
+  'Seasonal prestige is rejected'
+);
+RESET ROLE;
+
+SELECT is(
+  (
+    SELECT jsonb_agg(to_jsonb(run) ORDER BY run.created_at, run.id)
+    FROM public.user_prestige_runs AS run
+    WHERE run.user_id = (SELECT user_id FROM prestige_progress_fixture)
+  ),
+  (SELECT prestige_rows FROM prestige_progress_snapshot),
+  'rejected Seasonal prestige does not create an archive'
+);
+SELECT is(
+  (
+    SELECT to_jsonb(progress)
+    FROM public.user_progress AS progress
+    WHERE progress.user_id = (SELECT user_id FROM prestige_progress_fixture)
+  ),
+  (SELECT legacy_row FROM prestige_progress_snapshot),
+  'rejected Seasonal prestige leaves legacy progress unchanged'
+);
+SELECT is(
+  (
+    SELECT jsonb_agg(to_jsonb(progress) ORDER BY progress.game_mode, progress.season_number)
+    FROM public.user_game_mode_progress AS progress
+    WHERE progress.user_id = (SELECT user_id FROM prestige_progress_fixture)
+  ),
+  (SELECT mode_rows FROM prestige_progress_snapshot),
+  'rejected Seasonal prestige leaves normalized progress unchanged'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/supabase/tests/database/seasonal_progress.test.sql
+++ b/supabase/tests/database/seasonal_progress.test.sql
@@ -1,0 +1,368 @@
+BEGIN;
+
+SELECT plan(17);
+
+CREATE TEMP TABLE seasonal_progress_fixture AS
+SELECT
+  '00000000-0000-0000-0000-000000000761'::UUID AS synced_user_id,
+  '00000000-0000-0000-0000-000000000762'::UUID AS viewer_id,
+  '00000000-0000-0000-0000-000000000763'::UUID AS outsider_id,
+  '00000000-0000-0000-0000-000000000764'::UUID AS team_id,
+  private.active_season_number() AS active_season,
+  (private.active_season_number() + 1)::SMALLINT AS rollover_active_season,
+  jsonb_build_object(
+    'pvp', jsonb_build_object(
+      'displayName', 'Synced PvP',
+      'level', 11,
+      'taskCompletions', jsonb_build_object('pvp-task', jsonb_build_object('complete', true))
+    ),
+    'pve', jsonb_build_object(
+      'displayName', 'Synced PvE',
+      'level', 22,
+      'taskCompletions', jsonb_build_object('pve-task', jsonb_build_object('complete', true))
+    ),
+    'seasonal', jsonb_build_object(
+      'displayName', 'Synced Seasonal',
+      'level', 33,
+      'taskCompletions', jsonb_build_object(
+        'complete-task', jsonb_build_object('complete', true),
+        'incomplete-task', jsonb_build_object('complete', false)
+      )
+    )
+  ) AS initial_modes,
+  jsonb_build_object(
+    'pvp', jsonb_build_object('displayName', 'Stale input PvP', 'level', 44),
+    'pve', jsonb_build_object('displayName', 'Stale input PvE', 'level', 55),
+    'seasonal', jsonb_build_object('displayName', 'Stale Seasonal', 'level', 66)
+  ) AS stale_modes,
+  jsonb_build_object(
+    'pvp', jsonb_build_object('displayName', 'Omitted season PvP', 'level', 45),
+    'pve', jsonb_build_object('displayName', 'Omitted season PvE', 'level', 56),
+    'seasonal', jsonb_build_object('displayName', 'Unstamped Seasonal', 'level', 67)
+  ) AS omitted_season_modes;
+
+INSERT INTO auth.users (id, email)
+VALUES
+  ((SELECT synced_user_id FROM seasonal_progress_fixture), 'seasonal-synced@example.invalid'),
+  ((SELECT viewer_id FROM seasonal_progress_fixture), 'seasonal-viewer@example.invalid'),
+  ((SELECT outsider_id FROM seasonal_progress_fixture), 'seasonal-outsider@example.invalid');
+
+INSERT INTO public.teams (id, name, join_code, max_members, owner_id, game_mode)
+VALUES (
+  (SELECT team_id FROM seasonal_progress_fixture),
+  'Seasonal progress test team',
+  'seasonal-progress-test-code',
+  5,
+  (SELECT viewer_id FROM seasonal_progress_fixture),
+  'seasonal'
+);
+
+INSERT INTO public.team_memberships (team_id, user_id, role, game_mode)
+VALUES
+  (
+    (SELECT team_id FROM seasonal_progress_fixture),
+    (SELECT viewer_id FROM seasonal_progress_fixture),
+    'owner',
+    'seasonal'
+  ),
+  (
+    (SELECT team_id FROM seasonal_progress_fixture),
+    (SELECT synced_user_id FROM seasonal_progress_fixture),
+    'member',
+    'seasonal'
+  );
+
+GRANT SELECT ON seasonal_progress_fixture TO authenticated;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  (SELECT synced_user_id::TEXT FROM seasonal_progress_fixture),
+  TRUE
+);
+SELECT lives_ok(
+  $$SELECT public.sync_user_game_mode_progress(
+    'seasonal'::TEXT,
+    4::INTEGER,
+    761761::BIGINT,
+    (SELECT initial_modes FROM seasonal_progress_fixture),
+    (SELECT active_season FROM seasonal_progress_fixture)
+  )$$,
+  'an active-season all-mode sync succeeds'
+);
+RESET ROLE;
+
+CREATE TEMP TABLE seasonal_progress_expected (
+  game_mode TEXT NOT NULL,
+  season_number SMALLINT NOT NULL,
+  progress_data JSONB NOT NULL
+);
+INSERT INTO seasonal_progress_expected (game_mode, season_number, progress_data)
+SELECT
+  'pvp',
+  0::SMALLINT,
+  public.sanitize_user_progress_mode_data(initial_modes->'pvp')
+FROM seasonal_progress_fixture
+UNION ALL
+SELECT
+  'pve',
+  0::SMALLINT,
+  public.sanitize_user_progress_mode_data(initial_modes->'pve')
+FROM seasonal_progress_fixture
+UNION ALL
+SELECT
+  'seasonal',
+  active_season,
+  public.sanitize_user_progress_mode_data(initial_modes->'seasonal')
+FROM seasonal_progress_fixture;
+
+SELECT results_eq(
+  $$SELECT game_mode, season_number, progress_data
+    FROM public.user_game_mode_progress
+    WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)
+    ORDER BY game_mode, season_number$$,
+  $$SELECT game_mode, season_number, progress_data
+    FROM seasonal_progress_expected
+    ORDER BY game_mode, season_number$$,
+  'the sync stores PvP and PvE at season zero and Seasonal at the active season'
+);
+SELECT is(
+  (SELECT pvp_data FROM public.user_progress
+   WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)),
+  (SELECT progress_data FROM seasonal_progress_expected WHERE game_mode = 'pvp'),
+  'the legacy PvP mirror matches normalized PvP progress'
+);
+SELECT is(
+  (SELECT pve_data FROM public.user_progress
+   WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)),
+  (SELECT progress_data FROM seasonal_progress_expected WHERE game_mode = 'pve'),
+  'the legacy PvE mirror matches normalized PvE progress'
+);
+
+CREATE TEMP TABLE seasonal_progress_snapshot AS
+SELECT
+  (
+    SELECT jsonb_agg(to_jsonb(progress) ORDER BY progress.season_number)
+    FROM public.user_game_mode_progress AS progress
+    WHERE progress.user_id = fixture.synced_user_id
+      AND progress.game_mode = 'seasonal'
+  ) AS seasonal_rows
+FROM seasonal_progress_fixture AS fixture;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  (SELECT synced_user_id::TEXT FROM seasonal_progress_fixture),
+  TRUE
+);
+SELECT lives_ok(
+  $$SELECT public.sync_user_game_mode_progress(
+    'pvp'::TEXT,
+    9::INTEGER,
+    999999::BIGINT,
+    (SELECT stale_modes FROM seasonal_progress_fixture),
+    ((SELECT active_season FROM seasonal_progress_fixture) - 1)::SMALLINT
+  )$$,
+  'a stale Seasonal entry does not abort valid persistent-mode changes'
+);
+RESET ROLE;
+
+SELECT results_eq(
+  $$SELECT current_game_mode, game_edition, tarkov_uid, pvp_data, pve_data
+    FROM public.user_progress
+    WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)$$,
+  $$SELECT
+      'pvp'::TEXT,
+      9::INTEGER,
+      999999::BIGINT,
+      public.sanitize_user_progress_mode_data(stale_modes->'pvp'),
+      public.sanitize_user_progress_mode_data(stale_modes->'pve')
+    FROM seasonal_progress_fixture$$,
+  'a stale Seasonal entry still commits account metadata and both legacy mirrors'
+);
+SELECT results_eq(
+  $$SELECT game_mode, season_number, progress_data
+    FROM public.user_game_mode_progress
+    WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)
+      AND game_mode IN ('pvp', 'pve')
+    ORDER BY game_mode, season_number$$,
+  $$SELECT
+      'pve'::TEXT,
+      0::SMALLINT,
+      public.sanitize_user_progress_mode_data(stale_modes->'pve')
+    FROM seasonal_progress_fixture
+    UNION ALL
+    SELECT
+      'pvp'::TEXT,
+      0::SMALLINT,
+      public.sanitize_user_progress_mode_data(stale_modes->'pvp')
+    FROM seasonal_progress_fixture$$,
+  'a stale Seasonal entry still commits both normalized persistent modes'
+);
+SELECT is(
+  (
+    SELECT jsonb_agg(to_jsonb(progress) ORDER BY progress.season_number)
+    FROM public.user_game_mode_progress AS progress
+    WHERE progress.user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)
+      AND progress.game_mode = 'seasonal'
+  ),
+  (SELECT seasonal_rows FROM seasonal_progress_snapshot),
+  'a stale Seasonal entry preserves the saved Seasonal row without adding another season'
+);
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  (SELECT synced_user_id::TEXT FROM seasonal_progress_fixture),
+  TRUE
+);
+SELECT lives_ok(
+  $$SELECT public.sync_user_game_mode_progress(
+    'pve'::TEXT,
+    8::INTEGER,
+    888888::BIGINT,
+    (SELECT omitted_season_modes FROM seasonal_progress_fixture)
+  )$$,
+  'omitting the season argument does not abort valid persistent-mode changes'
+);
+RESET ROLE;
+
+SELECT results_eq(
+  $$SELECT current_game_mode, game_edition, tarkov_uid, pvp_data, pve_data
+    FROM public.user_progress
+    WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)$$,
+  $$SELECT
+      'pve'::TEXT,
+      8::INTEGER,
+      888888::BIGINT,
+      public.sanitize_user_progress_mode_data(omitted_season_modes->'pvp'),
+      public.sanitize_user_progress_mode_data(omitted_season_modes->'pve')
+    FROM seasonal_progress_fixture$$,
+  'an omitted season still commits account metadata and both legacy mirrors'
+);
+SELECT results_eq(
+  $$SELECT game_mode, season_number, progress_data
+    FROM public.user_game_mode_progress
+    WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)
+      AND game_mode IN ('pvp', 'pve')
+    ORDER BY game_mode, season_number$$,
+  $$SELECT
+      'pve'::TEXT,
+      0::SMALLINT,
+      public.sanitize_user_progress_mode_data(omitted_season_modes->'pve')
+    FROM seasonal_progress_fixture
+    UNION ALL
+    SELECT
+      'pvp'::TEXT,
+      0::SMALLINT,
+      public.sanitize_user_progress_mode_data(omitted_season_modes->'pvp')
+    FROM seasonal_progress_fixture$$,
+  'an omitted season still commits both normalized persistent modes'
+);
+SELECT is(
+  (
+    SELECT jsonb_agg(to_jsonb(progress) ORDER BY progress.season_number)
+    FROM public.user_game_mode_progress AS progress
+    WHERE progress.user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)
+      AND progress.game_mode = 'seasonal'
+  ),
+  (SELECT seasonal_rows FROM seasonal_progress_snapshot),
+  'an omitted season preserves the saved Seasonal row without adding another season'
+);
+
+SELECT set_config(
+  'test.active_season_number',
+  (SELECT rollover_active_season::TEXT FROM seasonal_progress_fixture),
+  TRUE
+);
+CREATE OR REPLACE FUNCTION private.active_season_number()
+RETURNS SMALLINT
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT current_setting('test.active_season_number')::SMALLINT;
+$$;
+
+-- Simulate a rollover inside this transaction so the row written above is genuinely historical.
+INSERT INTO public.user_game_mode_progress (user_id, game_mode, season_number, progress_data)
+SELECT
+  synced_user_id,
+  'seasonal',
+  rollover_active_season,
+  '{"displayName":"Rollover Seasonal","level":44,"taskCompletions":{"rollover-task":{"complete":true}}}'::JSONB
+FROM seasonal_progress_fixture;
+
+INSERT INTO public.user_game_mode_progress (user_id, game_mode, season_number, progress_data)
+SELECT
+  outsider_id,
+  'seasonal',
+  rollover_active_season,
+  '{"displayName":"Outsider Seasonal","level":88}'::JSONB
+FROM seasonal_progress_fixture;
+
+SET LOCAL ROLE authenticated;
+SELECT set_config(
+  'request.jwt.claim.sub',
+  (SELECT viewer_id::TEXT FROM seasonal_progress_fixture),
+  TRUE
+);
+SELECT results_eq(
+  $$SELECT display_name, level, tasks_completed
+    FROM public.team_member_mode_summary
+    WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)
+      AND game_mode = 'seasonal'
+      AND season_number = (SELECT rollover_active_season FROM seasonal_progress_fixture)$$,
+  $$VALUES ('Rollover Seasonal'::TEXT, 44::INTEGER, 1::INTEGER)$$,
+  'a teammate can read the active row for the shared mode'
+);
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.team_member_mode_summary
+    WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)
+      AND game_mode = 'seasonal'
+      AND season_number = (SELECT active_season FROM seasonal_progress_fixture)
+  ),
+  0,
+  'a teammate cannot read a retained historical Seasonal row'
+);
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.team_member_mode_summary
+    WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)
+      AND game_mode IN ('pvp', 'pve')
+  ),
+  0,
+  'a teammate cannot read progress from a mode they do not share'
+);
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.team_member_mode_summary
+    WHERE user_id = (SELECT outsider_id FROM seasonal_progress_fixture)
+  ),
+  0,
+  'a teammate cannot read active progress owned by an outsider'
+);
+SELECT set_config(
+  'request.jwt.claim.sub',
+  (SELECT outsider_id::TEXT FROM seasonal_progress_fixture),
+  TRUE
+);
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.team_member_mode_summary
+    WHERE user_id = (SELECT synced_user_id FROM seasonal_progress_fixture)
+  ),
+  0,
+  'an outsider cannot read any teammate summary rows'
+);
+RESET ROLE;
+
+SELECT * FROM finish();
+
+ROLLBACK;

--- a/supabase/tests/database/team_creation_atomicity.test.sql
+++ b/supabase/tests/database/team_creation_atomicity.test.sql
@@ -1,0 +1,106 @@
+BEGIN;
+
+SELECT plan(6);
+
+CREATE TEMP TABLE team_creation_atomicity_fixture AS
+SELECT '00000000-0000-0000-0000-000000000781'::UUID AS owner_id;
+
+INSERT INTO auth.users (id, email)
+VALUES (
+  (SELECT owner_id FROM team_creation_atomicity_fixture),
+  'team-creation-atomicity@example.invalid'
+);
+
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM public.user_system
+    WHERE user_id = (SELECT owner_id FROM team_creation_atomicity_fixture)
+      AND pvp_team_id IS NULL
+  ),
+  'the owner begins with an empty PvP team pointer'
+);
+
+CREATE FUNCTION public.test_648_reject_redundant_pvp_team_pointer()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF OLD.pvp_team_id IS NOT NULL
+    AND NEW.pvp_team_id IS NOT DISTINCT FROM OLD.pvp_team_id THEN
+    RAISE EXCEPTION 'test: rejected redundant PvP team pointer update';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.test_648_reject_redundant_pvp_team_pointer()
+  FROM PUBLIC, anon, authenticated;
+
+CREATE TRIGGER zzz_test_648_reject_redundant_pvp_team_pointer
+BEFORE UPDATE OF pvp_team_id ON public.user_system
+FOR EACH ROW
+EXECUTE FUNCTION public.test_648_reject_redundant_pvp_team_pointer();
+
+GRANT SELECT ON team_creation_atomicity_fixture TO service_role;
+
+SET LOCAL ROLE service_role;
+SELECT throws_ok(
+  $$SELECT public.create_team_with_owner(
+    'Atomic rollback test team',
+    'atomic-rollback-test-code',
+    5,
+    (SELECT owner_id FROM team_creation_atomicity_fixture),
+    'pvp'
+  )$$,
+  'test: rejected redundant PvP team pointer update',
+  'a failure at the final redundant pointer update aborts the team creation RPC'
+);
+RESET ROLE;
+
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.teams
+    WHERE owner_id = (SELECT owner_id FROM team_creation_atomicity_fixture)
+      AND name = 'Atomic rollback test team'
+      AND game_mode = 'pvp'
+  ),
+  0,
+  'the failed team creation rolls back the team row'
+);
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.team_memberships
+    WHERE user_id = (SELECT owner_id FROM team_creation_atomicity_fixture)
+      AND game_mode = 'pvp'
+  ),
+  0,
+  'the failed team creation rolls back the owner membership'
+);
+SELECT is(
+  (
+    SELECT COUNT(*)::INTEGER
+    FROM public.team_events
+    WHERE initiated_by = (SELECT owner_id FROM team_creation_atomicity_fixture)
+      AND event_type = 'team_created'
+  ),
+  0,
+  'the failed team creation leaves no team audit event'
+);
+SELECT ok(
+  EXISTS (
+    SELECT 1
+    FROM public.user_system
+    WHERE user_id = (SELECT owner_id FROM team_creation_atomicity_fixture)
+      AND pvp_team_id IS NULL
+  ),
+  'the failed team creation restores the owner team pointer'
+);
+
+SELECT * FROM finish();
+
+ROLLBACK;


### PR DESCRIPTION
# Pull Request

## Summary

Adds regression coverage for saved Seasonal progress, prestige archive/reset atomicity, teammate visibility, and team creation rollback. A stale or omitted season must preserve existing Seasonal progress while valid PvP/PvE updates still commit.

## Changes

- Verify active-season all-mode sync and legacy mirrors, then preserve an existing Seasonal row through stale and omitted season inputs while both persistent modes and account metadata change.
- Verify teammate summaries expose only the shared mode and active season, including a simulated rollover with retained history and outsider isolation.
- Exercise the current 11-argument prestige RPC: archive and reset PvP, preserve PvE/Seasonal, roll back on a nested sync failure, and reject Seasonal prestige without mutation.
- Inject a transaction-scoped failing trigger at the final team-pointer update and verify the team, owner membership, event, and pointer leave no partial state.

## Related Issues

Closes #648. Builds on merged #786 and complements its existing empty-Seasonal-row and PvP-only assertions.

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [x] Added/updated unit tests — pgTAP database regression suites
- [ ] Manual testing performed — no UI changes

### Test Plan

1. Reset a local Supabase database from current migrations, run all database suites, and lint the public schema with `pnpm run supabase:check`.
2. Run `pnpm run systems:check`, `pnpm run lint:blank-lines`, and whitespace checks.
3. Run `pnpm run format:check`; record the Windows launcher limitation and direct Prettier CLI workaround separately.
4. Independently review the complete diff and verify that transaction-scoped mutations are detected by the new assertions; finish with another clean database reset and full pgTAP run.

Validated on 2026-09-06 with Node 24.19.0, pnpm 11.14.0, and the frozen upstream lockfile. Base: `upstream/main` at `c17785fe5b747205f552988214fac02e71a5e6ec`. Final commit: `db32675228f9cb40f67ca540d11f032b7a5bc1a3`; working tree clean. Validation ran with only the three SQL test additions present, and the commit did not modify their contents.

- `pnpm run supabase:check`: passed a clean local reset, all 6 suites / 101 assertions (40 added here), and schema lint with no errors.
- `pnpm run systems:check`: passed.
- `pnpm run lint:blank-lines`: passed.
- `git diff --cached --check` before commit and `git diff upstream/main...HEAD --check` after commit: passed.
- `pnpm run format:check`: blocked by the existing Windows launcher error (`/*.json was unexpected at this time`). Invoking the pinned Prettier CLI through Node, with the same configured patterns and `--end-of-line auto` for the Windows checkout, passed. This is a local workaround, not a pass of the exact package command. None of the added SQL suites is in the repository's Prettier file set; pgTAP, schema lint, and Git whitespace checks validate the SQL. [PR CI](https://github.com/tarkovtracker-org/TarkovTracker/actions/runs/34063765045) passed for head `db326752`, including the Supabase database check (101 assertions and schema lint), Lint & Format, typecheck, and all four application test shards.
- Final verification: two independent read-only reviews found no actionable issues. The new suites detected all seven intentionally broken variants: skipped valid Seasonal writes, stale/omitted Seasonal overwrites, incorrectly aborted persistent-mode updates, cross-mode exposure, historical-season exposure, a retained archive after a swallowed nested failure, and removal of the final team-pointer upsert. Every mutation was rolled back and original function definitions were verified before the final clean reset and successful 101-assertion run.
- Application Vitest/typecheck were not rerun locally for this database-tests-only change; both passed in PR CI. All pre-existing pgTAP suites passed locally.

## Screenshots/Videos

Not applicable; no UI changes.

## Documentation impact

- [x] No behavior changed — no documentation review needed
- [ ] Behavior changed — existing documentation remains accurate
- [ ] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [x] Contributor documentation
- [x] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [ ] Screenshots or diagrams

`docs/SYSTEMS.md` already documents skip-and-commit and Seasonal prestige rejection correctly. The existing harness and automatic test discovery require no command or CI changes.

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass — all existing pgTAP suites passed locally; application test shards passed in CI
- [x] I have checked for any breaking changes

## Additional Notes

No production SQL, migrations, schemas, RPC signatures, generated types, package scripts, or localization changes. Test fixtures and injected functions/triggers are rolled back at the end of each suite. No deployment or rollback steps are required.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added coverage for prestige runs, including progress resets, archived completed runs, preserved unrelated progress, and full rollback after invalid input.
  - Added coverage for seasonal progress synchronization across active, stale, and missing season data, including visibility rules during season changes.
  - Added coverage confirming team creation remains atomic, with failed operations leaving no partial team, membership, audit, or account updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Adds transactional pgTAP regression coverage without changing production behavior.
- Covers atomic PvP prestige archive/reset, nested-failure rollback, preservation of PvE and Seasonal progress, and Seasonal prestige rejection.
- Covers active-season synchronization, stale or omitted season handling, and mode-, season-, and team-scoped teammate visibility.
- Covers complete rollback of team creation when its final team-pointer update fails.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge; the added tests align with the current database contracts and introduce no production behavior changes.

The new suites use transaction-scoped fixtures and overrides, exercise the intended RPC and RLS paths, assert the relevant persisted state, and roll all test mutations back.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| supabase/tests/database/prestige_progress.test.sql | Adds coherent coverage of the current prestige RPC signature, preservation guarantees, rollback behavior, and unsupported Seasonal prestige. |
| supabase/tests/database/seasonal_progress.test.sql | Adds regression coverage for Seasonal persistence and teammate visibility, including a transaction-local season rollover simulation. |
| supabase/tests/database/team_creation_atomicity.test.sql | Injects a targeted failure at the redundant team-pointer update and verifies that every preceding team-creation side effect rolls back. |

</details>

<sub>Reviews (1): Last reviewed commit: ["test: cover seasonal progress and databa..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/db32675228f9cb40f67ca540d11f032b7a5bc1a3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61041747)</sub>

<!-- /greptile_comment -->