### PR TITLE
fix: classify team creation membership races

### DIFF
--- a/.fallowrc.json
+++ b/.fallowrc.json
@@ -21,6 +21,7 @@
     "scripts/check-ci-result.mjs"
   ],
   "ignoreDependencies": [
+    "shared",
     "@iconify-json/heroicons",
     "@iconify-json/lucide",
     "@nuxt/image",

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -716,6 +716,8 @@ flowchart LR
 - `supabase/migrations/20260829120000_add_atomic_team_disband.sql` — owner-scoped atomic team
   disband RPC and grants
 - `supabase/functions/team-disband/index.ts` — authenticated owner disband endpoint
+- `supabase/functions/team-create/index.ts`, `supabase/functions/_shared/team-create-error.ts` —
+  authenticated team creation and database membership-conflict classification
 - `supabase/migrations/20260806120000_add_game_mode_progress_backfill_helper.sql` — retained,
   revoked helper for optional one-range-at-a-time operational maintenance. Correctness does not
   depend on running it; see the Database Migrations section of `docs/runbook.md`
@@ -739,6 +741,12 @@ flowchart LR
 - `pvp` and `pve` always use season `0`; `seasonal` always uses a positive season.
 - Legacy `user_system.team` / `team_id` values are used only when neither persistent mode-specific
   team ID exists. They must never make a PvP team appear as the active PvE team or vice versa.
+- Team creation maps both the `team_memberships_user_mode_unique` SQLSTATE `23505` conflict and
+  the exact SQLSTATE `P0001` message `You are already a member of a team for this game mode` from
+  `create_team_with_owner` to the existing actionable HTTP 400 membership response. The initial
+  membership check cannot prevent races; forward migrations changing that message or constraint
+  name must update the classifier and its regression tests together. Other exceptions retain their
+  existing HTTP 409/500 handling.
 - Team actions and invite links are unavailable until the active team row has loaded and its ID
   matches the mode-specific system-store team ID; stale owner or join-code state is never combined
   with another team's ID.

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -376,6 +376,7 @@ verify_jwt = false
 
 [functions.team-create]
 verify_jwt = false
+import_map = "./functions/deno.json"
 
 [functions.team-kick]
 verify_jwt = false

--- a/supabase/functions/_shared/team-create-error.deno.test.ts
+++ b/supabase/functions/_shared/team-create-error.deno.test.ts
@@ -1,0 +1,34 @@
+import { assertEquals } from 'jsr:@std/assert';
+import { isMembershipConflict } from './team-create-error.ts';
+Deno.test('recognizes the already-member race raised by create_team_with_owner', () => {
+  assertEquals(
+    isMembershipConflict({
+      code: 'P0001',
+      message: 'You are already a member of a team for this game mode',
+    }),
+    true
+  );
+});
+Deno.test('recognizes membership constraint violations in either error field', () => {
+  for (const field of ['message', 'details']) {
+    assertEquals(
+      isMembershipConflict({
+        code: '23505',
+        [field]: 'duplicate key violates team_memberships_user_mode_unique',
+      }),
+      true
+    );
+  }
+});
+Deno.test('does not classify other database failures as membership conflicts', () => {
+  for (const error of [
+    null,
+    {},
+    { code: 'P0001', message: 'Not authenticated' },
+    { code: '23505', message: 'teams_name_key' },
+    { code: 'XX000', message: 'team_memberships_user_mode_unique' },
+    { code: 'XX000', message: 'You are already a member of a team for this game mode' },
+  ]) {
+    assertEquals(isMembershipConflict(error), false);
+  }
+});

--- a/supabase/functions/_shared/team-create-error.ts
+++ b/supabase/functions/_shared/team-create-error.ts
@@ -5,11 +5,14 @@ export const isMembershipConflict = (
     message?: string;
   } | null
 ): boolean => {
-  if (error?.code === 'P0001') {
-    return error.message === 'You are already a member of a team for this game mode';
+  switch (error?.code) {
+    case 'P0001':
+      return error.message === 'You are already a member of a team for this game mode';
+    case '23505':
+      return [error.message, error.details].some((value) =>
+        value?.includes('team_memberships_user_mode_unique')
+      );
+    default:
+      return false;
   }
-  if (error?.code !== '23505') return false;
-  return [error.message, error.details].some((value) =>
-    value?.includes('team_memberships_user_mode_unique')
-  );
 };

--- a/supabase/functions/_shared/team-create-error.ts
+++ b/supabase/functions/_shared/team-create-error.ts
@@ -1,0 +1,15 @@
+export const isMembershipConflict = (
+  error: {
+    code?: string;
+    details?: string | null;
+    message?: string;
+  } | null
+): boolean => {
+  if (error?.code === 'P0001') {
+    return error.message === 'You are already a member of a team for this game mode';
+  }
+  if (error?.code !== '23505') return false;
+  return [error.message, error.details].some((value) =>
+    value?.includes('team_memberships_user_mode_unique')
+  );
+};

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -5,7 +5,8 @@
   "imports": {
     "@supabase/supabase-js": "npm:@supabase/supabase-js@2",
     "@supabase/functions-js/edge-runtime": "jsr:@supabase/functions-js@2/edge-runtime.d.ts",
-    "shared/auth": "./_shared/auth.ts"
+    "shared/auth": "./_shared/auth.ts",
+    "shared/team-create-error": "./_shared/team-create-error.ts"
   },
   "lint": {
     "rules": {

--- a/supabase/functions/team-create/index.ts
+++ b/supabase/functions/team-create/index.ts
@@ -13,7 +13,7 @@ import {
 } from '../_shared/authenticated-mutation.ts';
 import { isTeamGameMode, type TeamGameMode } from '../_shared/team-mode.ts';
 import { rejectExistingTeamMembership } from '../_shared/team-membership.ts';
-import { isMembershipConflict } from '../_shared/team-create-error.ts';
+import { isMembershipConflict } from 'shared/team-create-error';
 const DEFAULT_MAX_TEAM_MEMBERS = 5;
 type TeamRow = {
   created_at: string;

--- a/supabase/functions/team-create/index.ts
+++ b/supabase/functions/team-create/index.ts
@@ -13,6 +13,7 @@ import {
 } from '../_shared/authenticated-mutation.ts';
 import { isTeamGameMode, type TeamGameMode } from '../_shared/team-mode.ts';
 import { rejectExistingTeamMembership } from '../_shared/team-membership.ts';
+import { isMembershipConflict } from '../_shared/team-create-error.ts';
 const DEFAULT_MAX_TEAM_MEMBERS = 5;
 type TeamRow = {
   created_at: string;
@@ -101,18 +102,6 @@ const prepareCreate = async (req: Request): Promise<MutationStep<CreateContext>>
   const auth = await authenticateMutation(req, 'team-create');
   if (auth.response) return rejectMutationStep(auth.response);
   return parseCreateInput(req, auth.supabase, auth.user.id);
-};
-const isMembershipConflict = (
-  error: {
-    code?: string;
-    details?: string | null;
-    message?: string;
-  } | null
-): boolean => {
-  if (error?.code !== '23505') return false;
-  return [error.message, error.details].some((value) =>
-    value?.includes('team_memberships_user_mode_unique')
-  );
 };
 const createTeamInsertError = (
   req: Request,


### PR DESCRIPTION
A membership acquired between team-create’s preliminary check and create_team_with_owner currently produces a generic 500. Recognize the RPC’s specific P0001 already-member exception as the existing 400 membership response, retaining the constraint-specific 23505 handling and unrelated errors. Document the exception/constraint contract so forward migrations preserve this behavior.

Part of #646; database and Worker follow-ups are tracked separately. The helper uses the Edge Functions shared import-map namespace, explicitly selected for team-create deployment. Fallow treats the Deno-only shared prefix as an import-map namespace rather than an npm dependency.

Validation: final head a878e096 is mergeable with hosted CI green and zero unresolved review threads. Codex completed current-head review; Cubic and Greptile findings are addressed. Hosted CodeRabbit reported rate limiting, so its green status is not a completed review.

Local lint, typecheck, Fallow, shared Deno tests (6 tests, 6 steps), and endpoint Deno check passed for the executable change at 70e5fcdd; the subsequent docs-only correction passed Prettier, systems:check, and diff checks. The final head passed hosted full validation. Worktree isolated and clean. No migration or database rollout dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of team membership conflicts during team creation, including race conditions and database uniqueness errors.
  - Unrelated or malformed database errors continue to be handled separately.

- **Refactor**
  - Consolidated team membership-conflict detection for more consistent team-creation error handling.

- **Tests**
  - Added coverage for supported membership-conflict scenarios and rejection of unrelated errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->





<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR classifies the RPC’s exact already-member race as the existing membership-conflict response while preserving handling for unrelated database errors.
- Extracts membership-conflict classification into a shared helper with focused Deno tests.
- Configures the `team-create` import map and adds the helper’s `shared/` namespace mapping.
- Documents the recognized database errors and required deployment behavior.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| supabase/functions/team-create/index.ts | Replaces the local classifier with a shared import whose configured mapping resolves under the documented deployment path. |
| supabase/functions/_shared/team-create-error.ts | Recognizes the exact P0001 membership race and the existing constraint-specific 23505 conflict without broadening unrelated errors. |
| supabase/functions/_shared/team-create-error.deno.test.ts | Covers both accepted conflict forms and representative unrelated or malformed errors. |
| supabase/functions/deno.json | Maps the new shared helper specifier to its Edge Functions source file. |
| supabase/config.toml | Explicitly associates team-create with the shared Edge Functions import map. |

</details>

<sub>Reviews (4): Last reviewed commit: ["docs: record team creation membership co..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/a878e0961ebfea0e8c641e41f06cb90204c979d5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61207454)</sub>

<!-- /greptile_comment -->