### PR TITLE
feat(needed-items): search pooled quest objectives by any accepted item

### DIFF
--- a/app/composables/__tests__/useCyclingItem.test.ts
+++ b/app/composables/__tests__/useCyclingItem.test.ts
@@ -114,4 +114,63 @@ describe('useCyclingItem', () => {
     // Falls back to the primary item; no out-of-bounds access.
     expect(currentItem.value?.id).toBe('a');
   });
+  it('pins the display to the preferred index and pauses rotation', async () => {
+    const items = [makeItem('a'), makeItem('b'), makeItem('c')];
+    const preferredIndex = ref(-1);
+    const { currentItem, isCycling } = useCyclingItem(items, () => items[0] ?? null, {
+      intervalMs: 1000,
+      preferredIndex,
+    });
+    await nextTick();
+    expect(isCycling.value).toBe(true);
+    vi.advanceTimersByTime(2000);
+    expect(currentItem.value?.id).toBe('c');
+    preferredIndex.value = 1;
+    await nextTick();
+    expect(isCycling.value).toBe(false);
+    expect(currentItem.value?.id).toBe('b');
+    // Rotation stays paused while pinned.
+    vi.advanceTimersByTime(5000);
+    expect(currentItem.value?.id).toBe('b');
+  });
+  it('resumes normal rotation when the preferred index is cleared', async () => {
+    const items = [makeItem('a'), makeItem('b'), makeItem('c')];
+    const preferredIndex = ref(2);
+    const { currentItem, isCycling } = useCyclingItem(items, () => items[0] ?? null, {
+      intervalMs: 1000,
+      preferredIndex,
+    });
+    await nextTick();
+    expect(currentItem.value?.id).toBe('c');
+    preferredIndex.value = -1;
+    await nextTick();
+    expect(isCycling.value).toBe(true);
+    // Pin cleared: rotation restarts from the primary item.
+    expect(currentItem.value?.id).toBe('a');
+    vi.advanceTimersByTime(1000);
+    expect(currentItem.value?.id).toBe('b');
+  });
+  it('falls back to the primary item for an out-of-range preferred index', async () => {
+    const items = [makeItem('a'), makeItem('b')];
+    const preferredIndex = ref(7);
+    const { currentItem, isCycling } = useCyclingItem(items, () => items[0] ?? null, {
+      intervalMs: 1000,
+      preferredIndex,
+    });
+    await nextTick();
+    // Out-of-range pin shows the primary item and does not rotate.
+    expect(isCycling.value).toBe(false);
+    vi.advanceTimersByTime(1000);
+    expect(currentItem.value?.id).toBe('a');
+    // Becomes pinned once the index is in range.
+    preferredIndex.value = 1;
+    await nextTick();
+    expect(currentItem.value?.id).toBe('b');
+  });
+  it('pins to the primary item with an empty accepted list', () => {
+    const primary = makeItem('primary');
+    const { currentItem, isCycling } = useCyclingItem([], primary, { preferredIndex: 0 });
+    expect(isCycling.value).toBe(false);
+    expect(currentItem.value?.id).toBe('primary');
+  });
 });

--- a/app/composables/__tests__/useNeededItems.test.ts
+++ b/app/composables/__tests__/useNeededItems.test.ts
@@ -555,6 +555,67 @@ describe('useNeededItems', () => {
       expect(counts).toEqual(sortedCounts);
     });
   });
+  describe('pooled accepted item objectives', () => {
+    const createPooledObjective = (): NeededItemTaskObjective => {
+      const primary = createItem('item-cms', 'CMS Kit');
+      const augmentin = createItem('item-augmentin', 'Augmentin');
+      const analgin = createItem('item-analgin', 'Analgin');
+      return {
+        id: 'obj-pool',
+        needType: 'taskObjective',
+        taskId: 'task-1',
+        type: 'giveItem',
+        item: primary,
+        count: 5,
+        foundInRaid: true,
+        acceptedItems: [primary, augmentin, analgin],
+      };
+    };
+    it('matches pooled objectives by any accepted item name', async () => {
+      const { neededItems, search } = await setup({
+        metadataStore: { neededItemTaskObjectives: [createPooledObjective()] },
+      });
+      search.value = 'augmentin';
+      const ids = neededItems.filteredItems.value.map((item) => item.id);
+      expect(ids).toContain('obj-pool');
+      expect(ids).not.toContain('hideout-1');
+    });
+    it('matches pooled objectives by accepted item short name', async () => {
+      const { neededItems, search } = await setup({
+        metadataStore: { neededItemTaskObjectives: [createPooledObjective()] },
+      });
+      search.value = 'anal';
+      const ids = neededItems.filteredItems.value.map((item) => item.id);
+      expect(ids).toContain('obj-pool');
+    });
+    it('excludes pooled objectives when no accepted item matches', async () => {
+      const { neededItems, search } = await setup({
+        metadataStore: { neededItemTaskObjectives: [createPooledObjective()] },
+      });
+      search.value = 'wrench';
+      const ids = neededItems.filteredItems.value.map((item) => item.id);
+      expect(ids).not.toContain('obj-pool');
+    });
+    it('groups pooled objectives under the matched accepted item while searching', async () => {
+      const { neededItems, search } = await setup({
+        metadataStore: { neededItemTaskObjectives: [createPooledObjective()] },
+      });
+      search.value = 'augmentin';
+      const groupIds = neededItems.groupedItems.value.map((group) => group.item.id);
+      expect(groupIds).toContain('item-augmentin');
+      expect(groupIds).not.toContain('item-cms');
+      const registered = neededItems.objectivesByItemId.value.get('item-augmentin');
+      expect(registered?.taskObjectives.map((objective) => objective.id)).toEqual(['obj-pool']);
+    });
+    it('keeps the primary item as the group key when no accepted item matches', async () => {
+      const { neededItems, search } = await setup({
+        metadataStore: { neededItemTaskObjectives: [createPooledObjective()] },
+      });
+      search.value = 'cms';
+      const groupIds = neededItems.groupedItems.value.map((group) => group.item.id);
+      expect(groupIds).toContain('item-cms');
+    });
+  });
   describe('loading state', () => {
     it('reports items ready when loaded', async () => {
       const { neededItems } = await setup();

--- a/app/composables/__tests__/useNeededItems.test.ts
+++ b/app/composables/__tests__/useNeededItems.test.ts
@@ -607,13 +607,33 @@ describe('useNeededItems', () => {
       const registered = neededItems.objectivesByItemId.value.get('item-augmentin');
       expect(registered?.taskObjectives.map((objective) => objective.id)).toEqual(['obj-pool']);
     });
+    it('groups pooled objectives under an accepted item matched only by short name', async () => {
+      const primary = createItem('item-cms', 'CMS Kit');
+      const shortNameOnly = { ...createItem('item-analgin', 'Analgin Tablets'), shortName: 'AT-3' };
+      const pooled: NeededItemTaskObjective = {
+        ...createPooledObjective(),
+        item: primary,
+        acceptedItems: [primary, shortNameOnly],
+      };
+      const { neededItems, search } = await setup({
+        metadataStore: { neededItemTaskObjectives: [pooled] },
+      });
+      search.value = 'at-3';
+      const groupIds = neededItems.groupedItems.value.map((group) => group.item.id);
+      expect(groupIds).toContain('item-analgin');
+      expect(groupIds).not.toContain('item-cms');
+    });
     it('keeps the primary item as the group key when no accepted item matches', async () => {
       const { neededItems, search } = await setup({
         metadataStore: { neededItemTaskObjectives: [createPooledObjective()] },
       });
-      search.value = 'cms';
+      // Searching the task name includes the objective without matching any of
+      // its accepted items, exercising the primary-item group fallback.
+      search.value = 'task one';
       const groupIds = neededItems.groupedItems.value.map((group) => group.item.id);
       expect(groupIds).toContain('item-cms');
+      const registered = neededItems.objectivesByItemId.value.get('item-cms');
+      expect(registered?.taskObjectives.map((objective) => objective.id)).toEqual(['obj-pool']);
     });
   });
   describe('loading state', () => {

--- a/app/composables/useCyclingItem.ts
+++ b/app/composables/useCyclingItem.ts
@@ -10,14 +10,19 @@ export interface UseCyclingItemOptions {
   /**
    * When a valid list index is provided, the display pins to that item and
    * rotation pauses (e.g. a search matched one of the accepted items). Use -1
-   * (the default) to keep normal rotation behavior.
+   * (the default) to keep normal rotation behavior. `currentIndex` keeps
+   * tracking the rotation, not the pin.
    */
   preferredIndex?: MaybeRefOrGetter<number>;
 }
 export interface UseCyclingItemReturn {
-  /** The item currently being displayed (primary item when not cycling). */
+  /** The item currently being displayed (pinned item, primary item when not cycling). */
   currentItem: ComputedRef<TarkovItem | null>;
-  /** Zero-based index of the current item within the provided list. */
+  /**
+   * Zero-based rotation index within the provided list. It advances while
+   * cycling and resets when cycling pauses or the display is pinned; while
+   * pinned, the displayed item is the one at `preferredIndex` instead.
+   */
   currentIndex: Ref<number>;
   /** Total number of items available to cycle through. */
   total: ComputedRef<number>;

--- a/app/composables/useCyclingItem.ts
+++ b/app/composables/useCyclingItem.ts
@@ -7,6 +7,12 @@ export interface UseCyclingItemOptions {
   intervalMs?: number;
   /** When false (or 0/1 items) cycling pauses and the primary item is shown. */
   enabled?: MaybeRefOrGetter<boolean>;
+  /**
+   * When a valid list index is provided, the display pins to that item and
+   * rotation pauses (e.g. a search matched one of the accepted items). Use -1
+   * (the default) to keep normal rotation behavior.
+   */
+  preferredIndex?: MaybeRefOrGetter<number>;
 }
 export interface UseCyclingItemReturn {
   /** The item currently being displayed (primary item when not cycling). */
@@ -33,7 +39,11 @@ export function useCyclingItem(
   primaryItem: MaybeRefOrGetter<TarkovItem | null>,
   options: UseCyclingItemOptions = {}
 ): UseCyclingItemReturn {
-  const { intervalMs = DEFAULT_CYCLE_INTERVAL_MS, enabled = true } = options;
+  const { intervalMs = DEFAULT_CYCLE_INTERVAL_MS, enabled = true, preferredIndex = -1 } = options;
+  const pinnedIndex = computed(() => {
+    const resolved = Math.floor(toValue(preferredIndex));
+    return Number.isFinite(resolved) && resolved >= 0 ? resolved : -1;
+  });
   const itemList = computed(() => {
     const resolved = toValue(items);
     return Array.isArray(resolved) ? resolved.filter((entry): entry is TarkovItem => !!entry) : [];
@@ -42,7 +52,11 @@ export function useCyclingItem(
   const hasAlternatives = computed(() => total.value > 1);
   const reducedMotion = usePreferredReducedMotion();
   const isCycling = computed(
-    () => Boolean(toValue(enabled)) && reducedMotion.value !== 'reduce' && hasAlternatives.value
+    () =>
+      Boolean(toValue(enabled)) &&
+      reducedMotion.value !== 'reduce' &&
+      hasAlternatives.value &&
+      pinnedIndex.value < 0
   );
   const currentIndex = ref(0);
   // Keep the index within bounds if the list changes (e.g. filters/locale).
@@ -72,6 +86,9 @@ export function useCyclingItem(
   );
   const currentItem = computed(() => {
     const fallback = toValue(primaryItem) ?? null;
+    if (pinnedIndex.value >= 0) {
+      return itemList.value[pinnedIndex.value] ?? fallback;
+    }
     if (!isCycling.value) return fallback;
     return itemList.value[currentIndex.value] ?? fallback;
   });

--- a/app/composables/useCyclingItem.ts
+++ b/app/composables/useCyclingItem.ts
@@ -34,23 +34,23 @@ export interface UseCyclingItemReturn {
  * Display-only: this never mutates progress or counts. When there is one item
  * or fewer, or cycling is disabled, it simply returns the primary (first) item.
  */
+const normalizePinnedIndex = (index: number): number =>
+  Number.isFinite(index) && index >= 0 ? index : -1;
 export function useCyclingItem(
   items: MaybeRefOrGetter<TarkovItem[] | undefined>,
   primaryItem: MaybeRefOrGetter<TarkovItem | null>,
   options: UseCyclingItemOptions = {}
 ): UseCyclingItemReturn {
   const { intervalMs = DEFAULT_CYCLE_INTERVAL_MS, enabled = true, preferredIndex = -1 } = options;
-  const pinnedIndex = computed(() => {
-    const resolved = Math.floor(toValue(preferredIndex));
-    return Number.isFinite(resolved) && resolved >= 0 ? resolved : -1;
-  });
   const itemList = computed(() => {
     const resolved = toValue(items);
     return Array.isArray(resolved) ? resolved.filter((entry): entry is TarkovItem => !!entry) : [];
   });
+  const primary = computed(() => toValue(primaryItem) ?? null);
   const total = computed(() => itemList.value.length);
   const hasAlternatives = computed(() => total.value > 1);
   const reducedMotion = usePreferredReducedMotion();
+  const pinnedIndex = computed(() => normalizePinnedIndex(Math.floor(toValue(preferredIndex))));
   const isCycling = computed(
     () =>
       Boolean(toValue(enabled)) &&
@@ -84,13 +84,10 @@ export function useCyclingItem(
     },
     { immediate: true }
   );
+  const itemAtIndex = (index: number): TarkovItem | null => itemList.value[index] ?? primary.value;
   const currentItem = computed(() => {
-    const fallback = toValue(primaryItem) ?? null;
-    if (pinnedIndex.value >= 0) {
-      return itemList.value[pinnedIndex.value] ?? fallback;
-    }
-    if (!isCycling.value) return fallback;
-    return itemList.value[currentIndex.value] ?? fallback;
+    if (pinnedIndex.value >= 0) return itemAtIndex(pinnedIndex.value);
+    return isCycling.value ? itemAtIndex(currentIndex.value) : primary.value;
   });
   return {
     currentItem,

--- a/app/composables/useNeededItems.ts
+++ b/app/composables/useNeededItems.ts
@@ -1,5 +1,6 @@
 import { useNeededItemsSorting } from '@/composables/useNeededItemsSorting';
 import {
+  findAcceptedItemMatchIndex,
   getNeededItemData,
   getNeededItemId,
   isNonFirSpecialEquipment,
@@ -23,6 +24,7 @@ import type {
   GroupedNeededItem,
   NeededItemHideoutModule,
   NeededItemTaskObjective,
+  TarkovItem,
 } from '@/types/tarkov';
 const DEFAULT_FULL_LOAD_TIMEOUT_MS = 5000;
 const DEFAULT_FULL_LOAD_MIN_TIME_MS = 16;
@@ -478,7 +480,13 @@ export function useNeededItems(options: UseNeededItemsOptions = {}): UseNeededIt
       return true;
     }
     if (item.needType === 'taskObjective') {
-      const task = metadataStore.getTaskById((item as NeededItemTaskObjective).taskId);
+      const taskObjective = item as NeededItemTaskObjective;
+      // Pooled "any of these" objectives match any valid turn-in item, not just
+      // the primary/cycled one, so searching e.g. "Augmentin" surfaces the quest.
+      if (findAcceptedItemMatchIndex(taskObjective.acceptedItems, search.value) !== -1) {
+        return true;
+      }
+      const task = metadataStore.getTaskById(taskObjective.taskId);
       if (task?.name && fuzzyMatch(task.name, search.value)) {
         return true;
       }
@@ -531,20 +539,43 @@ export function useNeededItems(options: UseNeededItemsOptions = {}): UseNeededIt
     return sorted;
   });
   type GroupedNeededItemAccumulator = Omit<GroupedNeededItem, 'total' | 'currentCount'>;
+  type GroupTarget = { id: string; data: TarkovItem; name: string };
+  /**
+   * Resolves the item a need is grouped and registered under in the grouped
+   * view. When searching, a pooled "any of these" objective that matched an
+   * accepted item is grouped under that matched turn-in item so it is the
+   * visible entry; without an accepted match the primary item stays canonical.
+   * `name` mirrors the grouped-item rule that nameless items are not grouped.
+   */
+  const resolveGroupTarget = (
+    need: NeededItemTaskObjective | NeededItemHideoutModule
+  ): GroupTarget | null => {
+    const primaryData = getNeededItemData(need);
+    if (!primaryData?.id) return null;
+    if (need.needType === 'taskObjective' && search.value) {
+      const matchIndex = findAcceptedItemMatchIndex(need.acceptedItems, search.value);
+      const matchedItem = matchIndex >= 0 ? need.acceptedItems?.[matchIndex] : undefined;
+      if (matchedItem?.id && matchedItem.name) {
+        const { id, name } = matchedItem;
+        return { id, data: matchedItem, name };
+      }
+    }
+    if (!primaryData.name) return null;
+    return { id: primaryData.id, data: primaryData, name: primaryData.name };
+  };
   const groupedItems = computed((): GroupedNeededItem[] => {
     const startedAt = perfDebug.value ? perfNow() : 0;
     const groups = new Map<string, GroupedNeededItemAccumulator>();
     for (const need of filteredItems.value) {
-      const itemId = getNeededItemId(need);
-      if (!itemId) continue;
-      const itemData = getNeededItemData(need);
-      if (!itemData || !itemData.name) continue;
+      const target = resolveGroupTarget(need);
+      if (!target) continue;
+      const { id: itemId, data: itemData, name: itemName } = target;
       const existingGroup = groups.get(itemId);
       if (!existingGroup) {
         groups.set(itemId, {
           item: {
             id: itemData.id,
-            name: itemData.name,
+            name: itemName,
             iconLink: itemData.iconLink,
             image512pxLink: itemData.image512pxLink,
             wikiLink: itemData.wikiLink,
@@ -614,8 +645,7 @@ export function useNeededItems(options: UseNeededItemsOptions = {}): UseNeededIt
       }
     >();
     for (const need of filteredItems.value) {
-      const itemData = getNeededItemData(need);
-      const itemId = itemData?.id;
+      const itemId = resolveGroupTarget(need)?.id;
       if (!itemId) continue;
       if (!map.has(itemId)) {
         map.set(itemId, { taskObjectives: [], hideoutModules: [] });

--- a/app/composables/useNeededItems.ts
+++ b/app/composables/useNeededItems.ts
@@ -540,6 +540,20 @@ export function useNeededItems(options: UseNeededItemsOptions = {}): UseNeededIt
   });
   type GroupedNeededItemAccumulator = Omit<GroupedNeededItem, 'total' | 'currentCount'>;
   type GroupTarget = { id: string; data: TarkovItem; name: string };
+  const canGroupItem = (item: TarkovItem | undefined): item is TarkovItem & { name: string } =>
+    Boolean(item?.id && item?.name);
+  /**
+   * Returns the group target for the search-matched accepted item of a pooled
+   * "any of these" objective, or null when the search did not match one of its
+   * accepted items or the matched item cannot serve as a group entry.
+   */
+  const findAcceptedGroupTarget = (need: NeededItemTaskObjective): GroupTarget | null => {
+    const matchIndex = findAcceptedItemMatchIndex(need.acceptedItems, search.value);
+    const matchedItem = matchIndex >= 0 ? need.acceptedItems?.[matchIndex] : undefined;
+    if (!canGroupItem(matchedItem)) return null;
+    const { id, name } = matchedItem;
+    return { id, data: matchedItem, name };
+  };
   /**
    * Resolves the item a need is grouped and registered under in the grouped
    * view. When searching, a pooled "any of these" objective that matched an
@@ -550,17 +564,10 @@ export function useNeededItems(options: UseNeededItemsOptions = {}): UseNeededIt
   const resolveGroupTarget = (
     need: NeededItemTaskObjective | NeededItemHideoutModule
   ): GroupTarget | null => {
+    const acceptedTarget = need.needType === 'taskObjective' ? findAcceptedGroupTarget(need) : null;
+    if (acceptedTarget) return acceptedTarget;
     const primaryData = getNeededItemData(need);
-    if (!primaryData?.id) return null;
-    if (need.needType === 'taskObjective' && search.value) {
-      const matchIndex = findAcceptedItemMatchIndex(need.acceptedItems, search.value);
-      const matchedItem = matchIndex >= 0 ? need.acceptedItems?.[matchIndex] : undefined;
-      if (matchedItem?.id && matchedItem.name) {
-        const { id, name } = matchedItem;
-        return { id, data: matchedItem, name };
-      }
-    }
-    if (!primaryData.name) return null;
+    if (!canGroupItem(primaryData)) return null;
     return { id: primaryData.id, data: primaryData, name: primaryData.name };
   };
   const groupedItems = computed((): GroupedNeededItem[] => {

--- a/app/composables/useNeededItems.ts
+++ b/app/composables/useNeededItems.ts
@@ -4,6 +4,7 @@ import {
   getNeededItemData,
   getNeededItemId,
   isNonFirSpecialEquipment,
+  itemMatchesQuery,
 } from '@/features/neededitems/neededItemFilters';
 import { useMetadataStore } from '@/stores/useMetadata';
 import { usePreferencesStore } from '@/stores/usePreferences';
@@ -469,45 +470,38 @@ export function useNeededItems(options: UseNeededItemsOptions = {}): UseNeededIt
   ): boolean => {
     return !hideTeamItems.value || passesTeamFilter(item);
   };
+  /**
+   * Task objectives match their task's name, and pooled "any of these"
+   * objectives also match any valid turn-in item, not just the primary/cycled
+   * one, so searching e.g. "Augmentin" surfaces the quest.
+   */
+  const taskMatchesSearch = (taskObjective: NeededItemTaskObjective): boolean => {
+    if (findAcceptedItemMatchIndex(taskObjective.acceptedItems, search.value) !== -1) {
+      return true;
+    }
+    const task = metadataStore.getTaskById(taskObjective.taskId);
+    return Boolean(task?.name && fuzzyMatch(task.name, search.value));
+  };
+  const stationLevelMatchesSearch = (stationName: string, level: number): boolean => {
+    const stationWithLevel = `${stationName} ${level}`;
+    const stationWithLevelText = `${stationName} level ${level}`;
+    return (
+      fuzzyMatch(stationWithLevel, search.value) || fuzzyMatch(stationWithLevelText, search.value)
+    );
+  };
+  const stationMatchesSearch = (need: NeededItemHideoutModule): boolean => {
+    const station = metadataStore.getStationById(need.hideoutModule.stationId);
+    const stationName = station?.name;
+    if (!stationName) return false;
+    if (fuzzyMatch(stationName, search.value)) return true;
+    return stationLevelMatchesSearch(stationName, need.hideoutModule.level);
+  };
+  // An empty search matches every item (fuzzyMatch treats an empty query as a
+  // wildcard), so the item-name check doubles as the empty-search early-out.
   const passesSearchFilter = (item: NeededItemTaskObjective | NeededItemHideoutModule): boolean => {
-    if (!search.value) {
-      return true;
-    }
-    const itemObj = getNeededItemData(item);
-    const itemName = itemObj?.name ?? '';
-    const itemShortName = itemObj?.shortName ?? '';
-    if (fuzzyMatch(itemName, search.value) || fuzzyMatch(itemShortName, search.value)) {
-      return true;
-    }
-    if (item.needType === 'taskObjective') {
-      const taskObjective = item as NeededItemTaskObjective;
-      // Pooled "any of these" objectives match any valid turn-in item, not just
-      // the primary/cycled one, so searching e.g. "Augmentin" surfaces the quest.
-      if (findAcceptedItemMatchIndex(taskObjective.acceptedItems, search.value) !== -1) {
-        return true;
-      }
-      const task = metadataStore.getTaskById(taskObjective.taskId);
-      if (task?.name && fuzzyMatch(task.name, search.value)) {
-        return true;
-      }
-    }
-    if (item.needType === 'hideoutModule') {
-      const hideoutModule = (item as NeededItemHideoutModule).hideoutModule;
-      const station = metadataStore.getStationById(hideoutModule.stationId);
-      if (station?.name) {
-        if (fuzzyMatch(station.name, search.value)) {
-          return true;
-        }
-        const stationWithLevel = `${station.name} ${hideoutModule.level}`;
-        const stationWithLevelText = `${station.name} level ${hideoutModule.level}`;
-        if (
-          fuzzyMatch(stationWithLevel, search.value) ||
-          fuzzyMatch(stationWithLevelText, search.value)
-        ) {
-          return true;
-        }
-      }
-    }
+    if (itemMatchesQuery(getNeededItemData(item), search.value)) return true;
+    if (item.needType === 'taskObjective') return taskMatchesSearch(item);
+    if (item.needType === 'hideoutModule') return stationMatchesSearch(item);
     return false;
   };
   const filteredItems = computed(() => {

--- a/app/composables/useNeededItems.ts
+++ b/app/composables/useNeededItems.ts
@@ -536,29 +536,39 @@ export function useNeededItems(options: UseNeededItemsOptions = {}): UseNeededIt
   type GroupTarget = { id: string; data: TarkovItem; name: string };
   const canGroupItem = (item: TarkovItem | undefined): item is TarkovItem & { name: string } =>
     Boolean(item?.id && item?.name);
+  const groupEntryName = (item: TarkovItem | undefined): string | undefined => {
+    if (!item) return undefined;
+    return item.name || item.shortName;
+  };
+  const toGroupTarget = (item: TarkovItem | undefined): GroupTarget | null => {
+    const name = groupEntryName(item);
+    if (!item?.id || !name) return null;
+    return { id: item.id, data: item, name };
+  };
   /**
-   * Returns the group target for the search-matched accepted item of a pooled
-   * "any of these" objective, or null when the search did not match one of its
-   * accepted items or the matched item cannot serve as a group entry.
+   * Returns the search-matched accepted item of a pooled "any of these"
+   * objective, or undefined when the search did not match one of its accepted
+   * items. Uses the same name-or-short-name matching as the search filter and
+   * the display pin so all three stay consistent.
    */
-  const findAcceptedGroupTarget = (need: NeededItemTaskObjective): GroupTarget | null => {
+  const findAcceptedGroupMatch = (need: NeededItemTaskObjective): TarkovItem | undefined => {
     const matchIndex = findAcceptedItemMatchIndex(need.acceptedItems, search.value);
-    const matchedItem = matchIndex >= 0 ? need.acceptedItems?.[matchIndex] : undefined;
-    if (!canGroupItem(matchedItem)) return null;
-    const { id, name } = matchedItem;
-    return { id, data: matchedItem, name };
+    if (matchIndex < 0) return undefined;
+    return need.acceptedItems?.[matchIndex];
   };
   /**
    * Resolves the item a need is grouped and registered under in the grouped
    * view. When searching, a pooled "any of these" objective that matched an
-   * accepted item is grouped under that matched turn-in item so it is the
-   * visible entry; without an accepted match the primary item stays canonical.
-   * `name` mirrors the grouped-item rule that nameless items are not grouped.
+   * accepted item is grouped under that matched turn-in item (identified by
+   * name or short name, mirroring the search match) so it is the visible
+   * entry; without an accepted match the primary item stays canonical under
+   * the grouped-view rule that nameless items are not grouped.
    */
   const resolveGroupTarget = (
     need: NeededItemTaskObjective | NeededItemHideoutModule
   ): GroupTarget | null => {
-    const acceptedTarget = need.needType === 'taskObjective' ? findAcceptedGroupTarget(need) : null;
+    const acceptedTarget =
+      need.needType === 'taskObjective' ? toGroupTarget(findAcceptedGroupMatch(need)) : null;
     if (acceptedTarget) return acceptedTarget;
     const primaryData = getNeededItemData(need);
     if (!canGroupItem(primaryData)) return null;

--- a/app/features/neededitems/NeededItem.vue
+++ b/app/features/neededitems/NeededItem.vue
@@ -27,6 +27,7 @@
   import { useCraftableItem } from '@/composables/useCraftableItem';
   import { useCyclingItem } from '@/composables/useCyclingItem';
   import { neededItemKey, type NeededItemTeamNeed } from '@/features/neededitems/neededitem-keys';
+  import { findAcceptedItemMatchIndex } from '@/features/neededitems/neededItemFilters';
   import { useMetadataStore } from '@/stores/useMetadata';
   import { usePreferencesStore } from '@/stores/usePreferences';
   import { useProgressStore } from '@/stores/useProgress';
@@ -38,11 +39,14 @@
       itemStyle?: 'card' | 'row';
       initiallyVisible?: boolean;
       cardStyle?: 'compact' | 'expanded';
+      /** Active search term; pins pooled objectives to the matched accepted item. */
+      search?: string;
     }>(),
     {
       itemStyle: 'card',
       initiallyVisible: false,
       cardStyle: 'expanded',
+      search: '',
     }
   );
   const progressStore = useProgressStore();
@@ -254,10 +258,19 @@
     cyclingPaused.value = paused;
   };
   const hasAlternativeItems = computed(() => acceptedItems.value.length > 1);
+  // When a search matches one of the accepted items, pin the display to that
+  // item (instead of rotating) so users see exactly what matched, with the
+  // "Any of N" badge making clear the pool accepts alternatives.
+  const pinnedAcceptedIndex = computed(() =>
+    findAcceptedItemMatchIndex(acceptedItems.value, props.search)
+  );
   const { currentItem: cyclingItem, isCycling: isCyclingItems } = useCyclingItem(
     acceptedItems,
     primaryItem,
-    { enabled: () => !selfCompletedNeed.value && !cyclingPaused.value }
+    {
+      enabled: () => !selfCompletedNeed.value && !cyclingPaused.value,
+      preferredIndex: pinnedAcceptedIndex,
+    }
   );
   const relatedStation = computed(() => {
     const need = props.need;

--- a/app/features/neededitems/NeededItemGroupedModal.vue
+++ b/app/features/neededitems/NeededItemGroupedModal.vue
@@ -101,8 +101,8 @@
                 </div>
                 <div class="flex shrink-0 items-center gap-2">
                   <AcceptedItemsPopover
-                    v-if="(obj.acceptedItems?.length ?? 0) > 1"
-                    :items="obj.acceptedItems ?? []"
+                    v-if="acceptedItemsFor(obj).length > 1"
+                    :items="acceptedItemsFor(obj)"
                     trigger-class="bg-surface-700/60 text-surface-200 px-1.5 py-0.5 text-[10px] font-semibold ring-1 ring-white/10"
                   />
                   <span
@@ -237,6 +237,7 @@
     GroupedItemInfo,
     NeededItemHideoutModule,
     NeededItemTaskObjective,
+    TarkovItem,
   } from '@/types/tarkov';
   const { t } = useI18n({ useScope: 'global' });
   const toast = useToast();
@@ -289,6 +290,8 @@
     const task = taskLookup.value[obj.taskId];
     return task?.kappaRequired === true;
   };
+  const acceptedItemsFor = (obj: NeededItemTaskObjective): TarkovItem[] =>
+    obj.acceptedItems?.length ? obj.acceptedItems : [];
   const getObjectiveCount = (obj: NeededItemTaskObjective) =>
     tarkovStore.getObjectiveCount(obj.id) ?? 0;
   const getHideoutCount = (mod: NeededItemHideoutModule) =>

--- a/app/features/neededitems/NeededItemGroupedModal.vue
+++ b/app/features/neededitems/NeededItemGroupedModal.vue
@@ -100,6 +100,11 @@
                   </UBadge>
                 </div>
                 <div class="flex shrink-0 items-center gap-2">
+                  <AcceptedItemsPopover
+                    v-if="(obj.acceptedItems?.length ?? 0) > 1"
+                    :items="obj.acceptedItems ?? []"
+                    trigger-class="bg-surface-700/60 text-surface-200 px-1.5 py-0.5 text-[10px] font-semibold ring-1 ring-white/10"
+                  />
                   <span
                     class="text-xs"
                     :class="obj.foundInRaid ? 'text-warning-400' : 'text-surface-400'"

--- a/app/features/neededitems/neededItemFilters.ts
+++ b/app/features/neededitems/neededItemFilters.ts
@@ -1,3 +1,4 @@
+import { fuzzyMatch } from '@/utils/fuzzySearch';
 import type { NeededItemHideoutModule, NeededItemTaskObjective, TarkovItem } from '@/types/tarkov';
 /**
  * Type guard to check if a needed item has needType === 'taskObjective'.
@@ -35,6 +36,25 @@ export const getNeededItemData = (
     return need.item;
   }
   return isNeededItemTaskObjective(need) ? need.markerItem : undefined;
+};
+/**
+ * Returns the index of the first accepted item whose name or short name fuzzy
+ * matches the query, or -1 when the query is empty or nothing matches.
+ *
+ * Used so pooled "any of these" objectives surface when searching for any
+ * valid turn-in item, and so the matched item can be pinned for display.
+ */
+export const findAcceptedItemMatchIndex = (
+  items: readonly (TarkovItem | undefined)[] | undefined,
+  query: string
+): number => {
+  const normalizedQuery = query.trim();
+  if (!normalizedQuery || !items?.length) return -1;
+  return items.findIndex(
+    (entry) =>
+      fuzzyMatch(entry?.name ?? '', normalizedQuery) ||
+      fuzzyMatch(entry?.shortName ?? '', normalizedQuery)
+  );
 };
 const isSpecialEquipmentText = (value: string): boolean => {
   const lower = value.toLowerCase();

--- a/app/features/neededitems/neededItemFilters.ts
+++ b/app/features/neededitems/neededItemFilters.ts
@@ -37,6 +37,15 @@ export const getNeededItemData = (
   }
   return isNeededItemTaskObjective(need) ? need.markerItem : undefined;
 };
+const fuzzyMatchesQuery = (
+  name: string | undefined,
+  shortName: string | undefined,
+  query: string
+): boolean => fuzzyMatch(name ?? '', query) || fuzzyMatch(shortName ?? '', query);
+const acceptedItemMatchesQuery = (item: TarkovItem | undefined, query: string): boolean => {
+  if (!item) return false;
+  return fuzzyMatchesQuery(item.name, item.shortName, query);
+};
 /**
  * Returns the index of the first accepted item whose name or short name fuzzy
  * matches the query, or -1 when the query is empty or nothing matches.
@@ -50,11 +59,7 @@ export const findAcceptedItemMatchIndex = (
 ): number => {
   const normalizedQuery = query.trim();
   if (!normalizedQuery || !items?.length) return -1;
-  return items.findIndex(
-    (entry) =>
-      fuzzyMatch(entry?.name ?? '', normalizedQuery) ||
-      fuzzyMatch(entry?.shortName ?? '', normalizedQuery)
-  );
+  return items.findIndex((entry) => acceptedItemMatchesQuery(entry, normalizedQuery));
 };
 const isSpecialEquipmentText = (value: string): boolean => {
   const lower = value.toLowerCase();

--- a/app/features/neededitems/neededItemFilters.ts
+++ b/app/features/neededitems/neededItemFilters.ts
@@ -42,7 +42,11 @@ const fuzzyMatchesQuery = (
   shortName: string | undefined,
   query: string
 ): boolean => fuzzyMatch(name ?? '', query) || fuzzyMatch(shortName ?? '', query);
-const acceptedItemMatchesQuery = (item: TarkovItem | undefined, query: string): boolean => {
+/**
+ * Returns whether an item's name or short name fuzzy matches the query.
+ * Shared by the Needed Items search filter and accepted-item pool matching.
+ */
+export const itemMatchesQuery = (item: TarkovItem | undefined, query: string): boolean => {
   if (!item) return false;
   return fuzzyMatchesQuery(item.name, item.shortName, query);
 };
@@ -59,7 +63,7 @@ export const findAcceptedItemMatchIndex = (
 ): number => {
   const normalizedQuery = query.trim();
   if (!normalizedQuery || !items?.length) return -1;
-  return items.findIndex((entry) => acceptedItemMatchesQuery(entry, normalizedQuery));
+  return items.findIndex((entry) => itemMatchesQuery(entry, normalizedQuery));
 };
 const isSpecialEquipmentText = (value: string): boolean => {
   const lower = value.toLowerCase();

--- a/app/pages/needed-items.vue
+++ b/app/pages/needed-items.vue
@@ -80,6 +80,7 @@
                   :need="item"
                   item-style="row"
                   :initially-visible="index < adjustedRenderCount"
+                  :search="search"
                 />
               </div>
               <div
@@ -99,6 +100,7 @@
                   item-style="card"
                   :card-style="cardStyle"
                   :initially-visible="index < adjustedRenderCount"
+                  :search="search"
                   :data-index="index"
                   class="content-visibility-auto-240 h-full"
                 />

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1442,6 +1442,29 @@ their card. The dedicated chevron controls card expansion in both views. Hide-re
 to both list and map cards. Missing database columns use the existing preference-sync fallback,
 so new settings remain local until the compact-list preference migration is deployed.
 
+### Needed Items pooled objective search and grouping
+
+Pooled "any of these" task objectives (`NeededItemTaskObjective.acceptedItems` with more than one
+entry) have two identities on the Needed Items page, and they must not be conflated. Progress and
+counts are always keyed to the objective itself (`id` for `getObjectiveCount`, the primary item for
+legacy grouping); the visible item identity is display-only. The list and grid views rotate or pin
+the displayed item, the "Any of N" popover marks pool membership, and the combined view aggregates
+counts per displayed item.
+
+Search must match any accepted item's name or short name, not just the primary item, so a valid
+turn-in item like Augmentin surfaces quests such as Pets Won't Need It. While such a match is
+active, the combined view re-keys the pooled objective under the matched accepted item (identified
+by name or short name) and registers it in `objectivesByItemId` under the same key; list and grid
+views pin the display to the matched item. Without an accepted match, the primary item stays
+canonical under the grouped-view rule that nameless items are not grouped. A pooled objective
+always contributes to exactly one group, so search-time re-keying never double-counts; progress
+writes stay bound to the objective ID regardless of which item identity is displayed.
+
+Keep `findAcceptedItemMatchIndex` (search filter and display pin) and the grouped-view accepted
+match aligned: if one matches by name-or-short-name and the other does not, the grouped view shows
+a pooled objective under a different item than the list pins, which contradicts the searched
+identity.
+
 ## 14. CI validation selection
 
 `scripts/validation-plan.mjs` classifies Git paths and validates aggregate outcomes;


### PR DESCRIPTION
## Summary

Resolves #812.

Pooled "any of these" quest objectives (`acceptedItems` with more than one entry, e.g. Pets Won't Need It — any 1 of 56 medical items) previously only surfaced their primary/cycled item on the Needed Items page. Searching for any other valid turn-in item (e.g. "Augmentin") returned nothing, forcing users to check the task page or wiki.

### Changes

- **Search matches any accepted item** (`useNeededItems.ts`): pooled task objectives now match when the query fuzzy-matches any accepted item name/short name, not just the primary item. Shared helpers `itemMatchesQuery` / `findAcceptedItemMatchIndex` added to `neededItemFilters.ts` and reused by the filter, the display pin, and the grouped view.
- **Pinned display while searching** (`NeededItem.vue`, `useCyclingItem.ts`): when the search matches one of a pooled objective's accepted items, the list/grid row or card pins to that item (rotation pauses) so users see exactly what matched. The existing "Any of N" accepted-items popover keeps pool membership explicit, satisfying the "small tag" ask from the issue. `useCyclingItem` gains an optional `preferredIndex` option; default `-1` preserves existing behavior for all other consumers (task page objective display).
- **Combined (grouped) view** (`useNeededItems.ts`): when searching, a pooled objective that matched an accepted item is grouped under the matched turn-in item (identified by name or short name, mirroring the search match) and `objectivesByItemId` registers it under the same key so the grouped modal lists the task. Without an accepted match, the primary item stays canonical under the grouped-view rule that nameless items are not grouped. Grouping stays single-count: the objective contributes to exactly one group, so re-keying never double-counts.
- **Grouped modal pool badge** (`NeededItemGroupedModal.vue`): objective rows now show the existing "Any of N" popover badge when the objective accepts multiple items, consistent with row/card views.
- **Docs** (`docs/SYSTEMS.md`): records the pooled-objective identity invariant under "When this doc is wrong" — progress stays objective-keyed while the displayed/grouped item identity is display-only, and the search filter, display pin, and grouped-view match must stay aligned.

No locale changes: the existing `needed_items.any_of_items_short` / `needed_items.any_of_items` keys are reused. No new runtime dependencies; no changes to data fetching or upstream shapes (uses the existing display-only `acceptedItems` metadata).

## Validation

Branch is rebased on latest `main` (HEAD `670694a9`); validated with a clean tree (only unstaged `.nuxtrc` tooling churn from `nuxt prepare`).

- Focused Vitest set (`useCyclingItem`, `useNeededItems`, `useNeededItemsRouteSync`, `useItemDistribution`, `neededitems` feature tests, `AcceptedItemsPopover`, tasks objective equipment/grouping tests) — 114 tests passed, including pooled search, pinning, short-name-only grouping, primary-fallback grouping, and pin edge cases.
- `pnpm run typecheck` — pass.
- `pnpm run lint` (design lint + eslint `--max-warnings=0` + blank lines) — pass.
- `pnpm run lint:fallow --base origin/main` — pass, new-only gate reports 0 introduced findings (search matchers and group-target resolution were split into small helpers to stay under the complexity budgets).
- `pnpm run i18n:check` — pass (no locale changes).
- CI on HEAD: all checks green, including Fallow audit, SonarCloud Quality Gate (0 new issues), CodeQL, Lighthouse, all 4 test shards, and Workers.
- Manual browser verification against local dev server with live json.tarkov.dev data: searching "Augmentin" (inline and via the `?q=Augmentin` deep link) on /needed-items returns 6 pooled objectives across list, grid, and combined views — grid pins the Augmentin image with "Any 52/56/3358" badges; combined view shows one "Augmentin antibiotic pills" group (0/233) whose modal lists Pets Won't Need It (Any 56) and the Building Foundations sell pools with per-row "Any N" badges; the accepted-items popover lists all 56 items; empty search still shows the full 854-item list.

## Review outcomes

- CodeRabbit: 1 finding (fallback-branch test coverage) — fixed and confirmed by the reviewer; thread resolved.
- cubic: 1× P2 (short-name grouping consistency) — fixed; 2× P3 (fallback test, `currentIndex` docs) — fixed/documented; re-review on HEAD passes with no findings; threads resolved.
- Greptile: 1× P2 (document the grouping-identity invariant) — addressed in `docs/SYSTEMS.md`; thread resolved.
- SonarCloud: Quality Gate passed, 0 new issues on HEAD (an initial S3776 cognitive-complexity finding on the new code was resolved by extracting the search matchers).

`docs/SYSTEMS.md` updated in the same change per the maintenance contract; no other system docs are affected.
