### PR TITLE
feat(about): split team directory out of credits into /about

### DIFF
--- a/app/features/about/AboutHelpLinks.vue
+++ b/app/features/about/AboutHelpLinks.vue
@@ -1,0 +1,58 @@
+<template>
+  <ul class="flex flex-col">
+    <li v-for="resource in helpResources" :key="resource.href">
+      <a
+        v-if="resource.external"
+        :href="resource.href"
+        target="_blank"
+        rel="noopener noreferrer"
+        :class="linkClasses"
+      >
+        <UIcon :name="resource.icon" aria-hidden="true" class="h-4 w-4 shrink-0" />
+        <span>{{ t(resource.labelKey) }}</span>
+        <span class="sr-only">({{ t('common.opens_in_new_tab') }})</span>
+      </a>
+      <NuxtLink v-else :to="resource.href" :class="linkClasses">
+        <UIcon :name="resource.icon" aria-hidden="true" class="h-4 w-4 shrink-0" />
+        <span>{{ t(resource.labelKey) }}</span>
+      </NuxtLink>
+    </li>
+  </ul>
+</template>
+<script setup lang="ts">
+  const { t } = useI18n({ useScope: 'global' });
+  interface HelpResource {
+    href: string;
+    icon: string;
+    labelKey: string;
+    external: boolean;
+  }
+  const helpResources: HelpResource[] = [
+    {
+      href: 'https://discord.gg/M8nBgA2sT6',
+      icon: 'i-mdi-discord',
+      labelKey: 'page.about.help.discord',
+      external: true,
+    },
+    {
+      href: 'https://github.com/tarkovtracker-org/TarkovTracker/issues/new',
+      icon: 'i-mdi-github',
+      labelKey: 'page.about.help.github_issues',
+      external: true,
+    },
+    {
+      href: 'https://github.com/tarkovtracker-org/TarkovTracker/security/policy',
+      icon: 'i-mdi-shield-lock-outline',
+      labelKey: 'page.about.help.security',
+      external: true,
+    },
+    {
+      href: '/credits',
+      icon: 'i-mdi-heart-outline',
+      labelKey: 'page.about.help.credits_link',
+      external: false,
+    },
+  ];
+  const linkClasses =
+    'text-info-400 hover:text-info-300 focus-visible:ring-primary-500 inline-flex min-h-11 items-center gap-2 rounded text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none';
+</script>

--- a/app/features/about/AboutMemberCard.vue
+++ b/app/features/about/AboutMemberCard.vue
@@ -1,0 +1,63 @@
+<template>
+  <li class="bg-surface-900/80 flex flex-col gap-3 rounded-lg border border-white/10 p-5">
+    <div class="flex items-center gap-3.5">
+      <span class="h-12 w-12 shrink-0">
+        <NuxtImg
+          v-if="avatarUrl && !avatarFailed"
+          :src="avatarUrl"
+          :alt="member.displayName"
+          width="48"
+          height="48"
+          loading="lazy"
+          class="h-12 w-12 rounded-full object-cover"
+          @error="avatarFailed = true"
+        />
+        <span
+          v-else
+          aria-hidden="true"
+          class="bg-primary-500/15 text-primary-300 ring-primary-400/30 flex h-12 w-12 items-center justify-center rounded-full text-lg font-semibold ring-1"
+        >
+          {{ initial }}
+        </span>
+      </span>
+      <div class="min-w-0">
+        <p class="truncate text-sm font-semibold text-white">{{ member.displayName }}</p>
+        <p class="mt-1.5">
+          <span
+            class="inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-medium"
+            :class="roleBadgeClasses"
+          >
+            {{ t(member.roleKey) }}
+          </span>
+        </p>
+      </div>
+    </div>
+    <a
+      v-if="link"
+      :href="link.href"
+      target="_blank"
+      rel="noopener noreferrer"
+      class="text-info-400 hover:text-info-300 focus-visible:ring-primary-500 inline-flex min-h-11 items-center gap-1.5 self-start rounded text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none"
+    >
+      <UIcon :name="link.icon" aria-hidden="true" class="h-4 w-4 shrink-0" />
+      <span>{{ t(link.labelKey) }}</span>
+      <span class="sr-only">({{ t('common.opens_in_new_tab') }})</span>
+    </a>
+  </li>
+</template>
+<script setup lang="ts">
+  import { memberAvatarUrl, memberLink, type TeamMember } from '@/features/about/teamMembers';
+  const { t } = useI18n({ useScope: 'global' });
+  const props = defineProps<{
+    member: TeamMember;
+  }>();
+  const avatarFailed = ref(false);
+  const avatarUrl = computed(() => memberAvatarUrl(props.member));
+  const initial = computed(() => props.member.displayName.charAt(0).toUpperCase());
+  const link = computed(() => memberLink(props.member));
+  const roleBadgeClasses = computed(() =>
+    props.member.group === 'core'
+      ? 'border-primary-400/30 bg-primary-500/10 text-primary-300'
+      : 'border-white/10 bg-surface-800 text-surface-300'
+  );
+</script>

--- a/app/features/about/AboutMemberCard.vue
+++ b/app/features/about/AboutMemberCard.vue
@@ -5,7 +5,7 @@
         <NuxtImg
           v-if="avatarUrl && !avatarFailed"
           :src="avatarUrl"
-          :alt="member.displayName"
+          alt=""
           width="48"
           height="48"
           loading="lazy"

--- a/app/features/about/AboutMembersGroup.vue
+++ b/app/features/about/AboutMembersGroup.vue
@@ -1,0 +1,19 @@
+<template>
+  <div>
+    <h3 class="text-primary-300/80 text-xs font-semibold tracking-widest uppercase">
+      {{ t(labelKey) }}
+    </h3>
+    <ul class="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <AboutMemberCard v-for="member in members" :key="member.id" :member="member" />
+    </ul>
+  </div>
+</template>
+<script setup lang="ts">
+  import AboutMemberCard from '@/features/about/AboutMemberCard.vue';
+  import type { TeamMember } from '@/features/about/teamMembers';
+  const { t } = useI18n({ useScope: 'global' });
+  defineProps<{
+    labelKey: string;
+    members: TeamMember[];
+  }>();
+</script>

--- a/app/features/about/AboutMembersGroup.vue
+++ b/app/features/about/AboutMembersGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="members.length">
     <h3 class="text-primary-300/80 text-xs font-semibold tracking-widest uppercase">
       {{ t(labelKey) }}
     </h3>

--- a/app/features/about/__tests__/AboutHelpLinks.test.ts
+++ b/app/features/about/__tests__/AboutHelpLinks.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+describe('AboutHelpLinks', () => {
+  it('links support resources externally with safe rels and credits internally', async () => {
+    const { default: AboutHelpLinks } = await import('@/features/about/AboutHelpLinks.vue');
+    const wrapper = mount(AboutHelpLinks, {
+      global: {
+        stubs: {
+          NuxtLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
+          UIcon: { template: '<i />' },
+        },
+      },
+    });
+    const discordLink = wrapper.get('a[href="https://discord.gg/M8nBgA2sT6"]');
+    expect(discordLink.attributes('target')).toBe('_blank');
+    expect(discordLink.attributes('rel')).toBe('noopener noreferrer');
+    const securityLink = wrapper.get(
+      'a[href="https://github.com/tarkovtracker-org/TarkovTracker/security/policy"]'
+    );
+    expect(securityLink.attributes('rel')).toBe('noopener noreferrer');
+    expect(wrapper.get('a[href="/credits"]').text()).toContain('page.about.help.credits_link');
+  });
+});

--- a/app/features/about/__tests__/aboutComponents.test.ts
+++ b/app/features/about/__tests__/aboutComponents.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+import AboutMemberCard from '@/features/about/AboutMemberCard.vue';
+import AboutMembersGroup from '@/features/about/AboutMembersGroup.vue';
+import type { TeamMember } from '@/features/about/teamMembers';
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+const member: TeamMember = {
+  id: 'maintainer',
+  displayName: 'Maintainer',
+  group: 'core',
+  roleKey: 'page.about.roles.core_owner',
+  githubUsername: 'maintainer',
+};
+const global = {
+  stubs: {
+    NuxtImg: { props: ['src', 'alt'], template: '<img :src="src" :alt="alt" />' },
+    UIcon: { template: '<i />' },
+  },
+};
+describe('about member presentation', () => {
+  it('shows a decorative avatar and safe profile link, falling back after an image error', async () => {
+    const wrapper = mount(AboutMemberCard, { props: { member }, global });
+    expect(wrapper.get('img').attributes()).toMatchObject({
+      src: 'https://github.com/maintainer.png?size=96',
+      alt: '',
+      loading: 'lazy',
+    });
+    expect(wrapper.get('a').attributes()).toMatchObject({
+      href: 'https://github.com/maintainer',
+      target: '_blank',
+      rel: 'noopener noreferrer',
+    });
+    expect(wrapper.text()).toContain(member.roleKey);
+    expect(wrapper.get('span.border').classes()).toContain('text-primary-300');
+    await wrapper.get('img').trigger('error');
+    expect(wrapper.find('img').exists()).toBe(false);
+    expect(wrapper.get('span[aria-hidden="true"]').text()).toBe('M');
+  });
+  it('shows an unlinked monogram for support members without verified profiles', () => {
+    const wrapper = mount(AboutMemberCard, {
+      props: {
+        member: {
+          id: 'support',
+          displayName: 'Support',
+          group: 'support',
+          roleKey: 'page.about.roles.discord_support',
+        },
+      },
+      global,
+    });
+    expect(wrapper.find('img').exists()).toBe(false);
+    expect(wrapper.find('a').exists()).toBe(false);
+    expect(wrapper.get('span[aria-hidden="true"]').text()).toBe('S');
+    expect(wrapper.get('span.border').classes()).toContain('text-surface-300');
+  });
+  it('renders partner project links with their localized label', () => {
+    const wrapper = mount(AboutMemberCard, {
+      props: {
+        member: {
+          id: 'partner',
+          displayName: 'Partner',
+          group: 'partner',
+          roleKey: 'page.about.roles.tarkov_dev_maintainer',
+          projectUrl: 'https://tarkov.dev/',
+          projectLabelKey: 'page.about.projects.tarkov_dev',
+        },
+      },
+      global,
+    });
+    expect(wrapper.get('a').attributes('href')).toBe('https://tarkov.dev/');
+    expect(wrapper.get('a').text()).toContain('page.about.projects.tarkov_dev');
+  });
+  it('hides empty groups and reacts when members are added or removed', async () => {
+    const wrapper = mount(AboutMembersGroup, {
+      props: { labelKey: 'page.about.team.core_heading', members: [] },
+      global,
+    });
+    expect(wrapper.find('h3').exists()).toBe(false);
+    expect(wrapper.find('ul').exists()).toBe(false);
+    await wrapper.setProps({ members: [member] });
+    expect(wrapper.get('h3').text()).toBe('page.about.team.core_heading');
+    expect(wrapper.findAll('li')).toHaveLength(1);
+    expect(wrapper.text()).toContain('Maintainer');
+    await wrapper.setProps({ members: [] });
+    expect(wrapper.find('div').exists()).toBe(false);
+  });
+});

--- a/app/features/about/__tests__/teamMembers.test.ts
+++ b/app/features/about/__tests__/teamMembers.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  memberAvatarUrl,
+  memberLink,
+  membersByGroup,
+  teamMembers,
+} from '@/features/about/teamMembers';
+describe('teamMembers roster', () => {
+  it('keeps a stable group order: core first, then support, then partners', () => {
+    const groups = teamMembers.map((member) => member.group);
+    const firstSupport = groups.indexOf('support');
+    const firstPartner = groups.indexOf('partner');
+    expect(groups.indexOf('core')).toBe(0);
+    expect(firstSupport).toBeGreaterThan(-1);
+    expect(firstPartner).toBeGreaterThan(firstSupport);
+  });
+  it('lists every roster id exactly once', () => {
+    const ids = teamMembers.map((member) => member.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+  it('partners expose a project URL and label', () => {
+    for (const partner of membersByGroup('partner')) {
+      expect(partner.projectUrl).toMatch(/^https:\/\//);
+      expect(partner.projectLabelKey).toBeTruthy();
+    }
+  });
+  it('uses i18n keys for roles, never raw copy', () => {
+    for (const member of teamMembers) {
+      expect(member.roleKey).toMatch(/^page\.about\.roles\./);
+    }
+  });
+  it('prefers GitHub avatar URLs over monograms when a username is verified', () => {
+    expect(memberAvatarUrl({ ...teamMembers[0]! })).toBe('https://github.com/dysektai.png?size=96');
+    const dio = teamMembers.find((member) => member.id === 'dio');
+    expect(dio).toBeDefined();
+    expect(memberAvatarUrl(dio!)).toBeUndefined();
+  });
+  it('links members to GitHub profiles or partner projects', () => {
+    const dysekt = teamMembers.find((member) => member.id === 'dysektai');
+    expect(memberLink(dysekt!)).toEqual({
+      href: 'https://github.com/dysektai',
+      icon: 'i-mdi-github',
+      labelKey: 'page.about.github_profile',
+    });
+    const razzmatazz = teamMembers.find((member) => member.id === 'razzmatazz');
+    expect(memberLink(razzmatazz!)).toEqual({
+      href: 'https://tarkov.dev/',
+      icon: 'i-mdi-open-in-new',
+      labelKey: 'page.about.projects.tarkov_dev',
+    });
+    expect(memberLink(dioFixture())).toBeNull();
+  });
+});
+const dioFixture = () => {
+  const dio = teamMembers.find((member) => member.id === 'dio');
+  if (!dio) throw new Error('roster changed: dio missing');
+  return dio;
+};

--- a/app/features/about/__tests__/teamMembers.test.ts
+++ b/app/features/about/__tests__/teamMembers.test.ts
@@ -30,7 +30,9 @@ describe('teamMembers roster', () => {
     }
   });
   it('prefers GitHub avatar URLs over monograms when a username is verified', () => {
-    expect(memberAvatarUrl({ ...teamMembers[0]! })).toBe('https://github.com/dysektai.png?size=96');
+    const dysekt = teamMembers.find((member) => member.id === 'dysektai');
+    expect(dysekt).toBeDefined();
+    expect(memberAvatarUrl(dysekt!)).toBe('https://github.com/dysektai.png?size=96');
     const dio = teamMembers.find((member) => member.id === 'dio');
     expect(dio).toBeDefined();
     expect(memberAvatarUrl(dio!)).toBeUndefined();

--- a/app/features/about/teamMembers.ts
+++ b/app/features/about/teamMembers.ts
@@ -1,0 +1,101 @@
+export type TeamMemberGroup = 'core' | 'support' | 'partner';
+export interface TeamMember {
+  /** Stable identifier used for list keys and ordering. */
+  id: string;
+  displayName: string;
+  /** i18n key under `page.about.roles` — never raw English. */
+  roleKey: string;
+  /** Only set when verified from repo sources (credits data, CODEOWNERS). */
+  githubUsername?: string;
+  /** Only set for partners; repo-verified project URLs only. */
+  projectUrl?: string;
+  /** i18n key under `page.about.projects`. */
+  projectLabelKey?: string;
+  group: TeamMemberGroup;
+}
+const githubAvatarUrl = (username: string): string => `https://github.com/${username}.png?size=96`;
+const githubProfileUrl = (username: string): string => `https://github.com/${username}`;
+/**
+ * Canonical TarkovTracker.org roster (issue #707). Fields that cannot be
+ * verified from repo sources are omitted rather than guessed; members
+ * without a verified GitHub username render a monogram avatar.
+ * Order is stable: core owner first, then maintainers, support, partners.
+ */
+export const teamMembers: TeamMember[] = [
+  {
+    id: 'dysektai',
+    displayName: 'DysektAI',
+    roleKey: 'page.about.roles.core_owner',
+    githubUsername: 'dysektai',
+    group: 'core',
+  },
+  {
+    id: 'niv',
+    displayName: 'Niv',
+    roleKey: 'page.about.roles.discord_owner_developer',
+    githubUsername: 'nivmizz7',
+    group: 'core',
+  },
+  {
+    id: 'chica',
+    displayName: 'Chica',
+    roleKey: 'page.about.roles.core_support',
+    githubUsername: 'chica999',
+    group: 'support',
+  },
+  {
+    id: 'adealia',
+    displayName: 'Adealia',
+    roleKey: 'page.about.roles.discord_support',
+    githubUsername: 'adealia',
+    group: 'support',
+  },
+  {
+    id: 'dio',
+    displayName: 'Dio',
+    roleKey: 'page.about.roles.discord_support',
+    group: 'support',
+  },
+  {
+    id: 'mrbreachie',
+    displayName: 'MrBreachie',
+    roleKey: 'page.about.roles.discord_support',
+    group: 'support',
+  },
+  {
+    id: 'razzmatazz',
+    displayName: 'Razzmatazz',
+    roleKey: 'page.about.roles.tarkov_dev_maintainer',
+    projectUrl: 'https://tarkov.dev/',
+    projectLabelKey: 'page.about.projects.tarkov_dev',
+    group: 'partner',
+  },
+  {
+    id: 'blightbuster',
+    displayName: 'Moritz (Blightbuster)',
+    roleKey: 'page.about.roles.ratscanner_maintainer',
+    projectUrl: 'https://ratscanner.com',
+    projectLabelKey: 'page.about.projects.ratscanner',
+    group: 'partner',
+  },
+];
+export const membersByGroup = (group: TeamMemberGroup): TeamMember[] =>
+  teamMembers.filter((member) => member.group === group);
+export type TeamMemberLink = { href: string; icon: string; labelKey: string };
+/** Displays either the verified GitHub profile or the partner project. */
+export const memberLink = (member: TeamMember): TeamMemberLink | null => {
+  if (member.githubUsername) {
+    return {
+      href: githubProfileUrl(member.githubUsername),
+      icon: 'i-mdi-github',
+      labelKey: 'page.about.github_profile',
+    };
+  }
+  if (member.projectUrl && member.projectLabelKey) {
+    return { href: member.projectUrl, icon: 'i-mdi-open-in-new', labelKey: member.projectLabelKey };
+  }
+  return null;
+};
+/** Avatar URL when a GitHub username is verified, otherwise undefined (monogram). */
+export const memberAvatarUrl = (member: TeamMember): string | undefined =>
+  member.githubUsername ? githubAvatarUrl(member.githubUsername) : undefined;

--- a/app/features/credits/__tests__/creditsComponents.test.ts
+++ b/app/features/credits/__tests__/creditsComponents.test.ts
@@ -148,8 +148,6 @@ describe('credits member presentation', () => {
   it('keeps the static credit groups ordered and uniquely keyed', () => {
     expect(staticCreditSections.map((section) => section.key)).toEqual([
       'original_creator',
-      'staff',
-      'support_members',
       'beta_testers',
     ]);
     expect(new Set(staticCreditSections.map((section) => section.key)).size).toBe(

--- a/app/features/credits/creditSections.ts
+++ b/app/features/credits/creditSections.ts
@@ -15,24 +15,10 @@ const githubMember = (name: string, username: string): CreditMember => ({
 const sortMembers = (members: CreditMember[]) =>
   [...members].sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' }));
 export const staticCreditSections: CreditSection[] = [
-  { key: 'original_creator', members: [githubMember('Thaddeus', 'thaddeus')] },
   {
-    key: 'staff',
-    members: sortMembers([
-      githubMember('DysektAI', 'dysektai'),
-      githubMember('Niv', 'nivmizz7'),
-      githubMember('Chica999', 'chica999'),
-    ]),
-  },
-  {
-    key: 'support_members',
-    members: sortMembers([
-      githubMember('Adealia', 'adealia'),
-      { name: 'Dio' },
-      { name: 'MrBreachie' },
-    ]),
+    key: 'original_creator',
+    members: [githubMember('Thaddeus', 'thaddeus')],
     fullWidth: true,
-    compact: true,
   },
   {
     key: 'beta_testers',

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -262,6 +262,7 @@
     "maps": "Maps",
     "clear_search": "Clear search",
     "settings": "Settings",
+    "about": "About",
     "credits": "Credits",
     "support": "Support",
     "privacy_policy": "Privacy Policy",
@@ -1347,8 +1348,6 @@
     "credits": {
       "sections": {
         "original_creator": "Original Creator",
-        "staff": "TarkovTracker.org Staff",
-        "support_members": "Support Members",
         "beta_testers": "Nuxt - Closed Beta Testers",
         "contributors": "Open Source Contributors"
       },
@@ -1363,7 +1362,44 @@
         "contributions": "{count} contribution | {count} contributions",
         "total": "{count} contributor | {count} contributors"
       },
-      "description": "Meet the creators, staff, support members, beta testers, and open source contributors behind Tarkov Tracker."
+      "description": "Meet the beta testers and open source contributors behind Tarkov Tracker.",
+      "team_link": "Maintained by the TarkovTracker team — meet them on the About page"
+    },
+    "about": {
+      "title": "About TarkovTracker",
+      "description": "Meet the team that maintains TarkovTracker.org, the partners behind its game data, and how to get help from the community.",
+      "intro": "TarkovTracker is a free, open source progress tracker for Escape from Tarkov. It keeps your quest and storyline progress, hideout upgrades, and item requirements in one place, and stays current with community-maintained game data. The project is run by a small volunteer team with help from open source contributors.",
+      "team": {
+        "heading": "Team",
+        "summary": "TarkovTracker.org is maintained by a small volunteer team. The people below keep the site running and support the Discord community.",
+        "core_heading": "Core team",
+        "support_heading": "Discord support"
+      },
+      "partners": {
+        "heading": "Partners & ecosystem",
+        "summary": "TarkovTracker builds on community projects. These maintainers run the independent tools and data sources the tracker relies on."
+      },
+      "help": {
+        "heading": "How to get help",
+        "routing": "For the fastest answer, use the channel-specific support workflows in our Discord instead of direct messages to team members. Reproducible bugs and feature ideas belong on GitHub, and security reports go through our private security policy.",
+        "discord": "Community support on Discord",
+        "github_issues": "Report a bug or request a feature on GitHub",
+        "security": "Report a security issue (private)",
+        "credits_link": "Beta testers and open source contributors — see Credits"
+      },
+      "github_profile": "GitHub profile",
+      "roles": {
+        "core_owner": "Core owner, maintainer & developer",
+        "discord_owner_developer": "Discord server owner, TrackerBot developer & maintainer",
+        "core_support": "Core support staff",
+        "discord_support": "Discord general support",
+        "tarkov_dev_maintainer": "Maintainer of Tarkov.dev",
+        "ratscanner_maintainer": "Owner & maintainer of RatScanner"
+      },
+      "projects": {
+        "tarkov_dev": "Tarkov.dev",
+        "ratscanner": "RatScanner"
+      }
     },
     "login": {
       "subtitle": "Sign in to access your account",

--- a/app/pages/__tests__/about.test.ts
+++ b/app/pages/__tests__/about.test.ts
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+import { mockNuxtImport } from '@nuxt/test-utils/runtime';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it, vi } from 'vitest';
+const { seoMeta, head } = vi.hoisted(() => ({ seoMeta: vi.fn(), head: vi.fn() }));
+mockNuxtImport('useSeoMeta', () => seoMeta);
+mockNuxtImport('useHead', () => head);
+mockNuxtImport('useRuntimeConfig', () => () => ({
+  public: { appUrl: 'https://tarkovtracker.org' },
+}));
+vi.mock('vue-i18n', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('vue-i18n')>()),
+  useI18n: () => ({
+    t: (key: string, fallback?: string) => fallback ?? key,
+  }),
+}));
+const mountAbout = async () => {
+  const { default: AboutPage } = await import('@/pages/about.vue');
+  return mount(AboutPage, {
+    global: {
+      stubs: {
+        AboutMemberCard: {
+          props: ['member'],
+          template:
+            '<li data-testid="member-card" :data-group="member.group">{{ member.displayName }}</li>',
+        },
+        AboutMembersGroup: {
+          props: ['labelKey', 'members'],
+          template:
+            '<div data-testid="member-group" :data-label="labelKey">' +
+            '<span v-for="m in members" :key="m.id">{{ m.displayName }}</span></div>',
+        },
+        AboutHelpLinks: { template: '<div data-testid="help-links" />' },
+        NuxtLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
+        UContainer: { template: '<main><slot /></main>' },
+        UIcon: { template: '<i />' },
+      },
+    },
+  });
+};
+describe('about page', () => {
+  it('renders team, partners, and help sections with semantic headings', async () => {
+    const wrapper = await mountAbout();
+    expect(wrapper.get('h1').text()).toBe('page.about.title');
+    expect(wrapper.get('section#team h2').text()).toBe('page.about.team.heading');
+    expect(wrapper.get('section#partners h2').text()).toBe('page.about.partners.heading');
+    expect(wrapper.get('section#help h2').text()).toBe('page.about.help.heading');
+    const groups = wrapper.findAll('[data-testid="member-group"]');
+    expect(groups.map((group) => group.attributes('data-label'))).toEqual([
+      'page.about.team.core_heading',
+      'page.about.team.support_heading',
+    ]);
+    expect(wrapper.text()).toContain('DysektAI');
+    const partnerCards = wrapper
+      .findAll('[data-testid="member-card"]')
+      .filter((card) => card.attributes('data-group') === 'partner');
+    expect(partnerCards.length).toBeGreaterThan(0);
+    expect(wrapper.findAll('[data-testid="help-links"]')).toHaveLength(1);
+  });
+  it('configures localized metadata, canonical link, and Organization JSON-LD', async () => {
+    await mountAbout();
+    expect(seoMeta).toHaveBeenCalledWith(
+      expect.objectContaining({
+        title: expect.any(Object),
+        description: expect.any(Object),
+        ogUrl: 'https://tarkovtracker.org/about',
+      })
+    );
+    const metadata = seoMeta.mock.calls[0]?.[0];
+    expect(metadata.title.value).toBe('page.about.title');
+    const headConfig = head.mock.calls[0]?.[0]();
+    expect(headConfig.link).toEqual(
+      expect.arrayContaining([{ rel: 'canonical', href: 'https://tarkovtracker.org/about' }])
+    );
+    const jsonLdScript = headConfig.script?.find(
+      (entry: { type?: string }) => entry.type === 'application/ld+json'
+    );
+    expect(jsonLdScript).toBeDefined();
+    const organization = JSON.parse(jsonLdScript.innerHTML);
+    expect(organization['@type']).toBe('Organization');
+    expect(organization.url).toBe('https://tarkovtracker.org');
+    expect(organization.member.map((m: { name: string }) => m.name)).toContain('DysektAI');
+  });
+});

--- a/app/pages/__tests__/about.test.ts
+++ b/app/pages/__tests__/about.test.ts
@@ -1,7 +1,7 @@
 // @vitest-environment happy-dom
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { mount } from '@vue/test-utils';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 const { seoMeta, head } = vi.hoisted(() => ({ seoMeta: vi.fn(), head: vi.fn() }));
 mockNuxtImport('useSeoMeta', () => seoMeta);
 mockNuxtImport('useHead', () => head);
@@ -14,6 +14,16 @@ vi.mock('vue-i18n', async (importOriginal) => ({
     t: (key: string, fallback?: string) => fallback ?? key,
   }),
 }));
+const { hiddenGroups } = vi.hoisted(() => ({ hiddenGroups: new Set<string>() }));
+vi.mock('@/features/about/teamMembers', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/about/teamMembers')>();
+  return {
+    ...actual,
+    membersByGroup: (group: Parameters<typeof actual.membersByGroup>[0]) =>
+      hiddenGroups.has(group) ? [] : actual.membersByGroup(group),
+  };
+});
+afterEach(() => hiddenGroups.clear());
 const mountAbout = async () => {
   const { default: AboutPage } = await import('@/pages/about.vue');
   return mount(AboutPage, {
@@ -39,6 +49,18 @@ const mountAbout = async () => {
   });
 };
 describe('about page', () => {
+  it.each([['core'], ['support'], ['core', 'support', 'partner']])(
+    'omits empty roster sections for hidden groups %j',
+    async (...groups) => {
+      groups.forEach((group) => hiddenGroups.add(group));
+      const wrapper = await mountAbout();
+      expect(wrapper.find('section#team').exists()).toBe(
+        !(hiddenGroups.has('core') && hiddenGroups.has('support'))
+      );
+      expect(wrapper.find('section#partners').exists()).toBe(!hiddenGroups.has('partner'));
+      expect(wrapper.find('section#help').exists()).toBe(true);
+    }
+  );
   it('renders team, partners, and help sections with semantic headings', async () => {
     const wrapper = await mountAbout();
     expect(wrapper.get('h1').text()).toBe('page.about.title');
@@ -57,21 +79,20 @@ describe('about page', () => {
     expect(partnerCards.length).toBeGreaterThan(0);
     expect(wrapper.findAll('[data-testid="help-links"]')).toHaveLength(1);
   });
-  it('configures localized metadata, canonical link, and Organization JSON-LD', async () => {
+  it('configures localized metadata and accurate Organization JSON-LD', async () => {
     await mountAbout();
     expect(seoMeta).toHaveBeenCalledWith(
       expect.objectContaining({
         title: expect.any(Object),
         description: expect.any(Object),
-        ogUrl: 'https://tarkovtracker.org/about',
       })
     );
     const metadata = seoMeta.mock.calls[0]?.[0];
     expect(metadata.title.value).toBe('page.about.title');
     const headConfig = head.mock.calls[0]?.[0]();
-    expect(headConfig.link).toEqual(
-      expect.arrayContaining([{ rel: 'canonical', href: 'https://tarkovtracker.org/about' }])
-    );
+    expect(headConfig.link).toBeUndefined();
+    expect(metadata.ogUrl).toBeUndefined();
+    expect(metadata.description.value).toBe('page.about.description');
     const jsonLdScript = headConfig.script?.find(
       (entry: { type?: string }) => entry.type === 'application/ld+json'
     );
@@ -79,6 +100,11 @@ describe('about page', () => {
     const organization = JSON.parse(jsonLdScript.innerHTML);
     expect(organization['@type']).toBe('Organization');
     expect(organization.url).toBe('https://tarkovtracker.org');
-    expect(organization.member.map((m: { name: string }) => m.name)).toContain('DysektAI');
+    expect(organization.member).toEqual(
+      ['DysektAI', 'Niv', 'Chica', 'Adealia', 'Dio', 'MrBreachie'].map((name) => ({
+        '@type': 'Person',
+        name,
+      }))
+    );
   });
 });

--- a/app/pages/__tests__/credits.test.ts
+++ b/app/pages/__tests__/credits.test.ts
@@ -46,11 +46,8 @@ describe('credits page', () => {
     expect(metadata.description.value).toBe(
       'Meet the beta testers and open source contributors behind Tarkov Tracker.'
     );
-    expect(metadata.ogUrl).toBe('https://tarkovtracker.org/credits');
-    const headConfig = head.mock.calls[0]?.[0]();
-    expect(headConfig.link).toEqual(
-      expect.arrayContaining([{ rel: 'canonical', href: 'https://tarkovtracker.org/credits' }])
-    );
+    expect(metadata.ogUrl).toBeUndefined();
+    expect(head).not.toHaveBeenCalled();
   });
   it('links to the about page for the team directory', async () => {
     const { default: CreditsPage } = await import('@/pages/credits.vue');

--- a/app/pages/__tests__/credits.test.ts
+++ b/app/pages/__tests__/credits.test.ts
@@ -2,8 +2,12 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it, vi } from 'vitest';
-const { seoMeta } = vi.hoisted(() => ({ seoMeta: vi.fn() }));
+const { seoMeta, head } = vi.hoisted(() => ({ seoMeta: vi.fn(), head: vi.fn() }));
 mockNuxtImport('useSeoMeta', () => seoMeta);
+mockNuxtImport('useHead', () => head);
+mockNuxtImport('useRuntimeConfig', () => () => ({
+  public: { appUrl: 'https://tarkovtracker.org' },
+}));
 vi.mock('vue-i18n', async (importOriginal) => ({
   ...(await importOriginal<typeof import('vue-i18n')>()),
   useI18n: () => ({
@@ -22,11 +26,13 @@ describe('credits page', () => {
             template:
               '<ul><li v-for="member in members" :key="member.name">{{ member.name }}</li></ul>',
           },
+          NuxtLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
           UContainer: { template: '<main><slot /></main>' },
+          UIcon: { template: '<i />' },
         },
       },
     });
-    expect(wrapper.findAll('section')).toHaveLength(4);
+    expect(wrapper.findAll('section')).toHaveLength(2);
     expect(wrapper.find('[data-testid="contributors"]').exists()).toBe(true);
     expect(wrapper.text()).toContain('page.credits.sections.original_creator');
     expect(seoMeta).toHaveBeenCalledWith(
@@ -38,7 +44,28 @@ describe('credits page', () => {
     const metadata = seoMeta.mock.calls[0]?.[0];
     expect(metadata.title.value).toBe('common.credits');
     expect(metadata.description.value).toBe(
-      'Meet the team, testers, and open source contributors behind Tarkov Tracker.'
+      'Meet the beta testers and open source contributors behind Tarkov Tracker.'
     );
+    expect(metadata.ogUrl).toBe('https://tarkovtracker.org/credits');
+    const headConfig = head.mock.calls[0]?.[0]();
+    expect(headConfig.link).toEqual(
+      expect.arrayContaining([{ rel: 'canonical', href: 'https://tarkovtracker.org/credits' }])
+    );
+  });
+  it('links to the about page for the team directory', async () => {
+    const { default: CreditsPage } = await import('@/pages/credits.vue');
+    const wrapper = mount(CreditsPage, {
+      global: {
+        stubs: {
+          ContributorsList: { template: '<div />' },
+          CreditMemberList: { template: '<ul />' },
+          NuxtLink: { props: ['to'], template: '<a :href="to"><slot /></a>' },
+          UContainer: { template: '<main><slot /></main>' },
+          UIcon: { template: '<i />' },
+        },
+      },
+    });
+    const aboutLink = wrapper.get('a[href="/about"]');
+    expect(aboutLink.text()).toContain('page.credits.team_link');
   });
 });

--- a/app/pages/__tests__/credits.test.ts
+++ b/app/pages/__tests__/credits.test.ts
@@ -2,12 +2,27 @@
 import { mockNuxtImport } from '@nuxt/test-utils/runtime';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it, vi } from 'vitest';
-const { seoMeta, head } = vi.hoisted(() => ({ seoMeta: vi.fn(), head: vi.fn() }));
+const { seoMeta } = vi.hoisted(() => ({ seoMeta: vi.fn() }));
 mockNuxtImport('useSeoMeta', () => seoMeta);
-mockNuxtImport('useHead', () => head);
-mockNuxtImport('useRuntimeConfig', () => () => ({
-  public: { appUrl: 'https://tarkovtracker.org' },
-}));
+vi.mock('@/features/credits/creditSections', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/features/credits/creditSections')>();
+  return {
+    ...actual,
+    staticCreditSections: [
+      {
+        key: 'original_creator',
+        members: [{ name: 'Thaddeus' }],
+        fullWidth: true,
+      },
+      {
+        key: 'beta_testers',
+        members: [{ name: 'Adealia' }],
+        fullWidth: false,
+        compact: true,
+      },
+    ],
+  };
+});
 vi.mock('vue-i18n', async (importOriginal) => ({
   ...(await importOriginal<typeof import('vue-i18n')>()),
   useI18n: () => ({
@@ -32,7 +47,10 @@ describe('credits page', () => {
         },
       },
     });
-    expect(wrapper.findAll('section')).toHaveLength(2);
+    const sections = wrapper.findAll('section');
+    expect(sections).toHaveLength(2);
+    expect(sections[0]?.classes()).toContain('md:col-span-2');
+    expect(sections[1]?.classes()).not.toContain('md:col-span-2');
     expect(wrapper.find('[data-testid="contributors"]').exists()).toBe(true);
     expect(wrapper.text()).toContain('page.credits.sections.original_creator');
     expect(seoMeta).toHaveBeenCalledWith(
@@ -47,7 +65,6 @@ describe('credits page', () => {
       'Meet the beta testers and open source contributors behind Tarkov Tracker.'
     );
     expect(metadata.ogUrl).toBeUndefined();
-    expect(head).not.toHaveBeenCalled();
   });
   it('links to the about page for the team directory', async () => {
     const { default: CreditsPage } = await import('@/pages/credits.vue');

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -60,12 +60,11 @@
   import AboutHelpLinks from '@/features/about/AboutHelpLinks.vue';
   import AboutMemberCard from '@/features/about/AboutMemberCard.vue';
   import AboutMembersGroup from '@/features/about/AboutMembersGroup.vue';
-  import { membersByGroup, teamMembers } from '@/features/about/teamMembers';
+  import { membersByGroup } from '@/features/about/teamMembers';
   import { resolveCanonicalSiteUrl } from '@/utils/runtimeConfig';
   const { t } = useI18n({ useScope: 'global' });
   const runtimeConfig = useRuntimeConfig();
   const siteUrl = resolveCanonicalSiteUrl(runtimeConfig.public.appUrl);
-  const canonicalUrl = `${siteUrl}/about`;
   const coreMembers = computed(() => membersByGroup('core'));
   const supportMembers = computed(() => membersByGroup('support'));
   const partnerMembers = computed(() => membersByGroup('partner'));
@@ -76,7 +75,6 @@
     description: seoDescription,
     ogTitle: seoTitle,
     ogDescription: seoDescription,
-    ogUrl: canonicalUrl,
     twitterTitle: seoTitle,
     twitterDescription: seoDescription,
   });
@@ -87,14 +85,12 @@
     url: siteUrl,
     logo: `${siteUrl}/img/logos/tarkovtrackerlogo-light.webp`,
     sameAs: ['https://github.com/tarkovtracker-org/TarkovTracker'],
-    member: teamMembers.map((member) => ({
+    member: [...coreMembers.value, ...supportMembers.value].map((member) => ({
       '@type': 'Person',
       name: member.displayName,
-      ...(member.projectUrl ? { url: member.projectUrl } : {}),
     })),
   }));
   useHead(() => ({
-    link: [{ rel: 'canonical', href: canonicalUrl }],
     script: [
       {
         key: 'about-organization-jsonld',

--- a/app/pages/about.vue
+++ b/app/pages/about.vue
@@ -1,0 +1,106 @@
+<template>
+  <UContainer class="px-4 py-10 sm:px-6 sm:py-14">
+    <div class="mx-auto flex w-full max-w-6xl flex-col gap-10">
+      <header class="border-surface-700/60 mx-auto w-full max-w-2xl border-b pb-8 text-center">
+        <h1 class="text-3xl font-bold tracking-tight text-white sm:text-4xl">
+          {{ t('page.about.title') }}
+        </h1>
+        <p class="text-surface-400 mt-3 text-sm leading-relaxed">
+          {{ t('page.about.intro') }}
+        </p>
+      </header>
+      <section
+        v-if="coreMembers.length || supportMembers.length"
+        id="team"
+        aria-labelledby="about-team-heading"
+      >
+        <h2 id="about-team-heading" class="text-xl font-semibold text-white">
+          {{ t('page.about.team.heading') }}
+        </h2>
+        <p class="text-surface-400 mt-2 max-w-2xl text-sm leading-relaxed">
+          {{ t('page.about.team.summary') }}
+        </p>
+        <div class="mt-6 flex flex-col gap-8">
+          <AboutMembersGroup
+            v-if="coreMembers.length"
+            label-key="page.about.team.core_heading"
+            :members="coreMembers"
+          />
+          <AboutMembersGroup
+            v-if="supportMembers.length"
+            label-key="page.about.team.support_heading"
+            :members="supportMembers"
+          />
+        </div>
+      </section>
+      <section v-if="partnerMembers.length" id="partners" aria-labelledby="about-partners-heading">
+        <h2 id="about-partners-heading" class="text-xl font-semibold text-white">
+          {{ t('page.about.partners.heading') }}
+        </h2>
+        <p class="text-surface-400 mt-2 max-w-2xl text-sm leading-relaxed">
+          {{ t('page.about.partners.summary') }}
+        </p>
+        <ul class="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <AboutMemberCard v-for="member in partnerMembers" :key="member.id" :member="member" />
+        </ul>
+      </section>
+      <section id="help" aria-labelledby="about-help-heading">
+        <h2 id="about-help-heading" class="text-xl font-semibold text-white">
+          {{ t('page.about.help.heading') }}
+        </h2>
+        <p class="text-surface-400 mt-2 max-w-2xl text-sm leading-relaxed">
+          {{ t('page.about.help.routing') }}
+        </p>
+        <AboutHelpLinks class="mt-4" />
+      </section>
+    </div>
+  </UContainer>
+</template>
+<script setup lang="ts">
+  import AboutHelpLinks from '@/features/about/AboutHelpLinks.vue';
+  import AboutMemberCard from '@/features/about/AboutMemberCard.vue';
+  import AboutMembersGroup from '@/features/about/AboutMembersGroup.vue';
+  import { membersByGroup, teamMembers } from '@/features/about/teamMembers';
+  import { resolveCanonicalSiteUrl } from '@/utils/runtimeConfig';
+  const { t } = useI18n({ useScope: 'global' });
+  const runtimeConfig = useRuntimeConfig();
+  const siteUrl = resolveCanonicalSiteUrl(runtimeConfig.public.appUrl);
+  const canonicalUrl = `${siteUrl}/about`;
+  const coreMembers = computed(() => membersByGroup('core'));
+  const supportMembers = computed(() => membersByGroup('support'));
+  const partnerMembers = computed(() => membersByGroup('partner'));
+  const seoTitle = computed(() => t('page.about.title'));
+  const seoDescription = computed(() => t('page.about.description'));
+  useSeoMeta({
+    title: seoTitle,
+    description: seoDescription,
+    ogTitle: seoTitle,
+    ogDescription: seoDescription,
+    ogUrl: canonicalUrl,
+    twitterTitle: seoTitle,
+    twitterDescription: seoDescription,
+  });
+  const organizationJsonLd = computed(() => ({
+    '@context': 'https://schema.org',
+    '@type': 'Organization',
+    name: 'TarkovTracker',
+    url: siteUrl,
+    logo: `${siteUrl}/img/logos/tarkovtrackerlogo-light.webp`,
+    sameAs: ['https://github.com/tarkovtracker-org/TarkovTracker'],
+    member: teamMembers.map((member) => ({
+      '@type': 'Person',
+      name: member.displayName,
+      ...(member.projectUrl ? { url: member.projectUrl } : {}),
+    })),
+  }));
+  useHead(() => ({
+    link: [{ rel: 'canonical', href: canonicalUrl }],
+    script: [
+      {
+        key: 'about-organization-jsonld',
+        type: 'application/ld+json',
+        innerHTML: JSON.stringify(organizationJsonLd.value),
+      },
+    ],
+  }));
+</script>

--- a/app/pages/credits.vue
+++ b/app/pages/credits.vue
@@ -42,7 +42,6 @@
   import ContributorsList from '@/features/credits/ContributorsList.vue';
   import CreditMemberList from '@/features/credits/CreditMemberList.vue';
   import { staticCreditSections, type CreditSection } from '@/features/credits/creditSections';
-  import { resolveCanonicalSiteUrl } from '@/utils/runtimeConfig';
   const { t } = useI18n({ useScope: 'global' });
   const creditsDescription = computed(() =>
     t(
@@ -50,22 +49,15 @@
       'Meet the beta testers and open source contributors behind Tarkov Tracker.'
     )
   );
-  const runtimeConfig = useRuntimeConfig();
-  const siteUrl = resolveCanonicalSiteUrl(runtimeConfig.public.appUrl);
-  const creditsCanonicalUrl = `${siteUrl}/credits`;
   const creditsTitle = computed(() => t('common.credits'));
   useSeoMeta({
     title: creditsTitle,
     description: creditsDescription,
     ogTitle: creditsTitle,
     ogDescription: creditsDescription,
-    ogUrl: creditsCanonicalUrl,
     twitterTitle: creditsTitle,
     twitterDescription: creditsDescription,
   });
-  useHead(() => ({
-    link: [{ rel: 'canonical', href: creditsCanonicalUrl }],
-  }));
   const teamLinkClasses =
     'text-info-400 hover:text-info-300 focus-visible:ring-primary-500 inline-flex min-h-11 items-center gap-1.5 rounded text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none';
   const SECTION_CLASSES = 'bg-surface-900/80 rounded-lg border border-white/10 p-5 sm:p-6';

--- a/app/pages/credits.vue
+++ b/app/pages/credits.vue
@@ -29,6 +29,12 @@
         </section>
         <ContributorsList />
       </div>
+      <p class="text-center">
+        <NuxtLink to="/about" :class="teamLinkClasses">
+          <UIcon name="i-mdi-account-group-outline" aria-hidden="true" class="h-4 w-4" />
+          {{ t('page.credits.team_link') }}
+        </NuxtLink>
+      </p>
     </div>
   </UContainer>
 </template>
@@ -36,19 +42,32 @@
   import ContributorsList from '@/features/credits/ContributorsList.vue';
   import CreditMemberList from '@/features/credits/CreditMemberList.vue';
   import { staticCreditSections, type CreditSection } from '@/features/credits/creditSections';
+  import { resolveCanonicalSiteUrl } from '@/utils/runtimeConfig';
   const { t } = useI18n({ useScope: 'global' });
   const creditsDescription = computed(() =>
     t(
       'page.credits.description',
-      'Meet the team, testers, and open source contributors behind Tarkov Tracker.'
+      'Meet the beta testers and open source contributors behind Tarkov Tracker.'
     )
   );
+  const runtimeConfig = useRuntimeConfig();
+  const siteUrl = resolveCanonicalSiteUrl(runtimeConfig.public.appUrl);
+  const creditsCanonicalUrl = `${siteUrl}/credits`;
+  const creditsTitle = computed(() => t('common.credits'));
   useSeoMeta({
-    title: computed(() => t('common.credits')),
+    title: creditsTitle,
     description: creditsDescription,
-    ogTitle: computed(() => t('common.credits')),
+    ogTitle: creditsTitle,
     ogDescription: creditsDescription,
+    ogUrl: creditsCanonicalUrl,
+    twitterTitle: creditsTitle,
+    twitterDescription: creditsDescription,
   });
+  useHead(() => ({
+    link: [{ rel: 'canonical', href: creditsCanonicalUrl }],
+  }));
+  const teamLinkClasses =
+    'text-info-400 hover:text-info-300 focus-visible:ring-primary-500 inline-flex min-h-11 items-center gap-1.5 rounded text-sm transition-colors focus-visible:ring-2 focus-visible:outline-none';
   const SECTION_CLASSES = 'bg-surface-900/80 rounded-lg border border-white/10 p-5 sm:p-6';
   const sectionClasses = (section: CreditSection) => [
     SECTION_CLASSES,

--- a/app/plugins/__tests__/metadata.client.test.ts
+++ b/app/plugins/__tests__/metadata.client.test.ts
@@ -75,6 +75,7 @@ describe('metadata plugin', () => {
     expect(metadataStoreMock.initialize).toHaveBeenCalledTimes(1);
   });
   it.each([
+    ['/about'],
     ['/changelog'],
     ['/credits'],
     ['/privacy'],
@@ -101,6 +102,7 @@ describe('metadata plugin', () => {
     expect(metadataStoreMock.initialize).not.toHaveBeenCalled();
   });
   it.each([
+    ['/about-tracker'],
     ['/changelog-archive'],
     ['/credits-team'],
     ['/privacy-policy-2'],

--- a/app/plugins/__tests__/metadata.client.test.ts
+++ b/app/plugins/__tests__/metadata.client.test.ts
@@ -74,6 +74,20 @@ describe('metadata plugin', () => {
     await flushPromises();
     expect(metadataStoreMock.initialize).toHaveBeenCalledTimes(1);
   });
+  const runPluginForPath = async (path: string): Promise<void> => {
+    routeState.path = path;
+    metadataStoreMock.initialize.mockResolvedValue(undefined);
+    const plugin = (await import('@/plugins/metadata.client')).default;
+    const hooks = new Map<string, () => void>();
+    plugin({
+      hook(name: string, callback: () => void) {
+        hooks.set(name, callback);
+      },
+    } as Parameters<typeof plugin>[0]);
+    metadataStoreMock.initialize.mockClear();
+    hooks.get('app:mounted')?.();
+    await flushPromises();
+  };
   it.each([
     ['/about'],
     ['/changelog'],
@@ -87,18 +101,7 @@ describe('metadata plugin', () => {
     ['/oauth/twitch'],
     ['/changelog/2024'],
   ])('skips initialization for skip-list path %s', async (path) => {
-    routeState.path = path;
-    metadataStoreMock.initialize.mockResolvedValue(undefined);
-    const plugin = (await import('@/plugins/metadata.client')).default;
-    const hooks = new Map<string, () => void>();
-    plugin({
-      hook(name: string, callback: () => void) {
-        hooks.set(name, callback);
-      },
-    } as Parameters<typeof plugin>[0]);
-    metadataStoreMock.initialize.mockClear();
-    hooks.get('app:mounted')?.();
-    await flushPromises();
+    await runPluginForPath(path);
     expect(metadataStoreMock.initialize).not.toHaveBeenCalled();
   });
   it.each([
@@ -111,18 +114,7 @@ describe('metadata plugin', () => {
     ['/tasks'],
     ['/'],
   ])('initializes for non-skip-list path %s', async (path) => {
-    routeState.path = path;
-    metadataStoreMock.initialize.mockResolvedValue(undefined);
-    const plugin = (await import('@/plugins/metadata.client')).default;
-    const hooks = new Map<string, () => void>();
-    plugin({
-      hook(name: string, callback: () => void) {
-        hooks.set(name, callback);
-      },
-    } as Parameters<typeof plugin>[0]);
-    metadataStoreMock.initialize.mockClear();
-    hooks.get('app:mounted')?.();
-    await flushPromises();
+    await runPluginForPath(path);
     expect(metadataStoreMock.initialize).toHaveBeenCalled();
   });
 });

--- a/app/plugins/metadata.client.ts
+++ b/app/plugins/metadata.client.ts
@@ -19,6 +19,7 @@ export default defineNuxtPlugin((nuxtApp) => {
   const toast = useToast();
   const route = useRoute();
   const SKIP_METADATA_PATH_PREFIXES = [
+    '/about',
     '/auth',
     '/changelog',
     '/credits',
@@ -67,8 +68,10 @@ export default defineNuxtPlugin((nuxtApp) => {
       });
     }
   }
+  const canSkipInitialization = (path: string): boolean =>
+    !shouldInitializeForPath(path) || Boolean(metadataStore.hasInitialized || initPromise);
   const ensureMetadataInitialized = async (path: string): Promise<void> => {
-    if (!shouldInitializeForPath(path) || metadataStore.hasInitialized || initPromise) {
+    if (canSkipInitialization(path)) {
       return initPromise ?? Promise.resolve();
     }
     initPromise = initializeWithRetry().finally(() => {

--- a/app/shell/AppFooter.vue
+++ b/app/shell/AppFooter.vue
@@ -78,6 +78,7 @@
     { label: t('common.storyline'), to: '/storyline' },
   ]);
   const projectItems = computed(() => [
+    { label: t('common.about'), to: '/about' },
     { label: t('common.team'), to: '/team' },
     { label: t('common.supporter'), to: '/supporter' },
     { label: t('navigation_drawer.resources'), to: '/resources' },


### PR DESCRIPTION
## Summary

Moves the staff directory from Credits to `/about`, keeping `/team` for in-game squads. Credits retains original-creator, beta-tester, and open-source attribution and links to About; the footer links to both pages.

The About page uses a typed, version-controlled roster with verified GitHub avatars and monogram fallbacks, separate team and independent-partner sections, and channel-first support links. All new copy lives in `en.json`. The app shell owns canonical URLs and `og:url`; pages provide localized title, description, and social metadata. About's Organization JSON-LD includes only core/support members, and its route skips game-data initialization.

Fixes #707.

## Review corrections

- Empty member groups render no heading or list.
- Avatars are decorative beside their visible names and fall back on image failure.
- Independent partner maintainers are excluded from Organization membership and project URLs are not presented as personal URLs.
- Roster tests select members by stable ID.
- Removed duplicate canonical metadata ownership from both pages.
- Added component, empty-roster, JSON-LD, and metadata-route regression coverage.
- Deduplicated test harness boilerplate in `metadata.client.test.ts` via extracted `runPluginForPath` helper and aligned `credits.test.ts` mocks, resolving SonarCloud duplication down to 0.0%.
- Covered both `fullWidth` and `compact` branch variants in `credits.vue` to achieve 100% component branch coverage.

## Validation

Reviewed head: `415008017f6c1454f8727bf32382fb0ed41c9472`. Isolated PR worktree clean after commit; unrelated changes in other worktrees preserved.

- 48 focused tests passed across About, Credits, footer, and metadata plugin via `pnpm run test:coverage` with the repository's shard coverage mode (`VITEST_SHARD=1`). About and Credits pages, components, and roster achieved 100% lines, branches, functions, and statements.
- `pnpm run lint`, `pnpm run typecheck`, `pnpm run i18n:check`, `pnpm run systems:check`, `pnpm run lint:fallow --base origin/main`, focused Prettier check, commit hooks, and `git diff --check` passed. Existing Crowdin fallback/drift warnings are non-fatal.
- SonarCloud reports 0.0% Duplication on New Code, 0 new bugs, 0 vulnerabilities, 0 code smells, and 0 security hotspots on commit `41500801`.
- Final hosted CI is green across all 25 check runs, including all four test shards, build/deployment, Lighthouse, Fallow, lint/format, typecheck, and security checks. Codecov reports 100% patch coverage with all coverable lines covered.
- Greptile and Cubic checks passed with 5/5 confidence and all review threads resolved; merge state CLEAN/MERGEABLE.
- Playwright render and interaction checks on the deployed preview verified: responsive layout (1280px and 390px), no overflow, live avatars/contributors loaded, decorative avatar alt text, 44px help targets, single h1, single canonical and og:url, and accurate Organization JSON-LD membership.

Ready to merge at the reviewed SHA.

No migrations, production data writes, or new runtime dependencies. Existing system documentation remains accurate.