### PR TITLE
docs: require resolving Fallow findings instead of suppressing them

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,6 +68,17 @@ unless executable or test logic changes make it relevant.
   `pnpm --filter api-gateway exec wrangler deploy --config wrangler.toml --dry-run`.
 - Formatting is enforced by the repository hook and CI `format:check`; do not run the broad format
   command unless the hook is bypassed.
+- Fix Fallow findings; do not suppress them. `// fallow-ignore-next-line` hides a finding without
+  resolving it, and a hidden finding is never revisited. Resolve dead code by deleting it or
+  narrowing the export, and resolve complexity by decomposition: extract helpers, split validation
+  from assembly, and share an algorithm instead of duplicating it. Note that CRAP assumes zero
+  coverage, so a new function at cyclomatic 5 already breaches; treat cyclomatic 4 as the practical
+  ceiling for new functions. Suppress only when the finding is provably not actionable — an external
+  contract or framework indirection the analyzer cannot see, such as store state hydrated through
+  `$state`. A suppression must state why the finding cannot be fixed, not merely that tests cover the
+  code, and it is a reviewable decision rather than a formality. Existing suppressions are
+  grandfathered; remove them opportunistically when already editing that function, not as unrelated
+  cleanup in someone else's change.
 - Mock Supabase and network calls in tests so they stay deterministic.
 
 ## Invariants

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -168,9 +168,9 @@ indirection the analyzer cannot model (store state hydrated through `$state` is 
 example). Put `// fallow-ignore-next-line` directly above the flagged declaration and explain why
 the finding cannot be fixed. Explanatory `//` lines may precede the directive; the directive must be
 the final comment line. Placing more comment lines between the directive and declaration targets the
-wrong line and leaves the finding unsuppressed. A suppression is a reviewable decision, not a formality. Existing suppressions are
-grandfathered; remove them opportunistically when already editing that function rather than as
-unrelated cleanup in someone else's change.
+wrong line and leaves the finding unsuppressed. A suppression is a reviewable decision, not a
+formality. Existing suppressions are grandfathered; remove them opportunistically when already
+editing that function rather than as unrelated cleanup in someone else's change.
 
 ### 2. Security Scanning (`.github/workflows/security.yml`)
 

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -165,9 +165,10 @@ Treat cyclomatic 4 as the practical ceiling for new functions.
 
 Suppress only when the finding is provably not actionable, such as an external contract or framework
 indirection the analyzer cannot model (store state hydrated through `$state` is the recurring
-example). The comment must be a single line directly above the flagged declaration — a multi-line
-comment block suppresses the wrong line and silently fails — and must explain why the finding cannot
-be fixed. A suppression is a reviewable decision, not a formality. Existing suppressions are
+example). Put `// fallow-ignore-next-line` directly above the flagged declaration and explain why
+the finding cannot be fixed. Explanatory `//` lines may precede the directive; the directive must be
+the final comment line. Placing more comment lines between the directive and declaration targets the
+wrong line and leaves the finding unsuppressed. A suppression is a reviewable decision, not a formality. Existing suppressions are
 grandfathered; remove them opportunistically when already editing that function rather than as
 unrelated cleanup in someone else's change.
 

--- a/docs/WORKFLOW_AUTOMATION.md
+++ b/docs/WORKFLOW_AUTOMATION.md
@@ -149,6 +149,28 @@ are printed on stderr. Invalid refs and setup/analyzer failures exit nonzero ins
 Regression checks live in `scripts/fallow-audit.test.mjs` and run with the regular test suite or
 `pnpm exec vitest run scripts/fallow-audit.test.mjs`.
 
+##### Resolving findings instead of suppressing them
+
+Fix findings at the source. `// fallow-ignore-next-line` hides a finding without resolving it, and
+because no baseline is maintained, a hidden finding is never revisited — the debt simply stops being
+reported. Resolve dead code by deleting it or narrowing the export; resolve complexity by
+decomposition (extract helpers, split validation from assembly, share an algorithm rather than
+duplicating it).
+
+Complexity findings usually report `exceeded: crap`. CRAP is `complexity² × (1 − coverage)³ +
+complexity` and the audit runs without coverage data, so it assumes zero coverage: a function at
+cyclomatic 5 scores exactly the threshold of 30 and breaches. "It is covered by tests" is therefore
+not a resolution — the analyzer cannot see that coverage, and the finding will recur on every run.
+Treat cyclomatic 4 as the practical ceiling for new functions.
+
+Suppress only when the finding is provably not actionable, such as an external contract or framework
+indirection the analyzer cannot model (store state hydrated through `$state` is the recurring
+example). The comment must be a single line directly above the flagged declaration — a multi-line
+comment block suppresses the wrong line and silently fails — and must explain why the finding cannot
+be fixed. A suppression is a reviewable decision, not a formality. Existing suppressions are
+grandfathered; remove them opportunistically when already editing that function rather than as
+unrelated cleanup in someone else's change.
+
 ### 2. Security Scanning (`.github/workflows/security.yml`)
 
 Weekly security audits:


### PR DESCRIPTION
Document the resolve-rather-than-suppress policy for Fallow findings, including the current CRAP threshold and permitted framework false positives.

Clarify suppression placement: explanatory `//` lines may precede a directive, but `// fallow-ignore-next-line` must be the last comment directly above the declaration. Additional comment lines after the directive mis-target it; a preceding block of `//` explanations is valid.

Validation: focused Prettier checks, repository blank-line checks, diff checks, and the commit hook passed. No executable behavior changes.

Local head `410b0314` on `docs/fallow-suppression-policy`; clean worktree. The final commit rewraps the suppression paragraph at the file's 100-column prose width, which `proseWrap: preserve` does not enforce; the branch adds no line over that width beyond the 44 already present on `main`. Commands: `pnpm exec prettier --check AGENTS.md docs/WORKFLOW_AUTOMATION.md`, `pnpm run lint:blank-lines`, and `git diff --check`.




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR documents the resolve-rather-than-suppress policy for Fallow findings and clarifies the suppression placement previously questioned.
- Explains the current CRAP threshold and preferred complexity reductions.
- Limits suppressions to justified analyzer false positives.
- Clarifies that explanatory `//` lines may precede the directive, while no comments may intervene between the directive and declaration.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The documentation-only PR appears safe to merge.

No blocking failure remains; the previous suppression-placement issue is resolved by explicitly allowing explanatory comments before the directive and requiring the directive to remain directly above the declaration.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| AGENTS.md | Adds a compact repository-level policy requiring actionable Fallow findings to be resolved rather than suppressed. |
| docs/WORKFLOW_AUTOMATION.md | Documents Fallow remediation, complexity thresholds, permitted suppressions, and correctly clarifies the previously reported comment-placement distinction. |

</details>

<sub>Reviews (3): Last reviewed commit: ["docs: rewrap the Fallow suppression para..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/410b03147f07002b4557dd6c7a12a72bdf416e0c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62465680)</sub>

<!-- /greptile_comment -->
