### PR TITLE
fix(app): keep the editions cache payload structured-cloneable

### DIFF
--- a/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
+++ b/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
@@ -118,10 +118,17 @@ describe('useMetadataStore fetchEditionsData', () => {
       })
     );
     await store.fetchEditionsData(true);
+    expect(setCachedDataMock).toHaveBeenCalledTimes(1);
     const payload = setCachedDataMock.mock.calls.at(-1)?.[3];
+    expect(payload).toEqual({
+      editions: [createEdition('standard', 1, 'Standard')],
+      storyChapters: [],
+      seasonalPerks: [],
+    });
     // IndexedDB stores values with the structured clone algorithm, which throws
     // DataCloneError on a Vue reactive proxy. Reaching the cache with reactive
-    // state silently disables the editions cache for every visit.
+    // state silently disables the editions cache for every visit. The payload is
+    // asserted first because structuredClone(undefined) would pass vacuously.
     expect(() => structuredClone(payload)).not.toThrow();
   });
   it('caches a structured-cloneable editions payload in Seasonal', async () => {
@@ -141,7 +148,13 @@ describe('useMetadataStore fetchEditionsData', () => {
     );
     await store.fetchEditionsData(true);
     expect(store.seasonalPerks).toEqual([createSeasonalPerk('perk-1', 'Perk One')]);
+    expect(setCachedDataMock).toHaveBeenCalledTimes(1);
     const payload = setCachedDataMock.mock.calls.at(-1)?.[3];
+    expect(payload).toEqual({
+      editions: [createEdition('standard', 1, 'Standard')],
+      storyChapters: [],
+      seasonalPerks: [createSeasonalPerk('perk-1', 'Perk One')],
+    });
     expect(() => structuredClone(payload)).not.toThrow();
   });
   it('keeps cached editions when story chapters cache is missing and overlay fetch fails', async () => {

--- a/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
+++ b/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
@@ -5,7 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { useMetadataStore } from '@/stores/useMetadata';
 import * as cacheUtils from '@/utils/tarkovCache';
 import { createDeferred } from '@/utils/test-helpers';
-import type { GameEdition, StoryChapter } from '@/types/tarkov';
+import type { GameEdition, SeasonalPerk, StoryChapter } from '@/types/tarkov';
 const loggerMock = vi.hoisted(() => ({
   debug: vi.fn(),
   error: vi.fn(),
@@ -30,6 +30,15 @@ const createStoryChapter = (id: string, order: number, name: string): StoryChapt
   objectives: {},
   order,
   wikiLink: `https://example.com/${id}`,
+});
+const createSeasonalPerk = (id: string, name: string): SeasonalPerk => ({
+  id,
+  type: 'perk',
+  name,
+  description: '',
+  points: 0,
+  mutuallyExclusiveSeasonalPerkIds: [],
+  effects: [],
 });
 describe('useMetadataStore fetchEditionsData', () => {
   beforeEach(() => {
@@ -97,6 +106,43 @@ describe('useMetadataStore fetchEditionsData', () => {
       '[MetadataStore] Editions cache read failed:',
       expect.any(Error)
     );
+  });
+  it('caches a structured-cloneable editions payload in a persistent mode', async () => {
+    const store = useMetadataStore();
+    const setCachedDataMock = vi.spyOn(cacheUtils, 'setCachedData').mockResolvedValue();
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue(null);
+    vi.stubGlobal(
+      '$fetch',
+      vi.fn().mockResolvedValue({
+        data: { editions: [createEdition('standard', 1, 'Standard')], storyChapters: [] },
+      })
+    );
+    await store.fetchEditionsData(true);
+    const payload = setCachedDataMock.mock.calls.at(-1)?.[3];
+    // IndexedDB stores values with the structured clone algorithm, which throws
+    // DataCloneError on a Vue reactive proxy. Reaching the cache with reactive
+    // state silently disables the editions cache for every visit.
+    expect(() => structuredClone(payload)).not.toThrow();
+  });
+  it('caches a structured-cloneable editions payload in Seasonal', async () => {
+    const store = useMetadataStore();
+    store.currentGameMode = 'seasonal';
+    const setCachedDataMock = vi.spyOn(cacheUtils, 'setCachedData').mockResolvedValue();
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue(null);
+    vi.stubGlobal(
+      '$fetch',
+      vi.fn().mockResolvedValue({
+        data: {
+          editions: [createEdition('standard', 1, 'Standard')],
+          storyChapters: [],
+          seasonalPerks: [createSeasonalPerk('perk-1', 'Perk One')],
+        },
+      })
+    );
+    await store.fetchEditionsData(true);
+    expect(store.seasonalPerks).toEqual([createSeasonalPerk('perk-1', 'Perk One')]);
+    const payload = setCachedDataMock.mock.calls.at(-1)?.[3];
+    expect(() => structuredClone(payload)).not.toThrow();
   });
   it('keeps cached editions when story chapters cache is missing and overlay fetch fails', async () => {
     const store = useMetadataStore();

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -89,8 +89,14 @@ const PRESTIGE_CACHE_VERSION = 'json-v3';
 const EDITIONS_CACHE_VERSION = 'overlay-v2';
 const settledEditionScope = (requested: string, current: string) =>
   requested === current ? requested : '';
+/**
+ * Resolve the perk list for a mode, always returning a raw array. A plain array
+ * assigned to store state becomes a reactive proxy, and `structuredClone` rejects
+ * a proxy, so leaving the non-Seasonal branch unmarked made every IndexedDB
+ * editions write fail with `DataCloneError`.
+ */
 const perksForMode = (perks: SeasonalPerk[], mode: string) =>
-  mode === 'pvp-season' ? markRaw(perks) : [];
+  markRaw(mode === 'pvp-season' ? perks : []);
 const editionsPromiseForScope = (store: ReturnType<typeof getPromiseStore>, scope: string) =>
   store.editionsScope === scope ? store.editionsPromise : null;
 const CACHE_PURGE_STORAGE_KEY = STORAGE_KEYS.cachePurgeAt;
@@ -1519,8 +1525,7 @@ export const useMetadataStore = defineStore('metadata', {
           this.editions = markRaw(editions);
           this.storyChapters = markRaw(chapters);
           promiseStore.editionsSettledScope = scope;
-          this.seasonalPerks =
-            requestMode === 'pvp-season' ? markRaw(overlay.seasonalPerks ?? []) : [];
+          this.seasonalPerks = perksForMode(overlay.seasonalPerks ?? [], requestMode);
           if (typeof window !== 'undefined') {
             setCachedData(
               'editions' as CacheType,

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -239,7 +239,10 @@ replaces the key with the translated string.
    caching entirely and always fetch. Sets `X-Cache-Status: DEV`.
 
 On top of these, the **client** has its own IndexedDB cache in `useMetadataStore` so the browser
-does not re-fetch on every navigation. That layer is documented in `ARCHITECTURE.md`.
+does not re-fetch on every navigation. That layer is documented in `ARCHITECTURE.md`. Anything passed
+to `setCachedData` must be structured-cloneable, so store-held catalogs stay `markRaw` on every
+assignment including empty fallbacks: a plain array assigned to store state becomes a reactive proxy,
+and IndexedDB rejects a proxy with `DataCloneError`, disabling that cache entry for every visit.
 
 ### Stale-while-revalidate
 


### PR DESCRIPTION
# Pull Request

## Summary

The browser IndexedDB editions cache never wrote. Every page load logged
`DataCloneError: [object Array] could not be cloned` twice and refetched the progression catalog,
because `perksForMode` marked only its Seasonal branch raw.

`markRaw` was applied to the Seasonal branch but not the fallback, so in `pvp`, `pve`, and every
other persistent mode a plain `[]` was assigned to store state. Pinia made it reactive, and the
structured clone algorithm that backs `IDBObjectStore.put` rejects a reactive proxy. The write threw,
`setCachedData` logged and rethrew, and the caller's `.catch` logged again — one root cause, the two
console errors seen in production since v1.77.2.

Discovered while verifying the #830 deployment; pre-existing and unrelated to that change. The two
affected files were last touched by #826.

## Changes

- `perksForMode` marks both branches raw, so the resolved perk list is never reactive.
- `fetchEditionsData` reuses `perksForMode` instead of an inline ternary that duplicated the same
  defect, so the fix cannot drift back apart.
- Regression test asserting the payload handed to `setCachedData` is structured-cloneable, plus the
  Seasonal counterpart covering the other branch.
- `docs/SYSTEMS.md` records the invariant next to the client cache description.

## Related Issues

Related to #830 (found during its post-merge verification).

## Testing

- [x] Tested locally
- [x] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. `pnpm exec vitest run app/stores/__tests__/useMetadata.fetchEditionsData.test.ts` — 23 pass. The
   new persistent-mode test fails against the previous code with the exact production message,
   `DataCloneError: [object Array] could not be cloned`.
2. A/B against one `pnpm run dev` server, using two isolated browser contexts so each started with an
   empty IndexedDB:
   - Without the fix: both `[TarkovCache]` and `[MetadataStore]` errors logged, and
     `tarkov-editions-overlay-v2-regular-en` was absent from the `tarkov-data` object store while the
     seven other catalog entries were present.
   - With the fix: no console errors, and the editions key is present alongside the others.
3. Confirmed nothing mutates `seasonalPerks` in place, so `markRaw` cannot drop a needed deep-reactive
   update; the property is always replaced by assignment. No `.vue` file reads it directly.
4. Related suites: `useMetadata.fetchEditionsData`, `useMetadata.initialize`, `metadataStoreBridge`,
   `useMetadataCachePurge`, `seasonalPerks`, `useMetadata.promiseTracking` — 57 tests pass.
5. `pnpm run typecheck` exit 0; `pnpm run lint` 0 errors / 0 warnings; `pnpm run lint:fallow` new-only
   gate exit 0; `pnpm run systems:check` passed; focused `prettier --check`, `pnpm run lint:blank-lines`,
   and `git diff --check` clean.

Local head `3b351a1d`; clean worktree.

## Documentation impact

Select one:

- [ ] No behavior changed — no documentation review needed
- [ ] Behavior changed — existing documentation remains accurate
- [x] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [ ] Contributor documentation
- [x] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [ ] Screenshots or diagrams

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

Considered and rejected a defensive snapshot inside `setCachedData`. A `toRaw` there cannot help,
because the caller builds a fresh wrapper object and the proxies sit one level down; a deep snapshot
would add a clone of multi-megabyte catalog payloads on every cache write to paper over a caller bug.
Keeping store catalogs raw is both the narrower fix and the one that avoids deep reactivity over
large arrays, matching the `markRaw([])` already used in the state initializer and the cache-hydration
path.

A `toRaw` guard inside `perksForMode` was also written and then dropped: no observable failure could
be produced for it, because `markRaw` flags the proxy's target and Vue's read path then returns the
raw array anyway.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved metadata caching reliability by preventing cache write failures caused by reactive data.
  - Ensured edition and seasonal perk data can be stored and restored correctly from the client cache.

- **Documentation**
  - Clarified requirements for keeping cached catalog data compatible with structured cloning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->



<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR keeps both branches of the edition perk selection raw so IndexedDB can structured-clone the resulting cache payload.
- Centralizes mode-specific perk selection in `perksForMode`.
- Adds persistent and Seasonal mode regression coverage for structured-cloneable cache payloads.
- Documents the structured-cloneability invariant for client-side catalog caching.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/stores/useMetadata.ts | Consistently marks selected seasonal-perk arrays raw before assigning and caching them, without disrupting current replacement-based state updates. |
| app/stores/__tests__/useMetadata.fetchEditionsData.test.ts | Adds regression tests covering payload contents and structured-clone compatibility in persistent and Seasonal modes. |
| docs/SYSTEMS.md | Documents that catalog values passed to IndexedDB must remain structured-cloneable. |

</details>

<sub>Reviews (2): Last reviewed commit: ["test: anchor the editions cache assertio..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/96c68b776be5be49e7478300c2797901bb53ac8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62518106)</sub>

<!-- /greptile_comment -->