### PR TITLE
fix(api): align seasonal profile reads with database season

### DIFF
--- a/app/server/api/profile/[userId]/[mode].get.ts
+++ b/app/server/api/profile/[userId]/[mode].get.ts
@@ -7,6 +7,7 @@ import {
 } from 'h3';
 import { normalizeSupabaseUrl } from '@/server/utils/adminSupabase';
 import { fetchWithTimeout, isAbortError } from '@/server/utils/fetchWithTimeout';
+import { resolveGameModeSeason } from '@/server/utils/gameModeSeason';
 import { createLogger } from '@/server/utils/logger';
 import { getProxyAwareClientIdentifier } from '@/server/utils/requestIdentity';
 import {
@@ -18,12 +19,7 @@ import {
   type SharedCacheHandle,
 } from '@/server/utils/sharedEdgeStore';
 import { fetchTarkovJsonEndpoint, type JsonTasksPayload } from '@/server/utils/tarkov-json';
-import {
-  API_GAME_MODES,
-  getGameModeSeasonNumber,
-  isGameMode,
-  type GameMode,
-} from '@/utils/constants';
+import { API_GAME_MODES, isGameMode, type GameMode } from '@/utils/constants';
 import { getLegacyModeProgressField, resolveModeProgressData } from '@/utils/modeProgressFallback';
 import {
   isRecord,
@@ -602,7 +598,8 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 429, statusMessage: 'Too many requests' });
     }
   }
-  const sharedProfileCacheKey = `${userId}:${mode}:${requesterKey}`;
+  const seasonNumber = await resolveGameModeSeason(mode, { supabaseUrl, supabaseServiceKey });
+  const sharedProfileCacheKey = `${userId}:${mode}:${seasonNumber}:${requesterKey}`;
   if (!isTestEnvironment) {
     const cached = await getCachedProfile(sharedCacheHandle, sharedProfileCacheKey);
     if (cached) {
@@ -646,7 +643,7 @@ export default defineEventHandler(async (event) => {
     [progressResponse, modeProgressResponse, preferencesResponse] = await Promise.all([
       restFetch(`user_progress?select=${progressSelect}&user_id=eq.${userId}&limit=1`),
       restFetch(
-        `user_game_mode_progress?select=user_id,progress_data,profile_public&user_id=eq.${userId}&game_mode=eq.${mode}&season_number=eq.${getGameModeSeasonNumber(mode)}&limit=1`
+        `user_game_mode_progress?select=user_id,progress_data,profile_public&user_id=eq.${userId}&game_mode=eq.${mode}&season_number=eq.${seasonNumber}&limit=1`
       ),
       restFetch(
         `user_preferences?select=streamer_mode,profile_share_pvp_public,profile_share_pve_public&user_id=eq.${userId}&limit=1`

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -194,7 +194,8 @@ describe('Shared Profile API', () => {
         visibility: 'public',
       });
     } finally {
-      process.env.NODE_ENV = originalNodeEnv;
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
       vi.resetModules();
     }
   });
@@ -629,7 +630,8 @@ describe('Shared Profile API', () => {
       expect(third.data).toEqual({ displayName: 'RefreshedPlayer', level: 30 });
       expect(mockFetch).toHaveBeenCalledTimes(6);
     } finally {
-      process.env.NODE_ENV = originalNodeEnv;
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
       vi.unstubAllGlobals();
       vi.stubGlobal('fetch', mockFetch as typeof fetch);
       vi.resetModules();
@@ -688,7 +690,8 @@ describe('Shared Profile API', () => {
       mockFetch.mockResolvedValueOnce({ ok: false });
       await expect(handler(mockEvent as H3Event)).rejects.toMatchObject({ statusCode: 503 });
     } finally {
-      process.env.NODE_ENV = originalNodeEnv;
+      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+      else process.env.NODE_ENV = originalNodeEnv;
       vi.unstubAllGlobals();
       vi.stubGlobal('fetch', mockFetch as typeof fetch);
       vi.resetModules();

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -388,13 +388,14 @@ describe('Shared Profile API', () => {
       return undefined;
     });
     mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => 2 })
       .mockResolvedValueOnce(progressResponse())
       .mockResolvedValueOnce(modeProgressResponse({ displayName: 'SeasonOne', level: 18 }))
       .mockResolvedValueOnce(preferencesResponse());
     const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
     const result = await handler(mockEvent as H3Event);
-    expect(String(mockFetch.mock.calls[1]?.[0])).toContain('game_mode=eq.seasonal');
-    expect(String(mockFetch.mock.calls[1]?.[0])).toContain('season_number=eq.1');
+    expect(String(mockFetch.mock.calls[2]?.[0])).toContain('game_mode=eq.seasonal');
+    expect(String(mockFetch.mock.calls[2]?.[0])).toContain('season_number=eq.2');
     expect(result).toMatchObject({
       data: { displayName: 'SeasonOne', level: 18 },
       mode: 'seasonal',
@@ -408,6 +409,7 @@ describe('Shared Profile API', () => {
       return undefined;
     });
     mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => 2 })
       .mockResolvedValueOnce(progressResponse())
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockResolvedValueOnce(preferencesResponse());
@@ -415,7 +417,6 @@ describe('Shared Profile API', () => {
     await expect(handler(mockEvent as H3Event)).rejects.toThrow('Profile is private for this mode');
   });
   it('returns an empty owner payload when the Seasonal row does not exist yet', async () => {
-    runtimeConfig.supabaseServiceKey = '';
     mockGetRequestHeader.mockImplementation((_, key: string) => {
       if (key === 'authorization') return 'Bearer owner-token';
       return undefined;
@@ -430,6 +431,7 @@ describe('Shared Profile API', () => {
         ok: true,
         json: async () => ({ id: '11111111-1111-4111-8111-111111111111' }),
       })
+      .mockResolvedValueOnce({ ok: true, json: async () => 2 })
       .mockResolvedValueOnce(progressResponse(2))
       .mockResolvedValueOnce({ ok: true, json: async () => [] })
       .mockResolvedValueOnce(preferencesResponse());
@@ -626,6 +628,65 @@ describe('Shared Profile API', () => {
       expect(second.data).toEqual({ displayName: 'PublicPlayer', level: 24 });
       expect(third.data).toEqual({ displayName: 'RefreshedPlayer', level: 30 });
       expect(mockFetch).toHaveBeenCalledTimes(6);
+    } finally {
+      process.env.NODE_ENV = originalNodeEnv;
+      vi.unstubAllGlobals();
+      vi.stubGlobal('fetch', mockFetch as typeof fetch);
+      vi.resetModules();
+    }
+  });
+  it('does not reuse a cached Seasonal profile after database rollover', async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    try {
+      process.env.NODE_ENV = 'development';
+      runtimeConfig.sharedProfileCacheTtlMs = 5000;
+      mockGetRouterParam.mockImplementation((_, key: string) =>
+        key === 'mode' ? 'seasonal' : '11111111-1111-4111-8111-111111111111'
+      );
+      runtimeConfig.sharedProfileRateLimitPerMinute = 1000;
+      vi.resetModules();
+      const sharedCacheEntries = new Map<string, string>();
+      const cacheApi = {
+        match: vi.fn(async (request: Request) => {
+          const payload = sharedCacheEntries.get(request.url);
+          return payload
+            ? new Response(payload, { headers: { 'Content-Type': 'application/json' } })
+            : undefined;
+        }),
+        put: vi.fn(async (request: Request, response: Response) => {
+          sharedCacheEntries.set(request.url, await response.clone().text());
+        }),
+      };
+      vi.stubGlobal('caches', { default: cacheApi });
+      let now = 0;
+      vi.spyOn(Date, 'now').mockImplementation(() => now);
+      mockFetch
+        .mockResolvedValueOnce({ ok: true, json: async () => 2 })
+        .mockResolvedValueOnce(progressResponse())
+        .mockResolvedValueOnce(modeProgressResponse({ displayName: 'PublicPlayer', level: 24 }))
+        .mockResolvedValueOnce(preferencesResponse())
+        .mockResolvedValueOnce({ ok: true, json: async () => 2 })
+        .mockResolvedValueOnce({ ok: true, json: async () => 3 })
+        .mockResolvedValueOnce(progressResponse())
+        .mockResolvedValueOnce(modeProgressResponse({ displayName: 'RefreshedPlayer', level: 30 }))
+        .mockResolvedValueOnce(preferencesResponse());
+      const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
+      const first = await handler(mockEvent as H3Event);
+      now = 30;
+      const second = await handler(mockEvent as H3Event);
+      now = 60;
+      const third = await handler(mockEvent as H3Event);
+      expect(first.data).toEqual({ displayName: 'PublicPlayer', level: 24 });
+      expect(second.data).toEqual({ displayName: 'PublicPlayer', level: 24 });
+      expect(third.data).toEqual({ displayName: 'RefreshedPlayer', level: 30 });
+      expect(mockFetch).toHaveBeenCalledTimes(9);
+      const reads = mockFetch.mock.calls.filter((call) =>
+        String(call[0]).includes('user_game_mode_progress')
+      );
+      expect(String(reads[0]?.[0])).toContain('season_number=eq.2');
+      expect(String(reads[1]?.[0])).toContain('season_number=eq.3');
+      mockFetch.mockResolvedValueOnce({ ok: false });
+      await expect(handler(mockEvent as H3Event)).rejects.toMatchObject({ statusCode: 503 });
     } finally {
       process.env.NODE_ENV = originalNodeEnv;
       vi.unstubAllGlobals();

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -590,111 +590,67 @@ describe('Shared Profile API', () => {
       'Shared profiles unavailable on this environment'
     );
   });
-  it('refreshes cache after fixed ttl even when profile is read repeatedly', async () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    try {
-      process.env.NODE_ENV = 'development';
-      runtimeConfig.sharedProfileCacheTtlMs = 50;
-      runtimeConfig.sharedProfileRateLimitPerMinute = 1000;
-      vi.resetModules();
-      const sharedCacheEntries = new Map<string, string>();
-      const cacheApi = {
-        match: vi.fn(async (request: Request) => {
-          const payload = sharedCacheEntries.get(request.url);
-          return payload
-            ? new Response(payload, { headers: { 'Content-Type': 'application/json' } })
-            : undefined;
-        }),
-        put: vi.fn(async (request: Request, response: Response) => {
-          sharedCacheEntries.set(request.url, await response.clone().text());
-        }),
-      };
-      vi.stubGlobal('caches', { default: cacheApi });
-      let now = 0;
-      vi.spyOn(Date, 'now').mockImplementation(() => now);
-      mockFetch
-        .mockResolvedValueOnce(progressResponse())
-        .mockResolvedValueOnce(modeProgressResponse({ displayName: 'PublicPlayer', level: 24 }))
-        .mockResolvedValueOnce(preferencesResponse())
-        .mockResolvedValueOnce(progressResponse())
-        .mockResolvedValueOnce(modeProgressResponse({ displayName: 'RefreshedPlayer', level: 30 }))
-        .mockResolvedValueOnce(preferencesResponse());
-      const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
-      const first = await handler(mockEvent as H3Event);
-      now = 30;
-      const second = await handler(mockEvent as H3Event);
-      now = 60;
-      const third = await handler(mockEvent as H3Event);
-      expect(first.data).toEqual({ displayName: 'PublicPlayer', level: 24 });
-      expect(second.data).toEqual({ displayName: 'PublicPlayer', level: 24 });
-      expect(third.data).toEqual({ displayName: 'RefreshedPlayer', level: 30 });
-      expect(mockFetch).toHaveBeenCalledTimes(6);
-    } finally {
-      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
-      else process.env.NODE_ENV = originalNodeEnv;
-      vi.unstubAllGlobals();
-      vi.stubGlobal('fetch', mockFetch as typeof fetch);
-      vi.resetModules();
+  it.each(['pvp', 'seasonal'])(
+    'refreshes %s cache on expiry or database rollover',
+    async (mode) => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      try {
+        process.env.NODE_ENV = 'development';
+        runtimeConfig.sharedProfileCacheTtlMs = mode === 'seasonal' ? 5000 : 50;
+        runtimeConfig.sharedProfileRateLimitPerMinute = 1000;
+        mockGetRouterParam.mockImplementation((_, key: string) =>
+          key === 'mode' ? mode : '11111111-1111-4111-8111-111111111111'
+        );
+        vi.resetModules();
+        const entries = new Map<string, string>();
+        vi.stubGlobal('caches', {
+          default: {
+            match: async (request: Request) => {
+              const payload = entries.get(request.url);
+              return payload ? new Response(payload) : undefined;
+            },
+            put: async (request: Request, response: Response) => {
+              entries.set(request.url, await response.clone().text());
+            },
+          },
+        });
+        let now = 0;
+        let season = 2;
+        let lookupOk = true;
+        let level = 24;
+        vi.spyOn(Date, 'now').mockImplementation(() => now);
+        mockFetch.mockImplementation(async (url: string) => {
+          if (url.includes('/rpc/')) return { ok: lookupOk, json: async () => season };
+          if (url.includes('/user_game_mode_progress?')) return modeProgressResponse({ level });
+          if (url.includes('/user_progress?')) return progressResponse();
+          if (url.includes('/user_preferences?')) return preferencesResponse();
+          throw new Error(`Unexpected test request: ${url}`);
+        });
+        const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
+        expect((await handler(mockEvent as H3Event)).data).toEqual({ level: 24 });
+        now = 30;
+        level = 30;
+        expect((await handler(mockEvent as H3Event)).data).toEqual({ level: 24 });
+        now = 60;
+        season = 3;
+        expect((await handler(mockEvent as H3Event)).data).toEqual({ level: 30 });
+        const reads = mockFetch.mock.calls.filter((call) =>
+          String(call[0]).includes('user_game_mode_progress')
+        );
+        expect(reads).toHaveLength(2);
+        expect(String(reads[0]?.[0])).toContain(`season_number=eq.${mode === 'seasonal' ? 2 : 0}`);
+        expect(String(reads[1]?.[0])).toContain(`season_number=eq.${mode === 'seasonal' ? 3 : 0}`);
+        if (mode === 'seasonal') {
+          lookupOk = false;
+          await expect(handler(mockEvent as H3Event)).rejects.toMatchObject({ statusCode: 503 });
+        }
+      } finally {
+        if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = originalNodeEnv;
+        vi.unstubAllGlobals();
+        vi.stubGlobal('fetch', mockFetch as typeof fetch);
+        vi.resetModules();
+      }
     }
-  });
-  it('does not reuse a cached Seasonal profile after database rollover', async () => {
-    const originalNodeEnv = process.env.NODE_ENV;
-    try {
-      process.env.NODE_ENV = 'development';
-      runtimeConfig.sharedProfileCacheTtlMs = 5000;
-      mockGetRouterParam.mockImplementation((_, key: string) =>
-        key === 'mode' ? 'seasonal' : '11111111-1111-4111-8111-111111111111'
-      );
-      runtimeConfig.sharedProfileRateLimitPerMinute = 1000;
-      vi.resetModules();
-      const sharedCacheEntries = new Map<string, string>();
-      const cacheApi = {
-        match: vi.fn(async (request: Request) => {
-          const payload = sharedCacheEntries.get(request.url);
-          return payload
-            ? new Response(payload, { headers: { 'Content-Type': 'application/json' } })
-            : undefined;
-        }),
-        put: vi.fn(async (request: Request, response: Response) => {
-          sharedCacheEntries.set(request.url, await response.clone().text());
-        }),
-      };
-      vi.stubGlobal('caches', { default: cacheApi });
-      let now = 0;
-      vi.spyOn(Date, 'now').mockImplementation(() => now);
-      mockFetch
-        .mockResolvedValueOnce({ ok: true, json: async () => 2 })
-        .mockResolvedValueOnce(progressResponse())
-        .mockResolvedValueOnce(modeProgressResponse({ displayName: 'PublicPlayer', level: 24 }))
-        .mockResolvedValueOnce(preferencesResponse())
-        .mockResolvedValueOnce({ ok: true, json: async () => 2 })
-        .mockResolvedValueOnce({ ok: true, json: async () => 3 })
-        .mockResolvedValueOnce(progressResponse())
-        .mockResolvedValueOnce(modeProgressResponse({ displayName: 'RefreshedPlayer', level: 30 }))
-        .mockResolvedValueOnce(preferencesResponse());
-      const { default: handler } = await import('@/server/api/profile/[userId]/[mode].get');
-      const first = await handler(mockEvent as H3Event);
-      now = 30;
-      const second = await handler(mockEvent as H3Event);
-      now = 60;
-      const third = await handler(mockEvent as H3Event);
-      expect(first.data).toEqual({ displayName: 'PublicPlayer', level: 24 });
-      expect(second.data).toEqual({ displayName: 'PublicPlayer', level: 24 });
-      expect(third.data).toEqual({ displayName: 'RefreshedPlayer', level: 30 });
-      expect(mockFetch).toHaveBeenCalledTimes(9);
-      const reads = mockFetch.mock.calls.filter((call) =>
-        String(call[0]).includes('user_game_mode_progress')
-      );
-      expect(String(reads[0]?.[0])).toContain('season_number=eq.2');
-      expect(String(reads[1]?.[0])).toContain('season_number=eq.3');
-      mockFetch.mockResolvedValueOnce({ ok: false });
-      await expect(handler(mockEvent as H3Event)).rejects.toMatchObject({ statusCode: 503 });
-    } finally {
-      if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
-      else process.env.NODE_ENV = originalNodeEnv;
-      vi.unstubAllGlobals();
-      vi.stubGlobal('fetch', mockFetch as typeof fetch);
-      vi.resetModules();
-    }
-  });
+  );
 });

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { H3Event, H3EventContext } from 'h3';
-type SiteConfigStackEntry = Record<string, unknown>;
+import { BASE_SITE_CONTEXT, createRouterStub } from '@/server/utils/__tests__/eventStubs';
+import type { H3Event } from 'h3';
 const { mockGetRequestHeader, mockGetRouterParam, mockFetch } = vi.hoisted(() => ({
   mockGetRequestHeader: vi.fn(),
   mockGetRouterParam: vi.fn(),
@@ -69,22 +69,9 @@ vi.mock('h3', async () => {
   };
 });
 mockNuxtImport('useRuntimeConfig', () => () => runtimeConfig);
-mockNuxtImport('useRouter', () => () => ({
-  afterEach: vi.fn(),
-  beforeEach: vi.fn(),
-  beforeResolve: vi.fn(),
-  onError: vi.fn(),
-}));
+mockNuxtImport('useRouter', () => () => createRouterStub());
 describe('Shared Profile API', () => {
   let mockEvent: Partial<H3Event>;
-  const BASE_SITE_CONTEXT: Pick<H3EventContext, 'siteConfig' | 'siteConfigNitroOrigin'> = {
-    siteConfig: {
-      stack: [] as Partial<SiteConfigStackEntry>[],
-      push: vi.fn(() => () => {}),
-      get: vi.fn(() => ({})),
-    },
-    siteConfigNitroOrigin: '',
-  };
   afterEach(() => {
     vi.useRealTimers();
     vi.restoreAllMocks();

--- a/app/server/api/profile/__tests__/shared-profile.test.ts
+++ b/app/server/api/profile/__tests__/shared-profile.test.ts
@@ -1,7 +1,11 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { BASE_SITE_CONTEXT, createRouterStub } from '@/server/utils/__tests__/eventStubs';
+import {
+  BASE_SITE_CONTEXT,
+  createRouterStub,
+  stubEdgeCache,
+} from '@/server/utils/__tests__/eventStubs';
 import type { H3Event } from 'h3';
 const { mockGetRequestHeader, mockGetRouterParam, mockFetch } = vi.hoisted(() => ({
   mockGetRequestHeader: vi.fn(),
@@ -589,18 +593,7 @@ describe('Shared Profile API', () => {
           key === 'mode' ? mode : '11111111-1111-4111-8111-111111111111'
         );
         vi.resetModules();
-        const entries = new Map<string, string>();
-        vi.stubGlobal('caches', {
-          default: {
-            match: async (request: Request) => {
-              const payload = entries.get(request.url);
-              return payload ? new Response(payload) : undefined;
-            },
-            put: async (request: Request, response: Response) => {
-              entries.set(request.url, await response.clone().text());
-            },
-          },
-        });
+        stubEdgeCache();
         let now = 0;
         let season = 2;
         let lookupOk = true;

--- a/app/server/api/streamer/__tests__/kappa.test.ts
+++ b/app/server/api/streamer/__tests__/kappa.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import type { H3Event, H3EventContext } from 'h3';
-type SiteConfigStackEntry = Record<string, unknown>;
+import { BASE_SITE_CONTEXT, createRouterStub } from '@/server/utils/__tests__/eventStubs';
+import type { H3Event } from 'h3';
 const {
   mockComputeStreamerKappaMetrics,
   mockGetRequestHeader,
@@ -34,24 +34,11 @@ vi.mock('@/composables/useGraphBuilder', () => ({
 vi.mock('@/server/utils/streamerKappa', () => ({
   computeStreamerKappaMetrics: mockComputeStreamerKappaMetrics,
 }));
-mockNuxtImport('useRouter', () => () => ({
-  afterEach: vi.fn(),
-  beforeEach: vi.fn(),
-  beforeResolve: vi.fn(),
-  onError: vi.fn(),
-}));
+mockNuxtImport('useRouter', () => () => createRouterStub());
 describe('Streamer Kappa API', () => {
   const USER_ID = '11111111-1111-4111-8111-111111111111';
   let mockEvent: Partial<H3Event>;
   let originalFetch: typeof mockDollarFetch | undefined;
-  const BASE_SITE_CONTEXT: Pick<H3EventContext, 'siteConfig' | 'siteConfigNitroOrigin'> = {
-    siteConfig: {
-      stack: [] as Partial<SiteConfigStackEntry>[],
-      push: vi.fn(() => () => {}),
-      get: vi.fn(() => ({})),
-    },
-    siteConfigNitroOrigin: '',
-  };
   beforeEach(() => {
     vi.resetAllMocks();
     mockEvent = {

--- a/app/server/api/team/__tests__/members.test.ts
+++ b/app/server/api/team/__tests__/members.test.ts
@@ -489,6 +489,7 @@ describe('Team Members API', () => {
             { game_mode: 'seasonal', user_id: '11111111-1111-4111-8111-111111111111' },
           ],
         })
+        .mockResolvedValueOnce({ ok: true, json: async () => 2 })
         .mockResolvedValueOnce({
           ok: true,
           json: async () => [{ user_id: '11111111-1111-4111-8111-111111111111' }],
@@ -510,9 +511,9 @@ describe('Team Members API', () => {
         });
       const { default: handler } = await import('@/server/api/team/members');
       await handler(mockEvent as H3Event);
-      const profileUrl = String(mockFetch.mock.calls[2]?.[0] ?? '');
+      const profileUrl = String(mockFetch.mock.calls[3]?.[0] ?? '');
       expect(profileUrl).toContain('team_member_mode_summary');
-      expect(profileUrl).toContain('season_number=eq.1');
+      expect(profileUrl).toContain('season_number=eq.2');
       expect(profileUrl).not.toContain('progress_data');
       expect(mockFetch.mock.calls.some((call) => String(call[0]).includes('progress_data'))).toBe(
         false
@@ -529,6 +530,7 @@ describe('Team Members API', () => {
               { game_mode: 'seasonal', user_id: '11111111-1111-4111-8111-111111111111' },
             ],
           })
+          .mockResolvedValueOnce({ ok: true, json: async () => 2 })
           .mockResolvedValueOnce({
             ok: true,
             json: async () => [{ user_id: '11111111-1111-4111-8111-111111111111' }],

--- a/app/server/api/team/__tests__/members.test.ts
+++ b/app/server/api/team/__tests__/members.test.ts
@@ -9,7 +9,11 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { BASE_SITE_CONTEXT, createRouterStub } from '@/server/utils/__tests__/eventStubs';
+import {
+  BASE_SITE_CONTEXT,
+  createRouterStub,
+  stubEdgeCache,
+} from '@/server/utils/__tests__/eventStubs';
 import type { H3Event } from 'h3';
 const VALID_TEAM_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5';
 const VALID_USER_ID = '11111111-1111-4111-8111-111111111111';
@@ -591,18 +595,7 @@ describe('Team Members API', () => {
       try {
         process.env.NODE_ENV = 'development';
         vi.resetModules();
-        const entries = new Map<string, string>();
-        vi.stubGlobal('caches', {
-          default: {
-            match: async (request: Request) => {
-              const payload = entries.get(request.url);
-              return payload ? new Response(payload) : undefined;
-            },
-            put: async (request: Request, response: Response) => {
-              entries.set(request.url, await response.clone().text());
-            },
-          },
-        });
+        const entries = stubEdgeCache();
         mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
         mockFetch.mockImplementation(async (url: string | URL) => {
           const target = String(url);

--- a/app/server/api/team/__tests__/members.test.ts
+++ b/app/server/api/team/__tests__/members.test.ts
@@ -602,7 +602,7 @@ describe('Team Members API', () => {
           const season = gameMode === 'seasonal' ? 2 : 0;
           mockFetch.mockImplementation(async (url: string | URL) => {
             const target = String(url);
-            if (target.includes('/rpc/get_active_season_number'))
+            if (gameMode === 'seasonal' && target.includes('/rpc/get_active_season_number'))
               return activeSeasonResponse(season);
             if (target.includes('team_memberships?')) {
               return membershipResponse(gameMode);

--- a/app/server/api/team/__tests__/members.test.ts
+++ b/app/server/api/team/__tests__/members.test.ts
@@ -590,77 +590,83 @@ describe('Team Members API', () => {
     });
   });
   describe('Team members caching', () => {
-    it('serves the season-scoped cached payload without re-reading team data', async () => {
-      const originalNodeEnv = process.env.NODE_ENV;
-      try {
-        process.env.NODE_ENV = 'development';
-        vi.resetModules();
-        const entries = stubEdgeCache();
-        mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
-        mockFetch.mockImplementation(async (url: string | URL) => {
-          const target = String(url);
-          if (target.includes('team_memberships?')) {
-            return membershipResponse('pvp');
-          }
-          if (target.includes('team_member_mode_summary?')) {
-            return {
-              ok: true,
-              json: async () => [
-                {
-                  user_id: VALID_USER_ID,
-                  display_name: 'Cached Player',
-                  level: 9,
-                  tasks_completed: 4,
-                },
-              ],
-            };
-          }
-          if (target.includes('user_progress?')) {
-            return {
-              ok: true,
-              json: async () => [{ user_id: VALID_USER_ID, game_edition: 2 }],
-            };
-          }
-          throw new Error(`Unexpected test request: ${target}`);
-        });
-        const { default: handler } = await import('@/server/api/team/members');
-        const fresh = await handler(mockEvent as H3Event);
-        expect(fresh).toEqual({
-          members: [VALID_USER_ID],
-          profiles: {
-            [VALID_USER_ID]: {
-              displayName: 'Cached Player',
-              gameEdition: 2,
-              gameMode: 'pvp',
-              level: 9,
-              tasksCompleted: 4,
+    it.each(['pvp', 'seasonal'] as const)(
+      'serves the %s cache using the database-resolved season',
+      async (gameMode) => {
+        const originalNodeEnv = process.env.NODE_ENV;
+        try {
+          process.env.NODE_ENV = 'development';
+          vi.resetModules();
+          const entries = stubEdgeCache();
+          mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
+          const season = gameMode === 'seasonal' ? 2 : 0;
+          mockFetch.mockImplementation(async (url: string | URL) => {
+            const target = String(url);
+            if (target.includes('/rpc/get_active_season_number'))
+              return activeSeasonResponse(season);
+            if (target.includes('team_memberships?')) {
+              return membershipResponse(gameMode);
+            }
+            if (target.includes('team_member_mode_summary?')) {
+              return {
+                ok: true,
+                json: async () => [
+                  {
+                    user_id: VALID_USER_ID,
+                    display_name: 'Cached Player',
+                    level: 9,
+                    tasks_completed: 4,
+                  },
+                ],
+              };
+            }
+            if (target.includes('user_progress?')) {
+              return {
+                ok: true,
+                json: async () => [{ user_id: VALID_USER_ID, game_edition: 2 }],
+              };
+            }
+            throw new Error(`Unexpected test request: ${target}`);
+          });
+          const { default: handler } = await import('@/server/api/team/members');
+          const fresh = await handler(mockEvent as H3Event);
+          expect(fresh).toEqual({
+            members: [VALID_USER_ID],
+            profiles: {
+              [VALID_USER_ID]: {
+                displayName: 'Cached Player',
+                gameEdition: 2,
+                gameMode,
+                level: 9,
+                tasksCompleted: 4,
+              },
             },
-          },
-        });
-        const cacheKeys = [...entries.keys()].filter((url) =>
-          url.includes('/__edge-cache/team-members/')
-        );
-        expect(cacheKeys).toHaveLength(1);
-        expect(cacheKeys[0]).toContain(
-          `/__edge-cache/team-members/${encodeURIComponent(`${VALID_TEAM_ID}:${VALID_USER_ID}:0`)}`
-        );
-        const summaryCallsBefore = mockFetch.mock.calls.filter((call) =>
-          String(call[0]).includes('team_member_mode_summary')
-        ).length;
-        const cached = await handler(mockEvent as H3Event);
-        expect(cached).toEqual(fresh);
-        expect(
-          mockFetch.mock.calls.filter((call) =>
+          });
+          const cacheKeys = [...entries.keys()].filter((url) =>
+            url.includes('/__edge-cache/team-members/')
+          );
+          expect(cacheKeys).toHaveLength(1);
+          expect(cacheKeys[0]).toContain(
+            `/__edge-cache/team-members/${encodeURIComponent(`${VALID_TEAM_ID}:${VALID_USER_ID}:${season}`)}`
+          );
+          const summaryCallsBefore = mockFetch.mock.calls.filter((call) =>
             String(call[0]).includes('team_member_mode_summary')
-          ).length
-        ).toBe(summaryCallsBefore);
-      } finally {
-        if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
-        else process.env.NODE_ENV = originalNodeEnv;
-        vi.unstubAllGlobals();
-        vi.resetModules();
+          ).length;
+          const cached = await handler(mockEvent as H3Event);
+          expect(cached).toEqual(fresh);
+          expect(
+            mockFetch.mock.calls.filter((call) =>
+              String(call[0]).includes('team_member_mode_summary')
+            ).length
+          ).toBe(summaryCallsBefore);
+        } finally {
+          if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+          else process.env.NODE_ENV = originalNodeEnv;
+          vi.unstubAllGlobals();
+          vi.resetModules();
+        }
       }
-    });
+    );
   });
   describe('Authentication fallback', () => {
     it('should reject malformed auth context user id', async () => {

--- a/app/server/api/team/__tests__/members.test.ts
+++ b/app/server/api/team/__tests__/members.test.ts
@@ -657,8 +657,8 @@ describe('Team Members API', () => {
           expect(
             mockFetch.mock.calls.filter((call) =>
               String(call[0]).includes('team_member_mode_summary')
-            ).length
-          ).toBe(summaryCallsBefore);
+            )
+          ).toHaveLength(summaryCallsBefore);
         } finally {
           if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
           else process.env.NODE_ENV = originalNodeEnv;

--- a/app/server/api/team/__tests__/members.test.ts
+++ b/app/server/api/team/__tests__/members.test.ts
@@ -9,14 +9,41 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { H3Event, H3EventContext } from 'h3';
-type SiteConfigStackEntry = Record<string, unknown>;
+import { BASE_SITE_CONTEXT, createRouterStub } from '@/server/utils/__tests__/eventStubs';
+import type { H3Event } from 'h3';
 const VALID_TEAM_ID = 'a1b2c3d4-e5f6-4a7b-8c9d-e0f1a2b3c4d5';
+const VALID_USER_ID = '11111111-1111-4111-8111-111111111111';
 const { mockGetQuery, mockGetRequestHeader, mockFetch } = vi.hoisted(() => ({
   mockGetQuery: vi.fn(),
   mockGetRequestHeader: vi.fn(),
   mockFetch: vi.fn(),
 }));
+// Reused supabase response stubs; each handler call consumes one link in order.
+const membershipResponse = (gameMode: 'pvp' | 'seasonal') => ({
+  ok: true,
+  json: async () => [{ game_mode: gameMode, user_id: VALID_USER_ID }],
+});
+const memberIdsResponse = () => ({
+  ok: true,
+  json: async () => [{ user_id: VALID_USER_ID }],
+});
+const emptySummaryResponse = () => ({ ok: true, json: async () => [] });
+const editionResponse = (gameEdition: number) => ({
+  ok: true,
+  json: async () => [{ game_edition: gameEdition, user_id: VALID_USER_ID }],
+});
+const activeSeasonResponse = (season: number) => ({ ok: true, json: async () => season });
+const seasonalSummaryResponse = (tasksCompleted: number | null) => ({
+  ok: true,
+  json: async () => [
+    {
+      user_id: VALID_USER_ID,
+      display_name: 'Seasonal Player',
+      level: 12,
+      tasks_completed: tasksCompleted,
+    },
+  ],
+});
 const runtimeConfig = {
   apiProtection: {
     trustProxy: false,
@@ -35,22 +62,9 @@ vi.mock('h3', async () => {
 });
 global.fetch = mockFetch as typeof fetch;
 mockNuxtImport('useRuntimeConfig', () => () => runtimeConfig);
-mockNuxtImport('useRouter', () => () => ({
-  beforeEach: vi.fn(),
-  beforeResolve: vi.fn(),
-  onError: vi.fn(),
-  afterEach: vi.fn(),
-}));
+mockNuxtImport('useRouter', () => () => createRouterStub());
 describe('Team Members API', () => {
   let mockEvent: Partial<H3Event>;
-  const BASE_SITE_CONTEXT: Pick<H3EventContext, 'siteConfig' | 'siteConfigNitroOrigin'> = {
-    siteConfig: {
-      stack: [] as Partial<SiteConfigStackEntry>[],
-      push: vi.fn(() => () => {}),
-      get: vi.fn(() => ({})),
-    },
-    siteConfigNitroOrigin: '',
-  };
   beforeEach(() => {
     vi.clearAllMocks();
     // `clearAllMocks` keeps `mockResolvedValueOnce` queues, so unconsumed
@@ -333,19 +347,10 @@ describe('Team Members API', () => {
     it('returns a partial team response when the legacy fallback fetch throws', async () => {
       mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ game_mode: 'pvp', user_id: '11111111-1111-4111-8111-111111111111' }],
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ user_id: '11111111-1111-4111-8111-111111111111' }],
-        })
-        .mockResolvedValueOnce({ ok: true, json: async () => [] })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ game_edition: 3, user_id: '11111111-1111-4111-8111-111111111111' }],
-        })
+        .mockResolvedValueOnce(membershipResponse('pvp'))
+        .mockResolvedValueOnce(memberIdsResponse())
+        .mockResolvedValueOnce(emptySummaryResponse())
+        .mockResolvedValueOnce(editionResponse(3))
         .mockRejectedValueOnce(new Error('Timed out while loading team metadata'));
       const { default: handler } = await import('@/server/api/team/members');
       const result = await handler(mockEvent as H3Event);
@@ -440,19 +445,10 @@ describe('Team Members API', () => {
     it('summarizes legacy persistent progress when normalized team rows are missing', async () => {
       mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ game_mode: 'pvp', user_id: '11111111-1111-4111-8111-111111111111' }],
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ user_id: '11111111-1111-4111-8111-111111111111' }],
-        })
-        .mockResolvedValueOnce({ ok: true, json: async () => [] })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ game_edition: 3, user_id: '11111111-1111-4111-8111-111111111111' }],
-        })
+        .mockResolvedValueOnce(membershipResponse('pvp'))
+        .mockResolvedValueOnce(memberIdsResponse())
+        .mockResolvedValueOnce(emptySummaryResponse())
+        .mockResolvedValueOnce(editionResponse(3))
         .mockResolvedValueOnce({
           ok: true,
           json: async () => [
@@ -483,32 +479,11 @@ describe('Team Members API', () => {
     it('reads the season-aware summary view instead of progress blobs', async () => {
       mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
       mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            { game_mode: 'seasonal', user_id: '11111111-1111-4111-8111-111111111111' },
-          ],
-        })
-        .mockResolvedValueOnce({ ok: true, json: async () => 2 })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ user_id: '11111111-1111-4111-8111-111111111111' }],
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [
-            {
-              user_id: '11111111-1111-4111-8111-111111111111',
-              display_name: 'Seasonal Player',
-              level: 12,
-              tasks_completed: 3,
-            },
-          ],
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: async () => [{ game_edition: 1, user_id: '11111111-1111-4111-8111-111111111111' }],
-        });
+        .mockResolvedValueOnce(membershipResponse('seasonal'))
+        .mockResolvedValueOnce(activeSeasonResponse(2))
+        .mockResolvedValueOnce(memberIdsResponse())
+        .mockResolvedValueOnce(seasonalSummaryResponse(3))
+        .mockResolvedValueOnce(editionResponse(1));
       const { default: handler } = await import('@/server/api/team/members');
       await handler(mockEvent as H3Event);
       const profileUrl = String(mockFetch.mock.calls[3]?.[0] ?? '');
@@ -524,28 +499,10 @@ describe('Team Members API', () => {
       try {
         mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
         mockFetch
-          .mockResolvedValueOnce({
-            ok: true,
-            json: async () => [
-              { game_mode: 'seasonal', user_id: '11111111-1111-4111-8111-111111111111' },
-            ],
-          })
-          .mockResolvedValueOnce({ ok: true, json: async () => 2 })
-          .mockResolvedValueOnce({
-            ok: true,
-            json: async () => [{ user_id: '11111111-1111-4111-8111-111111111111' }],
-          })
-          .mockResolvedValueOnce({
-            ok: true,
-            json: async () => [
-              {
-                user_id: '11111111-1111-4111-8111-111111111111',
-                display_name: 'Seasonal Player',
-                level: 12,
-                tasks_completed: null,
-              },
-            ],
-          })
+          .mockResolvedValueOnce(membershipResponse('seasonal'))
+          .mockResolvedValueOnce(activeSeasonResponse(2))
+          .mockResolvedValueOnce(memberIdsResponse())
+          .mockResolvedValueOnce(seasonalSummaryResponse(null))
           .mockResolvedValueOnce({ ok: false, status: 503 });
         const { default: handler } = await import('@/server/api/team/members');
         const result = await handler(mockEvent as H3Event);
@@ -625,6 +582,90 @@ describe('Team Members API', () => {
         );
       } finally {
         errorSpy.mockRestore();
+      }
+    });
+  });
+  describe('Team members caching', () => {
+    it('serves the season-scoped cached payload without re-reading team data', async () => {
+      const originalNodeEnv = process.env.NODE_ENV;
+      try {
+        process.env.NODE_ENV = 'development';
+        vi.resetModules();
+        const entries = new Map<string, string>();
+        vi.stubGlobal('caches', {
+          default: {
+            match: async (request: Request) => {
+              const payload = entries.get(request.url);
+              return payload ? new Response(payload) : undefined;
+            },
+            put: async (request: Request, response: Response) => {
+              entries.set(request.url, await response.clone().text());
+            },
+          },
+        });
+        mockGetQuery.mockReturnValue({ teamId: VALID_TEAM_ID });
+        mockFetch.mockImplementation(async (url: string | URL) => {
+          const target = String(url);
+          if (target.includes('team_memberships?')) {
+            return membershipResponse('pvp');
+          }
+          if (target.includes('team_member_mode_summary?')) {
+            return {
+              ok: true,
+              json: async () => [
+                {
+                  user_id: VALID_USER_ID,
+                  display_name: 'Cached Player',
+                  level: 9,
+                  tasks_completed: 4,
+                },
+              ],
+            };
+          }
+          if (target.includes('user_progress?')) {
+            return {
+              ok: true,
+              json: async () => [{ user_id: VALID_USER_ID, game_edition: 2 }],
+            };
+          }
+          throw new Error(`Unexpected test request: ${target}`);
+        });
+        const { default: handler } = await import('@/server/api/team/members');
+        const fresh = await handler(mockEvent as H3Event);
+        expect(fresh).toEqual({
+          members: [VALID_USER_ID],
+          profiles: {
+            [VALID_USER_ID]: {
+              displayName: 'Cached Player',
+              gameEdition: 2,
+              gameMode: 'pvp',
+              level: 9,
+              tasksCompleted: 4,
+            },
+          },
+        });
+        const cacheKeys = [...entries.keys()].filter((url) =>
+          url.includes('/__edge-cache/team-members/')
+        );
+        expect(cacheKeys).toHaveLength(1);
+        expect(cacheKeys[0]).toContain(
+          `/__edge-cache/team-members/${encodeURIComponent(`${VALID_TEAM_ID}:${VALID_USER_ID}:0`)}`
+        );
+        const summaryCallsBefore = mockFetch.mock.calls.filter((call) =>
+          String(call[0]).includes('team_member_mode_summary')
+        ).length;
+        const cached = await handler(mockEvent as H3Event);
+        expect(cached).toEqual(fresh);
+        expect(
+          mockFetch.mock.calls.filter((call) =>
+            String(call[0]).includes('team_member_mode_summary')
+          ).length
+        ).toBe(summaryCallsBefore);
+      } finally {
+        if (originalNodeEnv === undefined) delete process.env.NODE_ENV;
+        else process.env.NODE_ENV = originalNodeEnv;
+        vi.unstubAllGlobals();
+        vi.resetModules();
       }
     });
   });

--- a/app/server/api/team/members.ts
+++ b/app/server/api/team/members.ts
@@ -1,5 +1,6 @@
 import { createError, defineEventHandler, getQuery, getRequestHeader, setResponseHeader } from 'h3';
 import { fetchWithTimeout } from '@/server/utils/fetchWithTimeout';
+import { resolveGameModeSeason } from '@/server/utils/gameModeSeason';
 import { createLogger } from '@/server/utils/logger';
 import { getProxyAwareClientIdentifier } from '@/server/utils/requestIdentity';
 import {
@@ -10,7 +11,7 @@ import {
   writeSharedCache,
   type SharedCacheHandle,
 } from '@/server/utils/sharedEdgeStore';
-import { getGameModeSeasonNumber, isGameMode, type GameMode } from '@/utils/constants';
+import { isGameMode, type GameMode } from '@/utils/constants';
 import {
   getLegacyModeProgressField,
   hasMaterializedProgress,
@@ -305,13 +306,6 @@ export default defineEventHandler(async (event) => {
       throw createError({ statusCode: 429, statusMessage: 'Too many requests' });
     }
   }
-  const teamMembersCacheKey = `${teamId}:${userId}`;
-  if (!isTestEnvironment && !forceRefresh) {
-    const cached = await getCachedTeamMembers(sharedCacheHandle, teamMembersCacheKey);
-    if (cached) {
-      return cached;
-    }
-  }
   const restApiKey = supabaseServiceKey || supabaseAnonKey;
   const restAuthorization =
     authHeader || (supabaseServiceKey ? `Bearer ${supabaseServiceKey}` : '');
@@ -372,6 +366,14 @@ export default defineEventHandler(async (event) => {
     throw createError({ statusCode: 500, statusMessage: 'Team has an invalid game mode' });
   }
   const gameMode: GameMode = gameModeValue;
+  const seasonNumber = await resolveGameModeSeason(gameMode, { supabaseUrl, supabaseServiceKey });
+  const teamMembersCacheKey = `${teamId}:${userId}:${seasonNumber}`;
+  if (!isTestEnvironment && !forceRefresh) {
+    const cached = await getCachedTeamMembers(sharedCacheHandle, teamMembersCacheKey);
+    if (cached) {
+      return cached;
+    }
+  }
   const membersResp = await restFetch(
     buildRestPath('team_memberships', {
       select: 'user_id',
@@ -389,7 +391,7 @@ export default defineEventHandler(async (event) => {
     const profilesResp = await restFetch(
       buildRestPath('team_member_mode_summary', {
         game_mode: `eq.${gameMode}`,
-        season_number: `eq.${getGameModeSeasonNumber(gameMode)}`,
+        season_number: `eq.${seasonNumber}`,
         select: 'user_id,display_name,level,tasks_completed',
         user_id: idsParam,
       })
@@ -429,7 +431,7 @@ export default defineEventHandler(async (event) => {
         const resp = await restFetch(
           buildRestPath('team_member_mode_summary', {
             game_mode: `eq.${gameMode}`,
-            season_number: `eq.${getGameModeSeasonNumber(gameMode)}`,
+            season_number: `eq.${seasonNumber}`,
             select: 'user_id,display_name,level,tasks_completed',
             user_id: `eq.${id}`,
           })

--- a/app/server/routes/overlay/kappa/__tests__/route.test.ts
+++ b/app/server/routes/overlay/kappa/__tests__/route.test.ts
@@ -1,8 +1,8 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { H3Event, H3EventContext } from 'h3';
-type SiteConfigStackEntry = Record<string, unknown>;
+import { BASE_SITE_CONTEXT, createRouterStub } from '@/server/utils/__tests__/eventStubs';
+import type { H3Event } from 'h3';
 const { mockGetQuery, mockGetRouterParam, mockSetHeader, mockSetResponseHeader } = vi.hoisted(
   () => ({
     mockGetQuery: vi.fn(),
@@ -21,22 +21,9 @@ vi.mock('h3', async () => {
     setResponseHeader: mockSetResponseHeader,
   };
 });
-mockNuxtImport('useRouter', () => () => ({
-  afterEach: vi.fn(),
-  beforeEach: vi.fn(),
-  beforeResolve: vi.fn(),
-  onError: vi.fn(),
-}));
+mockNuxtImport('useRouter', () => () => createRouterStub());
 describe('Overlay Kappa Route', () => {
   let mockEvent: Partial<H3Event>;
-  const BASE_SITE_CONTEXT: Pick<H3EventContext, 'siteConfig' | 'siteConfigNitroOrigin'> = {
-    siteConfig: {
-      stack: [] as Partial<SiteConfigStackEntry>[],
-      push: vi.fn(() => () => {}),
-      get: vi.fn(() => ({})),
-    },
-    siteConfigNitroOrigin: '',
-  };
   beforeEach(() => {
     vi.clearAllMocks();
     mockEvent = {

--- a/app/server/utils/__tests__/eventStubs.ts
+++ b/app/server/utils/__tests__/eventStubs.ts
@@ -1,0 +1,20 @@
+import { vi } from 'vitest';
+import type { H3EventContext } from 'h3';
+type SiteConfigStackEntry = Record<string, unknown>;
+// Nuxt site config is injected into server event context; server route tests
+// stub the minimal shape the routes rely on.
+export const BASE_SITE_CONTEXT: Pick<H3EventContext, 'siteConfig' | 'siteConfigNitroOrigin'> = {
+  siteConfig: {
+    stack: [] as Partial<SiteConfigStackEntry>[],
+    push: vi.fn(() => () => {}),
+    get: vi.fn(() => ({})),
+  },
+  siteConfigNitroOrigin: '',
+};
+// Router stub matching the `useRouter` surface touched by server route tests.
+export const createRouterStub = () => ({
+  afterEach: vi.fn(),
+  beforeEach: vi.fn(),
+  beforeResolve: vi.fn(),
+  onError: vi.fn(),
+});

--- a/app/server/utils/__tests__/eventStubs.ts
+++ b/app/server/utils/__tests__/eventStubs.ts
@@ -20,15 +20,12 @@ export const createRouterStub = () => ({
 });
 // Minimal Cache API implementation shared by server cache integration tests.
 export const stubEdgeCache = () => {
-  const entries = new Map<string, string>();
+  const entries = new Map<string, Response>();
   vi.stubGlobal('caches', {
     default: {
-      match: async (request: Request) => {
-        const payload = entries.get(request.url);
-        return payload ? new Response(payload) : undefined;
-      },
+      match: async (request: Request) => entries.get(request.url)?.clone(),
       put: async (request: Request, response: Response) => {
-        entries.set(request.url, await response.clone().text());
+        entries.set(request.url, response.clone());
       },
     },
   });

--- a/app/server/utils/__tests__/eventStubs.ts
+++ b/app/server/utils/__tests__/eventStubs.ts
@@ -18,3 +18,19 @@ export const createRouterStub = () => ({
   beforeResolve: vi.fn(),
   onError: vi.fn(),
 });
+// Minimal Cache API implementation shared by server cache integration tests.
+export const stubEdgeCache = () => {
+  const entries = new Map<string, string>();
+  vi.stubGlobal('caches', {
+    default: {
+      match: async (request: Request) => {
+        const payload = entries.get(request.url);
+        return payload ? new Response(payload) : undefined;
+      },
+      put: async (request: Request, response: Response) => {
+        entries.set(request.url, await response.clone().text());
+      },
+    },
+  });
+  return entries;
+};

--- a/app/server/utils/__tests__/gameModeSeason.test.ts
+++ b/app/server/utils/__tests__/gameModeSeason.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { resolveGameModeSeason } from '@/server/utils/gameModeSeason';
+const config = { supabaseUrl: 'https://example.supabase.co', supabaseServiceKey: 'test-key' };
+afterEach(() => vi.unstubAllGlobals());
+describe('database season resolution', () => {
+  it('keeps persistent modes independent of the season service', async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal('fetch', fetch);
+    expect(await resolveGameModeSeason('pvp', { supabaseUrl: '' })).toBe(0);
+    expect(await resolveGameModeSeason('pve', { supabaseUrl: '' })).toBe(0);
+    expect(fetch).not.toHaveBeenCalled();
+  });
+  it('observes rollover on the next request without reusing the compiled season', async () => {
+    const fetch = vi
+      .fn()
+      .mockResolvedValueOnce(Response.json(2))
+      .mockResolvedValueOnce(Response.json(3));
+    vi.stubGlobal('fetch', fetch);
+    expect(await resolveGameModeSeason('seasonal', config)).toBe(2);
+    expect(await resolveGameModeSeason('seasonal', config)).toBe(3);
+    expect(fetch).toHaveBeenCalledWith(
+      'https://example.supabase.co/rest/v1/rpc/get_active_season_number',
+      expect.objectContaining({ method: 'POST', redirect: 'manual', body: '{}' })
+    );
+  });
+  it.each([null, false, '2', [], {}, 0, -1, 1.5])('rejects invalid season %j', async (value) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(Response.json(value)));
+    await expect(resolveGameModeSeason('seasonal', config)).rejects.toMatchObject({
+      statusCode: 503,
+    });
+  });
+  it.each([302, 403, 500])('fails closed on HTTP %i', async (status) => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status })));
+    await expect(resolveGameModeSeason('seasonal', config)).rejects.toMatchObject({
+      statusCode: 503,
+    });
+  });
+  it('fails closed on a network failure', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('offline')));
+    await expect(resolveGameModeSeason('seasonal', config)).rejects.toMatchObject({
+      statusCode: 503,
+    });
+  });
+  it('requires service credentials and HTTPS before sending a seasonal request', async () => {
+    const fetch = vi.fn();
+    vi.stubGlobal('fetch', fetch);
+    await expect(
+      resolveGameModeSeason('seasonal', { supabaseUrl: config.supabaseUrl })
+    ).rejects.toMatchObject({ statusCode: 503 });
+    await expect(
+      resolveGameModeSeason('seasonal', { ...config, supabaseUrl: 'http://example.com' })
+    ).rejects.toMatchObject({ statusCode: 503 });
+    expect(fetch).not.toHaveBeenCalled();
+  });
+});

--- a/app/server/utils/gameModeSeason.ts
+++ b/app/server/utils/gameModeSeason.ts
@@ -1,0 +1,45 @@
+import { createError } from 'h3';
+import { fetchWithTimeout } from '@/server/utils/fetchWithTimeout';
+import type { GameMode } from '@/utils/constants';
+type SeasonConfig = { supabaseUrl: string; supabaseServiceKey?: string };
+// Resolve each seasonal request independently, including requests with cached profile data.
+// Never fall back to the compiled client season when the database cannot be consulted.
+export const resolveGameModeSeason = async (
+  mode: GameMode,
+  config: SeasonConfig
+): Promise<number> => {
+  if (mode !== 'seasonal') return 0;
+  if (!config.supabaseServiceKey) {
+    throw createError({ statusCode: 503, statusMessage: 'Seasonal data unavailable' });
+  }
+  try {
+    const url = new URL(config.supabaseUrl);
+    if (url.protocol !== 'https:') throw new Error('Expected HTTPS');
+    url.pathname = `${url.pathname.replace(/\/+$/, '')}/rest/v1/rpc/get_active_season_number`;
+    url.search = '';
+    url.hash = '';
+    const response = await fetchWithTimeout(
+      url.toString(),
+      {
+        method: 'POST',
+        redirect: 'manual',
+        headers: {
+          Authorization: `Bearer ${config.supabaseServiceKey}`,
+          apikey: config.supabaseServiceKey,
+          'Content-Type': 'application/json',
+        },
+        body: '{}',
+      },
+      8000,
+      'Timed out while resolving the active season'
+    );
+    if (!response.ok) throw new Error('Active season lookup failed');
+    const value: unknown = await response.json();
+    if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
+      throw new Error('Invalid active season');
+    }
+    return value;
+  } catch {
+    throw createError({ statusCode: 503, statusMessage: 'Seasonal data unavailable' });
+  }
+};

--- a/app/server/utils/gameModeSeason.ts
+++ b/app/server/utils/gameModeSeason.ts
@@ -1,7 +1,33 @@
 import { createError } from 'h3';
+import { normalizeSupabaseUrl } from '@/server/utils/adminSupabase';
 import { fetchWithTimeout } from '@/server/utils/fetchWithTimeout';
 import type { GameMode } from '@/utils/constants';
 type SeasonConfig = { supabaseUrl: string; supabaseServiceKey?: string };
+const isSeasonNumber = (value: unknown): value is number =>
+  typeof value === 'number' && Number.isInteger(value) && value > 0;
+const fetchActiveSeason = async (baseUrl: string, serviceKey: string): Promise<number> => {
+  const url = normalizeSupabaseUrl(baseUrl);
+  if (!url) throw new Error('Invalid Supabase URL');
+  const response = await fetchWithTimeout(
+    `${url}/rest/v1/rpc/get_active_season_number`,
+    {
+      method: 'POST',
+      redirect: 'manual',
+      headers: {
+        Authorization: `Bearer ${serviceKey}`,
+        apikey: serviceKey,
+        'Content-Type': 'application/json',
+      },
+      body: '{}',
+    },
+    8000,
+    'Timed out while resolving the active season'
+  );
+  if (!response.ok) throw new Error('Active season lookup failed');
+  const value: unknown = await response.json();
+  if (!isSeasonNumber(value)) throw new Error('Invalid active season');
+  return value;
+};
 // Resolve each seasonal request independently, including requests with cached profile data.
 // Never fall back to the compiled client season when the database cannot be consulted.
 export const resolveGameModeSeason = async (
@@ -9,38 +35,9 @@ export const resolveGameModeSeason = async (
   config: SeasonConfig
 ): Promise<number> => {
   if (mode !== 'seasonal') return 0;
-  if (!config.supabaseServiceKey) {
-    throw createError({ statusCode: 503, statusMessage: 'Seasonal data unavailable' });
-  }
   try {
-    const url = new URL(config.supabaseUrl);
-    if (url.protocol !== 'https:') throw new Error('Expected HTTPS');
-    let path = url.pathname;
-    while (path.endsWith('/')) path = path.slice(0, -1);
-    url.pathname = `${path}/rest/v1/rpc/get_active_season_number`;
-    url.search = '';
-    url.hash = '';
-    const response = await fetchWithTimeout(
-      url.toString(),
-      {
-        method: 'POST',
-        redirect: 'manual',
-        headers: {
-          Authorization: `Bearer ${config.supabaseServiceKey}`,
-          apikey: config.supabaseServiceKey,
-          'Content-Type': 'application/json',
-        },
-        body: '{}',
-      },
-      8000,
-      'Timed out while resolving the active season'
-    );
-    if (!response.ok) throw new Error('Active season lookup failed');
-    const value: unknown = await response.json();
-    if (typeof value !== 'number' || !Number.isInteger(value) || value <= 0) {
-      throw new Error('Invalid active season');
-    }
-    return value;
+    if (!config.supabaseServiceKey) throw new Error('Missing service credential');
+    return await fetchActiveSeason(config.supabaseUrl, config.supabaseServiceKey);
   } catch {
     throw createError({ statusCode: 503, statusMessage: 'Seasonal data unavailable' });
   }

--- a/app/server/utils/gameModeSeason.ts
+++ b/app/server/utils/gameModeSeason.ts
@@ -15,7 +15,9 @@ export const resolveGameModeSeason = async (
   try {
     const url = new URL(config.supabaseUrl);
     if (url.protocol !== 'https:') throw new Error('Expected HTTPS');
-    url.pathname = `${url.pathname.replace(/\/+$/, '')}/rest/v1/rpc/get_active_season_number`;
+    let path = url.pathname;
+    while (path.endsWith('/')) path = path.slice(0, -1);
+    url.pathname = `${path}/rest/v1/rpc/get_active_season_number`;
     url.search = '';
     url.hash = '';
     const response = await fetchWithTimeout(

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -754,6 +754,12 @@ flowchart LR
 - Team actions and invite links are unavailable until the active team row has loaded and its ID
   matches the mode-specific system-store team ID; stale owner or join-code state is never combined
   with another team's ID.
+- Nitro shared-profile and team-member reads resolve Seasonal through the service-role-only
+  `get_active_season_number` RPC on each request before cache lookup. Cache keys include the resolved
+  season; missing credentials, failed lookups and invalid responses return 503 rather than falling
+  back to the bundled season. Persistent modes use season 0 without an RPC. The resolver is
+  `app/server/utils/gameModeSeason.ts`. A request uses one resolved season for its reads; a rollover
+  during that request is observed by the next request.
 - App `ACTIVE_SEASON` metadata must match the database's `private.active_season_*()` functions;
   the Worker resolves the active Seasonal number through the database instead of carrying a
   second runtime constant.


### PR DESCRIPTION
Seasonal profile and team-member reads now resolve the active season from the existing database RPC before cache lookup. This keeps a stale app deployment from reading the wrong season after rollover. Cache keys include the resolved season, lookup failures return 503, and team membership is checked before cached responses. Persistent modes remain on season 0.

Closes #644.

Validated head: `364f280ec0653342edea851bf6de2d94123660e0`; tracked worktree clean.

- Focused resolver/profile/team regressions pass, including rollover, cached lookup failures, membership rechecks, Seasonal cache hits and no persistent-mode season RPC.
- `pnpm run lint` and `pnpm run typecheck` pass. Hosted CI passes all test shards, database checks, lint/format, types, Fallow, SonarCloud, CodeQL, coverage and Cloudflare preview.
- Independent review and local CodeRabbit review completed; findings were addressed. Codex reviewed this head without major issues. All review threads are resolved.

No migration is required. The existing service-role credential and deployed `get_active_season_number` RPC remain runtime prerequisites. Tests mock RPC/network behavior; production rollover was not exercised.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Seasonal profile and team data now uses the current active season for each request.
  - Cache entries are separated by season, so season rollovers return refreshed data instead of stale results.
  - Invalid or unavailable seasonal lookups now return a clear `503` error rather than using outdated season information.
  - Persistent game modes continue to use their standard non-seasonal data behavior.

- **Documentation**
  - Updated system documentation to describe seasonal data resolution, caching, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR aligns Nitro seasonal reads with the database-managed active season.
- Adds a service-role RPC resolver that fails closed when the active season cannot be determined.
- Uses the resolved season for shared-profile and team-member queries and cache keys.
- Moves team-member cache access after membership verification and expands regression coverage.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/server/utils/gameModeSeason.ts | Adds validated, service-role-only active-season resolution with fail-closed error handling. |
| app/server/api/profile/[userId]/[mode].get.ts | Resolves the database season before cache access and applies it consistently to profile queries and cache identity. |
| app/server/api/team/members.ts | Verifies membership before cache access and scopes seasonal summary reads and cache entries to the resolved season. |
| app/server/api/profile/__tests__/shared-profile.test.ts | Covers database/application season disagreement, rollover behavior, cache expiry, and resolution failures. |
| app/server/api/team/__tests__/members.test.ts | Covers database-resolved seasonal summaries and season-scoped cache-hit behavior. |
| docs/SYSTEMS.md | Documents per-request season resolution, failure behavior, cache scoping, and persistent-mode handling. |

</details>


<details open><summary><h3>Sequence Diagram</h3></summary>

```mermaid
sequenceDiagram
    participant Client
    participant API as Nitro API
    participant DB as Supabase
    participant Cache as Edge Cache
    Client->>API: Seasonal profile/team request
    API->>DB: Verify requester or membership
    API->>DB: get_active_season_number()
    DB-->>API: Active season
    API->>Cache: Lookup season-scoped key
    alt Cache hit
        Cache-->>API: Cached response
    else Cache miss
        API->>DB: Read rows for resolved season
        DB-->>API: Seasonal data
        API->>Cache: Store season-scoped response
    end
    API-->>Client: Response
```
</details>

<sub>Reviews (8): Last reviewed commit: ["test(api): improve cached summary assert..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/364f280ec0653342edea851bf6de2d94123660e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=61265052)</sub>

<!-- /greptile_comment -->