### PR TITLE
fix(tasks): block tasks whose declared gate cannot be interpreted

### DIFF
--- a/app/composables/__tests__/useProfileTaskMetadata.test.ts
+++ b/app/composables/__tests__/useProfileTaskMetadata.test.ts
@@ -227,3 +227,39 @@ it('ignores a required catalog rejection after its scope is disposed', async () 
   expect(result.error.value).toBeNull();
   expect(result.tasks.value).toEqual([]);
 });
+it.each([undefined, null, [{ id: 'updated' }]])(
+  'preserves core gates while merging objective fields with value %j',
+  async (value) => {
+    const core = {
+      id: 'target',
+      requirementDiagnostics: ['task_requirement', 'prestige_reference'],
+      objectives: [{ id: 'original' }],
+      failConditions: [{ id: 'original-failure' }],
+    };
+    const update = {
+      id: 'target',
+      requirementDiagnostics: ['task_requirement'],
+      objectives: value,
+      failConditions: value,
+    };
+    const responses: Record<string, unknown> = {
+      '/api/tarkov/tasks-core': { data: { tasks: [core] } },
+      '/api/tarkov/tasks-objectives': { data: { tasks: [update] } },
+      '/api/tarkov/prestige': { data: { prestige: [] } },
+      '/api/tarkov/editions': { data: { editions: [], storyChapters: [] } },
+    };
+    vi.stubGlobal(
+      '$fetch',
+      vi.fn(async (url: string) => responses[url])
+    );
+    const scope = effectScope();
+    const result = scope.run(() => useProfileTaskMetadata(ref<GameMode>('pvp'), ref('en')))!;
+    await flushPromises();
+    expect(result.tasks.value[0]).toMatchObject({
+      requirementDiagnostics: core.requirementDiagnostics,
+      objectives: value === undefined ? core.objectives : (value ?? []),
+      failConditions: value === undefined ? core.failConditions : value,
+    });
+    scope.stop();
+  }
+);

--- a/app/composables/useProfileTaskMetadata.ts
+++ b/app/composables/useProfileTaskMetadata.ts
@@ -81,8 +81,9 @@ const mergeProfileTasks = (
     if (!update) return task;
     return {
       ...task,
-      objectives: update.objectives ?? task.objectives,
-      failConditions: update.failConditions ?? task.failConditions,
+      objectives: update.objectives !== undefined ? update.objectives : task.objectives,
+      failConditions:
+        update.failConditions !== undefined ? update.failConditions : task.failConditions,
     };
   });
   return dedupeTaskObjectiveIds(

--- a/app/composables/useProfileTaskMetadata.ts
+++ b/app/composables/useProfileTaskMetadata.ts
@@ -65,13 +65,26 @@ const optionalPrestige = (response: { data: { prestige: PrestigeLevel[] } }): Pr
   }
   return prestige;
 };
-/** Merge the core and objectives catalogs, then dedupe shared objective IDs. */
+/**
+ * Merge the core and objectives catalogs, then dedupe shared objective IDs. The objectives response
+ * contributes only objective data, matching `useMetadata.mergeTaskObjectives`: a blanket spread would
+ * let stray fields an overlay patch merged into that response replace the core catalog's declared
+ * gates and their `requirementDiagnostics`.
+ */
 const mergeProfileTasks = (
   core: { data: TarkovTasksCoreQueryResult },
   objectives: { data: { tasks: Task[] } }
 ) => {
   const byId = new Map(objectives.data.tasks.map((task) => [task.id, task]));
-  const merged = core.data.tasks.map((task) => ({ ...task, ...byId.get(task.id) }));
+  const merged = core.data.tasks.map((task) => {
+    const update = byId.get(task.id);
+    if (!update) return task;
+    return {
+      ...task,
+      objectives: update.objectives ?? task.objectives,
+      failConditions: update.failConditions ?? task.failConditions,
+    };
+  });
   return dedupeTaskObjectiveIds(
     merged.map((task) => ({
       ...task,

--- a/app/server/utils/__tests__/declaredTaskGates.test.ts
+++ b/app/server/utils/__tests__/declaredTaskGates.test.ts
@@ -236,6 +236,27 @@ describe('overlay declared-gate normalization', () => {
     expect(task.requirementDiagnostics).toEqual(['task_requirement', 'prestige_reference']);
     expect(evaluate(task).available).toBe(false);
   });
+  it.each(['ordinary', 'locale'])(
+    'ignores diagnostic overrides in %s corrections',
+    async (scope) => {
+      const patch = { name: 'Renamed', requirementDiagnostics: [] };
+      const tasks = { target: patch };
+      const overlay = scope === 'locale' ? { locales: { en: { tasks } } } : { tasks };
+      const task = await correct(overlay, [brokenTask()]);
+      expect(task.requirementDiagnostics).toEqual(['task_requirement', 'prestige_reference']);
+      expect(evaluate(task).available).toBe(false);
+    }
+  );
+  it.each(['ordinary', 'locale'])(
+    'retains untouched diagnostics when %s corrections repair one gate',
+    async (scope) => {
+      const tasks = { target: { taskRequirements: [], requirementDiagnostics: [] } };
+      const overlay = scope === 'locale' ? { locales: { en: { tasks } } } : { tasks };
+      const task = await correct(overlay, [brokenTask()]);
+      expect(task.requirementDiagnostics).toEqual(['prestige_reference']);
+      expect(evaluate(task).available).toBe(false);
+    }
+  );
   it('normalizes an ordinary correction using its original task id', async () => {
     const patch = { id: 'renamed', requiredPrestige: {}, taskRequirements: {} };
     const task = await correct({ tasks: { target: patch } }, [baseTask()]);

--- a/app/server/utils/__tests__/declaredTaskGates.test.ts
+++ b/app/server/utils/__tests__/declaredTaskGates.test.ts
@@ -118,6 +118,29 @@ describe('malformed declared prestige references', () => {
     expect(task.requirementDiagnostics).toEqual(['prestige_reference']);
     expect(evaluate(task).available).toBe(false);
   });
+  it.each([0, 4, 5])(
+    'blocks a malformed gate despite an inferred level at prestige %i',
+    (prestigeLevel) => {
+      const task = adaptTask({
+        id: 'new_beginning_prestige_5',
+        requiredPrestige: { unexpected: 'prestige-id' },
+        storyUnlocks: [{ id: 'chapter-1', name: 'Batya' }],
+      });
+      const prestigeTaskMap = buildPrestigeTaskMap([task], []);
+      expect(prestigeTaskMap.get(task.id)).toBe(4);
+      const evaluated = buildTaskEvaluations(
+        [task],
+        new Map([
+          ['self', progress({ prestigeLevel, storyChapters: { 'chapter-1': { complete: true } } })],
+        ]),
+        { requireTraderLevels: false, prestigeTaskMap }
+      )[task.id]!.self!;
+      expect(evaluated).toEqual({
+        available: false,
+        blockers: [{ type: 'unknown', reason: 'prestige_reference' }],
+      });
+    }
+  );
   it('still coerces a numeric id rather than narrowing a supported shape', () => {
     const task = adaptTask({ requiredPrestige: { id: 42 } });
     expect(task.requiredPrestige).toEqual({ id: '42' });
@@ -213,6 +236,13 @@ describe('overlay declared-gate normalization', () => {
     expect(task.requirementDiagnostics).toEqual(['task_requirement', 'prestige_reference']);
     expect(evaluate(task).available).toBe(false);
   });
+  it('normalizes an ordinary correction using its original task id', async () => {
+    const patch = { id: 'renamed', requiredPrestige: {}, taskRequirements: {} };
+    const task = await correct({ tasks: { target: patch } }, [baseTask()]);
+    expect(task.id).toBe('renamed');
+    expect(task.requirementDiagnostics).toEqual(['task_requirement', 'prestige_reference']);
+    expect(evaluate(task).available).toBe(false);
+  });
   it('clears an adapter diagnostic when a correction repairs the gate', async () => {
     const patch = { requiredPrestige: 'prestige1', taskRequirements: [] };
     const task = await correct({ tasks: { target: patch } }, [brokenTask()]);
@@ -258,7 +288,14 @@ describe('overlay declared-gate normalization', () => {
     const task = await correct({ tasksAdd: { new_beginning_prestige_5: added } }, []);
     expect(task.requirementDiagnostics).toBeUndefined();
     expect(task.requiredPrestige).toEqual(requiredPrestige);
-    expect(buildPrestigeTaskMap([task], []).get(task.id)).toBe(4);
+    const prestigeTaskMap = buildPrestigeTaskMap([task], []);
+    expect(prestigeTaskMap.get(task.id)).toBe(4);
+    expect(
+      buildTaskEvaluations([task], new Map([['self', progress({ prestigeLevel: 4 })]]), {
+        requireTraderLevels: false,
+        prestigeTaskMap,
+      })[task.id]!.self!.available
+    ).toBe(true);
   });
   // Locale corrections are applied last, so a gate one of them declares needs the same treatment.
   // The patch is keyed by the pre-patch id, so one that also rewrites `id` must still be seen.

--- a/app/server/utils/__tests__/declaredTaskGates.test.ts
+++ b/app/server/utils/__tests__/declaredTaskGates.test.ts
@@ -109,6 +109,7 @@ describe('malformed declared prestige references', () => {
     ['an empty object', {}],
     ['an empty string', ''],
     ['an empty id', { id: '' }],
+    ['a blank id', { id: '   ' }],
     ['a number', 3],
     ['a list', ['prestige-1']],
   ])('blocks a declared prestige reference serialized as %s', (_label, requiredPrestige) => {
@@ -116,6 +117,17 @@ describe('malformed declared prestige references', () => {
     expect(task.requirementDiagnostics).toEqual(['prestige_reference']);
     expect(evaluate(task).available).toBe(false);
   });
+  // A stale payload can still carry a declared falsy reference the adapter would now drop.
+  it.each([[''], [0], [false]])(
+    'blocks a declared falsy reference reaching the evaluator as %p',
+    (requiredPrestige) => {
+      const stale = { id: 'target', requiredPrestige } as unknown as Task;
+      expect(evaluate(stale)).toEqual({
+        available: false,
+        blockers: [{ type: 'unknown', reason: 'prestige_reference' }],
+      });
+    }
+  );
   it('keeps a genuinely absent reference unlocked', () => {
     for (const raw of [{}, { requiredPrestige: null }]) {
       const task = adaptTask(raw);
@@ -286,5 +298,34 @@ describe('overlay declared-gate normalization', () => {
     expect(task.requirementDiagnostics).toBeUndefined();
     expect(task.requiredPrestige).toEqual(requiredPrestige);
     expect(buildPrestigeTaskMap([task], []).get(task.id)).toBe(4);
+  });
+  // Locale corrections are applied last, so a gate one of them declares needs the same treatment.
+  it('diagnoses a malformed gate introduced by a locale correction', async () => {
+    stubOverlayFetch({
+      ...overlayMeta,
+      locales: { en: { tasks: { target: { taskRequirements: { task: 'missing' } } } } },
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({
+      data: { tasks: [adaptTask({}) as unknown as { id: string }] },
+    });
+    const task = result.data!.tasks![0] as unknown as Task;
+    expect(task.taskRequirements).toBeUndefined();
+    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
+    expect(evaluate(task).available).toBe(false);
+  });
+  it('leaves an ordinary locale correction free of a fabricated diagnostic', async () => {
+    stubOverlayFetch({
+      ...overlayMeta,
+      locales: { en: { tasks: { target: { name: 'Localized' } } } },
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({
+      data: { tasks: [adaptTask({ requiredPrestige: 'prestige1' }) as unknown as { id: string }] },
+    });
+    const task = result.data!.tasks![0] as unknown as Task;
+    expect(task.name).toBe('Localized');
+    expect(task.requiredPrestige).toEqual({ id: 'prestige1' });
+    expect(task.requirementDiagnostics).toBeUndefined();
   });
 });

--- a/app/server/utils/__tests__/declaredTaskGates.test.ts
+++ b/app/server/utils/__tests__/declaredTaskGates.test.ts
@@ -183,83 +183,42 @@ describe('overlay declared-gate normalization', () => {
   const overlayMeta = {
     $meta: { generated: '2026-09-10T00:00:00.000Z', sha256: 'gate-sha', version: 'gate-v1' },
   };
-  it('diagnoses a malformed gate introduced by a task correction', async () => {
-    stubOverlayFetch({
-      ...overlayMeta,
-      tasks: {
-        target: {
-          requiredPrestige: { unexpected: 'prestige-id' },
-          taskRequirements: { task: 'missing' },
-        },
-      },
-    });
+  /** Apply one overlay over one base task and return the corrected task. */
+  const correct = async (
+    overlay: Record<string, unknown>,
+    base: Array<Record<string, unknown>>
+  ): Promise<Task> => {
+    stubOverlayFetch({ ...overlayMeta, ...overlay });
     const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({ data: { tasks: base as Array<{ id: string }> } });
+    return result.data!.tasks![0] as unknown as Task;
+  };
+  const brokenTask = () =>
+    adaptTask({
+      requiredPrestige: { unexpected: 'prestige-id' },
+      taskRequirements: { task: 'missing' },
+    }) as unknown as Record<string, unknown>;
+  const baseTask = (raw: Record<string, unknown> = {}) =>
+    adaptTask(raw) as unknown as Record<string, unknown>;
+  it('diagnoses a malformed gate introduced by a task correction', async () => {
     // deepMerge treats an object patch over an existing array as an id-keyed patch map, so the
     // reachable case is a correction that declares a gate the adapted task does not carry.
-    const result = await applyOverlay({
-      data: { tasks: [adaptTask({}) as unknown as { id: string }] },
-    });
-    const task = result.data!.tasks![0] as unknown as Task;
+    const patch = {
+      requiredPrestige: { unexpected: 'prestige-id' },
+      taskRequirements: { task: 'missing' },
+    };
+    const task = await correct({ tasks: { target: patch } }, [baseTask()]);
     expect(task.taskRequirements).toBeUndefined();
     expect(task.requiredPrestige).toBeUndefined();
     expect(task.requirementDiagnostics).toEqual(['task_requirement', 'prestige_reference']);
     expect(evaluate(task).available).toBe(false);
   });
   it('clears an adapter diagnostic when a correction repairs the gate', async () => {
-    stubOverlayFetch({
-      ...overlayMeta,
-      tasks: { target: { requiredPrestige: 'prestige1', taskRequirements: [] } },
-    });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const broken = adaptTask({
-      requiredPrestige: { unexpected: 'prestige-id' },
-      taskRequirements: { task: 'missing' },
-    });
-    const result = await applyOverlay({
-      data: { tasks: [broken as unknown as { id: string }] },
-    });
-    const task = result.data!.tasks![0] as unknown as Task;
+    const patch = { requiredPrestige: 'prestige1', taskRequirements: [] };
+    const task = await correct({ tasks: { target: patch } }, [brokenTask()]);
     expect(task.requirementDiagnostics).toBeUndefined();
     expect(task.requiredPrestige).toEqual({ id: 'prestige1' });
     expect(task.taskRequirements).toEqual([]);
-  });
-  it('diagnoses a malformed gate on an overlay-injected task', async () => {
-    stubOverlayFetch({
-      ...overlayMeta,
-      tasksAdd: {
-        added: { id: 'added', name: 'Added', taskRequirements: { task: 'missing' } },
-      },
-    });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const result = await applyOverlay({ data: { tasks: [] } });
-    const task = result.data!.tasks![0] as unknown as Task;
-    expect(task.id).toBe('added');
-    expect(task.taskRequirements).toBeUndefined();
-    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
-    expect(evaluate(task).available).toBe(false);
-  });
-  it('leaves an untouched task free of a fabricated diagnostic', async () => {
-    stubOverlayFetch({ ...overlayMeta, tasks: { target: { name: 'Renamed' } } });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const result = await applyOverlay({
-      data: { tasks: [adaptTask({ requiredPrestige: 'prestige1' }) as unknown as { id: string }] },
-    });
-    const task = result.data!.tasks![0] as unknown as Task;
-    expect(task.name).toBe('Renamed');
-    expect(task.requiredPrestige).toEqual({ id: 'prestige1' });
-    expect(task.requirementDiagnostics).toBeUndefined();
-  });
-  it('preserves an adapter diagnostic when a correction ignores the gate', async () => {
-    stubOverlayFetch({ ...overlayMeta, tasks: { target: { name: 'Renamed' } } });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const result = await applyOverlay({
-      data: {
-        tasks: [adaptTask({ taskRequirements: { task: 'missing' } }) as unknown as { id: string }],
-      },
-    });
-    const task = result.data!.tasks![0] as unknown as Task;
-    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
-    expect(evaluate(task).available).toBe(false);
   });
   // A correction may only clear the diagnostic for the gate it actually rewrites. The adapter has
   // already dropped the other malformed value, so a recomputation alone cannot re-detect it.
@@ -267,16 +226,7 @@ describe('overlay declared-gate normalization', () => {
     ['a prestige correction over a prerequisite diagnostic', 'requiredPrestige', 'prestige1'],
     ['a prerequisite correction over a prestige diagnostic', 'taskRequirements', []],
   ])('retains the untouched gate diagnostic under %s', async (_label, field, value) => {
-    stubOverlayFetch({ ...overlayMeta, tasks: { target: { [field]: value } } });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const broken = adaptTask({
-      requiredPrestige: { unexpected: 'prestige-id' },
-      taskRequirements: { task: 'missing' },
-    });
-    const result = await applyOverlay({
-      data: { tasks: [broken as unknown as { id: string }] },
-    });
-    const task = result.data!.tasks![0] as unknown as Task;
+    const task = await correct({ tasks: { target: { [field]: value } } }, [brokenTask()]);
     const retained =
       field === 'requiredPrestige' ? 'task_requirement' : ('prestige_reference' as const);
     expect(task.requirementDiagnostics).toEqual([retained]);
@@ -284,72 +234,59 @@ describe('overlay declared-gate normalization', () => {
     expect(evaluated.available).toBe(false);
     expect(evaluated.blockers).toContainEqual({ type: 'unknown', reason: retained });
   });
+  it('preserves an adapter diagnostic when a correction ignores the gate', async () => {
+    const broken = adaptTask({ taskRequirements: { task: 'missing' } });
+    const task = await correct({ tasks: { target: { name: 'Renamed' } } }, [
+      broken as unknown as Record<string, unknown>,
+    ]);
+    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
+    expect(evaluate(task).available).toBe(false);
+  });
+  it('diagnoses a malformed gate on an overlay-injected task', async () => {
+    const added = { id: 'added', name: 'Added', taskRequirements: { task: 'missing' } };
+    const task = await correct({ tasksAdd: { added } }, []);
+    expect(task.id).toBe('added');
+    expect(task.taskRequirements).toBeUndefined();
+    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
+    expect(evaluate(task).available).toBe(false);
+  });
   // The published overlay declares injected prestige gates this way. `applyOverlay` keeps the
   // reference verbatim, so nothing is lost and the level still resolves from the task id.
   it('accepts the id-less prestige reference the overlay injects', async () => {
     const requiredPrestige = { name: 'Prestige 4', prestigeLevel: 4 };
-    stubOverlayFetch({
-      ...overlayMeta,
-      tasksAdd: {
-        new_beginning_prestige_5: {
-          id: 'new_beginning_prestige_5',
-          name: 'New Beginning',
-          requiredPrestige,
-        },
-      },
-    });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const result = await applyOverlay({ data: { tasks: [] } });
-    const task = result.data!.tasks![0] as unknown as Task;
+    const added = { id: 'new_beginning_prestige_5', name: 'New Beginning', requiredPrestige };
+    const task = await correct({ tasksAdd: { new_beginning_prestige_5: added } }, []);
     expect(task.requirementDiagnostics).toBeUndefined();
     expect(task.requiredPrestige).toEqual(requiredPrestige);
     expect(buildPrestigeTaskMap([task], []).get(task.id)).toBe(4);
   });
   // Locale corrections are applied last, so a gate one of them declares needs the same treatment.
-  it('diagnoses a malformed gate introduced by a locale correction', async () => {
-    stubOverlayFetch({
-      ...overlayMeta,
-      locales: { en: { tasks: { target: { taskRequirements: { task: 'missing' } } } } },
-    });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const result = await applyOverlay({
-      data: { tasks: [adaptTask({}) as unknown as { id: string }] },
-    });
-    const task = result.data!.tasks![0] as unknown as Task;
+  // The patch is keyed by the pre-patch id, so one that also rewrites `id` must still be seen.
+  it.each([
+    ['a locale correction', { taskRequirements: { task: 'missing' } }, 'target'],
+    [
+      'a locale correction that rewrites the task id',
+      { id: 'renamed', taskRequirements: {} },
+      'renamed',
+    ],
+  ])('diagnoses a malformed gate introduced by %s', async (_label, patch, expectedId) => {
+    const task = await correct({ locales: { en: { tasks: { target: patch } } } }, [baseTask()]);
+    expect(task.id).toBe(expectedId);
     expect(task.taskRequirements).toBeUndefined();
     expect(task.requirementDiagnostics).toEqual(['task_requirement']);
     expect(evaluate(task).available).toBe(false);
   });
-  it('leaves an ordinary locale correction free of a fabricated diagnostic', async () => {
-    stubOverlayFetch({
-      ...overlayMeta,
-      locales: { en: { tasks: { target: { name: 'Localized' } } } },
-    });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const result = await applyOverlay({
-      data: { tasks: [adaptTask({ requiredPrestige: 'prestige1' }) as unknown as { id: string }] },
-    });
-    const task = result.data!.tasks![0] as unknown as Task;
-    expect(task.name).toBe('Localized');
+  it.each([
+    ['a task correction', { tasks: { target: { name: 'Renamed' } } }, 'Renamed'],
+    [
+      'a locale correction',
+      { locales: { en: { tasks: { target: { name: 'Localized' } } } } },
+      'Localized',
+    ],
+  ])('leaves %s free of a fabricated diagnostic', async (_label, overlay, expectedName) => {
+    const task = await correct(overlay, [baseTask({ requiredPrestige: 'prestige1' })]);
+    expect(task.name).toBe(expectedName);
     expect(task.requiredPrestige).toEqual({ id: 'prestige1' });
     expect(task.requirementDiagnostics).toBeUndefined();
-  });
-  // The patch is keyed by the pre-patch id, so a patch that also rewrites `id` must still be seen.
-  it('normalizes a locale correction that rewrites the task id', async () => {
-    stubOverlayFetch({
-      ...overlayMeta,
-      locales: {
-        en: { tasks: { target: { id: 'renamed', taskRequirements: { task: 'missing' } } } },
-      },
-    });
-    const { applyOverlay } = await import('@/server/utils/overlay');
-    const result = await applyOverlay({
-      data: { tasks: [adaptTask({}) as unknown as { id: string }] },
-    });
-    const task = result.data!.tasks![0] as unknown as Task;
-    expect(task.id).toBe('renamed');
-    expect(task.taskRequirements).toBeUndefined();
-    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
-    expect(evaluate(task).available).toBe(false);
   });
 });

--- a/app/server/utils/__tests__/declaredTaskGates.test.ts
+++ b/app/server/utils/__tests__/declaredTaskGates.test.ts
@@ -110,12 +110,18 @@ describe('malformed declared prestige references', () => {
     ['an empty string', ''],
     ['an empty id', { id: '' }],
     ['a blank id', { id: '   ' }],
+    ['an object id', { id: {} }],
     ['a number', 3],
     ['a list', ['prestige-1']],
   ])('blocks a declared prestige reference serialized as %s', (_label, requiredPrestige) => {
     const task = adaptTask({ requiredPrestige });
     expect(task.requirementDiagnostics).toEqual(['prestige_reference']);
     expect(evaluate(task).available).toBe(false);
+  });
+  it('still coerces a numeric id rather than narrowing a supported shape', () => {
+    const task = adaptTask({ requiredPrestige: { id: 42 } });
+    expect(task.requiredPrestige).toEqual({ id: '42' });
+    expect(task.requirementDiagnostics).toBeUndefined();
   });
   // A stale payload can still carry a declared falsy reference the adapter would now drop.
   it.each([[''], [0], [false]])(
@@ -327,5 +333,23 @@ describe('overlay declared-gate normalization', () => {
     expect(task.name).toBe('Localized');
     expect(task.requiredPrestige).toEqual({ id: 'prestige1' });
     expect(task.requirementDiagnostics).toBeUndefined();
+  });
+  // The patch is keyed by the pre-patch id, so a patch that also rewrites `id` must still be seen.
+  it('normalizes a locale correction that rewrites the task id', async () => {
+    stubOverlayFetch({
+      ...overlayMeta,
+      locales: {
+        en: { tasks: { target: { id: 'renamed', taskRequirements: { task: 'missing' } } } },
+      },
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({
+      data: { tasks: [adaptTask({}) as unknown as { id: string }] },
+    });
+    const task = result.data!.tasks![0] as unknown as Task;
+    expect(task.id).toBe('renamed');
+    expect(task.taskRequirements).toBeUndefined();
+    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
+    expect(evaluate(task).available).toBe(false);
   });
 });

--- a/app/server/utils/__tests__/declaredTaskGates.test.ts
+++ b/app/server/utils/__tests__/declaredTaskGates.test.ts
@@ -1,0 +1,290 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { testOverlayEditions } from '@/server/utils/__tests__/overlayFixtures';
+import { adaptTasksCoreResponse } from '@/server/utils/tarkov-json';
+import { buildTaskEvaluations, type TaskAvailabilityTeamData } from '@/stores/taskAvailability';
+import { buildPrestigeTaskMap } from '@/utils/prestige';
+import type { Task } from '@/types/tarkov';
+/**
+ * A declared gate that cannot be interpreted must reach the evaluator as a diagnostic. Absence of
+ * an optional gate and a malformed explicit gate are not allowed to become indistinguishable,
+ * because the second one silently unlocks the task.
+ */
+const mapsPayload = { maps: { map1: { id: 'map1', name: 'Customs' } } };
+const tradersPayload = { trader1: { id: 'trader1', name: 'Prapor' } };
+const adaptTask = (raw: Record<string, unknown>): Task => {
+  const tasks = { target: { id: 'target', name: 'Target', trader: 'trader1', ...raw } };
+  const [task] = adaptTasksCoreResponse({ tasks }, mapsPayload, tradersPayload).data.tasks;
+  return task!;
+};
+const progress = (overrides: Partial<TaskAvailabilityTeamData> = {}): TaskAvailabilityTeamData => ({
+  completions: {},
+  faction: 'USEC',
+  level: 99,
+  mode: 'pvp',
+  traders: {},
+  prestigeLevel: 0,
+  storyChapters: {},
+  ...overrides,
+});
+const evaluate = (task: Task, data = progress(), others: Task[] = []) =>
+  buildTaskEvaluations([task, ...others], new Map([['self', data]]), {
+    requireTraderLevels: false,
+  })[task.id]!.self!;
+const stubOverlayFetch = (overlay: Record<string, unknown>) => {
+  const fetchMock = vi.fn(
+    async () =>
+      new Response(JSON.stringify({ editions: testOverlayEditions, ...overlay }), {
+        headers: { 'Content-Type': 'application/json' },
+        status: 200,
+      })
+  );
+  vi.stubGlobal('fetch', fetchMock as typeof fetch);
+};
+afterEach(() => {
+  vi.resetModules();
+  vi.unstubAllGlobals();
+});
+describe('malformed declared prerequisite collections', () => {
+  it('blocks with an unknown diagnostic instead of discarding a non-array collection', () => {
+    const task = adaptTask({ taskRequirements: { task: 'missing', status: ['complete'] } });
+    expect(task.taskRequirements).toBeUndefined();
+    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
+    expect(evaluate(task)).toEqual({
+      available: false,
+      blockers: [{ type: 'unknown', reason: 'task_requirement' }],
+    });
+  });
+  it.each([
+    ['a bare id string', 'task0'],
+    ['a number', 7],
+    ['a boolean', true],
+  ])('blocks a declared collection serialized as %s', (_label, taskRequirements) => {
+    const task = adaptTask({ taskRequirements });
+    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
+    expect(evaluate(task).available).toBe(false);
+  });
+  it('keeps a genuinely absent or empty collection unlocked', () => {
+    for (const raw of [{}, { taskRequirements: null }, { taskRequirements: [] }]) {
+      const task = adaptTask(raw);
+      expect(task.requirementDiagnostics).toBeUndefined();
+      expect(evaluate(task).available).toBe(true);
+    }
+  });
+  it('retains the legacy bare-string prerequisite reference', () => {
+    const task = adaptTask({ taskRequirements: [{ task: 'prior', status: ['complete'] }] });
+    expect(task.taskRequirements).toEqual([{ task: { id: 'prior' }, status: ['complete'] }]);
+    const prior: Task = { id: 'prior' };
+    expect(evaluate(task, progress(), [prior]).available).toBe(false);
+    expect(
+      evaluate(task, progress({ completions: { prior: { complete: true } } }), [prior]).available
+    ).toBe(true);
+  });
+  it('lets a satisfied story route still unlock a task with a malformed collection', () => {
+    const task = adaptTask({ taskRequirements: { task: 'missing' } });
+    task.storyUnlocks = [{ id: 'chapter-1', name: 'Batya' }];
+    expect(evaluate(task).available).toBe(false);
+    expect(
+      evaluate(task, progress({ storyChapters: { 'chapter-1': { complete: true } } })).available
+    ).toBe(true);
+  });
+  it('survives a non-array collection that reaches the evaluator from a stale payload', () => {
+    const stale = { id: 'target', taskRequirements: { task: 'missing' } } as unknown as Task;
+    expect(evaluate(stale)).toEqual({
+      available: false,
+      blockers: [{ type: 'unknown', reason: 'task_requirement' }],
+    });
+  });
+});
+describe('malformed declared prestige references', () => {
+  it('blocks with an unknown diagnostic instead of discarding an id-less reference', () => {
+    const task = adaptTask({ requiredPrestige: { unexpected: 'prestige-id' } });
+    expect(task.requiredPrestige).toBeUndefined();
+    expect(task.requirementDiagnostics).toEqual(['prestige_reference']);
+    expect(evaluate(task)).toEqual({
+      available: false,
+      blockers: [{ type: 'unknown', reason: 'prestige_reference' }],
+    });
+  });
+  it.each([
+    ['an empty object', {}],
+    ['an empty string', ''],
+    ['an empty id', { id: '' }],
+    ['a number', 3],
+    ['a list', ['prestige-1']],
+  ])('blocks a declared prestige reference serialized as %s', (_label, requiredPrestige) => {
+    const task = adaptTask({ requiredPrestige });
+    expect(task.requirementDiagnostics).toEqual(['prestige_reference']);
+    expect(evaluate(task).available).toBe(false);
+  });
+  it('keeps a genuinely absent reference unlocked', () => {
+    for (const raw of [{}, { requiredPrestige: null }]) {
+      const task = adaptTask(raw);
+      expect(task.requirementDiagnostics).toBeUndefined();
+      expect(evaluate(task).available).toBe(true);
+    }
+  });
+  it.each([
+    ['a bare id string', 'prestige1'],
+    ['an object ref', { id: 'prestige1' }],
+  ])('retains the supported %s reference', (_label, requiredPrestige) => {
+    const task = adaptTask({ requiredPrestige });
+    expect(task.requiredPrestige).toEqual({ id: 'prestige1' });
+    expect(task.requirementDiagnostics).toBeUndefined();
+    const options = { requireTraderLevels: false, prestigeTaskMap: new Map([['target', 1]]) };
+    const evaluated = buildTaskEvaluations(
+      [task],
+      new Map([['self', progress({ prestigeLevel: 1 })]]),
+      options
+    );
+    expect(evaluated.target!.self!.available).toBe(true);
+  });
+  // The adapter can only store an id reference, so an id-less one is a loss and must be reported.
+  // The overlay keeps the same shape verbatim instead, which is covered below.
+  it('reports an id-less reference the adapter cannot store', () => {
+    const task = adaptTask({ requiredPrestige: { name: 'Prestige 4', prestigeLevel: 4 } });
+    expect(task.requiredPrestige).toBeUndefined();
+    expect(task.requirementDiagnostics).toEqual(['prestige_reference']);
+    expect(evaluate(task).available).toBe(false);
+  });
+  it('reports both malformed gates on the same task', () => {
+    const task = adaptTask({
+      requiredPrestige: { unexpected: 'prestige-id' },
+      taskRequirements: { task: 'missing' },
+    });
+    expect(task.requirementDiagnostics).toEqual(['task_requirement', 'prestige_reference']);
+    expect(evaluate(task).blockers).toEqual(
+      expect.arrayContaining([
+        { type: 'unknown', reason: 'task_requirement' },
+        { type: 'unknown', reason: 'prestige_reference' },
+      ])
+    );
+    expect(evaluate(task).blockers).toHaveLength(2);
+  });
+});
+describe('overlay declared-gate normalization', () => {
+  const overlayMeta = {
+    $meta: { generated: '2026-09-10T00:00:00.000Z', sha256: 'gate-sha', version: 'gate-v1' },
+  };
+  it('diagnoses a malformed gate introduced by a task correction', async () => {
+    stubOverlayFetch({
+      ...overlayMeta,
+      tasks: {
+        target: {
+          requiredPrestige: { unexpected: 'prestige-id' },
+          taskRequirements: { task: 'missing' },
+        },
+      },
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    // deepMerge treats an object patch over an existing array as an id-keyed patch map, so the
+    // reachable case is a correction that declares a gate the adapted task does not carry.
+    const result = await applyOverlay({
+      data: { tasks: [adaptTask({}) as unknown as { id: string }] },
+    });
+    const task = result.data!.tasks![0] as unknown as Task;
+    expect(task.taskRequirements).toBeUndefined();
+    expect(task.requiredPrestige).toBeUndefined();
+    expect(task.requirementDiagnostics).toEqual(['task_requirement', 'prestige_reference']);
+    expect(evaluate(task).available).toBe(false);
+  });
+  it('clears an adapter diagnostic when a correction repairs the gate', async () => {
+    stubOverlayFetch({
+      ...overlayMeta,
+      tasks: { target: { requiredPrestige: 'prestige1', taskRequirements: [] } },
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const broken = adaptTask({
+      requiredPrestige: { unexpected: 'prestige-id' },
+      taskRequirements: { task: 'missing' },
+    });
+    const result = await applyOverlay({
+      data: { tasks: [broken as unknown as { id: string }] },
+    });
+    const task = result.data!.tasks![0] as unknown as Task;
+    expect(task.requirementDiagnostics).toBeUndefined();
+    expect(task.requiredPrestige).toEqual({ id: 'prestige1' });
+    expect(task.taskRequirements).toEqual([]);
+  });
+  it('diagnoses a malformed gate on an overlay-injected task', async () => {
+    stubOverlayFetch({
+      ...overlayMeta,
+      tasksAdd: {
+        added: { id: 'added', name: 'Added', taskRequirements: { task: 'missing' } },
+      },
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({ data: { tasks: [] } });
+    const task = result.data!.tasks![0] as unknown as Task;
+    expect(task.id).toBe('added');
+    expect(task.taskRequirements).toBeUndefined();
+    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
+    expect(evaluate(task).available).toBe(false);
+  });
+  it('leaves an untouched task free of a fabricated diagnostic', async () => {
+    stubOverlayFetch({ ...overlayMeta, tasks: { target: { name: 'Renamed' } } });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({
+      data: { tasks: [adaptTask({ requiredPrestige: 'prestige1' }) as unknown as { id: string }] },
+    });
+    const task = result.data!.tasks![0] as unknown as Task;
+    expect(task.name).toBe('Renamed');
+    expect(task.requiredPrestige).toEqual({ id: 'prestige1' });
+    expect(task.requirementDiagnostics).toBeUndefined();
+  });
+  it('preserves an adapter diagnostic when a correction ignores the gate', async () => {
+    stubOverlayFetch({ ...overlayMeta, tasks: { target: { name: 'Renamed' } } });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({
+      data: {
+        tasks: [adaptTask({ taskRequirements: { task: 'missing' } }) as unknown as { id: string }],
+      },
+    });
+    const task = result.data!.tasks![0] as unknown as Task;
+    expect(task.requirementDiagnostics).toEqual(['task_requirement']);
+    expect(evaluate(task).available).toBe(false);
+  });
+  // A correction may only clear the diagnostic for the gate it actually rewrites. The adapter has
+  // already dropped the other malformed value, so a recomputation alone cannot re-detect it.
+  it.each([
+    ['a prestige correction over a prerequisite diagnostic', 'requiredPrestige', 'prestige1'],
+    ['a prerequisite correction over a prestige diagnostic', 'taskRequirements', []],
+  ])('retains the untouched gate diagnostic under %s', async (_label, field, value) => {
+    stubOverlayFetch({ ...overlayMeta, tasks: { target: { [field]: value } } });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const broken = adaptTask({
+      requiredPrestige: { unexpected: 'prestige-id' },
+      taskRequirements: { task: 'missing' },
+    });
+    const result = await applyOverlay({
+      data: { tasks: [broken as unknown as { id: string }] },
+    });
+    const task = result.data!.tasks![0] as unknown as Task;
+    const retained =
+      field === 'requiredPrestige' ? 'task_requirement' : ('prestige_reference' as const);
+    expect(task.requirementDiagnostics).toEqual([retained]);
+    const evaluated = evaluate(task);
+    expect(evaluated.available).toBe(false);
+    expect(evaluated.blockers).toContainEqual({ type: 'unknown', reason: retained });
+  });
+  // The published overlay declares injected prestige gates this way. `applyOverlay` keeps the
+  // reference verbatim, so nothing is lost and the level still resolves from the task id.
+  it('accepts the id-less prestige reference the overlay injects', async () => {
+    const requiredPrestige = { name: 'Prestige 4', prestigeLevel: 4 };
+    stubOverlayFetch({
+      ...overlayMeta,
+      tasksAdd: {
+        new_beginning_prestige_5: {
+          id: 'new_beginning_prestige_5',
+          name: 'New Beginning',
+          requiredPrestige,
+        },
+      },
+    });
+    const { applyOverlay } = await import('@/server/utils/overlay');
+    const result = await applyOverlay({ data: { tasks: [] } });
+    const task = result.data!.tasks![0] as unknown as Task;
+    expect(task.requirementDiagnostics).toBeUndefined();
+    expect(task.requiredPrestige).toEqual(requiredPrestige);
+    expect(buildPrestigeTaskMap([task], []).get(task.id)).toBe(4);
+  });
+});

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -516,19 +516,27 @@ function applyDeclaredGateNormalization(
   recordGateDiagnostics(task, [...retained, ...diagnosticsFor(dropped)]);
 }
 /**
- * Re-normalize a corrected upstream task. Only patched tasks are fresh `deepMerge` results, so
- * normalization is scoped to the fields a patch actually touched to avoid mutating shared input
- * and to let a correction clear a diagnostic the adapter recorded for that same field.
+ * Normalize the gates a patch touched. Only patched entities are fresh `deepMerge` results, so this
+ * both avoids mutating shared input and lets a correction clear the diagnostic for the field it
+ * rewrote while leaving an untouched field's diagnostic intact.
  */
+function applyPatchedGateNormalization<T extends { id: string }>(
+  task: T,
+  patch: Record<string, unknown> | undefined
+): T {
+  if (!patchesDeclaredGates(patch)) return task;
+  const record = task as Record<string, unknown>;
+  applyDeclaredGateNormalization(record, retainedGateDiagnostics(record, patch));
+  return task;
+}
+/** Re-normalize a corrected upstream task. */
 function applyTaskPatchNormalization<T extends { id: string }>(
   task: T,
   patch: Record<string, unknown> | undefined
 ): T {
   const record = task as Record<string, unknown>;
   if (patchesField(patch, 'traderRequirements')) applyTraderRequirementSplit(record);
-  if (patchesDeclaredGates(patch))
-    applyDeclaredGateNormalization(record, retainedGateDiagnostics(record, patch));
-  return applyTaskObjectiveAdditions(task);
+  return applyTaskObjectiveAdditions(applyPatchedGateNormalization(task, patch));
 }
 /** Overlay additions never pass through the adapter, so their raw gates are all still readable. */
 function applyTaskAdditionNormalization<T extends { id: string }>(task: T): T {
@@ -563,11 +571,20 @@ type OverlayTargetData = {
   hideoutStations?: Array<{ id: string }>;
 };
 function applyLocaleOverlays(target: OverlayTargetData, localeOverlay: LocaleOverlayData): void {
-  for (const collection of ['tasks', 'items', 'maps', 'traders'] as const) {
+  for (const collection of ['items', 'maps', 'traders'] as const) {
     const entities = target[collection];
     if (Array.isArray(entities))
       target[collection] = applyLocaleOverlay(entities, localeOverlay[collection]);
   }
+  // Locale patches land after the main task pass, so a gate one of them declares needs the same
+  // normalization. Locale corrections are meant to be locale-sensitive fields only; this keeps a
+  // stray gate from reaching consumers unchecked rather than trusting that convention.
+  const tasks = target.tasks;
+  if (!Array.isArray(tasks)) return;
+  const patches = localeOverlay.tasks;
+  target.tasks = applyLocaleOverlay(tasks, patches).map((task) =>
+    applyPatchedGateNormalization(task, patches?.[task.id])
+  );
 }
 function applyEntityCollectionOverlay(
   target: OverlayTargetData,

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -578,13 +578,16 @@ function applyLocaleOverlays(target: OverlayTargetData, localeOverlay: LocaleOve
   }
   // Locale patches land after the main task pass, so a gate one of them declares needs the same
   // normalization. Locale corrections are meant to be locale-sensitive fields only; this keeps a
-  // stray gate from reaching consumers unchecked rather than trusting that convention.
+  // stray gate from reaching consumers unchecked rather than trusting that convention. The merge and
+  // the normalization share one pass so the patch stays associated with its pre-patch task id.
   const tasks = target.tasks;
   if (!Array.isArray(tasks)) return;
-  const patches = localeOverlay.tasks;
-  target.tasks = applyLocaleOverlay(tasks, patches).map((task) =>
-    applyPatchedGateNormalization(task, patches?.[task.id])
-  );
+  target.tasks = tasks.map((task) => {
+    const patch = localeOverlay.tasks?.[task.id];
+    if (!isPlainObject(patch)) return task;
+    const merged = deepMerge(task as Record<string, unknown>, patch) as { id: string };
+    return applyPatchedGateNormalization(merged, patch);
+  });
 }
 function applyEntityCollectionOverlay(
   target: OverlayTargetData,

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -526,13 +526,12 @@ function applyPatchedGateNormalization<T extends { id: string }>(
   task: T,
   patch: Record<string, unknown> | undefined,
   original: T
-): T {
+): void {
   const record = task as Record<string, unknown>;
   // Diagnostics are derived state: corrections cannot replace the adapter's evidence.
   recordGateDiagnostics(record, recordedGateDiagnostics(original as Record<string, unknown>));
-  if (!patchesDeclaredGates(patch)) return task;
+  if (!patchesDeclaredGates(patch)) return;
   applyDeclaredGateNormalization(record, retainedGateDiagnostics(record, patch));
-  return task;
 }
 /** Re-normalize a corrected upstream task. */
 function applyTaskPatchNormalization<T extends { id: string }>(
@@ -542,7 +541,8 @@ function applyTaskPatchNormalization<T extends { id: string }>(
 ): T {
   const record = task as Record<string, unknown>;
   if (patchesField(patch, 'traderRequirements')) applyTraderRequirementSplit(record);
-  return applyPatchedGateNormalization(task, patch, original);
+  applyPatchedGateNormalization(task, patch, original);
+  return task;
 }
 /** Overlay additions never pass through the adapter, so their raw gates are all still readable. */
 function applyTaskAdditionNormalization<T extends { id: string }>(task: T): T {
@@ -592,7 +592,8 @@ function applyLocaleOverlays(target: OverlayTargetData, localeOverlay: LocaleOve
     const patch = localeOverlay.tasks?.[task.id];
     if (!isPlainObject(patch)) return task;
     const merged = deepMerge(task as Record<string, unknown>, patch) as { id: string };
-    return applyPatchedGateNormalization(merged, patch, task);
+    applyPatchedGateNormalization(merged, patch, task);
+    return merged;
   });
 }
 function applyEntityCollectionOverlay(

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -1,7 +1,10 @@
 import {
+  hasDeclaredPrestigeLevel,
+  isDeclaredGate,
   isValidTraderLevel,
   normalizeTraderReference,
   normalizeTraderRequirements,
+  resolveRequiredPrestige,
 } from '@/utils/taskRequirements';
 /**
  * Overlay utility for applying tarkov-data-overlay corrections to tarkov.dev API data.
@@ -24,7 +27,7 @@ import { mergeOverlayRecords, scopedOverlay } from './overlayProjectors';
 import { validateOverlayData, unknownOverlaySections } from './overlayValidation';
 import { TARKOVTRACKER_USER_AGENT } from './userAgent';
 import type { OverlayData, OverlayLocaleData as LocaleOverlayData } from './overlayTypes';
-import type { HideoutStation, TarkovItem } from '@/types/tarkov';
+import type { HideoutStation, TarkovItem, Task, TaskRequirementDiagnostic } from '@/types/tarkov';
 const logger = createLogger('Overlay');
 type OverlayStatus = 'fresh' | 'cached' | 'stale' | 'missing';
 export interface OverlayMeta {
@@ -447,6 +450,93 @@ function applyTraderRequirementSplit(task: Record<string, unknown>): void {
     traderLevelRequirements.length > 0 ? traderLevelRequirements : undefined;
   task.traderRequirements = traderRequirements.length > 0 ? traderRequirements : undefined;
 }
+const DECLARED_GATE_DIAGNOSTICS = {
+  taskRequirements: 'task_requirement',
+  requiredPrestige: 'prestige_reference',
+} as const satisfies Partial<Record<keyof Task, TaskRequirementDiagnostic>>;
+type DeclaredGateField = keyof typeof DECLARED_GATE_DIAGNOSTICS;
+const DECLARED_GATE_FIELDS = Object.keys(DECLARED_GATE_DIAGNOSTICS) as DeclaredGateField[];
+const patchesField = (patch: Record<string, unknown> | undefined, field: string): boolean =>
+  patch != null && field in patch;
+const patchesDeclaredGates = (patch: Record<string, unknown> | undefined): boolean =>
+  DECLARED_GATE_FIELDS.some((field) => patchesField(patch, field));
+const declaredGateFields = (task: Record<string, unknown>): DeclaredGateField[] =>
+  DECLARED_GATE_FIELDS.filter((field) => isDeclaredGate(task[field]));
+const diagnosticsFor = (fields: DeclaredGateField[]): TaskRequirementDiagnostic[] =>
+  fields.map((field) => DECLARED_GATE_DIAGNOSTICS[field]);
+const normalizeDeclaredRequirements = (task: Record<string, unknown>): void => {
+  if (Array.isArray(task.taskRequirements)) return;
+  delete task.taskRequirements;
+};
+const normalizeDeclaredPrestige = (task: Record<string, unknown>): void => {
+  const resolved = resolveRequiredPrestige(task.requiredPrestige);
+  if (resolved) task.requiredPrestige = resolved;
+  else if (!hasDeclaredPrestigeLevel(task.requiredPrestige)) delete task.requiredPrestige;
+};
+const orderedGateDiagnostics = (
+  diagnostics: TaskRequirementDiagnostic[]
+): TaskRequirementDiagnostic[] =>
+  diagnosticsFor(DECLARED_GATE_FIELDS).filter((diagnostic) => diagnostics.includes(diagnostic));
+const recordGateDiagnostics = (
+  task: Record<string, unknown>,
+  diagnostics: TaskRequirementDiagnostic[]
+): void => {
+  if (diagnostics.length) task.requirementDiagnostics = orderedGateDiagnostics(diagnostics);
+  else delete task.requirementDiagnostics;
+};
+const recordedGateDiagnostics = (task: Record<string, unknown>): TaskRequirementDiagnostic[] =>
+  Array.isArray(task.requirementDiagnostics)
+    ? (task.requirementDiagnostics as TaskRequirementDiagnostic[])
+    : [];
+/**
+ * A patch that leaves a gate field alone must not clear the diagnostic the adapter recorded for it:
+ * the adapter already dropped the value a recomputation would need in order to re-detect it.
+ */
+const retainedGateDiagnostics = (
+  task: Record<string, unknown>,
+  patch: Record<string, unknown> | undefined
+): TaskRequirementDiagnostic[] => {
+  const untouched = DECLARED_GATE_FIELDS.filter((field) => !patchesField(patch, field));
+  const kept = new Set(diagnosticsFor(untouched));
+  return recordedGateDiagnostics(task).filter((diagnostic) => kept.has(diagnostic));
+};
+/**
+ * The overlay merges into already-adapted tasks, so a correction or an injected task can reintroduce
+ * a raw gate the adapter would have normalized. Recomputing here keeps `taskRequirements` a list and
+ * resolves `requiredPrestige`, then reports exactly the declared gates normalization had to drop.
+ */
+function applyDeclaredGateNormalization(
+  task: Record<string, unknown>,
+  retained: TaskRequirementDiagnostic[]
+): void {
+  const declared = declaredGateFields(task);
+  normalizeDeclaredRequirements(task);
+  normalizeDeclaredPrestige(task);
+  const dropped = declared.filter((field) => task[field] === undefined);
+  recordGateDiagnostics(task, [...retained, ...diagnosticsFor(dropped)]);
+}
+/**
+ * Re-normalize a corrected upstream task. Only patched tasks are fresh `deepMerge` results, so
+ * normalization is scoped to the fields a patch actually touched to avoid mutating shared input
+ * and to let a correction clear a diagnostic the adapter recorded for that same field.
+ */
+function applyTaskPatchNormalization<T extends { id: string }>(
+  task: T,
+  patch: Record<string, unknown> | undefined
+): T {
+  const record = task as Record<string, unknown>;
+  if (patchesField(patch, 'traderRequirements')) applyTraderRequirementSplit(record);
+  if (patchesDeclaredGates(patch))
+    applyDeclaredGateNormalization(record, retainedGateDiagnostics(record, patch));
+  return applyTaskObjectiveAdditions(task);
+}
+/** Overlay additions never pass through the adapter, so their raw gates are all still readable. */
+function applyTaskAdditionNormalization<T extends { id: string }>(task: T): T {
+  const record = task as Record<string, unknown>;
+  if ('traderRequirements' in record) applyTraderRequirementSplit(record);
+  applyDeclaredGateNormalization(record, []);
+  return applyTaskObjectiveAdditions(task);
+}
 function mergeModeCorrections(
   shared: Record<string, Record<string, unknown>> | undefined,
   modeSpecific: Record<string, Record<string, unknown>> | undefined
@@ -537,13 +627,7 @@ export async function applyOverlay<T extends { data?: OverlayTargetData }>(
     const correctedTasks = applyEntityOverlay(
       result.data.tasks as Array<{ id: string }>,
       mergedTasks
-    ).map((task) => {
-      const patch = mergedTasks?.[task.id];
-      if (patch && 'traderRequirements' in patch) {
-        applyTraderRequirementSplit(task as Record<string, unknown>);
-      }
-      return applyTaskObjectiveAdditions(task);
-    });
+    ).map((task) => applyTaskPatchNormalization(task, mergedTasks?.[task.id]));
     const normalizedAdditions = normalizeTaskAdditions(mergedTasksAdd);
     logger.info(
       `Overlay tasksAdd: ${normalizedAdditions.length} additions after filtering disabled`
@@ -551,12 +635,7 @@ export async function applyOverlay<T extends { data?: OverlayTargetData }>(
     const addedTasks = applyEntityOverlay(normalizedAdditions, mergedTasks, {
       logLabel: 'tasksAdd',
       logEvenWhenZero: false,
-    }).map((task) => {
-      if ('traderRequirements' in task) {
-        applyTraderRequirementSplit(task as Record<string, unknown>);
-      }
-      return applyTaskObjectiveAdditions(task);
-    });
+    }).map(applyTaskAdditionNormalization);
     const existingIds = new Set(correctedTasks.map((task) => task.id));
     const dedupedAdditions = addedTasks.filter((task) => !existingIds.has(task.id));
     logger.info(`Overlay tasksAdd: ${dedupedAdditions.length} additions after dedupe`);

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -242,7 +242,8 @@ export async function fetchOverlay(
  * Apply overlay corrections to an array of entities
  * Filters out entities marked as disabled after applying corrections
  */
-type ApplyEntityOverlayOptions = {
+type ApplyEntityOverlayOptions<T extends { id: string }> = {
+  normalize?: (task: T, patch: Record<string, unknown>) => T;
   logLabel?: string;
   /** If true, log even when appliedCount and disabledCount are both zero. Default: true */
   logEvenWhenZero?: boolean;
@@ -250,7 +251,7 @@ type ApplyEntityOverlayOptions = {
 function applyEntityOverlay<T extends { id: string }>(
   entities: T[],
   corrections: Record<string, Record<string, unknown>> | undefined,
-  options: ApplyEntityOverlayOptions = {}
+  options: ApplyEntityOverlayOptions<T> = {}
 ): T[] {
   if (!corrections || !entities) return entities;
   let appliedCount = 0;
@@ -262,7 +263,8 @@ function applyEntityOverlay<T extends { id: string }>(
         appliedCount++;
         logger.debug(`Applying correction to ${entity.id}:`, correction);
         // Deep merge the correction into the entity (recursively merges nested objects)
-        return deepMerge(entity as Record<string, unknown>, correction) as T;
+        const merged = deepMerge(entity as Record<string, unknown>, correction) as T;
+        return options.normalize ? options.normalize(merged, correction) : merged;
       }
       return entity;
     })
@@ -536,7 +538,7 @@ function applyTaskPatchNormalization<T extends { id: string }>(
 ): T {
   const record = task as Record<string, unknown>;
   if (patchesField(patch, 'traderRequirements')) applyTraderRequirementSplit(record);
-  return applyTaskObjectiveAdditions(applyPatchedGateNormalization(task, patch));
+  return applyPatchedGateNormalization(task, patch);
 }
 /** Overlay additions never pass through the adapter, so their raw gates are all still readable. */
 function applyTaskAdditionNormalization<T extends { id: string }>(task: T): T {
@@ -646,8 +648,9 @@ export async function applyOverlay<T extends { data?: OverlayTargetData }>(
     const mergedTasksAdd = mergeModeCorrections(overlay.tasksAdd, modeOverlay?.tasksAdd);
     const correctedTasks = applyEntityOverlay(
       result.data.tasks as Array<{ id: string }>,
-      mergedTasks
-    ).map((task) => applyTaskPatchNormalization(task, mergedTasks?.[task.id]));
+      mergedTasks,
+      { normalize: applyTaskPatchNormalization }
+    ).map(applyTaskObjectiveAdditions);
     const normalizedAdditions = normalizeTaskAdditions(mergedTasksAdd);
     logger.info(
       `Overlay tasksAdd: ${normalizedAdditions.length} additions after filtering disabled`

--- a/app/server/utils/overlay.ts
+++ b/app/server/utils/overlay.ts
@@ -243,7 +243,7 @@ export async function fetchOverlay(
  * Filters out entities marked as disabled after applying corrections
  */
 type ApplyEntityOverlayOptions<T extends { id: string }> = {
-  normalize?: (task: T, patch: Record<string, unknown>) => T;
+  normalize?: (task: T, patch: Record<string, unknown>, original: T) => T;
   logLabel?: string;
   /** If true, log even when appliedCount and disabledCount are both zero. Default: true */
   logEvenWhenZero?: boolean;
@@ -264,7 +264,7 @@ function applyEntityOverlay<T extends { id: string }>(
         logger.debug(`Applying correction to ${entity.id}:`, correction);
         // Deep merge the correction into the entity (recursively merges nested objects)
         const merged = deepMerge(entity as Record<string, unknown>, correction) as T;
-        return options.normalize ? options.normalize(merged, correction) : merged;
+        return options.normalize ? options.normalize(merged, correction, entity) : merged;
       }
       return entity;
     })
@@ -524,21 +524,25 @@ function applyDeclaredGateNormalization(
  */
 function applyPatchedGateNormalization<T extends { id: string }>(
   task: T,
-  patch: Record<string, unknown> | undefined
+  patch: Record<string, unknown> | undefined,
+  original: T
 ): T {
-  if (!patchesDeclaredGates(patch)) return task;
   const record = task as Record<string, unknown>;
+  // Diagnostics are derived state: corrections cannot replace the adapter's evidence.
+  recordGateDiagnostics(record, recordedGateDiagnostics(original as Record<string, unknown>));
+  if (!patchesDeclaredGates(patch)) return task;
   applyDeclaredGateNormalization(record, retainedGateDiagnostics(record, patch));
   return task;
 }
 /** Re-normalize a corrected upstream task. */
 function applyTaskPatchNormalization<T extends { id: string }>(
   task: T,
-  patch: Record<string, unknown> | undefined
+  patch: Record<string, unknown> | undefined,
+  original: T
 ): T {
   const record = task as Record<string, unknown>;
   if (patchesField(patch, 'traderRequirements')) applyTraderRequirementSplit(record);
-  return applyPatchedGateNormalization(task, patch);
+  return applyPatchedGateNormalization(task, patch, original);
 }
 /** Overlay additions never pass through the adapter, so their raw gates are all still readable. */
 function applyTaskAdditionNormalization<T extends { id: string }>(task: T): T {
@@ -588,7 +592,7 @@ function applyLocaleOverlays(target: OverlayTargetData, localeOverlay: LocaleOve
     const patch = localeOverlay.tasks?.[task.id];
     if (!isPlainObject(patch)) return task;
     const merged = deepMerge(task as Record<string, unknown>, patch) as { id: string };
-    return applyPatchedGateNormalization(merged, patch);
+    return applyPatchedGateNormalization(merged, patch, task);
   });
 }
 function applyEntityCollectionOverlay(

--- a/app/server/utils/tarkov-json.ts
+++ b/app/server/utils/tarkov-json.ts
@@ -4,7 +4,12 @@ import { useRuntimeConfig } from '#imports';
 import { createLogger } from '@/server/utils/logger';
 import { TARKOVTRACKER_USER_AGENT } from '@/server/utils/userAgent';
 import { buildSkillImageUrl } from '@/utils/tarkovUrls';
-import { isValidTraderLevel, normalizeTraderRequirements } from '@/utils/taskRequirements';
+import {
+  isValidTraderLevel,
+  normalizeTraderRequirements,
+  resolveRequiredPrestige,
+  taskRequirementDiagnostics,
+} from '@/utils/taskRequirements';
 import type { ValidGameMode } from '@/server/utils/tarkov-cache-config';
 import type {
   FinishRewards,
@@ -809,13 +814,6 @@ function adaptTraderRequirements(
     traderRequirements: onlyIfPopulated(traderRequirements),
   };
 }
-// json.tarkov.dev may serialize requiredPrestige as a bare id string or as an object ref.
-// Accept both shapes.
-function adaptRequiredPrestigeRef(value: unknown): { id: string } | undefined {
-  if (typeof value === 'string' && value) return { id: value };
-  if (isRecord(value) && value.id != null) return { id: String(value.id) };
-  return undefined;
-}
 function adaptTaskCore(raw: JsonRecord, context: AdapterContext): Task {
   return compactObject({
     id: stringId(raw) ?? '',
@@ -828,10 +826,12 @@ function adaptTaskCore(raw: JsonRecord, context: AdapterContext): Task {
     experience: typeof raw.experience === 'number' ? raw.experience : undefined,
     wikiLink: typeof raw.wikiLink === 'string' ? raw.wikiLink : undefined,
     minPlayerLevel: typeof raw.minPlayerLevel === 'number' ? raw.minPlayerLevel : undefined,
-    requiredPrestige: adaptRequiredPrestigeRef(raw.requiredPrestige),
+    requiredPrestige: resolveRequiredPrestige(raw.requiredPrestige),
     taskRequirements: Array.isArray(raw.taskRequirements)
       ? raw.taskRequirements.map((requirement) => adaptTaskRequirement(requirement, context))
       : undefined,
+    // Dropping a declared gate above must stay observable, or a malformed gate reads as no gate.
+    requirementDiagnostics: onlyIfPopulated(taskRequirementDiagnostics(raw)),
     objectives: [],
     failConditions: [],
     ...adaptTraderRequirements(raw.traderRequirements, context),

--- a/app/stores/taskAvailability.ts
+++ b/app/stores/taskAvailability.ts
@@ -1,5 +1,9 @@
 import { resolveTraderUnlockTaskIds, type GameMode } from '@/utils/constants';
-import { compareRequirement, getTaskTraderRequirements } from '@/utils/taskRequirements';
+import {
+  compareRequirement,
+  getTaskTraderRequirements,
+  hasMalformedTaskRequirements,
+} from '@/utils/taskRequirements';
 import {
   isTaskActive,
   isTaskComplete,
@@ -7,7 +11,12 @@ import {
   type RawTaskCompletion,
 } from '@/utils/taskStatus';
 import type { UserProgressData } from '@/types/progress';
-import type { RequirementComparison, Task, TaskRequirement } from '@/types/tarkov';
+import type {
+  RequirementComparison,
+  Task,
+  TaskRequirement,
+  TaskRequirementDiagnostic,
+} from '@/types/tarkov';
 export type TaskAvailabilityTeamData = {
   completions: Record<string, RawTaskCompletion>;
   faction: string;
@@ -66,6 +75,17 @@ const isValidRequirement = (
 ): requirement is TaskRequirement =>
   Boolean(requirement?.task?.id) &&
   normalizeStatuses(requirement!).every((status) => KNOWN_STATUSES.has(status));
+const hasDiagnostic = (task: Task, diagnostic: TaskRequirementDiagnostic): boolean =>
+  (task.requirementDiagnostics ?? []).includes(diagnostic);
+/**
+ * A declared prerequisite collection the server had to drop, or one that survived in a stale
+ * payload as a non-list, cannot be read as "no prerequisites": the task stays blocked instead.
+ */
+const interpretableRequirements = (task: Task): boolean => {
+  if (hasMalformedTaskRequirements(task.taskRequirements)) return false;
+  if (hasDiagnostic(task, 'task_requirement')) return false;
+  return (task.taskRequirements ?? []).every(isValidRequirement);
+};
 const completedObjective = (
   objectives: NonNullable<UserProgressData['storyChapters']>[string]['objectives'] = {}
 ) => Object.values(objectives).some((objective) => objective.complete === true);
@@ -133,7 +153,9 @@ const terminalBlockers = (
   return undefined;
 };
 const missingPrestige = (task: Task): TaskBlocker[] =>
-  task.requiredPrestige ? [{ type: 'unknown', reason: 'prestige_reference' }] : [];
+  task.requiredPrestige || hasDiagnostic(task, 'prestige_reference')
+    ? [{ type: 'unknown', reason: 'prestige_reference' }]
+    : [];
 const traderNameFor = (task: Task) =>
   task.trader?.normalizedName || task.trader?.name?.toLowerCase();
 const traderDisplayName = (task: Task, fallback: string) => task.trader?.name || fallback;
@@ -196,13 +218,11 @@ const createTeamEvaluator = (
       return knownTraderBlockers(requirement);
     });
   const prerequisiteBlockers = (task: Task): TaskBlocker[] => {
-    const requirements = task.taskRequirements ?? [];
     const chapterIds = storyChapterIds(task);
     // A wired story route can satisfy the quest group, never trader/faction/prestige gates.
     if (chapterIds.some((id) => hasStoryUnlockProgress(id, data))) return [];
-    const malformed = requirements.filter((requirement) => !isValidRequirement(requirement));
-    if (malformed.length) return [{ type: 'unknown', reason: 'task_requirement' }];
-    return unmetPrerequisiteBlockers(requirements, chapterIds);
+    if (!interpretableRequirements(task)) return [{ type: 'unknown', reason: 'task_requirement' }];
+    return unmetPrerequisiteBlockers(task.taskRequirements ?? [], chapterIds);
   };
   const unmetPrerequisiteBlockers = (
     requirements: TaskRequirement[],

--- a/app/stores/taskAvailability.ts
+++ b/app/stores/taskAvailability.ts
@@ -157,6 +157,9 @@ const missingPrestige = (task: Task): TaskBlocker[] =>
   isDeclaredGate(task.requiredPrestige) || hasDiagnostic(task, 'prestige_reference')
     ? [{ type: 'unknown', reason: 'prestige_reference' }]
     : [];
+/** Compare a resolved prestige gate independently of malformed-reference detection. */
+const resolvedPrestigeBlockers = (current: number, required: number): TaskBlocker[] =>
+  current === required ? [] : [{ type: 'prestige', current, required, compareMethod: '=' }];
 const traderNameFor = (task: Task) =>
   task.trader?.normalizedName || task.trader?.name?.toLowerCase();
 const traderDisplayName = (task: Task, fallback: string) => task.trader?.name || fallback;
@@ -267,12 +270,10 @@ const createTeamEvaluator = (
     ];
   };
   const prestigeBlockers = (task: Task): TaskBlocker[] => {
+    if (hasDiagnostic(task, 'prestige_reference')) return missingPrestige(task);
     const required = options.prestigeTaskMap?.get(task.id);
     if (required === undefined) return missingPrestige(task);
-    const current = data.prestigeLevel ?? 0;
-    return current === required
-      ? []
-      : [{ type: 'prestige', current, required, compareMethod: '=' }];
+    return resolvedPrestigeBlockers(data.prestigeLevel ?? 0, required);
   };
   const cachedResult = (key: string, taskId: string) =>
     memo.get(key) ?? (visiting.has(key) ? result([{ type: 'cycle', taskId }]) : undefined);

--- a/app/stores/taskAvailability.ts
+++ b/app/stores/taskAvailability.ts
@@ -3,6 +3,7 @@ import {
   compareRequirement,
   getTaskTraderRequirements,
   hasMalformedTaskRequirements,
+  isDeclaredGate,
 } from '@/utils/taskRequirements';
 import {
   isTaskActive,
@@ -153,7 +154,7 @@ const terminalBlockers = (
   return undefined;
 };
 const missingPrestige = (task: Task): TaskBlocker[] =>
-  task.requiredPrestige || hasDiagnostic(task, 'prestige_reference')
+  isDeclaredGate(task.requiredPrestige) || hasDiagnostic(task, 'prestige_reference')
     ? [{ type: 'unknown', reason: 'prestige_reference' }]
     : [];
 const traderNameFor = (task: Task) =>

--- a/app/types/tarkov.ts
+++ b/app/types/tarkov.ts
@@ -109,6 +109,15 @@ export interface TraderRequirement {
   compareMethod?: RequirementComparison;
 }
 /**
+ * A task's declared prestige gate. Adapted upstream references carry `id`; overlay-injected tasks
+ * keep the declared reference verbatim, which names a level instead. Readers must not assume `id`.
+ */
+export interface TaskPrestigeReference {
+  id?: string;
+  name?: string;
+  prestigeLevel?: number;
+}
+/**
  * A gate the source declared but that could not be interpreted. Absence of an optional gate is
  * never a diagnostic, so these values keep a malformed explicit gate distinguishable from no gate.
  */
@@ -255,11 +264,7 @@ export interface Task {
   taskRequirements?: TaskRequirement[];
   storyUnlocks?: Array<{ id: string; name: string }>;
   minPlayerLevel?: number;
-  /**
-   * Adapted upstream references are always `{ id }`. Overlay-injected tasks may instead carry the
-   * declared reference verbatim (`{ name, prestigeLevel }`), so readers use `?.id` or truthiness.
-   */
-  requiredPrestige?: { id: string };
+  requiredPrestige?: TaskPrestigeReference;
   /**
    * Declared gates dropped because they could not be interpreted. The evaluator turns each one
    * into an unknown blocker so a malformed gate cannot pass as a genuinely absent optional gate.

--- a/app/types/tarkov.ts
+++ b/app/types/tarkov.ts
@@ -108,6 +108,11 @@ export interface TraderRequirement {
   requirementType?: 'level' | 'reputation';
   compareMethod?: RequirementComparison;
 }
+/**
+ * A gate the source declared but that could not be interpreted. Absence of an optional gate is
+ * never a diagnostic, so these values keep a malformed explicit gate distinguishable from no gate.
+ */
+export type TaskRequirementDiagnostic = 'prestige_reference' | 'task_requirement';
 export interface TaskTraderLevelRequirement {
   id: string;
   trader: { id: string; name: string };
@@ -250,7 +255,16 @@ export interface Task {
   taskRequirements?: TaskRequirement[];
   storyUnlocks?: Array<{ id: string; name: string }>;
   minPlayerLevel?: number;
+  /**
+   * Adapted upstream references are always `{ id }`. Overlay-injected tasks may instead carry the
+   * declared reference verbatim (`{ name, prestigeLevel }`), so readers use `?.id` or truthiness.
+   */
   requiredPrestige?: { id: string };
+  /**
+   * Declared gates dropped because they could not be interpreted. The evaluator turns each one
+   * into an unknown blocker so a malformed gate cannot pass as a genuinely absent optional gate.
+   */
+  requirementDiagnostics?: TaskRequirementDiagnostic[];
   failedRequirements?: TaskRequirement[];
   normalizedTraderRequirements?: NormalizedTraderRequirement[];
   traderLevelRequirements?: TaskTraderLevelRequirement[];

--- a/app/utils/taskRequirements.ts
+++ b/app/utils/taskRequirements.ts
@@ -103,9 +103,11 @@ export const isDeclaredGate = (value: unknown): boolean => value !== null && val
 // Accept both shapes.
 const nonemptyString = (value: unknown): value is string =>
   typeof value === 'string' && value.trim().length > 0;
+// A numeric id is coerced because it still names a real prestige row; anything else would fabricate
+// a reference (`String({})` is `'[object Object]'`), so it is treated as unresolved and reported.
 const declaredId = (value: unknown): string | undefined => {
-  if (!isRecord(value) || value.id == null) return undefined;
-  const id = String(value.id);
+  if (!isRecord(value)) return undefined;
+  const id = typeof value.id === 'number' ? String(value.id) : value.id;
   return nonemptyString(id) ? id : undefined;
 };
 export const resolveRequiredPrestige = (value: unknown): { id: string } | undefined => {

--- a/app/utils/taskRequirements.ts
+++ b/app/utils/taskRequirements.ts
@@ -1,4 +1,9 @@
-import type { NormalizedTraderRequirement, RequirementComparison, Task } from '@/types/tarkov';
+import type {
+  NormalizedTraderRequirement,
+  RequirementComparison,
+  Task,
+  TaskRequirementDiagnostic,
+} from '@/types/tarkov';
 const comparisons = new Set(['>=', '>', '<=', '<', '=', '==', '!=']);
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
@@ -91,3 +96,45 @@ export const getTaskTraderRequirements = (task: Task): NormalizedTraderRequireme
     ...(task.traderRequirements ?? []),
   ].map((value, index) => normalizeTraderRequirement(value, index));
 };
+// `null` and `undefined` are how the source spells "no gate here". Every other value is a gate the
+// source declared, so it has to survive normalization or be reported rather than quietly disappear.
+export const isDeclaredGate = (value: unknown): boolean => value !== null && value !== undefined;
+// json.tarkov.dev may serialize requiredPrestige as a bare id string or as an object ref.
+// Accept both shapes.
+const nonemptyString = (value: unknown): value is string =>
+  typeof value === 'string' && value.length > 0;
+const declaredId = (value: unknown): string | undefined => {
+  if (!isRecord(value) || value.id == null) return undefined;
+  const id = String(value.id);
+  return nonemptyString(id) ? id : undefined;
+};
+export const resolveRequiredPrestige = (value: unknown): { id: string } | undefined => {
+  if (nonemptyString(value)) return { id: value };
+  const id = declaredId(value);
+  return id ? { id } : undefined;
+};
+/** A declared prerequisite collection has to be a list; a bare object is not an empty list. */
+export const hasMalformedTaskRequirements = (value: unknown): boolean =>
+  isDeclaredGate(value) && !Array.isArray(value);
+// The published overlay declares the prestige gate of an injected task as `{ name, prestigeLevel }`
+// with no id. `applyOverlay` keeps that reference verbatim, so nothing is lost and there is nothing
+// to report; the gate itself is resolved from the task id by `buildPrestigeTaskMap`.
+export const hasDeclaredPrestigeLevel = (value: unknown): boolean =>
+  isRecord(value) && Number.isFinite(value.prestigeLevel);
+const hasUnresolvablePrestigeReference = (value: unknown): boolean =>
+  isDeclaredGate(value) && !resolveRequiredPrestige(value);
+/**
+ * Diagnostics for the declared gates a caller had to drop. `tarkov-json.ts` models
+ * `requiredPrestige` as an id reference only, so every other declared reference is dropped and
+ * reported here. `overlay.ts` keeps some references verbatim and derives its own diagnostics from
+ * what it actually dropped.
+ */
+export const taskRequirementDiagnostics = (raw: {
+  requiredPrestige?: unknown;
+  taskRequirements?: unknown;
+}): TaskRequirementDiagnostic[] => [
+  ...(hasMalformedTaskRequirements(raw.taskRequirements) ? (['task_requirement'] as const) : []),
+  ...(hasUnresolvablePrestigeReference(raw.requiredPrestige)
+    ? (['prestige_reference'] as const)
+    : []),
+];

--- a/app/utils/taskRequirements.ts
+++ b/app/utils/taskRequirements.ts
@@ -102,7 +102,7 @@ export const isDeclaredGate = (value: unknown): boolean => value !== null && val
 // json.tarkov.dev may serialize requiredPrestige as a bare id string or as an object ref.
 // Accept both shapes.
 const nonemptyString = (value: unknown): value is string =>
-  typeof value === 'string' && value.length > 0;
+  typeof value === 'string' && value.trim().length > 0;
 const declaredId = (value: unknown): string | undefined => {
   if (!isRecord(value) || value.id == null) return undefined;
   const id = String(value.id);

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1677,6 +1677,15 @@ empty list, so an older payload cannot make availability read a broken collectio
 That guard covers the evaluator only: other task consumers still assume a list, and a pre-fix payload
 that dropped a gate without recording a diagnostic stays unlocked until the refresh below replaces it.
 
+An authoritative `prestigeTaskMap` entry still governs the prestige gate and takes precedence over a
+`prestige_reference` diagnostic for the same task, including an entry inferred from a New Beginning
+task id or wikiLink. The gate is enforced from the resolved level rather than reported as unreadable,
+exactly as it already is for a valid reference that no prestige row resolves. Two adjacent paths keep
+the diagnostic intact rather than losing it: a locale task patch is re-normalized after it merges,
+because locale corrections are applied last, and `useProfileTaskMetadata.mergeProfileTasks` takes only
+objective data from the objectives catalog, so a stray gate field an overlay patch merged into that
+response cannot replace the core catalog's gates.
+
 `app/stores/taskAvailability.ts` evaluates each task/user with memoization and cycle protection.
 The result carries availability and blockers for levels, loyalty, reputation, quest statuses,
 failed branches, faction, trader unlocks, prestige and unsupported data. `useProgress.taskEvaluations`
@@ -1735,11 +1744,12 @@ not import quest completions and therefore has no trader/task backfill path.
 - A declared gate that cannot be interpreted never reads as an absent gate. An absent optional gate
   leaves the task available; a malformed explicit prerequisite collection or prestige reference keeps
   it blocked behind an unknown blocker.
-- `requirementDiagnostics` is additive to the `tasks-core-json-v3` contract and deliberately does not
-  bump the precompute or browser cache versions. A payload without the field behaves exactly as it
-  did before, the evaluator independently blocks a non-list `taskRequirements` from any payload
-  vintage, and the 12-hour edge TTL plus the matching precompute cron close the remaining gap without
-  the operator-gated 48-key rollout below.
+- `requirementDiagnostics` is additive to the `tasks-core-json-v3` contract, so recording it does not
+  bump the precompute or browser cache versions and adds no new rollout requirement. The
+  `tasks-core-json-v3` operator rollout in the next invariant is unchanged and still applies on its
+  own terms. A payload without the field behaves exactly as it did before, the evaluator
+  independently blocks a non-list `taskRequirements` from any payload vintage, and the 12-hour edge
+  TTL plus the matching precompute cron bound how long a pre-diagnostic payload can survive.
 - PvP, PvE and Seasonal evaluate only their own progress and mode-specific task metadata.
 - `tasks-core-json-v3` keys invalidate incompatible edge/precompute payloads together. Browser
   IndexedDB schema 8 clears the old task contract. Missing new KV entries fall back to the normal

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -377,6 +377,16 @@ sequenceDiagram
   `traderRequirements` (reputation-only) for compatibility, and regenerates the canonical
   `normalizedTraderRequirements` consumed by availability, badges and progress implications
   (section 15). A patch's `traderRequirements` replaces the whole requirement set.
+- Overlay corrections and `tasksAdd` entries merge into already-adapted tasks, so `applyOverlay`
+  re-normalizes the declared prerequisite and prestige gates it can reach. A corrected task is
+  re-normalized only when the patch touches `taskRequirements` or `requiredPrestige`, and a
+  recomputation clears only the diagnostic for the field that patch rewrote: the adapter already
+  dropped the other malformed value, so its diagnostic is retained rather than recomputed away. Every
+  injected task is re-normalized because additions never pass through the adapter. `taskRequirements`
+  stays a list and a resolvable `requiredPrestige` becomes a normalized `{ id }` reference. The
+  overlay keeps an id-less `{ name, prestigeLevel }` reference verbatim, so it is not a loss and gets
+  no diagnostic; only a declared gate the normalization had to drop becomes a
+  `requirementDiagnostics` entry (section 15).
 - On fetch failure, serves the last good overlay (stale) rather than failing the request.
 - Overlay supports mode-specific corrections under `modes[gameMode]` plus global corrections.
 - Per-locale corrections under `locales[locale]` patch `tasks`, `items`, `traders` and `maps`
@@ -1650,6 +1660,23 @@ become diagnostic unknown requirements, not reputation guesses. A missing compar
 legacy requirement defaults to `>=`. Declared `>=`, `>`, `<=`, `<`, `=`, `==` and `!=` are evaluated
 literally. Neither trader identity nor the sign of a value selects its meaning.
 
+Declared prerequisite collections and prestige references follow the same rule. `null` and
+`undefined` mean the optional gate is absent; every other value is a gate the source declared, so it
+either survives normalization or is recorded in `Task.requirementDiagnostics` as `task_requirement`
+or `prestige_reference`. `tarkov-json.ts` models `requiredPrestige` as an id reference only, so it
+drops anything else and records the diagnostic; `overlay.ts` reports exactly the gates its own
+normalization dropped; `taskAvailability.ts` turns each diagnostic into an unknown blocker. Supported
+source shapes are unaffected: a bare prerequisite task id, a bare prestige id string, and a prestige
+object reference all still resolve, an absent or empty collection still leaves the task available,
+and the overlay keeps the id-less `{ name, prestigeLevel }` gate of an injected New Beginning task
+verbatim (its level comes from `buildPrestigeTaskMap`'s task id/wikiLink inference, not from the
+reference). A satisfied story route continues to unlock a task whose quest group is uninterpretable,
+because that route is an alternative to the group rather than a bypass of an independent gate. The
+evaluator additionally treats a non-list `taskRequirements` as the same diagnostic rather than as an
+empty list, so an older payload cannot make availability read a broken collection as no collection.
+That guard covers the evaluator only: other task consumers still assume a list, and a pre-fix payload
+that dropped a gate without recording a diagnostic stays unlocked until the refresh below replaces it.
+
 `app/stores/taskAvailability.ts` evaluates each task/user with memoization and cycle protection.
 The result carries availability and blockers for levels, loyalty, reputation, quest statuses,
 failed branches, faction, trader unlocks, prestige and unsupported data. `useProgress.taskEvaluations`
@@ -1705,6 +1732,14 @@ not import quest completions and therefore has no trader/task backfill path.
 - Canonical requirements, blockers, status comparisons and story alternatives are shared by UI and
   recommendations; no new dependency on the removed upstream task `alternatives` is introduced.
 - Known trader gates may be disabled by preference; unknown data never silently unlocks a task.
+- A declared gate that cannot be interpreted never reads as an absent gate. An absent optional gate
+  leaves the task available; a malformed explicit prerequisite collection or prestige reference keeps
+  it blocked behind an unknown blocker.
+- `requirementDiagnostics` is additive to the `tasks-core-json-v3` contract and deliberately does not
+  bump the precompute or browser cache versions. A payload without the field behaves exactly as it
+  did before, the evaluator independently blocks a non-list `taskRequirements` from any payload
+  vintage, and the 12-hour edge TTL plus the matching precompute cron close the remaining gap without
+  the operator-gated 48-key rollout below.
 - PvP, PvE and Seasonal evaluate only their own progress and mode-specific task metadata.
 - `tasks-core-json-v3` keys invalidate incompatible edge/precompute payloads together. Browser
   IndexedDB schema 8 clears the old task contract. Missing new KV entries fall back to the normal

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1682,6 +1682,7 @@ inferred from a New Beginning task id or wikiLink: inference cannot repair a mal
 Without a diagnostic, the map continues to govern supported prestige references and inferred tasks.
 The overlay's supported id-less prestige shape is retained without a diagnostic. Two adjacent paths keep
 the diagnostic intact rather than losing it: task patches are normalized using their original id,
+and retain pre-merge diagnostics rather than accepting a patch-supplied diagnostic array,
 including locale patches after they merge,
 because locale corrections are applied last, and `useProfileTaskMetadata.mergeProfileTasks` takes only
 objective data from the objectives catalog, so a stray gate field an overlay patch merged into that

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -1677,11 +1677,12 @@ empty list, so an older payload cannot make availability read a broken collectio
 That guard covers the evaluator only: other task consumers still assume a list, and a pre-fix payload
 that dropped a gate without recording a diagnostic stays unlocked until the refresh below replaces it.
 
-An authoritative `prestigeTaskMap` entry still governs the prestige gate and takes precedence over a
-`prestige_reference` diagnostic for the same task, including an entry inferred from a New Beginning
-task id or wikiLink. The gate is enforced from the resolved level rather than reported as unreadable,
-exactly as it already is for a valid reference that no prestige row resolves. Two adjacent paths keep
-the diagnostic intact rather than losing it: a locale task patch is re-normalized after it merges,
+A `prestige_reference` diagnostic blocks independently of `prestigeTaskMap`, including entries
+inferred from a New Beginning task id or wikiLink: inference cannot repair a malformed declared gate.
+Without a diagnostic, the map continues to govern supported prestige references and inferred tasks.
+The overlay's supported id-less prestige shape is retained without a diagnostic. Two adjacent paths keep
+the diagnostic intact rather than losing it: task patches are normalized using their original id,
+including locale patches after they merge,
 because locale corrections are applied last, and `useProfileTaskMetadata.mergeProfileTasks` takes only
 objective data from the objectives catalog, so a stray gate field an overlay patch merged into that
 response cannot replace the core catalog's gates.
@@ -1748,8 +1749,11 @@ not import quest completions and therefore has no trader/task backfill path.
   bump the precompute or browser cache versions and adds no new rollout requirement. The
   `tasks-core-json-v3` operator rollout in the next invariant is unchanged and still applies on its
   own terms. A payload without the field behaves exactly as it did before, the evaluator
-  independently blocks a non-list `taskRequirements` from any payload vintage, and the 12-hour edge
-  TTL plus the matching precompute cron bound how long a pre-diagnostic payload can survive.
+  independently blocks a non-list `taskRequirements` from any payload vintage. Successful precompute
+  refreshes run every 12 hours, after which edge and browser caches must also refresh. This is not
+  a strict 12-hour recovery bound: failed runs can leave older KV entries serving for their seven-day
+  TTL. Verify a successful precompute from the deployed fix before claiming production diagnostics
+  are active; already-discarded gates cannot be recovered by the evaluator alone.
 - PvP, PvE and Seasonal evaluate only their own progress and mode-specific task metadata.
 - `tasks-core-json-v3` keys invalidate incompatible edge/precompute payloads together. Browser
   IndexedDB schema 8 clears the old task contract. Missing new KV entries fall back to the normal


### PR DESCRIPTION
# Pull Request

## Summary

Closes the remaining #727 defect: a malformed **explicit** task gate was discarded at the server
boundary, so it became indistinguishable from a genuinely **absent** optional gate and the task
silently unlocked. Both reproduced cases now produce an explicit unknown diagnostic and stay blocked.

| Source input on task `target`                                  | Before                          | After                              |
| -------------------------------------------------------------- | ------------------------------- | ---------------------------------- |
| `taskRequirements: {task:'missing', status:['complete']}`       | discarded, `available: true`    | `unknown/task_requirement`, blocked |
| `requiredPrestige: {unexpected:'prestige-id'}`                  | discarded, `available: true`    | `unknown/prestige_reference`, blocked |

The rule is now uniform: `null`/`undefined` mean the optional gate is absent, and every other value
is a gate the source declared, so it either survives normalization or is recorded in
`Task.requirementDiagnostics` for the evaluator to turn into an unknown blocker.

## Changes

- `app/types/tarkov.ts` — new `TaskRequirementDiagnostic` union (`'task_requirement' | 'prestige_reference'`)
  and additive `Task.requirementDiagnostics`.
- `app/utils/taskRequirements.ts` — shared declared-gate helpers (`isDeclaredGate`,
  `resolveRequiredPrestige`, `hasMalformedTaskRequirements`, `hasDeclaredPrestigeLevel`,
  `taskRequirementDiagnostics`). The local `adaptRequiredPrestigeRef` is folded into the shared resolver.
- `app/server/utils/tarkov-json.ts` — `adaptTaskCore` models `requiredPrestige` as an id reference
  only, so it reports every other declared reference it has to drop.
- `app/server/utils/overlay.ts` — the overlay merges into already-adapted tasks, so it re-normalizes
  the gates it can reach and reports exactly the ones **its own** normalization dropped. A correction
  is normalized only for the fields it touches, and the diagnostic for an untouched gate field is
  retained rather than recomputed away. Injected `tasksAdd` tasks are always normalized because they
  never pass through the adapter.
- `app/stores/taskAvailability.ts` — emits `unknown/task_requirement` after the story-route
  short-circuit (so OR-route semantics are preserved) and `unknown/prestige_reference` via
  `missingPrestige`. Also treats a non-list `taskRequirements` from an older payload as the same
  diagnostic instead of an empty list.
- `docs/SYSTEMS.md` — overlay behavior bullet (section 4), the declared-gate rule (section 15), and
  two new invariants including the recorded cache-version decision.

No new user-facing copy: `page.tasks.blockers.unknown` already exists.

### Preserved behavior

Absent (`undefined`, `null`) and empty (`[]`) gates stay available. The supported legacy shapes still
resolve: a bare prerequisite task id, a bare prestige id string, and a prestige object reference. The
published overlay's id-less `{ name, prestigeLevel }` gate on injected New Beginning tasks is kept
verbatim and is **not** reported (its level resolves from the task id in `buildPrestigeTaskMap`). A
satisfied story route still unlocks a task whose quest group is uninterpretable.

### Cache/contract version assessment

`requirementDiagnostics` is **purely additive**, so `TASKS_CORE_PRECOMPUTED_VERSION` and
`TASKS_CORE_CACHE_VERSION` are deliberately **not** bumped, and that decision is recorded as an
invariant in `docs/SYSTEMS.md` section 15. Reasoning:

- A payload without the field behaves exactly as it did before — no crash, no changed output.
- The evaluator independently blocks a non-list `taskRequirements` from any payload vintage.
- Successful precompute refreshes run every 12h, after which edge and browser caches must refresh.
  Failed runs can leave older KV entries serving for seven days; verify precompute from the deployed
  fix before claiming the new diagnostics are active. This is not a strict 12-hour recovery bound.
- A version bump would instead require the operator-gated rollout documented in the same section
  (48 verified KV writes), whose cold fallback exceeds the free-tier CPU budget. That cost is not
  justified for an additive field, especially as these shapes are not present in live upstream or
  overlay data (verified against the published overlay).

## Related Issues

Closes #727

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [x] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. Wrote `app/server/utils/__tests__/declaredTaskGates.test.ts` first as an adapter-to-evaluator
   reproduction: **16 failed / 6 passed** on `main`. The 6 passing were the controls (absent gates,
   valid legacy shapes), confirming the defect was scoped to malformed-but-declared input.
2. Applied the fix: **27/27 pass**. Coverage includes both reproduced cases, non-array collections as
   string/number/boolean, prestige references as empty object/empty string/empty id/number/list,
   absent and empty controls, both legacy shapes, the story-route OR case, the stale-payload
   evaluator entry, both gates malformed on one task, and five overlay cases (correction introducing
   a malformed gate, correction repairing one, injected task, untouched task, untouched gate field).
3. Full focused run — **171 passed across 8 suites**: `declaredTaskGates` 27, `tarkov-json` 31,
   `overlay` 29, `overlay.integration` 32, `taskAvailability` 30, `useMetadata.prestigeTaskMap` 7,
   `useTaskBlockerText` 5, `TaskCard` 10. Also verified `useDashboardRecommendations`,
   `taskProgressionSort`, `overlayProjectors` and `precomputedTarkov` (106 more) during development.
4. Required validation on the final diff: `pnpm run lint` PASS, `pnpm run typecheck` PASS,
   `pnpm run lint:fallow` PASS (no new complexity or dead-export findings), `prettier --check` clean.
5. Fetched the published overlay to confirm which shapes live data actually uses before deciding what
   counts as malformed.

Three independent review passes were run against the diff. The first found a blocker — a correction
touching one gate field erased the other field's adapter diagnostic, reproducing `available: true` —
plus that the live overlay's id-less prestige shape was being misclassified. Both are fixed and
covered by tests. The second found two documentation over-claims and an adapter/overlay asymmetry;
all corrected. The third approved with only low/informational findings, of which the `patchesField`
null-safety one was fixed.

## Documentation impact

- [x] Behavior changed — documentation was updated in this PR

Documents reviewed when relevant:

- [x] SYSTEMS or architecture

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [x] All existing tests still pass
- [x] I have checked for any breaking changes

## Latest review correction (`2f4fe6d6`)

The CodeRabbit finding outside the diff is fixed: ordinary and locale corrections cannot overwrite
server-derived requirement diagnostics, including when a patch repairs one gate but leaves another
malformed. Four regression cases failed before the fix and now pass. The 105 affected tests, lint,
typecheck, Fallow, formatting, and systems checks pass. Local CodeRabbit review reports zero findings;
the live-data rehearsal generated all 48 payloads successfully without production writes.
The follow-up `290d4147` makes the mutating helper return void, addressing the Sonar finding.
Final hosted tests pass, Sonar reports zero open issues, and Greptile/cubic pass. Hosted CodeRabbit
is rate-limited; the local review of the behavioral correction completed with zero findings.

## Previous validation (`6ce7c720`)

Malformed prestige diagnostics now block independently of inferred prestige levels. Ordinary task
corrections retain their original patch association when rewriting an ID, matching the locale fix.
Profile catalog regression tests verify that objective updates preserve all core diagnostics and
correctly handle undefined, null, and replacement objective/failure fields.

- 207 focused tests passed across nine suites; lint, typecheck, Fallow, formatting, systems drift,
  and diff checks passed locally.
- Local CodeRabbit review completed with zero findings.
- Current published overlay 1.92 rehearsal generated all 48 payloads without failures or production
  writes (SHA `8c80102e9f0e1e731cc7030e4eddc3ac5ff43e6cc6b59f5e5feff8e05626c368`).
- Hosted CI and all four test shards passed on this commit; Codecov reports 100% of changed lines hit.
- The four outstanding review threads are resolved. Final hosted review status remains visible in checks.
- Only the unrelated pre-existing `.nuxtrc` edit remains locally; it was excluded from the commit.

## Additional Notes

Worktree state: clean except a pre-existing unrelated `.nuxtrc` change (`nuxt prepare` catching up to
`@nuxt/test-utils` 4.2.0), deliberately left out of this commit.

Out of scope, noted for follow-up rather than mixed in here: an overlay correction that writes
`taskRequirements` in the raw upstream element shape (`{task: 'prior'}` rather than
`{task: {id: 'prior'}}`) is treated as malformed by the evaluator. That is pre-existing and not
triggered by current overlay data — all six live corrections use the resolved form.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tasks with malformed prerequisites or prestige requirements are now blocked rather than incorrectly appearing available.
  * Valid task requirements are preserved when task data or localized overlays are applied.
  * Prestige requirements are handled consistently across supported reference formats.
  * Task metadata merging now retains core requirements, gates, and diagnostics.
  * Duplicate objective processing and incorrect diagnostic clearing during overlays are prevented.

* **Documentation**
  * Clarified how malformed requirements are diagnosed and handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->











<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR preserves malformed task-gate information through adaptation, overlays, profile metadata merging, and availability evaluation so explicitly declared but uninterpretable gates remain blocked.

- Adds typed diagnostics for malformed prerequisite and prestige gates.
- Normalizes and preserves gate diagnostics across ordinary, locale, and injected overlay tasks.
- Prevents objectives-catalog metadata from overwriting core task gates.
- Adds regression coverage and documents the declared-gate and cache-version contracts.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/server/utils/overlay.ts | Re-normalizes declared gates after task overlays while preserving diagnostics for untouched malformed fields. |
| app/server/utils/tarkov-json.ts | Records diagnostics whenever adaptation drops a declared prerequisite or prestige gate. |
| app/stores/taskAvailability.ts | Converts malformed or diagnosed gates into unknown blockers while retaining story-route alternative semantics. |
| app/utils/taskRequirements.ts | Centralizes declared-gate detection, prestige-reference resolution, and diagnostic derivation. |
| app/composables/useProfileTaskMetadata.ts | Restricts objectives-catalog merging to objective fields so core gates and diagnostics remain authoritative. |
| app/types/tarkov.ts | Adds the prestige-reference shape and task requirement diagnostic contract. |
| app/server/utils/__tests__/declaredTaskGates.test.ts | Covers malformed, absent, legacy, overlay, story-route, and stale-payload gate behavior. |
| docs/SYSTEMS.md | Documents gate normalization, diagnostic propagation, evaluator behavior, and the additive cache-contract decision. |

</details>


<details open><summary><h3>Flowchart</h3></summary>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Raw task gate] --> B{Absent or null?}
  B -- Yes --> C[Optional gate absent]
  B -- No --> D{Interpretable?}
  D -- Yes --> E[Normalized gate]
  D -- No --> F[Requirement diagnostic]
  E --> G[Availability evaluator]
  F --> G
  G --> H{Story route satisfies prerequisite group?}
  H -- Yes --> I[Quest-group gate satisfied]
  H -- No --> J{Diagnostic present?}
  J -- Yes --> K[Unknown blocker]
  J -- No --> L[Evaluate normalized gate]
```
</details>

<sub>Reviews (6): Last reviewed commit: ["refactor(tasks): make gate normalization..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/290d4147dd772bb02a61387e0d6f97f16196f27b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62556447)</sub>

<!-- /greptile_comment -->
