### PR TITLE
chore(repo): untrack generated .nuxtrc module setup marker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,4 +43,7 @@ Logs - Copy.zip
 __pycache__/
 *.py[cod]
 
+# Nuxt module setup bookkeeping (rewritten by `nuxt prepare` on every module version bump)
+.nuxtrc
+
 /precompute-manifest.json

--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,1 +1,0 @@
-setups.@nuxt/test-utils="4.1.0"


### PR DESCRIPTION
# Pull Request

## Summary

`.nuxtrc` is tracked in git but is not configuration we author. Its only content is
`setups.@nuxt/test-utils`, a version marker that `@nuxt/kit` rewrites whenever the installed module
version differs from the recorded one (`callLifecycleHooks`, `@nuxt/kit/dist/index.mjs`). Because
`nuxt prepare` runs on `postinstall` and inside `lint`, `lint:fix`, `format`, `dev`, and `build`, the
file goes dirty in every worktree immediately after install, before anyone edits anything.

The recorded value has drifted from the lockfile and been swept into unrelated commits repeatedly:

| Commit     | Recorded value                    |
| ---------- | --------------------------------- |
| `b3881ff7` | `3.23.0`                          |
| `e2efce76` | `4.0.0`                           |
| `a2a04de6` | `4.0.2`                           |
| `ba6985ff` | `4.0.2`                           |
| `a27cce4e` | `4.0.3`                           |
| `5a9327c6` | `4.1.0` ← current `main`          |

`pnpm-lock.yaml` on `main` pins `@nuxt/test-utils@4.2.0` (bumped in `bd517911`, #815), so `main` is
stale by one version today and every fresh install reproduces the dirty file.

This is derived state, not configuration. It only gates the `@nuxt/test-utils` install wizard, which
independently short-circuits on `isCI || !hasTTY || nuxt.options.test` and again when a root
`vitest.config.ts` exists (`@nuxt/test-utils/dist/module.mjs` L353–364) — both true for this repo.
Nothing in the repository reads the file.

## Changes

- Delete the tracked `.nuxtrc`; `nuxt prepare` regenerates it locally on demand.
- Add `.nuxtrc` to `.gitignore` with a comment explaining that it is rewritten on module version
  bumps, so it is not re-added by a future `git add -A`.

## Related Issues

None — this is repository hygiene surfaced while working in another branch.

## Testing

- [x] Tested locally
- [ ] Tested in production-like environment
- [ ] Added/updated unit tests
- [x] Manual testing performed

### Test Plan

1. Removed `.nuxtrc` and added the ignore rule, then ran `NODE_ENV=development nuxt prepare`: it
   completed normally (`Types generated in .nuxt`), no install wizard prompt appeared, and the file
   was regenerated as `setups.@nuxt/test-utils="4.2.0"`.
2. Re-ran `nuxt prepare` with the marker present: no wizard output, confirming the lifecycle hook is
   skipped once the version matches.
3. `git check-ignore -v --no-index .nuxtrc` resolves to the new `.gitignore` rule. After
   `git rm --cached`, plain `git check-ignore -v .nuxtrc` also reports it ignored (it reports "not
   ignored" while a path is still in the index, which is expected).
4. `grep -rn "nuxtrc"` across the repository excluding `.git`, `node_modules`, `.nuxt`, and `.wt`
   returns no matches, so no workflow, script, or document depends on the file.
5. CI on this PR exercises the case that cannot be reproduced locally: a clean checkout with no
   `.nuxtrc` in the repository, where `.github/actions/setup-project` runs
   `pnpm install --frozen-lockfile` and triggers `postinstall` → `nuxt prepare`.

## Screenshots/Videos

Not applicable — no user-facing surface changes.

## Documentation impact

Select one:

- [x] No behavior changed — no documentation review needed
- [ ] Behavior changed — existing documentation remains accurate
- [ ] Behavior changed — documentation was updated in this PR
- [ ] Behavior changed — follow-up documentation issue: #

Documents reviewed when relevant:

- [ ] README or user guidance
- [ ] Contributor documentation
- [ ] SYSTEMS or architecture
- [ ] API or rate-limit reference
- [ ] Runbook or environment variables
- [ ] Screenshots or diagrams

No documentation references `.nuxtrc`, and application behavior is unchanged.

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings or errors
- [x] I have tested my changes thoroughly
- [ ] All existing tests still pass
- [x] I have checked for any breaking changes

## Additional Notes

No executable code changes, so per `AGENTS.md` the full suite was not run locally; the test box above
is left for CI on this PR to substantiate.

Expected follow-on effect: branches that predate this change still track `.nuxtrc`, so checking one
out restores the tracked file and dirties it once more. That stops for good once those branches carry
this merge.


<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

This PR removes the generated Nuxt module setup-version marker from version control and ignores future regenerated copies.
- Deletes the stale tracked `.nuxtrc` marker.
- Adds a documented `.gitignore` entry for `.nuxtrc`.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge, with no actionable behavioral or security issues identified.

Clean installs continue to run Nuxt preparation safely, while the generated marker is recreated locally and ignored instead of dirtying the worktree.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .gitignore | Ignores the generated `.nuxtrc` bookkeeping file and explains why it should remain untracked. |
| .nuxtrc | Removes a generated version marker that Nuxt recreates during preparation without affecting authored configuration. |

</details>

<sub>Reviews (1): Last reviewed commit: ["chore(repo): untrack generated .nuxtrc m..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/eba265b19e2070bc5dc35fbf39bb9c0769b8b8d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62641521)</sub>

<!-- /greptile_comment -->