### PR TITLE
fix(ci): use valid Codecov comment layout separators

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -24,7 +24,7 @@ bundle_analysis:
   warning_threshold: 5%
 comment:
   # Codecov names these layout entries with underscores; hyphenated values fail validation and
-  # invalidate the whole file, which silently discards the coverage statuses defined above.
+  # invalidate the whole file, causing Codecov to reuse the last valid repository YAML.
   layout: 'condensed_header, condensed_files, footer'
   require_changes: true
   require_bundle_changes: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -23,7 +23,9 @@ bundle_analysis:
   status: informational
   warning_threshold: 5%
 comment:
-  layout: 'condensed-header, condensed-files, footer'
+  # Codecov names these layout entries with underscores; hyphenated values fail validation and
+  # invalidate the whole file, which silently discards the coverage statuses defined above.
+  layout: 'condensed_header, condensed_files, footer'
   require_changes: true
   require_bundle_changes: true
   bundle_change_threshold: '1Kb'


### PR DESCRIPTION
`codecov.yml` fails Codecov's own validator. Per Codecov's documentation, when a repository-level
YAML is invalid, Codecov "keep[s] using the last valid YAML provided" — so the gates written in this
file are not the gates actually in force.

## Changes

- Rename the `comment.layout` entries to Codecov's actual names, `condensed_header` and
  `condensed_files`. The hyphenated spellings are not valid layout values.
- Add a comment recording why the separators matter, so the spelling is not "tidied" back.

No coverage targets, thresholds, or `ignore` entries are changed — only the spelling that
invalidated the file.

## Evidence

Validated with Codecov's published validator, which is the authority for this file:

```
$ curl --data-binary @codecov.yml https://codecov.io/validate
# before
Error at ['comment', 'layout']:
Unexpected values on layout: condensed-files,condensed-header
# after
Valid!
```

The post-fix parsed output contains all three intended coverage statuses:
`coverage.status.project.default`, `coverage.status.project.absolute-floor`, and
`coverage.status.patch.default`. Before the fix the validator returns only the error, with no parsed
output at all.

## Scope: what this does and does not fix

This makes the file valid. It is **not** proven to restore the missing `project` statuses.

`codecov/project` and `codecov/project/absolute-floor` have never posted a commit status in this
repository. I checked the five most recent `main` commits and the head of #834: only
`codecov/patch` and `codecov/bundles` appear. That matters because
`.github/workflows/dependabot-auto-merge.yml` polls commit status contexts, and the comment in
`codecov.yml` states that a failed `absolute-floor` status is what blocks those merges — a status
that does not exist cannot block anything.

I expected this PR's own checks to show those statuses appear, because Codecov documents that it
"will always use the current YAML on the branch being tested". They did not: this PR's head still
reports only `codecov/patch` and `codecov/bundles`. So the invalid `layout` value is not, on its
own, the reason the `project` statuses are missing.

The remaining candidates both need Codecov credentials I do not have:

- The cached last-valid YAML that Codecov fell back to may itself predate the `project` statuses.
  Repo settings → General shows "Current repository YAML", which reveals what Codecov is actually
  using.
- A Global (organization) YAML may be suppressing them. Codecov merges Global and Repository YAML,
  so a Global setting applies wherever the repository YAML does not override it.

Landing this PR is a prerequisite for either diagnosis: while the file is invalid, Codecov ignores
it, so no repository-level change can take effect. Suggest an admin check both of the above after
merge and open a follow-up if the statuses still do not post.

## Documentation impact

- [x] No behavior changed — no documentation review needed

Application behaviour is unchanged; this only repairs CI configuration. `docs/testing-coverage.md`
already describes the intended floors and stays accurate.

## Notes

Found while reviewing #834. Kept separate from that PR because it is unrelated to the EFT log
streaming change, per the one-change-per-PR rule in `README.md` and `.github/CONTRIBUTING.md`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Codecov comment layout configuration for improved compatibility with current setting names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

Corrects invalid Codecov pull-request comment layout identifiers so the repository configuration can be parsed.
- Replaces hyphenated layout names with Codecov’s underscored identifiers.
- Adds an explanatory comment documenting why the spelling must be preserved.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| codecov.yml | The layout identifiers are corrected without changing coverage targets, thresholds, status definitions, or ignored paths. |

</details>

<sub>Reviews (2): Last reviewed commit: ["docs: clarify Codecov invalid configurat..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/48c24d8097b16868c56bb51927a42f78f2bf5e61) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62600504)</sub>

<!-- /greptile_comment -->