### PR TITLE
refactor: burn down all fallow-ignore complexity suppressions

### DIFF
--- a/app/composables/supabase/useSupabaseListener.ts
+++ b/app/composables/supabase/useSupabaseListener.ts
@@ -141,67 +141,96 @@ export function useSupabaseListener<
     const merged = reconcile(cleared);
     return Object.values(merged).some((value) => value !== undefined) ? (merged as TData) : null;
   };
-  // Initial fetch
-  // fallow-ignore-next-line complexity -- tested fetch cancellation and pending-save guards must share one response boundary
-  const fetchData = async (
-    reconnecting = false,
-    reconcile = syncController?.captureRemoteMerge?.()
-  ) => {
-    const pendingBeforeRead = syncController?.hasPendingChanges?.() === true;
-    const fetchVersion = ++latestFetchVersion;
+  const captureRemoteMerge = () => syncController?.captureRemoteMerge?.();
+  const hasPendingSaves = (): boolean => syncController?.hasPendingChanges?.() === true;
+  /**
+   * A reconnect must not replace state that still belongs to an outbound save,
+   * including edits saved while this request was in flight. A reconciled read
+   * merges instead of replacing, so it is always safe to apply.
+   */
+  const wouldClobberPendingSaves = (
+    reconnecting: boolean,
+    reconcile: RemoteStateMerge | undefined,
+    pendingBeforeRead: boolean
+  ): boolean => reconnecting && !reconcile && (pendingBeforeRead || hasPendingSaves());
+  /** Supersedes any in-flight read and returns the controller for this one. */
+  const beginFetch = (): AbortController => {
     activeFetchController?.abort();
-    const fetchController = new AbortController();
-    activeFetchController = fetchController;
+    const controller = new AbortController();
+    activeFetchController = controller;
+    return controller;
+  };
+  const endFetch = (controller: AbortController): void => {
+    if (activeFetchController === controller) activeFetchController = null;
+  };
+  const runSingleRowQuery = async (
+    filterQuery: { column: string; value: string },
+    signal: AbortSignal
+  ): Promise<{ data: TData | null; error: PostgrestError | null }> => {
+    const queryBuilder = $supabase.client
+      .from(table)
+      .select('*')
+      .eq(filterQuery.column, filterQuery.value)
+      .single() as QueryBuilderWithAbortSignal<TData>;
+    return typeof queryBuilder.abortSignal === 'function'
+      ? await queryBuilder.abortSignal(signal)
+      : await queryBuilder;
+  };
+  /**
+   * `PGRST116` is PostgREST's "no rows": a missing row is a valid state that the
+   * caller applies as a reset, not a read failure.
+   *
+   * @returns `true` when the read failed and must not be applied.
+   */
+  const reportFetchError = (error: PostgrestError): boolean => {
+    if (error.code === 'PGRST116') return false;
+    logger.error(`[${storeIdForLogging}] Error fetching initial data:`, error);
+    loadError.value = error;
+    hasInitiallyLoaded.value = true;
+    return true;
+  };
+  const applyFetchResult = (
+    result: { data: TData | null; error: PostgrestError | null },
+    context: { pendingBeforeRead: boolean; reconcile?: RemoteStateMerge; reconnecting: boolean }
+  ): void => {
+    if (result.error && reportFetchError(result.error)) return;
+    if (
+      wouldClobberPendingSaves(context.reconnecting, context.reconcile, context.pendingBeforeRead)
+    ) {
+      hasInitiallyLoaded.value = true;
+      return;
+    }
+    applyFetchedData(reconcileData(result.data, context.reconcile));
+    hasInitiallyLoaded.value = true;
+  };
+  const reportFetchFailure = (error: unknown, signal: AbortSignal): void => {
+    // An aborted request was superseded on purpose; there is nothing to report.
+    if (signal.aborted || isAbortError(error)) return;
+    logger.error(`[${storeIdForLogging}] Error fetching initial data:`, error);
+    hasInitiallyLoaded.value = true;
+  };
+  // Initial fetch
+  const fetchData = async (reconnecting = false, reconcile = captureRemoteMerge()) => {
+    const pendingBeforeRead = hasPendingSaves();
+    const fetchVersion = ++latestFetchVersion;
+    const fetchController = beginFetch();
     loadError.value = null;
     const filterQuery = parseFilter(getFilterValue());
     if (!filterQuery) return;
     try {
-      const queryBuilder = $supabase.client
-        .from(table)
-        .select('*')
-        .eq(filterQuery.column, filterQuery.value)
-        .single() as QueryBuilderWithAbortSignal<TData>;
-      const result =
-        typeof queryBuilder.abortSignal === 'function'
-          ? await queryBuilder.abortSignal(fetchController.signal)
-          : await queryBuilder;
-      if (fetchVersion !== latestFetchVersion) {
-        return;
-      }
-      const { data, error } = result;
-      if (error && error.code !== 'PGRST116') {
-        logger.error(`[${storeIdForLogging}] Error fetching initial data:`, error);
-        loadError.value = error;
-        hasInitiallyLoaded.value = true;
-        return;
-      }
-      // A reconnect must not replace state that still belongs to an outbound
-      // save, including edits that were saved while this request was in flight.
-      if (
-        reconnecting &&
-        !reconcile &&
-        (pendingBeforeRead || syncController?.hasPendingChanges?.())
-      ) {
-        hasInitiallyLoaded.value = true;
-        return;
-      }
-      applyFetchedData(reconcileData(data, reconcile));
-      hasInitiallyLoaded.value = true;
+      const result = await runSingleRowQuery(filterQuery, fetchController.signal);
+      // A newer request superseded this one, so its response is no longer current.
+      if (fetchVersion !== latestFetchVersion) return;
+      applyFetchResult(result, { pendingBeforeRead, reconcile, reconnecting });
     } catch (error) {
-      if (fetchController.signal.aborted || isAbortError(error)) {
-        return;
-      }
-      logger.error(`[${storeIdForLogging}] Error fetching initial data:`, error);
-      hasInitiallyLoaded.value = true;
+      reportFetchFailure(error, fetchController.signal);
     } finally {
-      if (activeFetchController === fetchController) {
-        activeFetchController = null;
-      }
+      endFetch(fetchController);
     }
   };
   const readData = (reconnecting = false) => {
     const version = cleanupVersion;
-    const read = (reconcile = syncController?.captureRemoteMerge?.()) =>
+    const read = (reconcile = captureRemoteMerge()) =>
       version === cleanupVersion ? fetchData(reconnecting, reconcile) : Promise.resolve();
     return syncController?.withSnapshot ? syncController.withSnapshot(read) : read();
   };

--- a/app/composables/supabase/useSupabaseSync.ts
+++ b/app/composables/supabase/useSupabaseSync.ts
@@ -117,6 +117,24 @@ function formatSupabaseError(error: SupabaseErrorLike) {
     message: error.message ?? null,
   };
 }
+/** Outcome of one write, including any columns dropped to satisfy an older schema. */
+type SupabaseSyncAttempt = {
+  synced: boolean;
+  error: SupabaseErrorLike | null;
+  removedMissingColumns: Set<string>;
+};
+/** An aborted write is worth one retry; every other failure is reported as-is. */
+const wasWriteAborted = (attempt: SupabaseSyncAttempt): boolean =>
+  !attempt.synced && attempt.error !== null && isAbortRequestError(attempt.error);
+const countModeTasks = (mode: UserProgressData | undefined): number =>
+  Object.keys(mode?.taskCompletions || {}).length;
+const describeProgressPayload = (userData: SupabaseUserData) => ({
+  gameMode: userData.current_game_mode,
+  pvpLevel: userData.pvp_data?.level,
+  pvpTasksCompleted: countModeTasks(userData.pvp_data),
+  pveLevel: userData.pve_data?.level,
+  pveTasksCompleted: countModeTasks(userData.pve_data),
+});
 export function useSupabaseSync<
   TState extends StateTree = StateTree,
   TPayload extends SupabaseSyncPayload = SupabaseSyncPayload,
@@ -139,29 +157,41 @@ export function useSupabaseSync<
   const pendingState = createPendingStateTracker(() => store.$state);
   let disposed = false;
   let syncQueue: Promise<TPayload | null> | null = null;
-  // fallow-ignore-next-line complexity -- development-only diagnostics exercised through sync tests; inferred coverage misses indirect calls
-  const logPayload = (dataToSave: TPayload) => {
-    // Log detailed info about what we're syncing (dev only)
-    if (import.meta.env.DEV) {
-      if (table === 'user_progress') {
-        const userData = dataToSave as SupabaseUserData;
-        const pvpTasks = Object.keys(userData.pvp_data?.taskCompletions || {}).length;
-        const pveTasks = Object.keys(userData.pve_data?.taskCompletions || {}).length;
-        logger.debug(`[Sync] About to upsert to ${table}:`, {
-          gameMode: userData.current_game_mode,
-          pvpLevel: userData.pvp_data?.level,
-          pvpTasksCompleted: pvpTasks,
-          pveLevel: userData.pve_data?.level,
-          pveTasksCompleted: pveTasks,
-        });
-      } else {
-        logger.debug('[Sync] About to upsert to', table);
-      }
+  /** Transmission is gated while paused or while a remote snapshot is in flight. */
+  const isSyncSuspended = (): boolean => isPaused.value || snapshotDepth > 0;
+  const syncOwnerId = (): string | null => ($supabase.user.loggedIn ? $supabase.user.id : null);
+  /**
+   * The user id this write may be sent for, or `null` when it must be dropped.
+   *
+   * Sync is gated rather than queued: the next store change re-triggers it.
+   */
+  const resolveSyncOwner = (): string | null => {
+    if (isSyncSuspended()) {
+      logger.debug('[Sync] Skipping - sync is paused');
+      return null;
     }
+    const ownerId = syncOwnerId();
+    if (!ownerId) logger.debug('[Sync] Skipping - user not logged in');
+    return ownerId;
+  };
+  const canQueueSync = (): boolean => !disposed && !isSyncSuspended() && syncOwnerId() !== null;
+  const logPayload = (dataToSave: TPayload) => {
+    // Development-only diagnostics; production builds skip the payload walk.
+    if (!import.meta.env.DEV) return;
+    if (table !== 'user_progress') {
+      logger.debug('[Sync] About to upsert to', table);
+      return;
+    }
+    logger.debug(
+      `[Sync] About to upsert to ${table}:`,
+      describeProgressPayload(dataToSave as SupabaseUserData)
+    );
   };
   const upsert = async (payload: Record<string, unknown>) =>
     sync ? sync(payload as TPayload) : $supabase.client.from(table).upsert(payload);
-  const upsertWithFallback = async (payload: Record<string, unknown>) => {
+  const upsertWithFallback = async (
+    payload: Record<string, unknown>
+  ): Promise<SupabaseSyncAttempt> => {
     let payloadToSync: Record<string, unknown> | null = payload;
     let error: SupabaseErrorLike | null = null;
     let synced = false;
@@ -189,43 +219,96 @@ export function useSupabaseSync<
     }
     return { synced, error, removedMissingColumns };
   };
-  // fallow-ignore-next-line complexity -- retry/fallback outcomes are covered by sync integration tests; keep error reporting with the write result
-  const writePayload = async (dataToSave: TPayload, ownerId: string): Promise<boolean> => {
-    let syncResult = await upsertWithFallback(dataToSave);
-    if (
-      !syncResult.synced &&
-      syncResult.error &&
-      isAbortRequestError(syncResult.error) &&
-      !isPaused.value
-    ) {
-      await delay(ABORT_RETRY_DELAY_MS);
-      if (
-        !isPaused.value &&
-        $supabase.user.loggedIn &&
-        $supabase.user.id === ownerId &&
-        !disposed
-      ) {
-        syncResult = await upsertWithFallback(dataToSave);
-      }
+  /** A retry is only valid while the same signed-in user still owns this write. */
+  const canRetryAbortedWrite = (ownerId: string): boolean =>
+    !isPaused.value && $supabase.user.loggedIn && $supabase.user.id === ownerId && !disposed;
+  const reportFailedWrite = (error: SupabaseErrorLike) => {
+    if (isAbortRequestError(error)) {
+      logger.warn(`[Sync] Sync to ${table} was aborted; retry did not succeed yet`, {
+        ...formatSupabaseError(error),
+        retryDelayMs: ABORT_RETRY_DELAY_MS,
+      });
+      return;
     }
-    if (syncResult.synced && syncResult.removedMissingColumns.size) {
-      logger.warn(
-        `[Sync] ${table} fallback sync succeeded after removing missing columns: ${Array.from(syncResult.removedMissingColumns).join(', ')}`
-      );
-    }
-    if (!syncResult.synced && syncResult.error) {
-      if (isAbortRequestError(syncResult.error)) {
-        logger.warn(`[Sync] Sync to ${table} was aborted; retry did not succeed yet`, {
-          ...formatSupabaseError(syncResult.error),
-          retryDelayMs: ABORT_RETRY_DELAY_MS,
-        });
-      } else {
-        logger.error(`[Sync] Error syncing to ${table}:`, formatSupabaseError(syncResult.error));
-      }
-    }
-    return syncResult.synced;
+    logger.error(`[Sync] Error syncing to ${table}:`, formatSupabaseError(error));
   };
-  // fallow-ignore-next-line complexity -- serialized save/cleanup/version guards are covered in useSupabaseSync.test.ts and sync integration tests
+  const reportWriteOutcome = (attempt: SupabaseSyncAttempt) => {
+    if (attempt.synced) {
+      if (attempt.removedMissingColumns.size) {
+        logger.warn(
+          `[Sync] ${table} fallback sync succeeded after removing missing columns: ${Array.from(attempt.removedMissingColumns).join(', ')}`
+        );
+      }
+      return;
+    }
+    if (attempt.error) reportFailedWrite(attempt.error);
+  };
+  const writePayload = async (dataToSave: TPayload, ownerId: string): Promise<boolean> => {
+    let attempt = await upsertWithFallback(dataToSave);
+    if (wasWriteAborted(attempt) && !isPaused.value) {
+      await delay(ABORT_RETRY_DELAY_MS);
+      if (canRetryAbortedWrite(ownerId)) attempt = await upsertWithFallback(dataToSave);
+    }
+    reportWriteOutcome(attempt);
+    return attempt.synced;
+  };
+  const clearPendingVersion = (syncVersion: number) => {
+    if (syncVersion === localVersion) pendingLocalChanges = false;
+  };
+  const buildSyncPayload = (transformedState: TPayload, ownerId: string): TPayload => {
+    const dataToSave: TPayload = { ...transformedState };
+    if (!dataToSave.user_id) dataToSave.user_id = ownerId;
+    return dataToSave;
+  };
+  /**
+   * A sign-out or teardown during the write means this payload no longer
+   * describes the signed-in user, so it must not be acknowledged.
+   */
+  const canCommitWrite = (ownerId: string): boolean => !disposed && $supabase.user.id === ownerId;
+  const commitSync = (currentHash: string, syncVersion: number, acknowledge: () => void) => {
+    acknowledge();
+    lastSyncedHash = currentHash;
+    clearPendingVersion(syncVersion);
+    logger.debug(`[Sync] ✅ Successfully synced to ${table}`);
+    onSynced?.();
+  };
+  const writeAndCommit = async (
+    dataToSave: TPayload,
+    transformedState: TPayload,
+    currentHash: string,
+    syncVersion: number,
+    acknowledge: () => void,
+    ownerId: string
+  ): Promise<TPayload | null> => {
+    logPayload(dataToSave);
+    const synced = await writePayload(dataToSave, ownerId);
+    if (synced && canCommitWrite(ownerId)) commitSync(currentHash, syncVersion, acknowledge);
+    return synced ? transformedState : null;
+  };
+  const runSyncToSupabase = async (
+    transformedState: TPayload,
+    syncVersion: number,
+    acknowledge: () => void,
+    ownerId: string
+  ): Promise<TPayload | null> => {
+    const dataToSave = buildSyncPayload(transformedState, ownerId);
+    // Skip unchanged writes; this is what keeps egress down.
+    const currentHash = hashState(dataToSave);
+    if (currentHash === lastSyncedHash) {
+      acknowledge();
+      clearPendingVersion(syncVersion);
+      logger.debug('[Sync] Skipping - data unchanged');
+      return null;
+    }
+    return await writeAndCommit(
+      dataToSave,
+      transformedState,
+      currentHash,
+      syncVersion,
+      acknowledge,
+      ownerId
+    );
+  };
   const syncToSupabase = async (
     transformedState: TPayload | null,
     syncVersion: number,
@@ -235,47 +318,16 @@ export function useSupabaseSync<
       loggedIn: $supabase.user.loggedIn,
       isPaused: isPaused.value,
     });
-    if (isPaused.value || snapshotDepth > 0) {
-      logger.debug('[Sync] Skipping - sync is paused');
+    const ownerId = resolveSyncOwner();
+    if (!ownerId) return null;
+    // Skip if transform returned null (e.g., during initial load)
+    if (!transformedState) {
+      logger.debug('[Sync] Skipping - transform returned null');
       return null;
     }
-    if (!$supabase.user.loggedIn || !$supabase.user.id) {
-      logger.debug('[Sync] Skipping - user not logged in');
-      return null;
-    }
-    const ownerId = $supabase.user.id;
     isSyncing.value = true;
     try {
-      // Skip if transform returned null (e.g., during initial load)
-      if (!transformedState) {
-        logger.debug('[Sync] Skipping - transform returned null');
-        isSyncing.value = false;
-        return null;
-      }
-      const dataToSave: TPayload = { ...transformedState };
-      // Ensure user_id is present if not already
-      if (!dataToSave.user_id) {
-        dataToSave.user_id = $supabase.user.id;
-      }
-      // Skip sync if data hasn't changed (reduces egress significantly)
-      const currentHash = hashState(dataToSave);
-      if (currentHash === lastSyncedHash) {
-        acknowledge();
-        if (syncVersion === localVersion) pendingLocalChanges = false;
-        logger.debug('[Sync] Skipping - data unchanged');
-        isSyncing.value = false;
-        return null;
-      }
-      logPayload(dataToSave);
-      const synced = await writePayload(dataToSave, ownerId);
-      if (synced && !disposed && $supabase.user.id === ownerId) {
-        acknowledge();
-        lastSyncedHash = currentHash;
-        if (syncVersion === localVersion) pendingLocalChanges = false;
-        logger.debug(`[Sync] ✅ Successfully synced to ${table}`);
-        onSynced?.();
-      }
-      return synced ? transformedState : null;
+      return await runSyncToSupabase(transformedState, syncVersion, acknowledge, ownerId);
     } catch (err) {
       logger.error('[Sync] Unexpected error:', err);
       return null;
@@ -295,18 +347,10 @@ export function useSupabaseSync<
       return null;
     }
   };
-  // fallow-ignore-next-line complexity -- save gates and serialization are exercised through the public method in useSupabaseSync.test.ts
   const enqueueSync = (state = store.$state as TState): Promise<TPayload | null> => {
     // Capture each request before queuing: later mutations must not change an
     // earlier payload, and resumed writes must not overtake an in-flight save.
-    if (
-      disposed ||
-      isPaused.value ||
-      snapshotDepth > 0 ||
-      !$supabase.user.loggedIn ||
-      !$supabase.user.id
-    )
-      return Promise.resolve(null);
+    if (!canQueueSync()) return Promise.resolve(null);
     const version = localVersion;
     const acknowledge = pendingState.captureAcknowledgement(snapshotSyncState(state));
     const snapshot = capturePayload(state);

--- a/app/features/team/TeamDangerZone.vue
+++ b/app/features/team/TeamDangerZone.vue
@@ -97,6 +97,7 @@
   import { useTeamStoreWithSupabase } from '@/stores/useTeamStore';
   import { GAME_MODES, type GameMode } from '@/utils/constants';
   import { logger } from '@/utils/logger';
+  import type { SystemState } from '@/types/tarkov';
   const { $supabase } = useNuxtApp();
   const { t } = useI18n({ useScope: 'global' });
   const toast = useToast();
@@ -130,17 +131,21 @@
   watch(confirmationOpen, (isOpen) => {
     if (!isOpen) pendingAction.value = null;
   });
+  // The legacy `team`/`team_id` columns predate per-mode keys and only ever
+  // mirror the non-seasonal team, so they are cleared alongside it.
+  const clearLegacyTeamColumns = (state: SystemState, removedTeamId: string) => {
+    if (state.team === removedTeamId) state.team = null;
+    if (state.team_id === removedTeamId) state.team_id = null;
+  };
   const clearLocalTeam = (mode: GameMode, removedTeamId: string) => {
     const key = getTeamIdStateKey(mode);
     if (getTeamIdFromState(systemStore.$state, mode) !== removedTeamId) return;
-    // fallow-ignore-next-line complexity -- cleanup guards protect replacement team state
     systemStore.$patch((state) => {
+      // Re-check inside the patch: a replacement team may have been joined
+      // between the guard above and this mutation.
       if (getTeamIdFromState(state, mode) !== removedTeamId) return;
       state[key] = null;
-      if (mode !== GAME_MODES.SEASONAL) {
-        if (state.team === removedTeamId) state.team = null;
-        if (state.team_id === removedTeamId) state.team_id = null;
-      }
+      if (mode !== GAME_MODES.SEASONAL) clearLegacyTeamColumns(state, removedTeamId);
     });
     if (teamStore.id === removedTeamId) teamStore.$reset();
   };

--- a/app/features/team/__tests__/TeamDangerZone.test.ts
+++ b/app/features/team/__tests__/TeamDangerZone.test.ts
@@ -105,6 +105,20 @@ describe('TeamDangerZone', () => {
     expect(mockTeamStore.$reset).toHaveBeenCalled();
     wrapper.unmount();
   });
+  it('preserves legacy aliases when leaving a Seasonal team', async () => {
+    mockTarkovStore.getCurrentGameMode.mockReturnValue('seasonal');
+    mockSystemState.seasonal_team_id = 'team-1';
+    const wrapper = await mountDangerZone();
+    await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
+    await wrapper.find('[data-testid="confirm-team-danger-action"]').trigger('click');
+    await flushPromises();
+    expect(mockDisbandTeam).toHaveBeenCalledWith('team-1');
+    expect(mockSystemState.seasonal_team_id).toBeNull();
+    expect(mockSystemState.pvp_team_id).toBe('team-1');
+    expect(mockSystemState.team).toBe('team-1');
+    expect(mockSystemState.team_id).toBe('team-1');
+    wrapper.unmount();
+  });
   it('uses the regular leave operation for non-owners', async () => {
     mockTeamStore.owner = 'other-user';
     const wrapper = await mountDangerZone();

--- a/app/features/team/__tests__/TeamDangerZone.test.ts
+++ b/app/features/team/__tests__/TeamDangerZone.test.ts
@@ -108,13 +108,15 @@ describe('TeamDangerZone', () => {
   it('preserves legacy aliases when leaving a Seasonal team', async () => {
     mockTarkovStore.getCurrentGameMode.mockReturnValue('seasonal');
     mockSystemState.seasonal_team_id = 'team-1';
+    mockSystemState.pvp_team_id = 'pvp-team';
+    // Matching legacy aliases make an accidental Seasonal alias cleanup observable.
     const wrapper = await mountDangerZone();
     await wrapper.find('[data-testid="open-team-danger-confirmation"]').trigger('click');
     await wrapper.find('[data-testid="confirm-team-danger-action"]').trigger('click');
     await flushPromises();
     expect(mockDisbandTeam).toHaveBeenCalledWith('team-1');
     expect(mockSystemState.seasonal_team_id).toBeNull();
-    expect(mockSystemState.pvp_team_id).toBe('team-1');
+    expect(mockSystemState.pvp_team_id).toBe('pvp-team');
     expect(mockSystemState.team).toBe('team-1');
     expect(mockSystemState.team_id).toBe('team-1');
     wrapper.unmount();

--- a/app/features/team/useTeamInviteLink.ts
+++ b/app/features/team/useTeamInviteLink.ts
@@ -2,19 +2,27 @@ import { useSystemStoreWithSupabase, getTeamIdFromState } from '@/stores/useSyst
 import { useTarkovStore } from '@/stores/useTarkov';
 import { useTeamStoreWithSupabase } from '@/stores/useTeamStore';
 import { GAME_MODES, type GameMode } from '@/utils/constants';
+const buildInviteUrl = (teamId: string, code: string): string => {
+  const inviteUrl = new URL(window.location.href);
+  inviteUrl.search = new URLSearchParams({ team: teamId, code }).toString();
+  return inviteUrl.toString();
+};
 export const useTeamInviteLink = () => {
   const { systemStore } = useSystemStoreWithSupabase();
   const { teamStore } = useTeamStoreWithSupabase();
   const tarkovStore = useTarkovStore();
   const getCurrentGameMode = (): GameMode => tarkovStore.getCurrentGameMode?.() || GAME_MODES.PVP;
-  // fallow-ignore-next-line complexity -- both valid and stale invite states have regression coverage
-  const teamUrl = computed(() => {
+  // Only the code issued for the team the user is currently in is shareable, so
+  // a stale code left over from a previous team resolves to no invite at all.
+  const resolveActiveInvite = (): { teamId: string; code: string } | null => {
     const teamId = getTeamIdFromState(systemStore.$state, getCurrentGameMode());
     const code = teamStore.id === teamId ? teamStore.inviteCode : null;
-    if (!teamId || !code || !import.meta.client) return '';
-    const inviteUrl = new URL(window.location.href);
-    inviteUrl.search = new URLSearchParams({ team: teamId, code }).toString();
-    return inviteUrl.toString();
+    return teamId && code ? { teamId, code } : null;
+  };
+  const teamUrl = computed(() => {
+    const invite = resolveActiveInvite();
+    if (!invite || !import.meta.client) return '';
+    return buildInviteUrl(invite.teamId, invite.code);
   });
   const maskedTeamUrl = computed(() => {
     if (!teamUrl.value) return '';

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -423,6 +423,26 @@ describe('seasonal progress realtime synchronization', () => {
     expect(createdChannels.filter(({ subscribed }) => subscribed)).toEqual([]);
     expect(openTopics.size).toBe(0);
   });
+  it('never joins a channel that teardown removed after ownership was published', async () => {
+    const { cleanupRealtimeListener, setupRealtimeListener } =
+      await import('@/stores/tarkov/realtimeListener');
+    const createChannel = supabaseContext.client.channel.getMockImplementation()!;
+    let teardown: Promise<void> | null = null;
+    // Queue teardown from the synchronous channel construction so it runs at the
+    // first microtask checkpoint after ownership is published. Publishing
+    // ownership and calling `subscribe()` must share one synchronous segment: if
+    // an await separates them, this teardown removes the channel and the setup
+    // then joins it anyway, leaving an orphan no ownership check can reclaim.
+    supabaseContext.client.channel.mockImplementationOnce((topic: string) => {
+      const created = createChannel(topic);
+      teardown = Promise.resolve().then(() => cleanupRealtimeListener());
+      return created;
+    });
+    await setupRealtimeListener(store);
+    await teardown;
+    expect(createdChannels.filter(({ subscribed }) => subscribed)).toEqual([]);
+    expect(openTopics.size).toBe(0);
+  });
   it('ignores progress and metadata from a listener after teardown starts', async () => {
     const { cleanupRealtimeListener, setupRealtimeListener } =
       await import('@/stores/tarkov/realtimeListener');

--- a/app/stores/__tests__/realtimeListener.seasonal.test.ts
+++ b/app/stores/__tests__/realtimeListener.seasonal.test.ts
@@ -384,6 +384,48 @@ describe('seasonal progress realtime synchronization', () => {
     await setup;
     expect(settled).toBe(true);
   });
+  it('reports an initial subscription failure and releases its channel', async () => {
+    subscribeGate.defer = true;
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    const setup = setupRealtimeListener(store);
+    const error = new Error('Join failed');
+    const rejected = expect(setup).rejects.toThrow('Join failed');
+    await vi.waitFor(() => expect(createdChannels[0]?.subscribeCallback).toBeDefined());
+    createdChannels[0]!.subscribeCallback!('CHANNEL_ERROR', error);
+    await rejected;
+    expect(openTopics.size).toBe(0);
+    expect(supabaseContext.client.removeChannel).toHaveBeenCalledWith(createdChannels[0]);
+  });
+  it('ignores a superseded join failure without removing the replacement', async () => {
+    subscribeGate.defer = true;
+    const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+    const older = setupRealtimeListener(store);
+    await vi.waitFor(() => expect(createdChannels[0]?.subscribeCallback).toBeDefined());
+    subscribeGate.defer = false;
+    await setupRealtimeListener(store);
+    createdChannels[0]!.subscribeCallback!('CHANNEL_ERROR', new Error('Obsolete join'));
+    await expect(older).resolves.toBeUndefined();
+    expect(createdChannels.filter(({ subscribed }) => subscribed)).toEqual([createdChannels[1]]);
+    expect(openTopics.size).toBe(1);
+  });
+  it('declines a same-topic replacement when the previous leave fails', async () => {
+    const previousUserId = supabaseContext.user.id;
+    supabaseContext.user.id = '33333333-3333-4333-8333-333333333333';
+    try {
+      const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');
+      await setupRealtimeListener(store);
+      supabaseContext.client.removeChannel.mockRejectedValueOnce(new Error('Leave failed'));
+      await setupRealtimeListener(store);
+      expect(createdChannels).toHaveLength(1);
+      expect(createdChannels[0]!.subscribe).toHaveBeenCalledOnce();
+      expect(logger.warn).toHaveBeenCalledWith(
+        '[TarkovStore] Failed to remove realtime channel:',
+        expect.any(Error)
+      );
+    } finally {
+      supabaseContext.user.id = previousUserId;
+    }
+  });
   it('does not block a new user on a different topic leave', async () => {
     try {
       const { setupRealtimeListener } = await import('@/stores/tarkov/realtimeListener');

--- a/app/stores/__tests__/teamChannelController.test.ts
+++ b/app/stores/__tests__/teamChannelController.test.ts
@@ -168,6 +168,34 @@ describe('createTeamChannelController', () => {
       }
     }
   );
+  it.each([true, false])(
+    'uses the owning transport after client replacement (owner suspended: %s)',
+    async (ownerSuspended) => {
+      const owner = createHarness();
+      const replacement = createHarness();
+      const transport = { connect: vi.fn(), disconnect: vi.fn(), getChannels: () => [] };
+      Object.assign(ownerSuspended ? owner.client : replacement.client, { realtime: transport });
+      const page = Object.assign(new EventTarget(), { visibilityState: 'hidden' as const });
+      const releaseVisibility = installRealtimeVisibility(transport, page);
+      const controller = createTeamChannelController(owner.deps);
+      try {
+        await controller.refresh();
+        owner.channels[0]!.status!('SUBSCRIBED');
+        owner.deps.getClient = () => replacement.client;
+        await vi.advanceTimersByTimeAsync(60_000);
+        for (let attempt = 0; attempt < 5; attempt++) {
+          owner.channels[0]!.status!('CHANNEL_ERROR', new Error('Transport disconnected'));
+        }
+        await vi.advanceTimersByTimeAsync(0);
+        expect(owner.removeChannel).toHaveBeenCalledTimes(ownerSuspended ? 0 : 1);
+        expect(loggerMock.warn).toHaveBeenCalledTimes(ownerSuspended ? 0 : 5);
+        expect(replacement.removeChannel).not.toHaveBeenCalled();
+      } finally {
+        releaseVisibility();
+        await controller.dispose();
+      }
+    }
+  );
   it('reports a rejected reconnect refresh without dispatching hydration', async () => {
     const harness = createHarness();
     const controller = createTeamChannelController(harness.deps);

--- a/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
+++ b/app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
@@ -107,6 +107,25 @@ describe('useMetadataStore fetchEditionsData', () => {
       expect.any(Error)
     );
   });
+  it('keeps the fetched catalog usable when its cache write fails', async () => {
+    const store = useMetadataStore();
+    const edition = createEdition('standard', 1, 'Standard');
+    const error = new Error('Storage quota exceeded');
+    vi.spyOn(cacheUtils, 'getCachedData').mockResolvedValue(null);
+    vi.spyOn(cacheUtils, 'setCachedData').mockRejectedValue(error);
+    vi.stubGlobal(
+      '$fetch',
+      vi.fn().mockResolvedValue({
+        data: { editions: [edition], storyChapters: [] },
+      })
+    );
+    await store.fetchEditionsData(true);
+    await flushPromises();
+    expect(store.editions).toEqual([edition]);
+    expect(store.editionsError).toBeNull();
+    expect(store.editionsLoading).toBe(false);
+    expect(loggerMock.error).toHaveBeenCalledWith('[MetadataStore] Error caching editions:', error);
+  });
   it('caches a structured-cloneable editions payload in a persistent mode', async () => {
     const store = useMetadataStore();
     const setCachedDataMock = vi.spyOn(cacheUtils, 'setCachedData').mockResolvedValue();

--- a/app/stores/tarkov/progressPersistence.ts
+++ b/app/stores/tarkov/progressPersistence.ts
@@ -104,7 +104,31 @@ export const syncProgressState = async (
     return { error: normalizedError };
   }
 };
-// fallow-ignore-next-line complexity -- active-mode timestamp and legacy fallback branches are covered in progressPersistence.test.ts
+const collectModeProgress = (
+  rows: ModeProgressRow[]
+): Partial<Record<GameMode, UserProgressData>> =>
+  Object.fromEntries(
+    rows.flatMap((row) => {
+      const active = getActiveModeProgress(row);
+      return active ? [[active.mode, active.progress] as const] : [];
+    })
+  ) as Partial<Record<GameMode, UserProgressData>>;
+const collectModeTimestamps = (rows: ModeProgressRow[]): Partial<Record<GameMode, number>> =>
+  Object.fromEntries(
+    rows.flatMap((row) => {
+      const active = getActiveModeProgress(row);
+      const timestamp = Date.parse(row.progress_updated_at ?? '');
+      return active && Number.isFinite(timestamp) ? [[active.mode, timestamp]] : [];
+    })
+  ) as Partial<Record<GameMode, number>>;
+/**
+ * The account-level clock is the newest per-mode clock, so a mode that predates
+ * the freshness column does not make the whole account look stale.
+ */
+const latestModeTimestamp = (byMode: Partial<Record<GameMode, number>>): number | undefined => {
+  const timestamps = Object.values(byMode);
+  return timestamps.length > 0 ? Math.max(...timestamps) : undefined;
+};
 export const loadModeProgress = async (
   client: ModeProgressClient,
   userId: string
@@ -128,24 +152,13 @@ export const loadModeProgress = async (
         .in('season_number', [0, ACTIVE_SEASON_NUMBER])
     );
     if (error) return { data: {}, error };
-    const entries = (rows ?? []).flatMap((row) => {
-      const activeProgress = getActiveModeProgress(row);
-      return activeProgress ? [[activeProgress.mode, activeProgress.progress] as const] : [];
-    });
-    const data = Object.fromEntries(entries) as Partial<Record<GameMode, UserProgressData>>;
-    const updatedAtByMode = Object.fromEntries(
-      (rows ?? []).flatMap((row) => {
-        const active = getActiveModeProgress(row);
-        const timestamp = Date.parse(row.progress_updated_at ?? '');
-        return active && Number.isFinite(timestamp) ? [[active.mode, timestamp]] : [];
-      })
-    ) as Partial<Record<GameMode, number>>;
-    const timestamps = Object.values(updatedAtByMode);
+    const loadedRows = rows ?? [];
+    const updatedAtByMode = collectModeTimestamps(loadedRows);
     return {
-      data,
+      data: collectModeProgress(loadedRows),
       error: null,
       updatedAtByMode,
-      updatedAt: timestamps.length > 0 ? Math.max(...timestamps) : undefined,
+      updatedAt: latestModeTimestamp(updatedAtByMode),
     };
   } catch (error) {
     const normalizedError = normalizePersistenceError(error);

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -186,6 +186,19 @@ const isStillSignedInAs = (currentUserId: string): boolean => {
 };
 const progressTopic = (userId: string) => `user_progress_${userId}`;
 /**
+ * Fails the snapshot read on any error that means data is missing.
+ *
+ * `PGRST116` is PostgREST's "no rows" for a `.single()` read: a user who has no
+ * legacy `user_progress` row is a normal state, not a read failure.
+ */
+const assertSnapshotReadable = (
+  metadataError: { code?: string } | null,
+  modesError: { message: string } | null
+): void => {
+  if (modesError) throw modesError;
+  if (metadataError && metadataError.code !== 'PGRST116') throw metadataError;
+};
+/**
  * Returns whether a setup still owns the current user and generation.
  *
  * Setup and teardown increment the generation synchronously, before awaiting
@@ -207,23 +220,94 @@ const releaseProgressChannel = (owned: OwnedRealtimeChannel): Promise<boolean> =
   channelRelease.hold(owned, removal);
   return channelRelease.release(owned.topic);
 };
-// fallow-ignore-next-line complexity -- same-topic joins must await a clean leave
+/**
+ * Releases the channel a new setup is replacing.
+ *
+ * A different user's topic can keep leaving in the background, but rejoining the
+ * same topic has to wait for that leave to finish.
+ *
+ * @returns `false` when the topic this setup needs may still be occupied.
+ */
+const releasePreviousProgressChannel = async (
+  previousChannel: OwnedRealtimeChannel,
+  currentUserId: string
+): Promise<boolean> => {
+  realtimeChannel = null;
+  const leftCleanly = releaseProgressChannel(previousChannel);
+  if (previousChannel.topic !== progressTopic(currentUserId)) return true;
+  return await leftCleanly;
+};
 const prepareProgressTopic = async (
   currentUserId: string,
   generation: number
 ): Promise<boolean> => {
   const previousChannel = realtimeChannel;
-  if (previousChannel) {
-    realtimeChannel = null;
-    const leftCleanly = releaseProgressChannel(previousChannel);
-    // A different user's topic can proceed while the old topic leaves. Rejoining
-    // the same topic still waits for its leave to finish.
-    if (previousChannel.topic === progressTopic(currentUserId) && !(await leftCleanly)) {
-      return false;
-    }
+  if (previousChannel && !(await releasePreviousProgressChannel(previousChannel, currentUserId))) {
+    return false;
   }
   if (!(await channelRelease.release(progressTopic(currentUserId)))) return false;
   return stillOwnsSetup(currentUserId, generation);
+};
+/** The signed-in user id this setup belongs to, or `null` when signed out. */
+const resolveActiveUserId = (user: { id: string | null; loggedIn: boolean }): string | null =>
+  user.loggedIn && user.id ? user.id : null;
+/**
+ * Publishes channel ownership before the join is awaited, so a newer setup can
+ * tear this channel down instead of creating a duplicate subscription.
+ *
+ * @returns `false` when this setup was superseded before it could publish.
+ */
+const claimProgressChannel = async (
+  owned: OwnedRealtimeChannel,
+  currentUserId: string,
+  generation: number
+): Promise<boolean> => {
+  if (!stillOwnsSetup(currentUserId, generation)) {
+    await releaseProgressChannel(owned);
+    return false;
+  }
+  realtimeChannel = owned;
+  return true;
+};
+const setupStillOwnsChannel = (
+  owned: OwnedRealtimeChannel,
+  currentUserId: string,
+  generation: number
+): boolean => stillOwnsSetup(currentUserId, generation) && realtimeChannel === owned;
+/** Tears down a channel only while this setup still owns it. */
+const abandonProgressChannel = async (owned: OwnedRealtimeChannel): Promise<void> => {
+  if (realtimeChannel === owned) await releaseProgressChannel(owned);
+};
+/**
+ * Awaits the initial join and hands the channel back on the way out if this
+ * setup lost ownership.
+ *
+ * A newer setup or teardown intentionally supersedes this request, so its
+ * subscription failure is no longer actionable and must not reject the newer
+ * request or surface as an initialization failure.
+ */
+const joinProgressChannel = async (
+  owned: OwnedRealtimeChannel,
+  currentUserId: string,
+  generation: number,
+  onRejoined: () => void
+): Promise<void> => {
+  try {
+    await subscribeAndWaitForRealtimeChannel(
+      owned.channel,
+      'TarkovStore',
+      { table: 'user_progress' },
+      REALTIME_SUBSCRIPTION_TIMEOUT_MS,
+      onRejoined
+    );
+  } catch (error) {
+    await abandonProgressChannel(owned);
+    if (!stillOwnsSetup(currentUserId, generation)) return;
+    throw error;
+  }
+  if (!setupStillOwnsChannel(owned, currentUserId, generation)) {
+    await abandonProgressChannel(owned);
+  }
 };
 /**
  * Starts listener setup immediately and lets the newest request win.
@@ -236,7 +320,6 @@ export function setupRealtimeListener(tarkovStore: TarkovStoreLike): Promise<voi
   const generation = ++listenerGeneration;
   return runSetupRealtimeListener(tarkovStore, generation);
 }
-// fallow-ignore-next-line complexity -- coordinates cancellation, topic release, and join readiness
 async function runSetupRealtimeListener(
   tarkovStore: TarkovStoreLike,
   generation: number
@@ -244,8 +327,8 @@ async function runSetupRealtimeListener(
   const { $supabase } = useNuxtApp();
   const metadataStore = useMetadataStore();
   const toastI18n = useToastI18n();
-  const currentUserId = $supabase.user.id;
-  if (!$supabase.user.loggedIn || !currentUserId) return;
+  const currentUserId = resolveActiveUserId($supabase.user);
+  if (!currentUserId) return;
   if (!(await prepareProgressTopic(currentUserId, generation))) return;
   const fallbackTracker = createPendingStateTracker(() => tarkovStore.$state);
   const captureRemoteMerge = () =>
@@ -396,80 +479,65 @@ async function runSetupRealtimeListener(
       (payload) => handleProgressChange(payload)
     );
   let refreshGeneration = 0;
-  // fallow-ignore-next-line complexity -- snapshot/event/edit races are covered in realtimeListener.seasonal.test.ts; keep generation checks together
+  // The refresh is stale once a newer reconnect starts, the user changes, or the
+  // socket is suspended.
+  const snapshotIsStale = (request: number): boolean =>
+    !isCurrentRealtimeUser() || request !== refreshGeneration;
+  const readProgressSnapshotRows = () =>
+    Promise.all([
+      client
+        .from('user_progress')
+        .select('current_game_mode,game_edition,tarkov_uid,updated_at')
+        .eq('user_id', currentUserId)
+        .single(),
+      readWithProgressFreshness((includeFreshness) => {
+        const query = client.from('user_game_mode_progress');
+        return includeFreshness
+          ? query
+              .select('game_mode,season_number,progress_data,updated_at,progress_updated_at')
+              .eq('user_id', currentUserId)
+          : query
+              .select('game_mode,season_number,progress_data,updated_at')
+              .eq('user_id', currentUserId);
+      }),
+    ]);
+  const applySnapshotMetadata = (metadataRow: unknown, reconcile: RemoteStateMerge) => {
+    if (metadataRow) handleProgressChange({ new: metadataRow, old: null }, reconcile);
+  };
+  const applySnapshotModes = (
+    modeRows: { game_mode: string }[] | null,
+    reconcile: RemoteStateMerge
+  ) => {
+    for (const row of modeRows ?? []) {
+      if (!isGameMode(row.game_mode)) continue;
+      handleModeProgressChange({ new: row }, reconcile);
+    }
+  };
   const refreshSnapshot = async (reconcile: RemoteStateMerge, request: number) => {
-    if (!isCurrentRealtimeUser() || request !== refreshGeneration) return;
+    if (snapshotIsStale(request)) return;
     try {
-      const [metadata, modes] = await Promise.all([
-        client
-          .from('user_progress')
-          .select('current_game_mode,game_edition,tarkov_uid,updated_at')
-          .eq('user_id', currentUserId)
-          .single(),
-        readWithProgressFreshness((includeFreshness) => {
-          const query = client.from('user_game_mode_progress');
-          return includeFreshness
-            ? query
-                .select('game_mode,season_number,progress_data,updated_at,progress_updated_at')
-                .eq('user_id', currentUserId)
-            : query
-                .select('game_mode,season_number,progress_data,updated_at')
-                .eq('user_id', currentUserId);
-        }),
-      ]);
-      if (!isCurrentRealtimeUser() || request !== refreshGeneration) return;
-      if (modes.error) throw modes.error;
-      if (metadata.error && metadata.error.code !== 'PGRST116') throw metadata.error;
-      if (metadata.data) {
-        handleProgressChange({ new: metadata.data, old: null }, reconcile);
-      }
-      for (const row of modes.data ?? []) {
-        if (!isGameMode(row.game_mode)) continue;
-        handleModeProgressChange({ new: row }, reconcile);
-      }
+      const [metadata, modes] = await readProgressSnapshotRows();
+      if (snapshotIsStale(request)) return;
+      assertSnapshotReadable(metadata.error, modes.error);
+      applySnapshotMetadata(metadata.data, reconcile);
+      applySnapshotModes(modes.data, reconcile);
     } catch (error) {
       logger.warn('[TarkovStore] Reconnect snapshot failed', error);
     }
   };
   const owned = { channel, client, topic } satisfies OwnedRealtimeChannel;
-  if (!stillOwnsSetup(currentUserId, generation)) {
-    await releaseProgressChannel(owned);
-    return;
-  }
-  // Publish ownership before awaiting the join so a newer setup can tear down
-  // this channel instead of creating a duplicate subscription for the topic.
-  realtimeChannel = owned;
-  try {
-    await subscribeAndWaitForRealtimeChannel(
-      channel,
-      'TarkovStore',
-      {
-        table: 'user_progress',
-      },
-      REALTIME_SUBSCRIPTION_TIMEOUT_MS,
-      () => {
-        const request = ++refreshGeneration;
-        const read = (reconcile: RemoteStateMerge) => refreshSnapshot(reconcile, request);
-        const controller = getRegisteredSyncController();
-        const refreshing = controller?.withSnapshot
-          ? controller.withSnapshot(read)
-          : read(captureRemoteMerge());
-        refreshing.catch((error: unknown) => {
-          logger.warn('[TarkovStore] Reconnect snapshot barrier failed', error);
-        });
-      }
-    );
-  } catch (error) {
-    if (realtimeChannel === owned) await releaseProgressChannel(owned);
-    // A newer setup or teardown intentionally superseded this request. Its
-    // subscription failure is no longer actionable and must not reject the new
-    // request or surface as an initialization failure.
-    if (!stillOwnsSetup(currentUserId, generation)) return;
-    throw error;
-  }
-  if (!stillOwnsSetup(currentUserId, generation) || realtimeChannel !== owned) {
-    if (realtimeChannel === owned) await releaseProgressChannel(owned);
-  }
+  if (!(await claimProgressChannel(owned, currentUserId, generation))) return;
+  await joinProgressChannel(owned, currentUserId, generation, () => {
+    const request = ++refreshGeneration;
+    const read = (reconcile: RemoteStateMerge) => refreshSnapshot(reconcile, request);
+    const controller = getRegisteredSyncController();
+    const refreshing = controller?.withSnapshot
+      ? controller.withSnapshot(read)
+      : read(captureRemoteMerge());
+    refreshing.catch((error: unknown) => {
+      logger.warn('[TarkovStore] Reconnect snapshot barrier failed', error);
+    });
+  });
 }
 /**
  * Removes the channel and stops its timers. Bumping the generation invalidates

--- a/app/stores/tarkov/realtimeListener.ts
+++ b/app/stores/tarkov/realtimeListener.ts
@@ -252,20 +252,24 @@ const prepareProgressTopic = async (
 const resolveActiveUserId = (user: { id: string | null; loggedIn: boolean }): string | null =>
   user.loggedIn && user.id ? user.id : null;
 /**
- * Publishes channel ownership before the join is awaited, so a newer setup can
- * tear this channel down instead of creating a duplicate subscription.
+ * Publishes channel ownership so a newer setup can tear this channel down
+ * instead of creating a duplicate subscription.
  *
- * @returns `false` when this setup was superseded before it could publish.
+ * Deliberately synchronous: it must run in the same segment as the `subscribe()`
+ * call that follows. An await between the two would let a teardown remove or
+ * replace this channel after it was published but before it joined, leaving an
+ * orphaned subscription that later ownership checks can no longer clean up,
+ * because `realtimeChannel` would already point at the newer owner.
+ *
+ * @returns `false` when this setup was superseded before it could publish; the
+ *   caller still owns releasing `owned`.
  */
-const claimProgressChannel = async (
+const claimProgressChannel = (
   owned: OwnedRealtimeChannel,
   currentUserId: string,
   generation: number
-): Promise<boolean> => {
-  if (!stillOwnsSetup(currentUserId, generation)) {
-    await releaseProgressChannel(owned);
-    return false;
-  }
+): boolean => {
+  if (!stillOwnsSetup(currentUserId, generation)) return false;
   realtimeChannel = owned;
   return true;
 };
@@ -526,7 +530,12 @@ async function runSetupRealtimeListener(
     }
   };
   const owned = { channel, client, topic } satisfies OwnedRealtimeChannel;
-  if (!(await claimProgressChannel(owned, currentUserId, generation))) return;
+  // No await between the claim and the join: `joinProgressChannel` reaches
+  // `channel.subscribe()` synchronously, so ownership cannot change in between.
+  if (!claimProgressChannel(owned, currentUserId, generation)) {
+    await releaseProgressChannel(owned);
+    return;
+  }
   await joinProgressChannel(owned, currentUserId, generation, () => {
     const request = ++refreshGeneration;
     const read = (reconcile: RemoteStateMerge) => refreshSnapshot(reconcile, request);

--- a/app/stores/tarkov/resetEngine.ts
+++ b/app/stores/tarkov/resetEngine.ts
@@ -47,6 +47,87 @@ export const getStoryProgressScore = (mode: UserProgressData | undefined): numbe
   }
   return score;
 };
+/** Freshness inputs that decide local-vs-remote precedence at startup. */
+type StartupClocks = {
+  localTimestamp: number | null;
+  remoteUpdatedAt: number | null;
+  localScore: number;
+  remoteScore: number;
+  modeUpdatedAt?: Partial<Record<GameMode, number>>;
+  localModeTimestamps?: Partial<Record<GameMode, number>>;
+};
+/**
+ * An explicit clock map distinguishes historical unknown progress from callers
+ * using the legacy account-clock contract. Account-only changes cannot establish
+ * whether an unknown mode is newer than an offline edit.
+ */
+const hasUnknownModeClock = (clocks: StartupClocks, mode: GameMode): boolean =>
+  clocks.modeUpdatedAt !== undefined && clocks.modeUpdatedAt[mode] === undefined;
+const resolveLocalModeTimestamp = (clocks: StartupClocks, mode: GameMode): number | null =>
+  clocks.localModeTimestamps?.[mode] ?? clocks.localTimestamp;
+const resolveRemoteModeTimestamp = (clocks: StartupClocks, mode: GameMode): number | null =>
+  clocks.modeUpdatedAt?.[mode] ?? clocks.remoteUpdatedAt;
+const shouldPreferLocalMode = (clocks: StartupClocks, mode: GameMode): boolean => {
+  const localModeTimestamp = resolveLocalModeTimestamp(clocks, mode);
+  if (hasUnknownModeClock(clocks, mode)) return (localModeTimestamp ?? 0) > 0;
+  return shouldPreferLocalStartupMetadata(
+    localModeTimestamp,
+    resolveRemoteModeTimestamp(clocks, mode),
+    clocks.localScore,
+    clocks.remoteScore
+  );
+};
+/**
+ * Seasonal writes can advance independently of account metadata. Keep entry
+ * timestamps and reset epochs while using this mode's own progress freshness.
+ */
+const mergeModeSnapshot = (
+  localModeData: UserProgressData,
+  remoteModeData: UserProgressData,
+  preferLocalMode: boolean
+): UserProgressData => {
+  const preferred = preferLocalMode ? localModeData : remoteModeData;
+  const merged = preferLocalMode
+    ? mergeProgressData(remoteModeData, localModeData, true)
+    : mergeProgressData(localModeData, remoteModeData, true);
+  return {
+    ...merged,
+    displayName: preferred.displayName,
+    pmcFaction: preferred.pmcFaction,
+    xpOffset: preferred.xpOffset,
+    skillOffsets: preferred.skillOffsets,
+  };
+};
+const mergeModeHistories = (
+  localModeData: UserProgressData,
+  remoteModeData: UserProgressData,
+  preferLocalMode: boolean
+): UserProgressData => ({
+  ...(preferLocalMode ? localModeData : remoteModeData),
+  ...mergeManualActivityHistory(localModeData, remoteModeData),
+  storyChapters: mergeStoryChapterProgress(
+    localModeData.storyChapters,
+    remoteModeData.storyChapters
+  ),
+});
+const resolveModeData = (
+  clocks: StartupClocks,
+  mergeModeSnapshots: boolean,
+  localModeData: UserProgressData,
+  remoteModeData: UserProgressData,
+  mode: GameMode
+): UserProgressData => {
+  // A differing reset epoch means one side was reset; that takes precedence over
+  // freshness comparisons.
+  if (toProgressEpoch(localModeData) !== toProgressEpoch(remoteModeData)) {
+    return mergeProgressData(localModeData, remoteModeData);
+  }
+  const preferLocalMode = shouldPreferLocalMode(clocks, mode);
+  if (mergeModeSnapshots || hasUnknownModeClock(clocks, mode)) {
+    return mergeModeSnapshot(localModeData, remoteModeData, preferLocalMode);
+  }
+  return mergeModeHistories(localModeData, remoteModeData, preferLocalMode);
+};
 export const resolveInitialSyncState = (
   localState: UserState,
   remoteState: UserState,
@@ -67,54 +148,20 @@ export const resolveInitialSyncState = (
     localScore,
     remoteScore
   );
-  // fallow-ignore-next-line complexity -- startup merge/reset precedence is covered in resetEngine.seasonalReset.test.ts
-  const resolveModeData = (
+  const clocks: StartupClocks = {
+    localTimestamp,
+    remoteUpdatedAt,
+    localScore,
+    remoteScore,
+    modeUpdatedAt,
+    localModeTimestamps: options.localModeTimestamps,
+  };
+  const resolveMode = (
     localModeData: UserProgressData,
     remoteModeData: UserProgressData,
     mode: GameMode
-  ): UserProgressData => {
-    const localEpoch = toProgressEpoch(localModeData);
-    const remoteEpoch = toProgressEpoch(remoteModeData);
-    if (localEpoch !== remoteEpoch) {
-      return mergeProgressData(localModeData, remoteModeData);
-    }
-    const localModeTimestamp = options.localModeTimestamps?.[mode] ?? localTimestamp;
-    // An explicit clock map distinguishes historical unknown progress from
-    // callers using the legacy account-clock contract. Account-only changes
-    // cannot establish whether an unknown mode is newer than an offline edit.
-    const unknownModeClock = modeUpdatedAt !== undefined && modeUpdatedAt[mode] === undefined;
-    const preferLocalMode = unknownModeClock
-      ? (localModeTimestamp ?? 0) > 0
-      : shouldPreferLocalStartupMetadata(
-          localModeTimestamp,
-          modeUpdatedAt?.[mode] ?? remoteUpdatedAt,
-          localScore,
-          remoteScore
-        );
-    const preferredModeData = preferLocalMode ? localModeData : remoteModeData;
-    // Seasonal writes can advance independently of account metadata. Keep entry
-    // timestamps and reset epochs while using this mode's own progress freshness.
-    if (mergeModeSnapshots || unknownModeClock) {
-      const merged = preferLocalMode
-        ? mergeProgressData(remoteModeData, localModeData, true)
-        : mergeProgressData(localModeData, remoteModeData, true);
-      return {
-        ...merged,
-        displayName: preferredModeData.displayName,
-        pmcFaction: preferredModeData.pmcFaction,
-        xpOffset: preferredModeData.xpOffset,
-        skillOffsets: preferredModeData.skillOffsets,
-      };
-    }
-    return {
-      ...preferredModeData,
-      ...mergeManualActivityHistory(localModeData, remoteModeData),
-      storyChapters: mergeStoryChapterProgress(
-        localModeData.storyChapters,
-        remoteModeData.storyChapters
-      ),
-    };
-  };
+  ): UserProgressData =>
+    resolveModeData(clocks, mergeModeSnapshots, localModeData, remoteModeData, mode);
   return {
     currentGameMode: preferLocalMetadata ? localState.currentGameMode : remoteState.currentGameMode,
     gameEdition: preferLocalMetadata
@@ -123,9 +170,9 @@ export const resolveInitialSyncState = (
     tarkovUid: preferLocalMetadata
       ? (localState.tarkovUid ?? null)
       : (remoteState.tarkovUid ?? null),
-    pvp: resolveModeData(localState.pvp, remoteState.pvp, GAME_MODES.PVP),
-    pve: resolveModeData(localState.pve, remoteState.pve, GAME_MODES.PVE),
-    seasonal: resolveModeData(localState.seasonal, remoteState.seasonal, GAME_MODES.SEASONAL),
+    pvp: resolveMode(localState.pvp, remoteState.pvp, GAME_MODES.PVP),
+    pve: resolveMode(localState.pve, remoteState.pve, GAME_MODES.PVE),
+    seasonal: resolveMode(localState.seasonal, remoteState.seasonal, GAME_MODES.SEASONAL),
     seasonalSeasonNumber: ACTIVE_SEASON_NUMBER,
   };
 };

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -222,8 +222,9 @@ const readCachedEditions = async (mode: string, language: string): Promise<Cache
     return {};
   }
 };
+type ProgressionCatalogState = Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>;
 const prepareEditionScope = (
-  state: Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>,
+  state: ProgressionCatalogState,
   store: ReturnType<typeof getPromiseStore>,
   scope: string
 ) => {
@@ -240,7 +241,7 @@ const hasValidCachedEditions = (editions: GameEdition[]): boolean =>
 const sortedStoryChapters = (chapters: StoryChapter[]): StoryChapter[] =>
   chapters.map((chapter) => normalizeStoryChapter(chapter)).sort((a, b) => a.order - b.order);
 const applyCachedEditions = async (
-  state: Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>,
+  state: ProgressionCatalogState,
   isCurrent: () => boolean,
   mode: string,
   language: string
@@ -260,7 +261,7 @@ const applyCachedEditions = async (
 };
 /** A cache read must never fail the request that can still fetch live data. */
 const applyCachedEditionsOrIgnore = (
-  state: Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>,
+  state: ProgressionCatalogState,
   isCurrent: () => boolean,
   mode: string,
   language: string
@@ -300,7 +301,7 @@ const fetchProgressionCatalog = async (
   return overlay;
 };
 const applyProgressionCatalog = (
-  state: Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>,
+  state: ProgressionCatalogState,
   overlay: ProgressionCatalog,
   mode: string
 ) => {
@@ -311,7 +312,7 @@ const applyProgressionCatalog = (
   state.seasonalPerks = perksForMode(overlay.seasonalPerks ?? [], mode);
 };
 const cacheProgressionCatalog = (
-  state: Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>,
+  state: ProgressionCatalogState,
   mode: string,
   language: string
 ) => {

--- a/app/stores/useMetadata.ts
+++ b/app/stores/useMetadata.ts
@@ -237,6 +237,8 @@ const prepareEditionScope = (
 };
 const hasValidCachedEditions = (editions: GameEdition[]): boolean =>
   editions.length > 0 && editions.every(isGameEdition);
+const sortedStoryChapters = (chapters: StoryChapter[]): StoryChapter[] =>
+  chapters.map((chapter) => normalizeStoryChapter(chapter)).sort((a, b) => a.order - b.order);
 const applyCachedEditions = async (
   state: Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>,
   isCurrent: () => boolean,
@@ -252,11 +254,110 @@ const applyCachedEditions = async (
   state.editions = markRaw(editions);
   state.seasonalPerks = perksForMode(seasonalPerks, mode);
   if (!storyChapters.length) return false;
-  state.storyChapters = markRaw(
-    storyChapters.map((chapter) => normalizeStoryChapter(chapter)).sort((a, b) => a.order - b.order)
-  );
+  state.storyChapters = markRaw(sortedStoryChapters(storyChapters));
   logger.debug('[MetadataStore] Editions loaded from cache');
   return true;
+};
+/** A cache read must never fail the request that can still fetch live data. */
+const applyCachedEditionsOrIgnore = (
+  state: Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>,
+  isCurrent: () => boolean,
+  mode: string,
+  language: string
+): Promise<boolean> =>
+  applyCachedEditions(state, isCurrent, mode, language).catch((error) => {
+    logger.warn('[MetadataStore] Editions cache read failed:', error);
+    return false;
+  });
+/** An overlay response that carries a complete, well-formed progression catalog. */
+type ProgressionCatalog = CachedEditions & {
+  editions: GameEdition[];
+  storyChapters: StoryChapter[];
+};
+const isProgressionCatalog = (
+  overlay: CachedEditions | undefined
+): overlay is ProgressionCatalog => {
+  if (!overlay) return false;
+  if (!Array.isArray(overlay.storyChapters)) return false;
+  return Array.isArray(overlay.editions) && overlay.editions.every(isGameEdition);
+};
+const fetchProgressionCatalog = async (
+  mode: string,
+  language: string,
+  forceRefresh: boolean
+): Promise<ProgressionCatalog> => {
+  const response = await $fetch<{ data: CachedEditions }>('/api/tarkov/editions', {
+    query: {
+      lang: language,
+      gameMode: mode,
+      ...(forceRefresh ? { cacheBust: '1' } : {}),
+    },
+  });
+  const overlay = response.data;
+  // Reject the whole payload up front so malformed chapters cannot partially
+  // replace edition eligibility.
+  if (!isProgressionCatalog(overlay)) throw new TypeError('Invalid progression catalog');
+  return overlay;
+};
+const applyProgressionCatalog = (
+  state: Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>,
+  overlay: ProgressionCatalog,
+  mode: string
+) => {
+  // Normalize before assigning; the guard already proved both lists are present.
+  const chapters = sortedStoryChapters([...overlay.storyChapters]);
+  state.editions = markRaw([...overlay.editions]);
+  state.storyChapters = markRaw(chapters);
+  state.seasonalPerks = perksForMode(overlay.seasonalPerks ?? [], mode);
+};
+const cacheProgressionCatalog = (
+  state: Pick<MetadataState, 'editions' | 'storyChapters' | 'seasonalPerks'>,
+  mode: string,
+  language: string
+) => {
+  if (typeof window === 'undefined') return;
+  setCachedData(
+    'editions' as CacheType,
+    `${EDITIONS_CACHE_VERSION}-${mode}`,
+    language,
+    {
+      editions: state.editions,
+      storyChapters: state.storyChapters,
+      seasonalPerks: state.seasonalPerks,
+    },
+    CACHE_CONFIG.MAX_TTL
+  ).catch((err) => logger.error('[MetadataStore] Error caching editions:', err));
+};
+/**
+ * Fetch, validate, apply, and cache the progression catalog. Every state write
+ * is fenced behind `isCurrent()` so a superseded scope cannot publish its result.
+ */
+const loadProgressionCatalog = async (
+  state: Pick<MetadataState, 'editions' | 'editionsError' | 'seasonalPerks' | 'storyChapters'>,
+  promiseStore: ReturnType<typeof getPromiseStore>,
+  context: {
+    forceRefresh: boolean;
+    isCurrent: () => boolean;
+    language: string;
+    mode: string;
+    scope: string;
+  }
+): Promise<void> => {
+  try {
+    const overlay = await fetchProgressionCatalog(
+      context.mode,
+      context.language,
+      context.forceRefresh
+    );
+    if (!context.isCurrent()) return;
+    applyProgressionCatalog(state, overlay, context.mode);
+    promiseStore.editionsSettledScope = context.scope;
+    cacheProgressionCatalog(state, context.mode, context.language);
+  } catch (err) {
+    if (!context.isCurrent()) return;
+    logger.error('[MetadataStore] Error fetching editions data:', err);
+    state.editionsError = err as Error;
+  }
 };
 export const useMetadataStore = defineStore('metadata', {
   state: (): MetadataState => ({
@@ -1475,7 +1576,6 @@ export const useMetadataStore = defineStore('metadata', {
       prepareEditionScope(this, promiseStore, scope);
       this.seasonalPerks = perksForMode(this.seasonalPerks, requestMode);
       // Register the promise before requests can settle or throw synchronously.
-      // fallow-ignore-next-line complexity -- CRAP assumes zero coverage; measured coverage and reduced complexity are documented in docs/task-performance-validation.md
       const promise = Promise.resolve().then(async () => {
         this.editionsError = null;
         const isCurrent = () =>
@@ -1484,12 +1584,7 @@ export const useMetadataStore = defineStore('metadata', {
           this.languageCode === requestLanguage;
         if (
           !forceRefresh &&
-          (await applyCachedEditions(this, isCurrent, requestMode, requestLanguage).catch(
-            (error) => {
-              logger.warn('[MetadataStore] Editions cache read failed:', error);
-              return false;
-            }
-          ))
+          (await applyCachedEditionsOrIgnore(this, isCurrent, requestMode, requestLanguage))
         ) {
           void this.fetchEditionsData(true).catch((error) =>
             logger.warn('[MetadataStore] Background editions revalidation failed:', error)
@@ -1498,52 +1593,13 @@ export const useMetadataStore = defineStore('metadata', {
         }
         if (!isCurrent()) return;
         this.editionsLoading = true;
-        try {
-          const response = await $fetch<{ data: CachedEditions }>('/api/tarkov/editions', {
-            query: {
-              lang: requestLanguage,
-              gameMode: requestMode,
-              ...(forceRefresh ? { cacheBust: '1' } : {}),
-            },
-          });
-          const overlay = response.data;
-          if (
-            !overlay ||
-            !Array.isArray(overlay.editions) ||
-            !overlay.editions.every(isGameEdition) ||
-            !Array.isArray(overlay.storyChapters)
-          )
-            throw new TypeError('Invalid progression catalog');
-          if (!isCurrent()) return;
-          // Normalize both before assigning so malformed chapters cannot partially replace eligibility.
-          const editions = Object.values(overlay?.editions ?? {});
-          const chapters = Object.values(overlay?.storyChapters ?? {})
-            .map((chapter) => normalizeStoryChapter(chapter))
-            .sort((a, b) => a.order - b.order);
-          if (!overlay?.editions)
-            logger.warn('[MetadataStore] No editions found in overlay response');
-          this.editions = markRaw(editions);
-          this.storyChapters = markRaw(chapters);
-          promiseStore.editionsSettledScope = scope;
-          this.seasonalPerks = perksForMode(overlay.seasonalPerks ?? [], requestMode);
-          if (typeof window !== 'undefined') {
-            setCachedData(
-              'editions' as CacheType,
-              `${EDITIONS_CACHE_VERSION}-${requestMode}`,
-              requestLanguage,
-              {
-                editions: this.editions,
-                storyChapters: this.storyChapters,
-                seasonalPerks: this.seasonalPerks,
-              },
-              CACHE_CONFIG.MAX_TTL
-            ).catch((err) => logger.error('[MetadataStore] Error caching editions:', err));
-          }
-        } catch (err) {
-          if (!isCurrent()) return;
-          logger.error('[MetadataStore] Error fetching editions data:', err);
-          this.editionsError = err as Error;
-        }
+        await loadProgressionCatalog(this, promiseStore, {
+          forceRefresh,
+          isCurrent,
+          language: requestLanguage,
+          mode: requestMode,
+          scope,
+        });
       });
       promiseStore.editionsPromise = promise;
       try {

--- a/app/stores/usePreferences.ts
+++ b/app/stores/usePreferences.ts
@@ -744,8 +744,13 @@ export const usePreferencesStore = defineStore('preferences', {
       const clamped = Math.min(0.5, Math.max(0.05, opacity));
       this.mapZoneOpacity = clamped;
     },
-    // Fallow cannot follow this action through the typed map-controls composable boundary.
-    // fallow-ignore-next-line unused-store-member -- accessed through typed map-controls composable
+    // Called as `preferences.setMapTooltipDensity(...)` inside
+    // useLeafletMapControls, whose `preferences` parameter is a structural
+    // interface rather than the store type. The action is reached through that
+    // interface, so no reference to this store member exists to detect, and the
+    // composable boundary is deliberate: it keeps the map controls unit-testable
+    // with a plain object instead of a live Pinia store.
+    // fallow-ignore-next-line unused-store-member -- not actionable: invoked through a structural interface parameter, not the store
     setMapTooltipDensity(density: 'default' | 'compact') {
       this.mapTooltipDensity = density;
     },

--- a/app/stores/useSystemStore.ts
+++ b/app/stores/useSystemStore.ts
@@ -44,24 +44,41 @@ export function hasTeamInState(state: SystemState, gameMode?: GameMode): boolean
  * System store definition with getters for user tokens and team info
  */
 export const useSystemStore = defineStore<string, SystemState, SystemGetters>('system', {
+  // Every key below mirrors a `user_system` column. The row is hydrated wholesale
+  // by the Supabase listener and read through the exported `SystemState` helpers
+  // above, never as `systemStore.<column>`, so there is no store-member reference
+  // for the analyzer to find. The keys also cannot be narrowed away: the row shape
+  // is the database contract, and dropping one would silently stop hydrating it.
   state: (): SystemState => ({
-    // fallow-ignore-next-line unused-store-member -- state hydrated/accessed via Supabase $state and middleware
+    // Only reachable through a `$state` type assertion (AdminCacheCard.vue), which
+    // erases the store type and leaves no member reference to detect.
+    // fallow-ignore-next-line unused-store-member -- not actionable: reads go through an erased `$state` assertion
     user_id: null,
-    // fallow-ignore-next-line unused-store-member -- state hydrated/accessed via Supabase $state and middleware
+    // Legacy pre-per-mode columns, read only by `getLegacyTeamId(state)` from a
+    // plain `SystemState` parameter. Removing them would drop the compatibility
+    // path for rows written before per-mode team ids existed.
+    // fallow-ignore-next-line unused-store-member -- not actionable: read via a plain `SystemState` parameter, not the store
     team: null,
-    // fallow-ignore-next-line unused-store-member -- state hydrated/accessed via Supabase $state and middleware
+    // fallow-ignore-next-line unused-store-member -- not actionable: read via a plain `SystemState` parameter, not the store
     team_id: null,
-    // fallow-ignore-next-line unused-store-member -- state hydrated/accessed via Supabase $state and middleware
+    // Reached only as `state[getTeamIdStateKey(mode)]`. A computed key cannot be
+    // resolved statically, so no access to these three can ever be attributed.
+    // fallow-ignore-next-line unused-store-member -- not actionable: only reachable through a computed key
     pvp_team_id: null,
-    // fallow-ignore-next-line unused-store-member -- state hydrated/accessed via Supabase $state and middleware
+    // fallow-ignore-next-line unused-store-member -- not actionable: only reachable through a computed key
     pve_team_id: null,
-    // fallow-ignore-next-line unused-store-member -- state hydrated/accessed via membership queries and $state
+    // fallow-ignore-next-line unused-store-member -- not actionable: only reachable through a computed key
     seasonal_team_id: null,
-    // fallow-ignore-next-line unused-store-member -- state hydrated/accessed via Supabase $state and middleware
+    // Read only by this store's own `isAdmin` getter, through its `state`
+    // parameter; no consumer touches `systemStore.is_admin` directly.
+    // fallow-ignore-next-line unused-store-member -- not actionable: consumed by this store's own getter, not by a consumer
     is_admin: false,
   }),
   getters: {
-    // fallow-ignore-next-line unused-store-member -- state hydrated/accessed via Supabase $state and middleware
+    // Consumers read `systemStore.userTeam`, but the wrapper exposes the store as
+    // the declared type `Store<string, SystemState, SystemGetters>`, which does not
+    // resolve back to this `defineStore` call, so the access is invisible here.
+    // fallow-ignore-next-line unused-store-member -- not actionable: reads resolve against the wrapper's declared store type
     userTeam(state): string | null {
       return getTeamIdFromState(state);
     },

--- a/app/stores/useSystemStore.ts
+++ b/app/stores/useSystemStore.ts
@@ -61,24 +61,29 @@ export const useSystemStore = defineStore<string, SystemState, SystemGetters>('s
     team: null,
     // fallow-ignore-next-line unused-store-member -- not actionable: read via a plain `SystemState` parameter, not the store
     team_id: null,
-    // Reached only as `state[getTeamIdStateKey(mode)]`. A computed key cannot be
-    // resolved statically, so no access to these three can ever be attributed.
-    // fallow-ignore-next-line unused-store-member -- not actionable: only reachable through a computed key
+    // Read only by `getTeamIdFromState(state)` from a plain `SystemState`
+    // parameter, whose active-mode lookup is the computed key
+    // `state[getTeamIdStateKey(mode)]`; no consumer names them on the store.
+    // fallow-ignore-next-line unused-store-member -- not actionable: read via a plain `SystemState` parameter and a computed key
     pvp_team_id: null,
-    // fallow-ignore-next-line unused-store-member -- not actionable: only reachable through a computed key
+    // fallow-ignore-next-line unused-store-member -- not actionable: read via a plain `SystemState` parameter and a computed key
     pve_team_id: null,
-    // fallow-ignore-next-line unused-store-member -- not actionable: only reachable through a computed key
+    // fallow-ignore-next-line unused-store-member -- not actionable: read via a plain `SystemState` parameter and a computed key
     seasonal_team_id: null,
-    // Read only by this store's own `isAdmin` getter, through its `state`
-    // parameter; no consumer touches `systemStore.is_admin` directly.
-    // fallow-ignore-next-line unused-store-member -- not actionable: consumed by this store's own getter, not by a consumer
+    // Read as `systemStore.$state.is_admin` by the admin route guard
+    // (`app/middleware/admin.ts`), the same erased-`$state` access as `user_id`:
+    // the assertion-free `$state` read never names this store member.
+    // fallow-ignore-next-line unused-store-member -- not actionable: reads go through `$state`, which names no store member
     is_admin: false,
   }),
   getters: {
-    // Consumers read `systemStore.userTeam`, but the wrapper exposes the store as
-    // the declared type `Store<string, SystemState, SystemGetters>`, which does not
-    // resolve back to this `defineStore` call, so the access is invisible here.
-    // fallow-ignore-next-line unused-store-member -- not actionable: reads resolve against the wrapper's declared store type
+    // Consumers read `systemStore.userTeam`, but only through
+    // `useSystemStoreWithSupabase()`, whose declared return type is the alias
+    // `Store<string, SystemState, SystemGetters>` and does not resolve back to
+    // this `defineStore` call. The sibling `isAdmin` getter reports clean purely
+    // because settings.vue also holds a direct `useSystemStore()` instance, so the
+    // only fix would be forcing consumers off the wrapper.
+    // fallow-ignore-next-line unused-store-member -- not actionable: reads resolve against the wrapper's aliased store type
     userTeam(state): string | null {
       return getTeamIdFromState(state);
     },

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -37,7 +37,12 @@ function getTeamIdFromSystemStore(
  */
 export const useTeamStore = defineStore<string, TeamState, TeamGetters>('team', {
   state: (): TeamState => ({
-    // fallow-ignore-next-line unused-store-member -- read directly by Team page consumers
+    // Consumers do read this, as `teamStore.id` in useTeamInviteLink.ts and
+    // TeamDangerZone.vue, but `.id` accesses are not attributed to a state key
+    // because `id` is also the identifier Pinia exposes on every store instance.
+    // The state is hydrated by `$patch(transformed as Partial<TeamState>)`, so the
+    // key is part of the row shape and cannot be renamed to dodge the collision.
+    // fallow-ignore-next-line unused-store-member -- not actionable: `.id` reads collide with Pinia's own store identifier
     id: null,
     owner: null,
     joinCode: null,
@@ -316,6 +321,44 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     if (errorCount < MAX_CHANNEL_ERRORS) return;
     scheduleRecovery();
   };
+  /** A deliberately suspended socket is disconnected by design, not a join failure. */
+  const isTransportSuspended = (): boolean => {
+    const { realtime } = deps.getClient();
+    return Boolean(realtime) && isRealtimeSuspended(realtime);
+  };
+  const handleJoined = (
+    owned: OwnedRealtimeChannel,
+    teamId: string,
+    filter: string | undefined
+  ) => {
+    joinedTeamId = teamId;
+    joinedFilter = filter;
+    errorCount = 0;
+    if (previouslyJoined.has(owned)) {
+      void reconcileRejoin(teamId);
+      return;
+    }
+    previouslyJoined.add(owned);
+    dispatchHydration(teamId);
+  };
+  /**
+   * A closed or failed channel is no longer joined, so drop the binding and let
+   * the next membership event rebuild it.
+   *
+   * Recovery can replace the owned channel before it rejoins, so the
+   * missed-progress refresh is carried across that replacement.
+   */
+  const handleLostChannel = (
+    owned: OwnedRealtimeChannel,
+    teamId: string,
+    status: string,
+    error?: Error
+  ) => {
+    if (previouslyJoined.has(owned)) hydrationTeam = teamId;
+    joinedTeamId = null;
+    joinedFilter = undefined;
+    recordStatusFailure(status, error);
+  };
   /**
    * Reacts to every subscribe status rather than only `SUBSCRIBED`.
    *
@@ -324,7 +367,6 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
    * invisible while Realtime rejoins forever. The binding is recorded as joined
    * only here, so a join that silently no-ops is never mistaken for a live one.
    */
-  // fallow-ignore-next-line complexity -- tested subscription ownership and recovery state machine; inferred coverage misses callback calls
   const handleStatus = (
     owned: OwnedRealtimeChannel,
     teamId: string,
@@ -333,29 +375,12 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     error?: Error
   ) => {
     if (channel.value !== owned) return;
-    if (deps.getClient().realtime && isRealtimeSuspended(deps.getClient().realtime)) {
+    if (isTransportSuspended()) {
       previouslyJoined.add(owned);
       return;
     }
-    if (status === 'SUBSCRIBED') {
-      joinedTeamId = teamId;
-      joinedFilter = filter;
-      errorCount = 0;
-      if (previouslyJoined.has(owned)) void reconcileRejoin(teamId);
-      else {
-        previouslyJoined.add(owned);
-        dispatchHydration(teamId);
-      }
-      return;
-    }
-    // A closed channel is no longer joined, so drop the binding to let the next
-    // membership event rebuild it.
-    // Recovery can replace the owned channel before it rejoins. Carry the
-    // missed-progress refresh across that replacement, too.
-    if (previouslyJoined.has(owned)) hydrationTeam = teamId;
-    joinedTeamId = null;
-    joinedFilter = undefined;
-    recordStatusFailure(status, error);
+    if (status === 'SUBSCRIBED') handleJoined(owned, teamId, filter);
+    else handleLostChannel(owned, teamId, status, error);
   };
   const bindProgress = (source: SupabaseRealtimeChannel, filter: string): SupabaseRealtimeChannel =>
     source.on(
@@ -421,18 +446,33 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
   const isStale = (requestVersion: number): boolean => disposed || requestVersion !== version;
   const shouldContinue = async (requestVersion: number): Promise<boolean> =>
     !isStale(requestVersion) && (await resolveTargetTeam()) !== null;
-  // fallow-ignore-next-line complexity -- refresh success and generation fences are covered in teamChannelController.test.ts and useTeamStore.test.ts
+  /**
+   * Refreshes membership on behalf of a still-current request.
+   *
+   * @returns `false` when the request was superseded or the membership read
+   *   failed, in which case the channel must be left alone.
+   */
+  const refreshMembersForRequest = async (requestVersion: number): Promise<boolean> => {
+    if (!(await shouldContinue(requestVersion))) return false;
+    if (!(await deps.refreshMembers(true))) return false;
+    return await shouldContinue(requestVersion);
+  };
+  /**
+   * Hydrates an unchanged binding instead of rebuilding it. Only the winning
+   * refresh may do so: an older reconnect request may have been superseded by a
+   * membership event.
+   *
+   * @returns `true` when the existing channel already carries the right bindings.
+   */
+  const reuseCurrentBinding = (): boolean => {
+    if (needsRebuild(deps.getTeamId())) return false;
+    dispatchHydration(joinedTeamId);
+    return true;
+  };
   const refresh = async (): Promise<void> => {
     const requestVersion = ++version;
-    if (!(await shouldContinue(requestVersion))) return;
-    if (!(await deps.refreshMembers(true))) return;
-    if (!(await shouldContinue(requestVersion))) return;
-    if (!needsRebuild(deps.getTeamId())) {
-      // Only the winning refresh can hydrate an unchanged binding. An older
-      // reconnect request may have been superseded by a membership event.
-      dispatchHydration(joinedTeamId);
-      return;
-    }
+    if (!(await refreshMembersForRequest(requestVersion))) return;
+    if (reuseCurrentBinding()) return;
     await setup(requestVersion);
   };
   return {
@@ -815,32 +855,57 @@ export function useTeammateStores() {
         replayProgressMetadataMigration();
       };
       let hydrationRequest = 0;
-      // fallow-ignore-next-line complexity -- hydration ordering and stale-event guards are covered in useTeamStore.test.ts
+      const hydrationIsStale = (request: number): boolean =>
+        !isHydrationActive() || request !== hydrationRequest;
+      /**
+       * A season-0 row is the materialized copy of legacy progress. Without one,
+       * the legacy per-mode column on `user_progress` is still authoritative.
+       */
+      const hasMaterializedLegacyRow = (
+        rows: Array<Record<string, unknown>> | null | undefined
+      ): boolean =>
+        (rows ?? []).some(
+          (row) =>
+            row.game_mode === legacyMode &&
+            row.season_number === 0 &&
+            hasMaterializedProgress(row.progress_data)
+        );
+      const readLegacyTeammateProgress = async (
+        rows: Array<Record<string, unknown>> | null | undefined
+      ): Promise<{ data: unknown; error: unknown }> =>
+        hasMaterializedLegacyRow(rows)
+          ? { data: null, error: null }
+          : await fetchLegacyTeammateProgress($supabase.client, teammateId, legacyMode);
+      /**
+       * Reads the teammate's materialized mode rows, plus the legacy column when
+       * no materialized copy exists.
+       *
+       * @returns `null` when the request went stale or the read failed; a failed
+       *   read has already been reported.
+       */
+      const readTeammateProgressRows = async (request: number) => {
+        const modeRows = await $supabase.client
+          .from('user_game_mode_progress')
+          .select('game_mode,season_number,progress_data')
+          .eq('user_id', teammateId);
+        if (hydrationIsStale(request)) return null;
+        if (modeRows.error) {
+          logTeammateModeProgressHydrationFailure(modeRows.error, teammateId);
+          return null;
+        }
+        return {
+          legacyRow: await readLegacyTeammateProgress(modeRows.data),
+          modeRows: modeRows.data,
+        };
+      };
       const hydrateModeProgress = async () => {
         const request = ++hydrationRequest;
         appliedModes.clear();
         try {
-          const modeRows = await $supabase.client
-            .from('user_game_mode_progress')
-            .select('game_mode,season_number,progress_data')
-            .eq('user_id', teammateId);
-          if (!isHydrationActive() || request !== hydrationRequest) return;
-          if (modeRows.error) {
-            logTeammateModeProgressHydrationFailure(modeRows.error, teammateId);
-            return;
-          }
-          const needsLegacy = !(modeRows.data ?? []).some(
-            (row) =>
-              row.game_mode === legacyMode &&
-              row.season_number === 0 &&
-              hasMaterializedProgress(row.progress_data)
-          );
-          const legacyRow = needsLegacy
-            ? await fetchLegacyTeammateProgress($supabase.client, teammateId, legacyMode)
-            : { data: null, error: null };
-          if (!isHydrationActive() || request !== hydrationRequest) return;
-          applyModeProgressRows(modeRows.data);
-          applyLegacyModeProgress(legacyRow);
+          const rows = await readTeammateProgressRows(request);
+          if (!rows || hydrationIsStale(request)) return;
+          applyModeProgressRows(rows.modeRows);
+          applyLegacyModeProgress(rows.legacyRow);
           replayHydratedProgressMetadata();
         } catch (error) {
           logTeammateModeProgressHydrationFailure(error, teammateId);

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -230,6 +230,7 @@ export const applyTeammateProgressEvent = (
   });
   dispatchTeammateProgressEvent(data);
 };
+type OwnedTeamChannel = OwnedRealtimeChannel & { client: SupabaseClient };
 export type TeamChannelDeps = {
   /** Resolved per call: the plugin replaces the client during initialization. */
   getClient: () => SupabaseClient;
@@ -324,8 +325,8 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
     scheduleRecovery();
   };
   /** A deliberately suspended socket is disconnected by design, not a join failure. */
-  const isTransportSuspended = (): boolean => {
-    const { realtime } = deps.getClient();
+  const isTransportSuspended = (owned: OwnedTeamChannel): boolean => {
+    const { realtime } = owned.client;
     return Boolean(realtime) && isRealtimeSuspended(realtime);
   };
   const handleJoined = (
@@ -370,14 +371,14 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
    * only here, so a join that silently no-ops is never mistaken for a live one.
    */
   const handleStatus = (
-    owned: OwnedRealtimeChannel,
+    owned: OwnedTeamChannel,
     teamId: string,
     filter: string | undefined,
     status: string,
     error?: Error
   ) => {
     if (channel.value !== owned) return;
-    if (isTransportSuspended()) {
+    if (isTransportSuspended(owned)) {
       previouslyJoined.add(owned);
       return;
     }
@@ -408,7 +409,7 @@ export const createTeamChannelController = (deps: TeamChannelDeps): TeamChannelC
       () => void refresh()
     );
     if (progressFilter) next = bindProgress(next, progressFilter);
-    const owned: OwnedRealtimeChannel = { channel: next, client, topic };
+    const owned: OwnedTeamChannel = { channel: next, client, topic };
     channel.value = owned;
     if (client.realtime && isRealtimeSuspended(client.realtime)) previouslyJoined.add(owned);
     next.subscribe((status, error) => handleStatus(owned, teamId, progressFilter, status, error));

--- a/app/stores/useTeamStore.ts
+++ b/app/stores/useTeamStore.ts
@@ -38,11 +38,13 @@ function getTeamIdFromSystemStore(
 export const useTeamStore = defineStore<string, TeamState, TeamGetters>('team', {
   state: (): TeamState => ({
     // Consumers do read this, as `teamStore.id` in useTeamInviteLink.ts and
-    // TeamDangerZone.vue, but `.id` accesses are not attributed to a state key
-    // because `id` is also the identifier Pinia exposes on every store instance.
-    // The state is hydrated by `$patch(transformed as Partial<TeamState>)`, so the
-    // key is part of the row shape and cannot be renamed to dodge the collision.
-    // fallow-ignore-next-line unused-store-member -- not actionable: `.id` reads collide with Pinia's own store identifier
+    // TeamDangerZone.vue, but Fallow does not attribute a `.id` read to this
+    // state key: `teamStore.owner`, read on the same line of TeamDangerZone.vue,
+    // is attributed and reports clean, while `id` stays flagged. Adding another
+    // consumer read cannot resolve it, and the key belongs to the row shape
+    // hydrated by `$patch(transformed as Partial<TeamState>)`, so renaming it to
+    // sidestep the rule would change the persisted contract.
+    // fallow-ignore-next-line unused-store-member -- not actionable: Fallow does not attribute `.id` reads to a state key
     id: null,
     owner: null,
     joinCode: null,

--- a/app/utils/__tests__/pendingState.test.ts
+++ b/app/utils/__tests__/pendingState.test.ts
@@ -77,6 +77,18 @@ describe('pending state reconciliation', () => {
     expect(snapshot).toEqual({ progress: { count: 2 }, empty: undefined });
     expect(snapshotSyncState(null)).toEqual({});
   });
+  it.each([() => undefined, Symbol('transient'), { toJSON: () => undefined }])(
+    'omits non-serializable fields without deleting matching remote values: %s',
+    (transient) => {
+      const base = snapshotSyncState({ transient, empty: undefined, persisted: 1 });
+      const local = snapshotSyncState({ empty: undefined, persisted: 2 });
+      expect(base).toStrictEqual({ empty: undefined, persisted: 1 });
+      expect(preservePendingPaths(base, local, { transient: 'remote', persisted: 3 })).toEqual({
+        transient: 'remote',
+        persisted: 2,
+      });
+    }
+  );
   it('preserves local deletion and array replacement while accepting other remote keys', () => {
     const base = { removed: { count: 5 }, list: ['a'], unchanged: 'old' };
     const local = { list: [], unchanged: 'old' };

--- a/app/utils/__tests__/realtimeChannel.test.ts
+++ b/app/utils/__tests__/realtimeChannel.test.ts
@@ -1,5 +1,6 @@
 // @vitest-environment happy-dom
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '@/utils/logger';
 import {
   createChannelReleaseLatch,
   subscribeAndWaitForRealtimeChannel,
@@ -134,6 +135,27 @@ describe('subscribeAndWaitForRealtimeChannel', () => {
     } finally {
       suspension.active = false;
     }
+  });
+  it('rejects a CLOSED status before the first join', async () => {
+    const { channel, emit } = createChannel();
+    const ready = subscribeAndWaitForRealtimeChannel(channel, 'test', {}, 1000);
+    emit('CLOSED');
+    await expect(ready).rejects.toThrow('Realtime subscription failed with status CLOSED');
+    expect(logger.warn).toHaveBeenCalled();
+  });
+  it('ignores normal close warnings after joining while retaining rejoin and error handling', async () => {
+    const { channel, emit } = createChannel();
+    const refresh = vi.fn();
+    const ready = subscribeAndWaitForRealtimeChannel(channel, 'test', {}, 1000, refresh);
+    emit('SUBSCRIBED');
+    await ready;
+    vi.mocked(logger.warn).mockClear();
+    emit('CLOSED');
+    expect(logger.warn).not.toHaveBeenCalled();
+    emit('SUBSCRIBED');
+    expect(refresh).toHaveBeenCalledOnce();
+    emit('CHANNEL_ERROR', new Error('Connection lost'));
+    expect(logger.warn).toHaveBeenCalledOnce();
   });
   it('rejects on an explicit subscription failure', async () => {
     const { channel, emit } = createChannel();

--- a/app/utils/pendingState.ts
+++ b/app/utils/pendingState.ts
@@ -11,34 +11,48 @@ export type RemoteStateMerge = (
 ) => Snapshot;
 const isRecord = (value: unknown): value is Snapshot =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
+// Marks a field the persistence contract cannot carry, so the caller can tell
+// "cloned to undefined" (a real JSON result) apart from "not serializable".
+const UNSERIALIZABLE = Symbol('unserializable');
+const cloneSerializable = (value: unknown): unknown => {
+  try {
+    const json = JSON.stringify(value);
+    return json === undefined ? undefined : JSON.parse(json);
+  } catch {
+    // Cyclic or otherwise non-encodable UI state.
+    return UNSERIALIZABLE;
+  }
+};
 // Snapshot JSON-backed fields independently so transient UI references cannot
 // prevent reconciliation of the persisted fields next to them.
-// fallow-ignore-next-line complexity -- JSON/undefined/cyclic fields are covered directly in pendingState.test.ts; estimated coverage reports none
 export const snapshotSyncState = (state: unknown): Snapshot => {
   const result: Snapshot = {};
   if (!isRecord(state)) return result;
   for (const [key, value] of Object.entries(state)) {
-    try {
-      const json = JSON.stringify(value);
-      result[key] = json === undefined ? undefined : JSON.parse(json);
-    } catch {
-      // Non-serializable UI state is not part of the persistence contract.
+    const clone = cloneSerializable(value);
+    if (clone !== UNSERIALIZABLE) result[key] = clone;
+  }
+  return result;
+};
+// Applies the per-key half of the three-way merge: a key the local side dropped
+// is deleted from the remote result, and every other key recurses.
+const mergePendingKeys = (base: Snapshot, local: Snapshot, remote: unknown): Snapshot => {
+  const result: Snapshot = isRecord(remote) ? { ...remote } : {};
+  for (const key of new Set([...Object.keys(base), ...Object.keys(local)])) {
+    if (Object.hasOwn(local, key)) {
+      result[key] = preservePendingPaths(base[key], local[key], result[key]);
+    } else {
+      Reflect.deleteProperty(result, key);
     }
   }
   return result;
 };
 // Three-way merge: retain only paths changed locally since the acknowledged
 // baseline. Remote changes to other paths still apply, including other modes.
-// fallow-ignore-next-line complexity -- deletion/array/remote-field merges are covered in pendingState.test.ts and live/snapshot integration tests
 export const preservePendingPaths = (base: unknown, local: unknown, remote: unknown): unknown => {
   if (deepEqual(base, local)) return remote;
   if (!isRecord(base) || !isRecord(local)) return local;
-  const result: Snapshot = isRecord(remote) ? { ...remote } : {};
-  for (const key of new Set([...Object.keys(base), ...Object.keys(local)])) {
-    if (!Object.hasOwn(local, key)) Reflect.deleteProperty(result, key);
-    else result[key] = preservePendingPaths(base[key], local[key], result[key]);
-  }
-  return result;
+  return mergePendingKeys(base, local, remote);
 };
 const reconcileValue = (
   base: unknown,

--- a/app/utils/pendingState.ts
+++ b/app/utils/pendingState.ts
@@ -12,12 +12,13 @@ export type RemoteStateMerge = (
 const isRecord = (value: unknown): value is Snapshot =>
   value !== null && typeof value === 'object' && !Array.isArray(value);
 // Marks a field the persistence contract cannot carry, so the caller can tell
-// "cloned to undefined" (a real JSON result) apart from "not serializable".
+// an explicit undefined field apart from a value JSON cannot serialize.
 const UNSERIALIZABLE = Symbol('unserializable');
 const cloneSerializable = (value: unknown): unknown => {
   try {
     const json = JSON.stringify(value);
-    return json === undefined ? undefined : JSON.parse(json);
+    if (json === undefined) return value === undefined ? undefined : UNSERIALIZABLE;
+    return JSON.parse(json);
   } catch {
     // Cyclic or otherwise non-encodable UI state.
     return UNSERIALIZABLE;

--- a/app/utils/realtimeChannel.ts
+++ b/app/utils/realtimeChannel.ts
@@ -188,7 +188,7 @@ export const subscribeAndWaitForRealtimeChannel = (
       needsRefresh = true;
       if (suspended()) return;
       if (
-        logChannelSubscribeFailure(label, status, error, context, { treatClosedAsFailure: true })
+        logChannelSubscribeFailure(label, status, error, context, { treatClosedAsFailure: !joined })
       ) {
         settle(error ?? new Error(`Realtime subscription failed with status ${status}`));
       }

--- a/app/utils/realtimeChannel.ts
+++ b/app/utils/realtimeChannel.ts
@@ -96,6 +96,14 @@ export const removeOwnedChannel = async (
 const HEALTHY_CHANNEL_STATUSES = new Set(['SUBSCRIBED', 'CLOSED']);
 const describeChannelError = (error: Error | undefined): string | null => error?.message ?? null;
 /**
+ * `CLOSED` is the expected terminal status while a channel is leaving, but an
+ * initial join that reports it has failed, so the caller decides how to read it.
+ */
+const isHealthyChannelStatus = (status: string, treatClosedAsFailure: boolean): boolean => {
+  if (!HEALTHY_CHANNEL_STATUSES.has(status)) return false;
+  return !(status === 'CLOSED' && treatClosedAsFailure);
+};
+/**
  * Logs any subscribe status that is neither a successful join nor the expected
  * terminal status while leaving.
  *
@@ -104,7 +112,6 @@ const describeChannelError = (error: Error | undefined): string | null => error?
  *
  * @returns `true` when the status indicates a failure.
  */
-// fallow-ignore-next-line complexity -- initial joins treat CLOSED as an explicit failure
 export const logChannelSubscribeFailure = (
   label: string,
   status: string,
@@ -112,12 +119,7 @@ export const logChannelSubscribeFailure = (
   context: Record<string, unknown>,
   options?: { treatClosedAsFailure?: boolean }
 ): boolean => {
-  if (
-    HEALTHY_CHANNEL_STATUSES.has(status) &&
-    !(status === 'CLOSED' && options?.treatClosedAsFailure)
-  ) {
-    return false;
-  }
+  if (isHealthyChannelStatus(status, options?.treatClosedAsFailure === true)) return false;
   logger.warn(`[${label}] Realtime channel is not subscribed:`, {
     ...context,
     error: describeChannelError(error),
@@ -172,26 +174,30 @@ export const subscribeAndWaitForRealtimeChannel = (
       if (error) reject(error);
       else resolve();
     };
+    // A join that follows an earlier join or a suspended socket is a rejoin, so
+    // the caller has to refetch whatever it missed while the channel was down.
+    const handleJoined = (): void => {
+      if (joined || needsRefresh) onRejoined?.();
+      needsRefresh = false;
+      joined = true;
+      settle();
+    };
+    // Any other status leaves the channel unsubscribed. While the socket is
+    // deliberately suspended that is expected, so it is not a failure.
+    const handleNonJoinStatus = (status: string, error?: Error): void => {
+      needsRefresh = true;
+      if (suspended()) return;
+      if (
+        logChannelSubscribeFailure(label, status, error, context, { treatClosedAsFailure: true })
+      ) {
+        settle(error ?? new Error(`Realtime subscription failed with status ${status}`));
+      }
+    };
     try {
-      // fallow-ignore-next-line complexity -- tested join/rejoin state machine; inferred coverage misses the SDK callback
       channel.subscribe((status: string, error?: Error) => {
         logger.debug(`[${label}] Realtime subscription status: ${status}`);
-        if (status === 'SUBSCRIBED') {
-          if (joined || needsRefresh) onRejoined?.();
-          needsRefresh = false;
-          joined = true;
-          settle();
-          return;
-        }
-        needsRefresh = true;
-        if (suspended()) return;
-        if (
-          logChannelSubscribeFailure(label, status, error, context, {
-            treatClosedAsFailure: true,
-          })
-        ) {
-          settle(error ?? new Error(`Realtime subscription failed with status ${status}`));
-        }
+        if (status === 'SUBSCRIBED') handleJoined();
+        else handleNonJoinStatus(status, error);
       });
     } catch (error) {
       settle(error instanceof Error ? error : new Error(String(error)));

--- a/app/utils/realtimeVisibility.ts
+++ b/app/utils/realtimeVisibility.ts
@@ -19,6 +19,10 @@ export const installRealtimeVisibility = (
     if (disposed || suspendedTransports.has(transport) || leaving) return;
     originalConnect.call(transport);
   };
+  // A newer visibility transition, a hidden tab, or teardown invalidates a
+  // resume that was queued behind an in-flight disconnect.
+  const resumeIsStale = (version: number): boolean =>
+    disposed || version !== generation || page.visibilityState === 'hidden';
   transport.connect = connect;
   const suspend = () => {
     timer = undefined;
@@ -44,9 +48,8 @@ export const installRealtimeVisibility = (
     if (!suspendedTransports.has(transport)) return;
     void Promise.resolve(leaving)
       .catch(() => undefined)
-      // fallow-ignore-next-line complexity -- disconnect/visibility races covered with the real SDK in realtimeVisibility.test.ts
       .then(() => {
-        if (disposed || version !== generation || page.visibilityState === 'hidden') return;
+        if (resumeIsStale(version)) return;
         leaving = null;
         suspendedTransports.delete(transport);
         if (transport.getChannels().length > 0) connect();

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -938,7 +938,8 @@ flowchart LR
 - The team channel records itself as bound only after `SUBSCRIBED`, so a silently failed join is never
   mistaken for a live one. Membership events rebuild it only when the topic or teammate-progress
   filter changed, and any non-subscribed status drops the binding so the next event rebuilds.
-- Subscribe callbacks log every status that is not `SUBSCRIBED` or `CLOSED`. Five consecutive failures
+- Subscribe callbacks log every status that is not `SUBSCRIBED` or `CLOSED`; an own-progress
+  `CLOSED` before the first join still fails that join. Five consecutive failures
   tear the team channel down and schedule one rebuild a minute later, replacing Realtime's unbounded
   rejoin loop with a bounded retry cycle.
 - `user_system` is included in `supabase_realtime`, and sign-out tears down all client channels.
@@ -947,6 +948,8 @@ flowchart LR
   an outstanding disconnect before reconnecting once. Auth, local persistence, and outbound saves
   remain active. Rejoined consumers refresh authoritative snapshots; owner progress uses existing
   merge/epoch rules, and snapshot responses cannot overwrite newer live events or another session.
+  Pending snapshots omit non-serializable fields, including functions and symbols, while retaining
+  explicit `undefined` fields. Removing transient state must not become a persisted field deletion.
   A three-way merge compares each field with its acknowledged baseline, retaining only locally
   changed paths while accepting unrelated remote changes, including changes in other modes.
   Live mode rows and startup snapshots resolve counts by entry timestamp rather than maximum,

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -930,6 +930,9 @@ flowchart LR
   invalidates older work at each asynchronous boundary and rejects progress and metadata callbacks
   from the superseded listener, including while its channel is leaving. A different user's topic may
   proceed while the previous user's topic is leaving, while a same-topic rejoin still waits for its leave.
+  Publishing channel ownership and starting the subscription share one synchronous segment: an
+  asynchronous boundary between them would let a teardown remove the published channel before it
+  joined, and the resulting subscription could no longer be attributed to this setup for cleanup.
 - The team channel records itself as bound only after `SUBSCRIBED`, so a silently failed join is never
   mistaken for a live one. Membership events rebuild it only when the topic or teammate-progress
   filter changed, and any non-subscribed status drops the binding so the next event rebuilds.

--- a/docs/SYSTEMS.md
+++ b/docs/SYSTEMS.md
@@ -921,7 +921,9 @@ flowchart LR
   cleanup, so their channel lifetime is independent of the route that first created them.
 - Every channel is stored with the client that created it and removed through that client, because
   `$supabase.client` starts as an offline stub and is replaced once background initialization
-  completes. Removal is awaited before the same topic is rejoined: `RealtimeClient.channel()` returns
+  completes. Team subscription callbacks also check suspension on that owning client’s transport,
+  so replacing the current client cannot hide failures or tear down a deliberately suspended channel.
+  Removal is awaited before the same topic is rejoined: `RealtimeClient.channel()` returns
   the existing channel until its `phx_leave` settles and `subscribe()` only rejoins a closed channel,
   so rejoining early yields a channel that never joins and never reports an error. An unclean leave
   skips the rejoin rather than binding to an occupied topic.

--- a/docs/task-performance-validation.md
+++ b/docs/task-performance-validation.md
@@ -350,8 +350,13 @@ Fallow classifies the refactored inherited callback as new and estimates zero co
 CRAP 210. A focused V8 coverage diagnostic instead measured **30/33 statements** and **17/18
 branches** covered inside this callback across ten edition tests. Using statement coverage in
 Fallow's documented CRAP formula puts it below 15, under the default 30 threshold. The narrowly
-scoped Fallow annotation documents this mismatch; no repository threshold or CI gate is changed.
+scoped Fallow annotation documented this mismatch; no repository threshold or CI gate was changed.
 Sonar's cognitive-complexity rule remains enabled.
+
+That annotation has since been removed (issue #832). The callback body was decomposed into
+`fetchProgressionCatalog`, `applyProgressionCatalog`, `cacheProgressionCatalog`, and
+`loadProgressionCatalog`, so the finding is resolved at the source and no longer depends on
+unmeasured coverage.
 
 The diagnostic command was `pnpm run test app/stores/__tests__/useMetadata.fetchEditionsData.test.ts
 --coverage --coverage.reporter=json`. Its ten tests passed; the command exits nonzero because a

--- a/workers/api-gateway/src/handlers/progress.ts
+++ b/workers/api-gateway/src/handlers/progress.ts
@@ -6,6 +6,7 @@ import {
   getLegacyModeProgressField,
   hasMaterializedProgress,
   resolveModeProgressData,
+  type LegacyModeProgressField,
   type LegacyModeProgressRow,
 } from '../../../../app/utils/modeProgressFallback';
 import { getTasks, getHideoutStations } from '../services/tarkov';
@@ -107,17 +108,27 @@ const getServiceHeaders = (env: Env) => ({
   Authorization: `Bearer ${env.SUPABASE_SERVICE_ROLE_KEY}`,
   apikey: env.SUPABASE_SERVICE_ROLE_KEY,
 });
-// fallow-ignore-next-line complexity -- normalized/legacy fallback branches are exercised by gateway.test.ts; inferred coverage misses indirect route calls
-async function fetchUserProgressMode(
+/** Row shape selected from the materialized per-mode progress table. */
+interface ProgressModeRowFragment {
+  progress_data: UserProgressModeRow['progress_data'];
+  user_id: string;
+}
+/** Row shape selected from `user_progress`, which still carries legacy columns. */
+interface ProgressMetadataRow {
+  game_edition: number | null;
+  pve_data: UserProgressModeRow['progress_data'];
+  pvp_data: UserProgressModeRow['progress_data'];
+  user_id: string;
+}
+const DEFAULT_GAME_EDITION = 1;
+async function fetchProgressRowPair(
   env: Env,
   userId: string,
-  gameMode: GameMode
-): Promise<UserProgressModeRow | null> {
-  const seasonNumber = await getGameModeSeasonNumber(env, gameMode);
-  const legacyProgressField = getLegacyModeProgressField(gameMode);
-  const metadataSelect = 'user_id,game_edition';
+  gameMode: GameMode,
+  seasonNumber: number
+): Promise<{ metadataRows: ProgressMetadataRow[]; modeRows: ProgressModeRowFragment[] }> {
   const modeUrl = `${env.SUPABASE_URL}/rest/v1/user_game_mode_progress?user_id=eq.${userId}&game_mode=eq.${gameMode}&season_number=eq.${seasonNumber}&select=user_id,progress_data&limit=1`;
-  const metadataUrl = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=eq.${userId}&select=${metadataSelect}&limit=1`;
+  const metadataUrl = `${env.SUPABASE_URL}/rest/v1/user_progress?user_id=eq.${userId}&select=user_id,game_edition&limit=1`;
   const [modeResponse, metadataResponse] = await Promise.all([
     fetch(modeUrl, { headers: getServiceHeaders(env) }),
     fetch(metadataUrl, { headers: getServiceHeaders(env) }),
@@ -125,36 +136,73 @@ async function fetchUserProgressMode(
   if (!modeResponse.ok || !metadataResponse.ok) {
     throw new Error('Failed to fetch user progress');
   }
-  const modeRows = (await modeResponse.json()) as Array<{
-    progress_data: UserProgressModeRow['progress_data'];
-    user_id: string;
-  }>;
-  const metadataRows = (await metadataResponse.json()) as Array<{
-    game_edition: number | null;
-    pve_data: UserProgressModeRow['progress_data'];
-    pvp_data: UserProgressModeRow['progress_data'];
-    user_id: string;
-  }>;
-  const modeRow = modeRows[0];
+  const modeRows = (await modeResponse.json()) as ProgressModeRowFragment[];
+  const metadataRows = (await metadataResponse.json()) as ProgressMetadataRow[];
+  return { metadataRows, modeRows };
+}
+const readLegacyModeField = (
+  legacy: LegacyProgressRecordRow | null,
+  field: LegacyModeProgressField
+): UserProgressModeRow['progress_data'] => legacy?.[field] as UserProgressModeRow['progress_data'];
+/**
+ * Until a mode row is materialized, the legacy per-mode column on
+ * `user_progress` still holds the only copy of that progress. Graft it onto the
+ * metadata rows so assembly can resolve it through the shared fallback helper.
+ * Seasonal has no legacy column, so it is a no-op there.
+ */
+async function applyLegacyProgressFallback(
+  env: Env,
+  userId: string,
+  gameMode: GameMode,
+  metadataRows: ProgressMetadataRow[]
+): Promise<void> {
+  const legacyProgressField = getLegacyModeProgressField(gameMode);
+  if (!legacyProgressField) return;
+  const legacy = await fetchLegacyProgressRow(env, userId, gameMode);
   const metadataRow = metadataRows[0];
-  if (legacyProgressField && !hasMaterializedProgress(modeRow?.progress_data)) {
-    const legacy = await fetchLegacyProgressRow(env, userId, gameMode);
-    if (metadataRow)
-      metadataRow[legacyProgressField] = legacy?.[
-        legacyProgressField
-      ] as typeof metadataRow.pvp_data;
-    else if (legacy)
-      metadataRows.push({
-        ...legacy,
-        user_id: userId,
-        game_edition: null,
-      } as (typeof metadataRows)[number]);
+  if (metadataRow) {
+    metadataRow[legacyProgressField] = readLegacyModeField(legacy, legacyProgressField);
+  } else if (legacy) {
+    metadataRows.push({ ...legacy, user_id: userId, game_edition: null } as ProgressMetadataRow);
   }
+}
+const readModeUserId = (modeRow: ProgressModeRowFragment | undefined, userId: string): string =>
+  modeRow?.user_id ?? userId;
+const readGameEdition = (metadataRow: ProgressMetadataRow | undefined): number =>
+  metadataRow?.game_edition ?? DEFAULT_GAME_EDITION;
+/**
+ * Assemble the response row. A user may be missing the materialized mode row,
+ * the `user_progress` metadata row, or both; each absence resolves to a
+ * documented default rather than failing the read.
+ */
+function buildProgressModeRow(
+  userId: string,
+  gameMode: GameMode,
+  modeRow: ProgressModeRowFragment | undefined,
+  metadataRow: ProgressMetadataRow | undefined
+): UserProgressModeRow {
   return {
-    user_id: modeRow?.user_id ?? userId,
-    game_edition: metadataRow?.game_edition ?? 1,
-    progress_data: resolveModeProgressData(gameMode, modeRow?.progress_data, metadataRows[0]),
+    user_id: readModeUserId(modeRow, userId),
+    game_edition: readGameEdition(metadataRow),
+    progress_data: resolveModeProgressData(gameMode, modeRow?.progress_data, metadataRow),
   };
+}
+async function fetchUserProgressMode(
+  env: Env,
+  userId: string,
+  gameMode: GameMode
+): Promise<UserProgressModeRow | null> {
+  const seasonNumber = await getGameModeSeasonNumber(env, gameMode);
+  const { metadataRows, modeRows } = await fetchProgressRowPair(
+    env,
+    userId,
+    gameMode,
+    seasonNumber
+  );
+  if (!hasMaterializedProgress(modeRows[0]?.progress_data)) {
+    await applyLegacyProgressFallback(env, userId, gameMode, metadataRows);
+  }
+  return buildProgressModeRow(userId, gameMode, modeRows[0], metadataRows[0]);
 }
 const asProgressRecord = (value: unknown): Record<string, unknown> =>
   value && typeof value === 'object' && !Array.isArray(value)


### PR DESCRIPTION
# Pull Request

## Summary

Removes all 22 Fallow complexity suppressions by decomposing the affected persistence, synchronization, metadata, team, and realtime functions. The 10 remaining unused-store-member suppressions document the framework or analyzer indirection that prevents an actionable finding.

The refactor preserves startup merge precedence, pending-save reconciliation, legacy progress fallback, catalog validation, and channel ownership fences. Review also corrected the claim-to-subscribe ordering and a team callback that inspected the replacement client's transport instead of its channel owner's transport.

## Changes

- Extract helpers within the original modules to resolve complexity findings without raising thresholds or adding suppressions.
- Preserve the synchronous interval between publishing own-progress channel ownership and starting its subscription; cover teardown during this interval with a regression test.
- Check team subscription suspension on the owning client. Tests reproduce both false teardown and missed recovery after client replacement, and pass with the correction.
- Cover failed same-topic leaves, initial and superseded join failures, edition cache-write rejection, and Seasonal team cleanup.
- Skip non-serializable snapshot fields while retaining explicit `undefined`, with function, symbol, and `toJSON` regression cases. Keep initial `CLOSED` join failures but stop false warnings after a successful join.
- Replace repeated catalog state types with `ProgressionCatalogState` to address Sonar's new maintainability issue.
- Correct retained suppression explanations: Pinia's instance identifier is `$id`; system-store state reads and computed keys retain their actual indirection, and the team `id` rationale describes the observed analyzer limitation without claiming a Pinia name collision.
- Update the realtime ownership invariants in `docs/SYSTEMS.md` and the obsolete complexity-annotation discussion in `docs/task-performance-validation.md`.

## Related Issues

Closes #832

## Testing

- [x] Tested locally
- [x] Added/updated unit tests
- [ ] Tested in production-like environment
- [ ] Manual browser testing performed

### Test Plan

Final local input matches commit `65877d7f2482ce52e9f5a64adc2806cc5872e196`; the PR worktree is clean after committing. The unrelated root worktree change was preserved.

- Focused application regressions: 359 tests across 29 files passed before the final team-owner correction; the affected team suites were rerun afterward, with 108 tests passing, including two new client-replacement cases. Those two cases both failed before the correction.
- `pnpm run test:api-gateway`: 184 tests across 11 files passed.
- Final `pnpm run lint`, `pnpm run typecheck`, `pnpm run format:check`, `pnpm run systems:check`, `pnpm run lint:fallow`, and `git diff --check`: passed.
- `pnpm --filter api-gateway run typecheck`, `pnpm --filter api-gateway run types:check`, and `pnpm --filter api-gateway exec wrangler deploy --config wrangler.toml --dry-run`: passed.
- `pnpm run test:coverage` at `b0eed19a`: 3,594 tests across 306 files passed with all configured coverage thresholds met. After the final snapshot/close corrections, the affected snapshot, sync, listener, and team suites were rerun: 120 tests across seven files passed. The new non-serializable-field and close-warning regressions fail before their fixes.
- Final complete-branch local CodeRabbit review: completed with zero findings after all corrections. Hosted Codex review of `65877d7f` completed with no major issues; Cubic reported zero issues in the final six-file update.
- Final-head hosted checks: all 30 applicable checks passed; two conditional checks were skipped. GitHub reports `MERGEABLE` / `CLEAN`, with zero unresolved review threads.
- Complete four-upload Codecov report for `65877d7f`: **237/237 changed coverable lines, 100% patch coverage, zero misses and zero partials**. Sonar reports zero open issues and a passing quality gate. No coverage thresholds or exclusions were changed.

## Documentation impact

- [x] Behavior changed — documentation was updated in this PR
- [x] SYSTEMS or architecture

## Checklist

- [x] My code follows the project's coding conventions (see AGENTS.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new local lint, type, or Fallow failures
- [x] I have tested the affected changes
- [x] All final-head hosted checks have completed
- [x] I have checked for breaking changes

## Additional Notes

The suggestion to settle edition and chapter network catalogs independently was reviewed and declined. Both `main` and `docs/SYSTEMS.md` require normalizing both before applying either, preserving existing data when normalization fails. This PR retains that contract.

The hosted CodeRabbit status was rate-limited on the prior head; it was not counted as a completed review. The final local review completed successfully. No migration or production data rewrite is required. Production deployment has not been verified.



---

## Review round

Verification above was re-run on the final commit `17113c20`; all 30 checks pass (the 2 skipping are
Dependabot auto-merge and Supabase Preview, neither applicable). All four reviewers re-ran clean on
it. Three of five findings were valid and fixed; two were declined with evidence.

**Fixed — `60dab16d`, a real regression this refactor introduced (Codex, P2).** Making
`claimProgressChannel` `async` put a microtask boundary between `realtimeChannel = owned` and
`channel.subscribe()`. The original had none: it ran the ownership check, the publish, and the
`subscribeAndWaitForRealtimeChannel(...)` call in one synchronous segment, since `channel.subscribe()`
is invoked inside that function's `new Promise` executor. A teardown landing in that window removes
the published channel, the setup joins it anyway, and the trailing ownership check cannot reclaim it
because `realtimeChannel` already points at the newer owner — an orphaned duplicate listener.

The claim is now synchronous, with the caller releasing the channel when it is refused. Added a
regression test that queues teardown from the synchronous `client.channel()` construction so it lands
on the first microtask checkpoint after the claim; **verified discriminating** — it fails with the
`async` claim restored (`expected [ { on: [Function Mock], …(4) } ] to deeply equal []`) and passes
with the synchronous one. The atomicity requirement is now recorded in the realtime invariants in
`docs/SYSTEMS.md`, which documented the generation fences but not this ordering constraint.

**Fixed — `17113c20`, two inaccurate suppression rationales (cubic, P3 ×2).** A suppression is meant
to be a reviewable decision, so a confidently wrong rationale is worse than the vague one it replaced.
Both were mechanism claims I had not actually verified:

- `is_admin` said no consumer reads it. `app/middleware/admin.ts:91` reads
  `systemStore.$state.is_admin`; it now documents the same erased-`$state` pattern as `user_id`.
- `useTeamStore.id` said `.id` collides with the identifier Pinia exposes. Pinia exposes `$id` on the
  instance; the bare `id` in its types (`pinia.d.ts:410`) belongs to `DefineStoreOptions`. The
  observation holds and is now stated as one: `teamStore.owner`, read on the same line of
  TeamDangerZone.vue through the same wrapper, is attributed and reports clean while `id` stays
  flagged.

Auditing the rest of the group for the same class of error found two more, corrected in the same
commit: `userTeam` now carries the contrast that proves its mechanism (the sibling `isAdmin` reports
clean only because `settings.vue:206` holds a direct `useSystemStore()` instance, while every
`userTeam` read goes through the wrapper's aliased `Store<string, SystemState, SystemGetters>`; the
*team* wrapper returns `ReturnType<typeof useTeamStore>` instead, which is why that store's other
members resolve), and the three per-mode team columns are also read directly off the `SystemState`
parameter, not only through the computed key. Cross-checked by enumerating every
`systemStore.<member>` read in the app: only `isAdmin` and `userTeam` appear, matching exactly which
members the rule reports.

**Declined — independent edition/chapter catalog settlement (cubic, P2).** All-or-nothing validation
is pre-existing and deliberate: `origin/main` rejects the identical union before writing any state,
carried the comment "malformed chapters cannot partially replace eligibility", and it is a written
invariant in `docs/SYSTEMS.md` L1566-1567 ("preserving existing data if normalization fails").
Changing it is a product decision needing its own invariant change and review, not a refactor detail.

**Declined — undocumented system invariants (Greptile, P2).** I checked every invariant this change
touches in the realtime block of `docs/SYSTEMS.md` against the code. They are written behaviourally,
name no functions or files, and each is still literally true; `pnpm run systems:check` passes. The
premise that "channel-release ordering was reorganized" is not accurate — the ordering is unchanged.
The reviewer agreed on the thread ("the original comment overstated the gap"). The one genuinely
missing item was narrower and is the same issue Codex caught, now documented as described above.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of realtime team and progression updates during reconnects, channel changes, visibility changes, and network failures.
  - Prevented cache-write failures from blocking successfully loaded progression data.
  - Preserved pending changes and prevented stale responses from overwriting newer data.
  - Added fallback handling for legacy progress records and missing metadata.
  - Team disbanding now clears seasonal team data while preserving unrelated team aliases.
  - Invite links no longer expose stale or invalid team invitations.
- **Documentation**
  - Clarified realtime subscription ownership and startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->




<!-- greptile_comment -->

<details open><summary><h3>Greptile Summary</h3></summary>

The PR decomposes complexity-suppressed persistence, synchronization, metadata, team, and realtime logic while retaining the existing behavioral contracts.
- Extracts focused helpers from synchronization and state-management workflows.
- Corrects realtime channel ownership and team transport handling, with regression coverage.
- Documents the synchronous claim-to-subscribe invariant and updates related architecture guidance.
</details>


<details open><summary><h3>Confidence Score: 5/5</h3></summary>

The PR appears safe to merge.

No blocking failure remains.
</details>


<details open><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| app/stores/tarkov/realtimeListener.ts | The ownership claim and subscription remain in one synchronous segment, and superseded or failed joins release only their owned channel. |
| app/stores/__tests__/realtimeListener.seasonal.test.ts | Adds regression coverage for initial and superseded join failures, same-topic leave failures, and teardown immediately after ownership publication. |
| docs/SYSTEMS.md | Accurately documents the realtime ownership, teardown, and synchronous claim-to-subscribe invariants. |

</details>

<sub>Reviews (5): Last reviewed commit: ["fix: preserve transient snapshot and cha..."](https://github.com/tarkovtracker-org/tarkovtracker/commit/65877d7f2482ce52e9f5a64adc2806cc5872e196) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62710868)</sub>

<!-- /greptile_comment -->
